### PR TITLE
cfg-grammar: fix context for looking up blocks

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -799,23 +799,23 @@ log_forks
         ;
 
 log_fork
-        : KW_LOG optional_string '{' log_content '}'
+        : KW_LOG optional_string '{' _log_context_push log_content _log_context_pop '}'
           {
             if ($2)
               {
-                log_expr_node_set_name($4, $2);
+                log_expr_node_set_name($5, $2);
                 free($2);
               }
-            $$ = $4;
+            $$ = $5;
           }
-        | KW_CHANNEL optional_string '{' log_content '}'
+        | KW_CHANNEL optional_string '{' _log_context_push log_content _log_context_pop '}'
           {
             if ($2)
               {
-                log_expr_node_set_name($4, $2);
+                log_expr_node_set_name($5, $2);
                 free($2);
               }
-            $$ = $4;
+            $$ = $5;
           }
         ;
 


### PR DESCRIPTION
Whenever we have an embedded block in a source/destination/parser/rewrite block, we did not push the log context while parsing those elements.

This prevented us from using "block log" elements in these contexts.

Fix that up.
