### PR TITLE
cfg-lex.l: allow an underscore in identifier names

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -347,7 +347,7 @@ filterx_word	[^ \#'"/\(\)\{\}\[\]\\;\r\n\t,|\.@:]
 <INITIAL>({word}+(\.)?)*{word}+    { return cfg_lexer_map_word_to_token(yyextra, yylval, yylloc, yytext); }
 
     /* and this is the version in filterx, which only allows "traditional" identifiers */
-<filterx>[a-zA-Z][_a-zA-Z0-9]* 	   { return cfg_lexer_map_word_to_token(yyextra, yylval, yylloc, yytext); }
+<filterx>[_a-zA-Z][_a-zA-Z0-9]* 	   { return cfg_lexer_map_word_to_token(yyextra, yylval, yylloc, yytext); }
 <filterx>\$\{([^}]+)\}   { yylval->cptr = strndup(yytext+2, strlen(yytext) - 3); return LL_MESSAGE_REF; }
 <INITIAL>\,	   	   ;
 


### PR DESCRIPTION
This PR fixes the filterx identifier pattern in the lexer to allow a leading underscore.
