### PR TITLE
docker: use syslog-ng-ctl healthcheck

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -64,6 +64,6 @@ EXPOSE 514/udp
 EXPOSE 601/tcp
 EXPOSE 6514/tcp
 
-HEALTHCHECK --interval=2m --timeout=3s --start-period=30s CMD /usr/sbin/syslog-ng-ctl log-level || exit 1
+HEALTHCHECK --interval=2m --timeout=5s --start-period=30s CMD /usr/sbin/syslog-ng-ctl healthcheck --timeout 5
 ENV LD_PRELOAD /usr/lib/libjemalloc.so.2
 ENTRYPOINT ["/usr/sbin/syslog-ng", "-F"]


### PR DESCRIPTION
Depends on syslog-ng/syslog-ng#4362