### PR TITLE
filterx: add vars() function 

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -38,6 +38,7 @@ set(FILTERX_HEADERS
     filterx/filterx-private.h
     filterx/func-istype.h
     filterx/func-len.h
+    filterx/func-vars.h
     filterx/expr-plus.h
     PARENT_SCOPE
     )
@@ -82,6 +83,7 @@ set(FILTERX_SOURCES
     filterx/expr-regexp.c
     filterx/func-istype.c
     filterx/func-len.c
+    filterx/func-vars.c
     filterx/expr-plus.c
     filterx/filterx-private.c
     PARENT_SCOPE

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -40,6 +40,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/expr-regexp.h		\
 	lib/filterx/func-istype.h		\
 	lib/filterx/func-len.h		\
+	lib/filterx/func-vars.h		\
 	lib/filterx/filterx-private.h
 
 
@@ -84,6 +85,7 @@ filterx_sources = 				\
 	lib/filterx/expr-regexp.c		\
 	lib/filterx/func-istype.c		\
 	lib/filterx/func-len.c		\
+	lib/filterx/func-vars.c		\
 	lib/filterx/filterx-private.c	\
 	lib/filterx/filterx-grammar.y
 

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -32,6 +32,7 @@
 #include "filterx/object-dict-interface.h"
 #include "filterx/func-istype.h"
 #include "filterx/func-len.h"
+#include "filterx/func-vars.h"
 
 static GHashTable *filterx_builtin_simple_functions = NULL;
 static GHashTable *filterx_builtin_function_ctors = NULL;
@@ -81,6 +82,7 @@ _simple_init(void)
   g_assert(filterx_builtin_simple_function_register("int", filterx_typecast_integer));
   g_assert(filterx_builtin_simple_function_register("double", filterx_typecast_double));
   g_assert(filterx_builtin_simple_function_register("len", filterx_simple_function_len));
+  g_assert(filterx_builtin_simple_function_register("vars", filterx_simple_function_vars));
 
 }
 

--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -59,6 +59,12 @@ filterx_variable_get_nv_handle(FilterXVariable *v)
   return v->handle & ~FILTERX_HANDLE_FLOATING_BIT;
 }
 
+const gchar *
+filterx_variable_get_name(FilterXVariable *v, gssize *len)
+{
+  return log_msg_get_handle_name(filterx_variable_get_nv_handle(v), len);
+}
+
 FilterXObject *
 filterx_variable_get_value(FilterXVariable *v)
 {

--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -239,6 +239,24 @@ filterx_scope_register_declared_variable(FilterXScope *self,
   return v;
 }
 
+gboolean
+filterx_scope_foreach_variable(FilterXScope *self, FilterXScopeForeachFunc func, gpointer user_data)
+{
+  for (gsize i = 0; i < self->variables->len; i++)
+    {
+      FilterXVariable *variable = &g_array_index(self->variables, FilterXVariable, i);
+
+      if (filterx_variable_handle_is_floating(variable->handle) &&
+          !variable->declared && variable->generation != self->generation)
+        continue;
+
+      if (!func(variable, user_data))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
 /*
  * 1) sync objects to message
  * 2) drop undeclared objects

--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -37,6 +37,7 @@ typedef enum
 
 gboolean filterx_variable_is_floating(FilterXVariable *v);
 gboolean filterx_variable_handle_is_floating(FilterXVariableHandle handle);
+const gchar *filterx_variable_get_name(FilterXVariable *v, gssize *len);
 FilterXObject *filterx_variable_get_value(FilterXVariable *v);
 void filterx_variable_set_value(FilterXVariable *v, FilterXObject *new_value);
 void filterx_variable_unset_value(FilterXVariable *v);

--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -56,6 +56,8 @@ gboolean filterx_variable_is_set(FilterXVariable *v);
  */
 typedef struct _FilterXScope FilterXScope;
 
+typedef gboolean (*FilterXScopeForeachFunc)(FilterXVariable *variable, gpointer user_data);
+
 void filterx_scope_set_dirty(FilterXScope *self);
 gboolean filterx_scope_is_dirty(FilterXScope *self);
 void filterx_scope_sync(FilterXScope *self, LogMessage *msg);
@@ -68,6 +70,7 @@ FilterXVariable *filterx_scope_register_variable(FilterXScope *self,
 FilterXVariable *filterx_scope_register_declared_variable(FilterXScope *self,
                                                           FilterXVariableHandle handle,
                                                           FilterXObject *initial_value);
+gboolean filterx_scope_foreach_variable(FilterXScope *self, FilterXScopeForeachFunc func, gpointer user_data);
 
 /* copy on write */
 void filterx_scope_write_protect(FilterXScope *self);

--- a/lib/filterx/func-vars.c
+++ b/lib/filterx/func-vars.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024 Attila Szakacs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "func-vars.h"
+#include "filterx-eval.h"
+#include "object-json.h"
+#include "object-string.h"
+
+static gboolean
+_add_to_dict(FilterXVariable *variable, gpointer user_data)
+{
+  FilterXObject *vars = (FilterXObject *) user_data;
+
+  gssize name_len;
+  const gchar *name_str = filterx_variable_get_name(variable, &name_len);
+  FilterXObject *name = filterx_string_new(name_str, name_len);
+
+  FilterXObject *value = filterx_variable_get_value(variable);
+  FilterXObject *cloned_value = filterx_object_clone(value);
+  filterx_object_unref(value);
+
+  gboolean success = filterx_object_set_subscript(vars, name, &cloned_value);
+
+  filterx_object_unref(cloned_value);
+  filterx_object_unref(name);
+  return success;
+}
+
+FilterXObject *
+filterx_simple_function_vars(GPtrArray *args)
+{
+  if (args && args->len != 0)
+    {
+      msg_error("filterx: vars() function does not take any arguments");
+      return NULL;
+    }
+
+  FilterXEvalContext *context = filterx_eval_get_context();
+  FilterXObject *vars = filterx_json_object_new_empty();
+
+  if (filterx_scope_foreach_variable(context->scope, _add_to_dict, vars))
+    return vars;
+
+  filterx_object_unref(vars);
+  return NULL;
+}

--- a/lib/filterx/func-vars.h
+++ b/lib/filterx/func-vars.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Attila Szakacs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_FUNC_VARS_H_INCLUDED
+#define FILTERX_FUNC_VARS_H_INCLUDED
+
+#include "filterx/expr-function.h"
+
+FilterXObject *filterx_simple_function_vars(GPtrArray *args);
+
+#endif


### PR DESCRIPTION
This function gathers all filterx variables to a json object. Similar to the python vars() function without arguments. https://docs.python.org/3/library/functions.html#vars

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>