### PR TITLE
docker/ci: fix Alpine snapshot package versioning

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           docker run --rm syslog-ng:test --syntax-only
           docker run --rm syslog-ng:test --module-registry
-          docker run --rm syslog-ng:test -V | grep 'Revision: .*\.g'
+          docker run --rm syslog-ng:test -V | grep 'Installer-Version: .*\.g'
 
           printf "@version: 4.0\n log { source { stdin(); }; destination { file("/dev/stdout"); }; };" > test.conf
           echo "test msg" | docker run -i --rm -v $(realpath test.conf):/etc/syslog-ng/syslog-ng.conf syslog-ng:test -F | grep "test msg"

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -22,7 +22,8 @@ RUN mkdir packages \
         [ -z "$tarball_filename" ] && echo "Tarball for nightly can not be found" && exit 1; \
         tarball_name="${tarball_filename/\.tar.*}"; \
         tarball_version="${tarball_name/syslog-ng-}"; \
-        sed -i -e "s|^pkgver=.*|pkgver=$tarball_version|" -e "s|^builddir=.*|builddir=\"\$srcdir/$tarball_name\"|" APKBUILD; \
+        pkg_version="$(echo $tarball_version | sed -E 's|(([0-9]+\.){2}[0-9]+).*|\1|')_git$(date +%Y%m%d)"; \
+        sed -i -e "s|^pkgver=.*|pkgver=$pkg_version|" -e "s|^builddir=.*|builddir=\"\$srcdir/$tarball_name\"|" APKBUILD; \
         sed -i -e "s|^source=.*|source=\"$tarball_filename\"|" APKBUILD; \
        fi \
     && abuild checksum \

--- a/apkbuild/axoflow/syslog-ng/APKBUILD
+++ b/apkbuild/axoflow/syslog-ng/APKBUILD
@@ -74,7 +74,6 @@ done
 
 build() {
 	CFLAGS="$CFLAGS -flto=auto" \
-	SOURCE_REVISION="$pkgver" \
 	./configure \
 		--prefix=/usr \
 		--sysconfdir=/etc/syslog-ng \
@@ -122,6 +121,9 @@ scl() {
 
 dev() {
 	default_dev
+
+	# fix snapshot version
+	sed -i -e "s|^Version: .*|Version: $pkgver|g" "$subpkgdir/usr/lib/pkgconfig/syslog-ng.pc"
 
 	_submv usr/share/syslog-ng/tools \
 		usr/share/syslog-ng/xsd


### PR DESCRIPTION
ERROR: syslog-ng: 4.0.1.89.g9496ec1 is not a valid version
ERROR: syslog-ng-dev*: usr/lib/pkgconfig/syslog-ng.pc: pkgconf version 4.0.1.89.g9496ec1 is invalid

New version format: 4.0.1_git20230125