### PR TITLE
filters: fix the precedence of ';'

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -157,6 +157,9 @@
 /* this is a placeholder for unit tests, must be the latest & largest */
 %token LL_CONTEXT_MAX                 27
 
+
+%left   ';'
+
 /* operators in the filter language, the order of this determines precedence */
 %right KW_ASSIGN 9000
 %right '?' ':'

--- a/lib/filter/filter-expr-grammar.ym
+++ b/lib/filter/filter-expr-grammar.ym
@@ -112,8 +112,6 @@ _translate_number_literals(CfgLexer *lexer, gint compare_mode, LogTemplate *expr
 %token KW_PROGRAM
 %token KW_IN_LIST
 
-%left   ';'
-
 %type	<node> filter_expr
 %type	<node> filter_simple_expr
 %type	<node> filter_plugin

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -255,6 +255,7 @@ tests/light/functional_tests/logpath/test_conditionals\.py
 tests/light/functional_tests/logpath/test_midpoint_destinations\.py
 tests/light/functional_tests/value-pairs/test_value_pairs\.py
 tests/light/functional_tests/templates/test_template_stmt\.py
+tests/light/functional_tests/filters/test_multiple_filters\.py
 tests/light/functional_tests/filterx/test_filterx\.py
 tests/light/functional_tests/filterx/test_filterx_scope\.py
 tests/light/functional_tests/parsers/metrics-probe/test_metrics_probe\.py

--- a/tests/light/functional_tests/Makefile.am
+++ b/tests/light/functional_tests/Makefile.am
@@ -18,6 +18,7 @@ EXTRA_DIST += \
 	tests/light/functional_tests/destination_drivers/unix_stream_destination/test_unix_stream_destination.py \
 	tests/light/functional_tests/filters/rate-limit/test_rate_limit_filter_acceptance.py \
 	tests/light/functional_tests/filters/test_filter_reference.py \
+	tests/light/functional_tests/filters/test_multiple_filters.py \
 	tests/light/functional_tests/logpath/__init__.py \
 	tests/light/functional_tests/logpath/test_conditionals.py \
 	tests/light/functional_tests/logpath/test_flags_catch_all.py \

--- a/tests/light/functional_tests/filters/test_multiple_filters.py
+++ b/tests/light/functional_tests/filters/test_multiple_filters.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2024 Attila Szakacs
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from src.syslog_ng_config.renderer import render_statement
+
+
+def test_multiple_filters_implicit_and(config, syslog_ng):
+    file_true = config.create_file_destination(file_name="dest-true.log", template="\"$MSG\\n\"")
+    file_false = config.create_file_destination(file_name="dest-false.log", template="\"$MSG\\n\"")
+
+    preamble = f"""
+@version: {config.get_version()}
+
+options {{ stats(level(1)); }};
+
+source genmsg {{
+    example-msg-generator(num(1) template("MESSAGE"));
+    example-msg-generator(num(1) template("foobar"));
+}};
+
+filter f_filter {{
+    not program("xyz");
+    message("MESSAGE");
+}};
+
+destination dest_true {{
+{render_statement(file_true)};
+}};
+
+destination dest_false {{
+{render_statement(file_false)};
+}};
+
+log {{
+    source(genmsg);
+    if {{
+        filter(f_filter);
+        destination(dest_true);
+    }} else {{
+        destination(dest_false);
+    }};
+}};
+"""
+    config.set_raw_config(preamble)
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert file_false.get_stats()["processed"] == 1
+
+    assert "MESSAGE" in file_true.read_log()
+    assert "foobar" in file_false.read_log()


### PR DESCRIPTION
In 6d74e60c4b2b51e9842ccab23902803b9ff8de2b, the precedence of ';' has implicitly changed for filter rules, changing the meaning of filter expressions:

The expression `not program("a"); message("b");` should have the following interpretation: `(not program("a")) and message("b")`.

Due to accidentally changed precedence of ';', currently it is interpreted as `not (message("a") and message("b"))`.

This patch recovers the original precedence, but also introduces precedence and left associativity for other semicolon-separated rules.

All the other (non-filter) uses of the ';' token are unambiguous, so this declaration won't interfere with those rules.

Related issue https://github.com/syslog-ng/syslog-ng/issues/4980