### PR TITLE
Build arm64 images for dev branches

### DIFF
--- a/.github/workflows/axosyslog-image-snapshot.yml
+++ b/.github/workflows/axosyslog-image-snapshot.yml
@@ -46,7 +46,7 @@ jobs:
     needs: tarball
     with:
       type: snapshot
-      platforms: ${{ inputs.platforms || 'linux/amd64' }}
+      platforms: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
       snapshot-tarball-artifact: source-tarball
       snapshot-version: ${{ needs.tarball.outputs.snapshot-version }}
       snapshot-tags: dev-${{ github.ref_name }}


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->

We need arm64 images for testing and development on macs.