### PR TITLE
Improve mktime cache

### DIFF
--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -270,7 +270,7 @@ _syslog_format_parse_timestamp(LogMessage *msg, UnixTime *stamp,
       result = scan_rfc5424_timestamp(data, length, &wct);
     }
 
-  if ((parse_flags & LP_NO_PARSE_DATE) == 0)
+  if (result && (parse_flags & LP_NO_PARSE_DATE) == 0)
     {
       convert_and_normalize_wall_clock_time_to_unix_time_with_tz_hint(&wct, stamp, recv_timezone_ofs);
 


### PR DESCRIPTION
This improves the caching in  cached_mktime() so that a single real mktime() invocation is valid for up to an hour.
