### PR TITLE
Filterx expr location fixes

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -71,6 +71,7 @@
     if (N)                                                              \
       {                                                                 \
         (Current).name         = YYRHSLOC(Rhs, 1).name;                 \
+        (Current).at_line      = YYRHSLOC (Rhs, 1).at_line;             \
         (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;          \
         (Current).first_column = YYRHSLOC (Rhs, 1).first_column;        \
         (Current).last_line    = YYRHSLOC (Rhs, N).last_line;           \
@@ -79,6 +80,7 @@
     else                                                                \
       {                                                                 \
         (Current).name         = YYRHSLOC(Rhs, 0).name;                 \
+        (Current).at_line      = YYRHSLOC (Rhs, 0).at_line;             \
         (Current).first_line   = (Current).last_line   =                \
           YYRHSLOC (Rhs, 0).last_line;                                  \
         (Current).first_column = (Current).last_column =                \

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -159,7 +159,7 @@ yy_filter_input(CfgLexer *self, gchar *buf, gsize buf_size)
 #define YY_USER_ACTION                                                  \
   do {                                                                  \
     CFG_LTYPE *cur_lloc = &yyextra->include_stack[yyextra->include_depth].lloc; \
-    if (YY_START == INITIAL || YY_START == filterx) 			\
+    if (YY_START == INITIAL || YY_START == filterx || YY_START == block) \
       {                                                                 \
         cur_lloc->first_column = cur_lloc->last_column;                 \
       }                                                                 \

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -86,10 +86,24 @@ typedef struct _CfgTokenBlock CfgTokenBlock;
 
 typedef struct CFG_LTYPE
 {
-  int first_line;
-  int first_column;
-  int last_line;
-  int last_column;
+  gint first_line;
+  gint first_column;
+  gint last_line;
+  gint last_column;
+
+  /* this value indicates that @line was used which changed lloc relative to
+   * an actual file */
+  struct
+  {
+    gboolean present;
+    /* the first line/column at the point of the @line directive */
+    gint captured_first_line;
+    gint captured_first_column;
+    const gchar *captured_name;
+    /* line/column specified by @line */
+    gint line;
+    gint column;
+  } at_line;
 
   const gchar *name;
 } CFG_LTYPE;
@@ -152,9 +166,8 @@ struct _CfgIncludeLevel
     } buffer;
   };
 
-  /* this value indicates that @line was used which changed lloc relative to
-   * an actual file */
-  gboolean lloc_changed_by_at_line;
+
+
   CFG_LTYPE lloc;
   struct yy_buffer_state *yybuf;
 };
@@ -207,6 +220,7 @@ gboolean cfg_lexer_include_buffer(CfgLexer *self, const gchar *name, const gchar
 gboolean cfg_lexer_include_buffer_without_backtick_substitution(CfgLexer *self,
     const gchar *name, const gchar *buffer, gsize length);
 const gchar *cfg_lexer_format_location(CfgLexer *self, const CFG_LTYPE *yylloc, gchar *buf, gsize buf_len);
+void cfg_lexer_undo_set_file_location(CfgLexer *self, CFG_LTYPE *yylloc);
 void cfg_lexer_set_file_location(CfgLexer *self, const gchar *filename, gint line, gint column);
 EVTTAG *cfg_lexer_format_location_tag(CfgLexer *self, const CFG_LTYPE *yylloc);
 

--- a/lib/cfg-source.c
+++ b/lib/cfg-source.c
@@ -234,6 +234,9 @@ _extract_source_from_buffer_location(GString *result, const gchar *buffer_conten
   if (num_lines <= yylloc->first_line)
     goto exit;
 
+  if (yylloc->first_column < 1)
+    goto exit;
+
   for (gint lineno = yylloc->first_line; lineno <= yylloc->last_line; lineno++)
     {
       gchar *line = lines[lineno - 1];
@@ -242,9 +245,9 @@ _extract_source_from_buffer_location(GString *result, const gchar *buffer_conten
       if (lineno == yylloc->first_line)
         {
           if (yylloc->first_line == yylloc->last_line)
-            g_string_append_len(result, &line[MIN(linelen, yylloc->first_column)], yylloc->last_column - yylloc->first_column);
+            g_string_append_len(result, &line[MIN(linelen, yylloc->first_column-1)], yylloc->last_column - yylloc->first_column);
           else
-            g_string_append(result, &line[MIN(linelen, yylloc->first_column)]);
+            g_string_append(result, &line[MIN(linelen, yylloc->first_column-1)]);
         }
       else if (lineno < yylloc->last_line)
         {

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -215,7 +215,12 @@ line_stmt
             cfg_lexer_set_file_location(lexer, $2, $3, $4);
             free($2);
           }
+	| KW_LINE LL_EOL
+          {
+            cfg_lexer_set_file_location(lexer, NULL, 0, 0);
+          }
 
+	;
 /* INCLUDE_RULES */
 
 %%

--- a/lib/tests/test_lexer.c
+++ b/lib/tests/test_lexer.c
@@ -188,57 +188,62 @@ Test(lexer, block_token_is_taken_literally_between_a_pair_of_enclosing_character
   _input(" { hello }");
   cfg_lexer_start_block_state(parser->lexer, "{}");
   assert_parser_block(" hello ");
-  assert_location_range(1, 1, 1, 11);
+  assert_location_range(1, 2, 1, 11);
 
   _input(" { hello\nworld }");
   cfg_lexer_start_block_state(parser->lexer, "{}");
   assert_parser_block(" hello\nworld ");
-  assert_location_range(1, 1, 2, 8);
+  assert_location_range(1, 2, 2, 8);
 
   _input(" { hello\\\nworld }");
   cfg_lexer_start_block_state(parser->lexer, "{}");
   assert_parser_block(" hello\\\nworld ");
-  assert_location_range(1, 1, 2, 8);
+  assert_location_range(1, 2, 2, 8);
 
   _input(" { 'hello' }");
   cfg_lexer_start_block_state(parser->lexer, "{}");
   assert_parser_block(" 'hello' ");
-  assert_location_range(1, 1, 1, 13);
+  assert_location_range(1, 2, 1, 13);
 
   _input(" { 'hello\nworld' }");
   cfg_lexer_start_block_state(parser->lexer, "{}");
   assert_parser_block(" 'hello\nworld' ");
-  assert_location_range(1, 1, 2, 9);
+  assert_location_range(1, 2, 2, 9);
 
   _input(" { 'hello\\\nworld' }");
   cfg_lexer_start_block_state(parser->lexer, "{}");
   assert_parser_block(" 'hello\\\nworld' ");
-  assert_location_range(1, 1, 2, 9);
+  assert_location_range(1, 2, 2, 9);
 
   _input(" { \"hello\" }");
   cfg_lexer_start_block_state(parser->lexer, "{}");
   assert_parser_block(" \"hello\" ");
-  assert_location_range(1, 1, 1, 13);
+  assert_location_range(1, 2, 1, 13);
 
   _input(" { \"hello\nworld\" }");
   cfg_lexer_start_block_state(parser->lexer, "{}");
   assert_parser_block(" \"hello\nworld\" ");
-  assert_location_range(1, 1, 2, 9);
+  assert_location_range(1, 2, 2, 9);
 
   _input(" { \"hello\\\nworld\" }");
   cfg_lexer_start_block_state(parser->lexer, "{}");
   assert_parser_block(" \"hello\\\nworld\" ");
-  assert_location_range(1, 1, 2, 9);
+  assert_location_range(1, 2, 2, 9);
 
   _input(" { \"hello \\a\\n\\r\\t\\v\\x40\\o100 world\" }");
   cfg_lexer_start_block_state(parser->lexer, "{}");
   assert_parser_block(" \"hello \\a\\n\\r\\t\\v\\x40\\o100 world\" ");
-  assert_location_range(1, 1, 1, 39);
+  assert_location_range(1, 2, 1, 39);
 
   _input(" { \"hello \\\" world\" }");
   cfg_lexer_start_block_state(parser->lexer, "{}");
   assert_parser_block(" \"hello \\\" world\" ");
-  assert_location_range(1, 1, 1, 22);
+  assert_location_range(1, 2, 1, 22);
+
+  _input("\n{\n \"hello \\\" world\" }");
+  cfg_lexer_start_block_state(parser->lexer, "{}");
+  assert_parser_block("\n \"hello \\\" world\" ");
+  assert_location_range(2, 1, 3, 20);
 }
 
 Test(lexer, block_new_lines_in_text_leading_to_the_opening_bracket_are_tracked_properly)

--- a/modules/appmodel/application.c
+++ b/modules/appmodel/application.c
@@ -24,24 +24,30 @@
 #include "application.h"
 
 void
-application_set_filter(Application *self, const gchar *filter_expr)
+application_set_filter(Application *self, const gchar *filter_expr, CFG_LTYPE *lloc)
 {
   g_free(self->filter_expr);
   self->filter_expr = g_strdup(filter_expr);
+  if (lloc)
+    self->filter_lloc = *lloc;
 }
 
 void
-application_set_parser(Application *self, const gchar *parser_expr)
+application_set_parser(Application *self, const gchar *parser_expr, CFG_LTYPE *lloc)
 {
   g_free(self->parser_expr);
   self->parser_expr = g_strdup(parser_expr);
+  if (lloc)
+    self->parser_lloc = *lloc;
 }
 
 void
-application_set_filterx(Application *self, const gchar *filterx_expr)
+application_set_filterx(Application *self, const gchar *filterx_expr, CFG_LTYPE *lloc)
 {
   g_free(self->filterx_expr);
   self->filterx_expr = g_strdup(filterx_expr);
+  if (lloc)
+    self->filterx_lloc = *lloc;
 }
 
 static void

--- a/modules/appmodel/application.h
+++ b/modules/appmodel/application.h
@@ -25,6 +25,7 @@
 #define APPMODEL_APPLICATION_H_INCLUDED
 
 #include "appmodel-context.h"
+#include "cfg-lexer.h"
 
 #define APPLICATION_TYPE_NAME "application"
 
@@ -34,11 +35,14 @@ typedef struct _Application
   gchar *filter_expr;
   gchar *parser_expr;
   gchar *filterx_expr;
+  CFG_LTYPE filter_lloc;
+  CFG_LTYPE parser_lloc;
+  CFG_LTYPE filterx_lloc;
 } Application;
 
-void application_set_filter(Application *self, const gchar *filter_expr);
-void application_set_parser(Application *self, const gchar *parser_expr);
-void application_set_filterx(Application *self, const gchar *parser_expr);
+void application_set_filter(Application *self, const gchar *filter_expr, CFG_LTYPE *lloc);
+void application_set_parser(Application *self, const gchar *parser_expr, CFG_LTYPE *lloc);
+void application_set_filterx(Application *self, const gchar *parser_expr, CFG_LTYPE *lloc);
 
 Application *application_new(const gchar *name, const gchar *topic);
 

--- a/modules/appmodel/appmodel-grammar.ym
+++ b/modules/appmodel/appmodel-grammar.ym
@@ -92,9 +92,9 @@ application_options
 	;
 
 application_option
-	: KW_FILTER _block_content_context_push LL_BLOCK _block_content_context_pop  { application_set_filter($<ptr>0, $3); free($3); }
-	| KW_PARSER _block_content_context_push LL_BLOCK _block_content_context_pop  { application_set_parser($<ptr>0, $3); free($3); }
-	| KW_FILTERX _block_content_context_push LL_BLOCK _block_content_context_pop  {	application_set_filterx($<ptr>0, $3); free($3); }
+	: KW_FILTER _block_content_context_push LL_BLOCK _block_content_context_pop  { application_set_filter($<ptr>0, $3, &@3); free($3); }
+	| KW_PARSER _block_content_context_push LL_BLOCK _block_content_context_pop  { application_set_parser($<ptr>0, $3, &@3); free($3); }
+	| KW_FILTERX _block_content_context_push LL_BLOCK _block_content_context_pop  {	application_set_filterx($<ptr>0, $3, &@3); free($3); }
 	;
 
 

--- a/modules/appmodel/tests/test_application.c
+++ b/modules/appmodel/tests/test_application.c
@@ -40,10 +40,10 @@ Test(application, filter_can_be_set_and_queried)
   const gchar *filter_expr2 = "'2' eq '2'";
 
   app = application_new("foobar", "*");
-  application_set_filter(app, filter_expr);
+  application_set_filter(app, filter_expr, NULL);
   cr_assert_str_eq(app->filter_expr, filter_expr);
 
-  application_set_filter(app, filter_expr2);
+  application_set_filter(app, filter_expr2, NULL);
   cr_assert_str_eq(app->filter_expr, filter_expr2);
   appmodel_object_free(&app->super);
 }
@@ -55,10 +55,10 @@ Test(application, parser_can_be_set_and_queried)
   const gchar *parser_expr2 = "csv-parser();";
 
   app = application_new("foobar", "*");
-  application_set_parser(app, parser_expr);
+  application_set_parser(app, parser_expr, NULL);
   cr_assert_str_eq(app->parser_expr, parser_expr);
 
-  application_set_parser(app, parser_expr2);
+  application_set_parser(app, parser_expr2, NULL);
   cr_assert_str_eq(app->parser_expr, parser_expr2);
   appmodel_object_free(&app->super);
 }


### PR DESCRIPTION
This improves filterx expression representation in trace level logs by improving the location tracking for filterx source text.

This will also cause any source related displays (e.g. error output or the filterx expression display) to use the _postprocessed_ output, e.g. the text _after_ substitution, instead of the original text read from the source file.

This makes it easier to find issues that are related to parts substituted from parameters/environment variables.

This sits on top of the app-transform() branch
