### PR TITLE
ssc,syslog-ng: relocate syslog-ng venv

### DIFF
--- a/ssc/Dockerfile
+++ b/ssc/Dockerfile
@@ -32,7 +32,7 @@ RUN apk add -U --upgrade --no-cache \
     && chmod 755 /var/log/syslog-ng.* \
     && pip3 --no-cache-dir install poetry \
     && poetry export --format requirements.txt \
-        | /var/lib/syslog-ng/python-venv/bin/pip3 --no-cache-dir install -r /dev/stdin \
+        | /var/lib/syslog-ng-venv/bin/pip3 --no-cache-dir install -r /dev/stdin \
     && apk del build-base python3-dev libffi-dev
 
 HEALTHCHECK --interval=10s --retries=6 --timeout=6s CMD /sbin/healthcheck.sh

--- a/ssc/entrypoint.sh
+++ b/ssc/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-. /var/lib/syslog-ng/python-venv/bin/activate
+. /var/lib/syslog-ng-venv/bin/activate
 exec /sbin/entrypoint.sh "$@"

--- a/syslog-ng/apkbuild/axoflow/syslog-ng/APKBUILD
+++ b/syslog-ng/apkbuild/axoflow/syslog-ng/APKBUILD
@@ -87,6 +87,7 @@ build() {
 		--enable-manpages \
 		--with-ivykis=system \
 		--with-jsonc=system \
+		--with-python-venv-dir=/var/lib/syslog-ng-venv \
 		\
 		--enable-all-modules \
 		--enable-ebpf \


### PR DESCRIPTION
This makes it possible to mount an empty "state" volume into /var/lib/syslog-ng.

Depends on syslog-ng/syslog-ng#4465