### PR TITLE
stats-query: fix assert and showing timestamps 

### DIFF
--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -94,7 +94,8 @@ _process_counter_if_matching(StatsCluster *sc, gint type, StatsCounterItem *coun
 static void
 _process_counters(StatsCluster *sc, gpointer user_data /*, gboolean* cancelled */)
 {
-  stats_cluster_foreach_counter(sc, _process_counter_if_matching, user_data /*, cancelled*/);
+  if (stats_cluster_key_is_legacy(&sc->key))
+    stats_cluster_foreach_counter(sc, _process_counter_if_matching, user_data /*, cancelled*/);
 }
 
 static gboolean

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -295,6 +295,7 @@ stats_register_associated_counter(StatsCluster *sc, gint type, StatsCounterItem 
   g_assert(sc->dynamic);
 
   *counter = stats_cluster_track_counter(sc, type);
+  _update_counter_name_if_needed(*counter, sc, type);
 }
 
 void

--- a/news/bugfix-129-2.md
+++ b/news/bugfix-129-2.md
@@ -1,0 +1,1 @@
+`syslog-ng-ctl query`: show timestamps and fix `g_pattern_spec_match_string` assert

--- a/news/bugfix-129.md
+++ b/news/bugfix-129.md
@@ -1,0 +1,3 @@
+`syslog-ng-ctl query`: fix showing Prometheus metrics as unnamed values
+
+`none.value=726685`


### PR DESCRIPTION
All new counters should have their names filled.

`g_pattern_spec_match_string: assertion 'string != NULL' failed`