### PR TITLE
json: fix copypaste error in cache_json_file() filterx fn

### DIFF
--- a/modules/json/filterx-cache-json-file.c
+++ b/modules/json/filterx-cache-json-file.c
@@ -168,7 +168,7 @@ _deep_freeze_dict(FilterXFuntionCacheJsonFile *self, FilterXObject *object)
 static void
 _deep_freeze_list(FilterXFuntionCacheJsonFile *self, FilterXObject *object)
 {
-  struct json_object *jso = filterx_json_object_get_value(object);
+  struct json_object *jso = filterx_json_array_get_value(object);
   guint64 len = json_object_array_length(jso);
 
   for (guint64 i = 0; i < len; i++)


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
