### PR TITLE
Filterx handle unknown function arguments

### DIFF
--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -257,9 +257,8 @@ report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, 
            * location.  */
 
           from_lloc = yylloc;
-          fprintf(stderr, "Error parsing %s, %s in %s:%d:%d-%d:%d:\n",
-                  what,
-                  msg,
+          fprintf(stderr, "\nError parsing %s: %s\n\nIn %s:%d:%d-%d:%d:\n",
+                  what, msg,
                   from_lloc->name,
                   from_lloc->first_line,
                   from_lloc->first_column,

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -232,10 +232,15 @@ CfgParser main_parser =
 
 CFG_PARSER_IMPLEMENT_LEXER_BINDING(main_, MAIN_, gpointer *)
 
+void
+syntax_error_footer(void)
+{
+  fprintf(stderr, "\nsyslog-ng documentation: %s\n"
+          "contact: %s\n", PRODUCT_DOCUMENTATION, PRODUCT_CONTACT);
+}
 
 void
-report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, const char *msg,
-                    gboolean in_main_grammar)
+report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, const char *msg)
 {
   CfgIncludeLevel *level = &lexer->include_stack[lexer->include_depth], *from;
 
@@ -273,11 +278,6 @@ report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, 
       cfg_source_print_source_context(lexer, from, from_lloc);
       fprintf(stderr, "\n");
     }
-
-  if (in_main_grammar)
-    fprintf(stderr, "\nsyslog-ng documentation: %s\n"
-            "contact: %s\n", PRODUCT_DOCUMENTATION, PRODUCT_CONTACT);
-
 }
 
 /* the debug flag for the main parser will be used for all parsers */
@@ -309,6 +309,8 @@ cfg_parser_parse(CfgParser *self, CfgLexer *lexer, gpointer *instance, gpointer 
       fprintf(stderr,
               "\nToo many tokens found during parsing, consider increasing YYMAXDEPTH in lib/cfg-grammar.y and recompiling.\n");
     }
+  if (!success && strcmp(self->name, "config") == 0)
+    syntax_error_footer();
   return success;
 }
 

--- a/lib/cfg-parser.h
+++ b/lib/cfg-parser.h
@@ -99,7 +99,7 @@ extern CfgParser main_parser;
     void                                                                      \
     parser_prefix ## error(const CFG_LTYPE *yylloc, CfgLexer *lexer, root_type instance, gpointer arg, const char *msg) \
     {                                                                 \
-      report_syntax_error(lexer, yylloc, cfg_lexer_get_context_description(lexer), msg); 				\
+      report_syntax_error(lexer, yylloc, cfg_lexer_get_context_description(lexer), msg);        \
     }
 
 void report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, const char *msg);

--- a/lib/cfg-parser.h
+++ b/lib/cfg-parser.h
@@ -99,13 +99,10 @@ extern CfgParser main_parser;
     void                                                                      \
     parser_prefix ## error(const CFG_LTYPE *yylloc, CfgLexer *lexer, root_type instance, gpointer arg, const char *msg) \
     {                                                                 \
-      gboolean in_main_grammar = __builtin_strcmp( # parser_prefix, "main_") == 0;              \
-      report_syntax_error(lexer, yylloc, cfg_lexer_get_context_description(lexer), msg,   \
-                          in_main_grammar);                                                     \
+      report_syntax_error(lexer, yylloc, cfg_lexer_get_context_description(lexer), msg); 				\
     }
 
-void report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, const char *msg,
-                         gboolean in_main_grammar);
+void report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, const char *msg);
 
 CFG_PARSER_DECLARE_LEXER_BINDING(main_, MAIN_, gpointer *)
 

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -132,7 +132,7 @@ void
 filterx_function_init_instance(FilterXFunction *s, const gchar *function_name)
 {
   filterx_expr_init_instance(&s->super);
-  s->function_name = g_strdup(function_name);
+  s->function_name = g_strdup_printf("%s()", function_name);
   s->super.free_fn = _function_free;
 }
 

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -46,6 +46,14 @@ typedef struct _FilterXSimpleFunction
   FilterXSimpleFunctionProto function_proto;
 } FilterXSimpleFunction;
 
+void
+filterx_simple_function_argument_error(FilterXExpr *s, gchar *error_info, gboolean free_info)
+{
+  FilterXSimpleFunction *self = (FilterXSimpleFunction *) s;
+
+  filterx_eval_push_error_info(self ? self->super.function_name : "n/a", s, error_info, free_info);
+}
+
 static GPtrArray *
 _simple_function_eval_args(FilterXSimpleFunction *self)
 {
@@ -65,7 +73,7 @@ _simple_function_eval_args(FilterXSimpleFunction *self)
   GError *error = NULL;
   if (!filterx_function_args_check(self->args, &error))
     {
-      filterx_eval_push_error_info(self->super.function_name, &self->super.super, error->message);
+      filterx_simple_function_argument_error(&self->super.super, error->message, TRUE);
       error->message = NULL;
       g_clear_error(&error);
       goto error;

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -205,6 +205,12 @@ filterx_function_args_len(FilterXFunctionArgs *self)
   return self->positional_args->len;
 }
 
+gboolean
+filterx_function_args_empty(FilterXFunctionArgs *self)
+{
+  return self->positional_args->len == 0 && g_hash_table_size(self->named_args) == 0;
+}
+
 FilterXExpr *
 filterx_function_args_get_expr(FilterXFunctionArgs *self, guint64 index)
 {

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -103,7 +103,7 @@ _simple_eval(FilterXExpr *s)
   FilterXSimpleFunctionProto f = self->function_proto;
 
   g_assert(f != NULL);
-  FilterXObject *res = f(args);
+  FilterXObject *res = f(s, args);
 
   if (args != NULL)
     g_ptr_array_free(args, TRUE);

--- a/lib/filterx/expr-function.h
+++ b/lib/filterx/expr-function.h
@@ -59,6 +59,7 @@ void filterx_function_free_method(FilterXFunction *s);
 FilterXFunctionArg *filterx_function_arg_new(const gchar *name, FilterXExpr *value);
 FilterXFunctionArgs *filterx_function_args_new(GList *args, GError **error);
 guint64 filterx_function_args_len(FilterXFunctionArgs *self);
+gboolean filterx_function_args_empty(FilterXFunctionArgs *self);
 FilterXExpr *filterx_function_args_get_expr(FilterXFunctionArgs *self, guint64 index);
 FilterXObject *filterx_function_args_get_object(FilterXFunctionArgs *self, guint64 index);
 const gchar *filterx_function_args_get_literal_string(FilterXFunctionArgs *self, guint64 index, gsize *len);

--- a/lib/filterx/expr-function.h
+++ b/lib/filterx/expr-function.h
@@ -28,7 +28,7 @@
 #include "filterx/filterx-object.h"
 #include "plugin.h"
 
-typedef FilterXObject *(*FilterXSimpleFunctionProto)(GPtrArray *);
+typedef FilterXObject *(*FilterXSimpleFunctionProto)(FilterXExpr *s, GPtrArray *);
 
 void filterx_simple_function_argument_error(FilterXExpr *s, gchar *error_info, gboolean free_info);
 

--- a/lib/filterx/expr-function.h
+++ b/lib/filterx/expr-function.h
@@ -25,7 +25,8 @@
 #define FILTERX_EXPR_FUNCTION_H_INCLUDED
 
 #include "filterx/filterx-expr.h"
-#include "filterx-object.h"
+#include "filterx/filterx-object.h"
+#include "plugin.h"
 
 typedef FilterXObject *(*FilterXSimpleFunctionProto)(GPtrArray *);
 
@@ -78,5 +79,28 @@ gboolean filterx_function_args_check(FilterXFunctionArgs *self, GError **error);
 void filterx_function_args_free(FilterXFunctionArgs *self);
 
 FilterXExpr *filterx_function_lookup(GlobalConfig *cfg, const gchar *function_name, GList *args, GError **error);
+
+
+#define FILTERX_SIMPLE_FUNCTION_PROTOTYPE(func_name) \
+  gpointer                                                              \
+  filterx_ ## func_name ## _construct(Plugin *self)
+
+#define FILTERX_SIMPLE_FUNCTION_DECLARE(func_name) \
+  FILTERX_SIMPLE_FUNCTION_PROTOTYPE(func_name);
+
+/* helper macros for template function plugins */
+#define FILTERX_SIMPLE_FUNCTION(func_name, call) \
+  FILTERX_SIMPLE_FUNCTION_PROTOTYPE(func_name)   \
+  {                                              \
+    FilterXSimpleFunctionProto f = call;         \
+    return (gpointer) f;                         \
+  }
+
+#define FILTERX_SIMPLE_FUNCTION_PLUGIN(func_name)      \
+  {                                                    \
+    .type = LL_CONTEXT_FILTERX_SIMPLE_FUNC,            \
+    .name = # func_name,                                 \
+    .construct = filterx_ ## func_name ## _construct,  \
+  }
 
 #endif

--- a/lib/filterx/expr-function.h
+++ b/lib/filterx/expr-function.h
@@ -40,6 +40,7 @@ typedef struct _FilterXFunctionArg
 {
   gchar *name;
   FilterXExpr *value;
+  gboolean retrieved;
 } FilterXFunctionArg;
 
 typedef FilterXFunction *(*FilterXFunctionCtor)(const gchar *, FilterXFunctionArgs *, GError **);
@@ -51,6 +52,7 @@ enum FilterXFunctionError
 {
   FILTERX_FUNCTION_ERROR_FUNCTION_NOT_FOUND,
   FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+  FILTERX_FUNCTION_ERROR_UNEXPECTED_ARGS,
 };
 
 void filterx_function_init_instance(FilterXFunction *s, const gchar *function_name);
@@ -70,6 +72,7 @@ const gchar *filterx_function_args_get_named_literal_string(FilterXFunctionArgs 
                                                             gsize *len, gboolean *exists);
 gboolean filterx_function_args_get_named_literal_boolean(FilterXFunctionArgs *self, const gchar *name,
                                                          gboolean *exists, gboolean *error);
+gboolean filterx_function_args_check(FilterXFunctionArgs *self, GError **error);
 void filterx_function_args_free(FilterXFunctionArgs *self);
 
 FilterXExpr *filterx_function_lookup(GlobalConfig *cfg, const gchar *function_name, GList *args, GError **error);

--- a/lib/filterx/expr-function.h
+++ b/lib/filterx/expr-function.h
@@ -29,6 +29,8 @@
 
 typedef FilterXObject *(*FilterXSimpleFunctionProto)(GPtrArray *);
 
+void filterx_simple_function_argument_error(FilterXExpr *s, gchar *error_info, gboolean free_info);
+
 typedef struct _FilterXFunction
 {
   FilterXExpr super;

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -68,11 +68,14 @@ filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObject *
 {
   FilterXEvalContext *context = filterx_eval_get_context();
 
-  filterx_eval_clear_error(&context->error);
-  context->error.message = message;
-  context->error.expr = expr;
-  context->error.object = filterx_object_ref(object);
-  context->error.info = NULL;
+  if (context)
+    {
+      filterx_eval_clear_error(&context->error);
+      context->error.message = message;
+      context->error.expr = expr;
+      context->error.object = filterx_object_ref(object);
+      context->error.info = NULL;
+    }
 }
 
 /* takes ownership of info */
@@ -81,12 +84,20 @@ filterx_eval_push_error_info(const gchar *message, FilterXExpr *expr, gchar *inf
 {
   FilterXEvalContext *context = filterx_eval_get_context();
 
-  filterx_eval_clear_error(&context->error);
-  context->error.message = message;
-  context->error.expr = expr;
-  context->error.object = NULL;
-  context->error.info = info;
-  context->error.free_info = free_info;
+  if (context)
+    {
+      filterx_eval_clear_error(&context->error);
+      context->error.message = message;
+      context->error.expr = expr;
+      context->error.object = NULL;
+      context->error.info = info;
+      context->error.free_info = free_info;
+    }
+  else
+    {
+      if (free_info)
+        g_free(info);
+    }
 }
 
 void

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -32,6 +32,8 @@ typedef struct _FilterXError
   const gchar *message;
   FilterXExpr *expr;
   FilterXObject *object;
+  gchar *info;
+  gboolean free_info;
 } FilterXError;
 
 typedef struct _FilterXEvalContext FilterXEvalContext;
@@ -49,6 +51,7 @@ struct _FilterXEvalContext
 FilterXEvalContext *filterx_eval_get_context(void);
 FilterXScope *filterx_eval_get_scope(void);
 void filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObject *object);
+void filterx_eval_push_error_info(const gchar *message, FilterXExpr *expr, gchar *info, gboolean free_info);
 void filterx_eval_set_context(FilterXEvalContext *context);
 gboolean filterx_eval_exec_statements(FilterXEvalContext *context, GList *statements, LogMessage *msg);
 void filterx_eval_sync_scope_and_message(FilterXScope *scope, LogMessage *msg);

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -40,9 +40,12 @@ filterx_expr_set_location(FilterXExpr *self, CfgLexer *lexer, CFG_LTYPE *lloc)
 EVTTAG *
 filterx_expr_format_location_tag(FilterXExpr *self)
 {
-  return evt_tag_printf("expr", "%s:%d:%d| %s",
-                        self->lloc.name, self->lloc.first_line, self->lloc.first_column,
-                        self->expr_text ? : "n/a");
+  if (self)
+    return evt_tag_printf("expr", "%s:%d:%d| %s",
+                          self->lloc.name, self->lloc.first_line, self->lloc.first_column,
+                          self->expr_text ? : "n/a");
+  else
+    return evt_tag_str("expr", "n/a");
 }
 
 void

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -27,8 +27,6 @@
 #include "filterx-object.h"
 #include "cfg-lexer.h"
 
-typedef struct _FilterXExpr FilterXExpr;
-
 struct _FilterXExpr
 {
   guint32 ref_cnt;

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -33,6 +33,7 @@
 #include "filterx/func-istype.h"
 #include "filterx/func-len.h"
 #include "filterx/func-vars.h"
+#include "filterx/filterx-eval.h"
 
 static GHashTable *filterx_builtin_simple_functions = NULL;
 static GHashTable *filterx_builtin_function_ctors = NULL;
@@ -197,11 +198,12 @@ filterx_global_deinit(void)
   filterx_types_deinit();
 }
 
-FilterXObject *filterx_typecast_get_arg(GPtrArray *args, gchar *alt_msg)
+FilterXObject *
+filterx_typecast_get_arg(FilterXExpr *s, GPtrArray *args)
 {
   if (args == NULL || args->len != 1)
     {
-      msg_error(alt_msg ? alt_msg : "filterx: typecast functions must have exactly 1 argument");
+      filterx_simple_function_argument_error(s, "Requires exactly one argument", FALSE);
       return NULL;
     }
 

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -206,11 +206,5 @@ FilterXObject *filterx_typecast_get_arg(GPtrArray *args, gchar *alt_msg)
     }
 
   FilterXObject *object = g_ptr_array_index(args, 0);
-  if (!object)
-    {
-      msg_error(alt_msg ? alt_msg : "filterx: invalid typecast argument, object can not be null" );
-      return NULL;
-    }
-
   return object;
 }

--- a/lib/filterx/filterx-globals.h
+++ b/lib/filterx/filterx-globals.h
@@ -41,6 +41,6 @@ FilterXType *filterx_type_lookup(const gchar *type_name);
 gboolean filterx_type_register(const gchar *type_name, FilterXType *fxtype);
 
 // Helpers
-FilterXObject *filterx_typecast_get_arg(GPtrArray *args, gchar *alt_msg);
+FilterXObject *filterx_typecast_get_arg(FilterXExpr *s, GPtrArray *args);
 
 #endif

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -76,6 +76,18 @@ construct_template_expr(LogTemplate *template)
   return result;
 }
 
+#define CHECK_FUNCTION_ERROR(val, token, function, error) do {       \
+    if (!(val))                                                         \
+      {                                                                 \
+        gchar __buf[256];                                               \
+        g_snprintf(__buf, sizeof(__buf), "%s(): %s", function, error->message); \
+        yyerror(& (token), lexer, NULL, NULL, __buf);                   \
+        g_clear_error(&error);						\
+        YYERROR;                                                        \
+      }                                                                 \
+  } while (0)
+
+
 }
 
 %define api.prefix {filterx_}
@@ -211,7 +223,7 @@ generator_casted_assignment
 						{
 						  GError *error = NULL;
 						  FilterXExpr *func = filterx_function_lookup(configuration, $3, NULL, &error);
-						  CHECK_ERROR_GERROR(func, @3, error, "function lookup failed: %s()", $3);
+						  CHECK_FUNCTION_ERROR(func, @3, $3, error);
 
 						  FilterXExpr *assign = filterx_assign_new($1, func);
 						  filterx_generator_set_fillable($5, filterx_expr_ref($1));
@@ -227,7 +239,7 @@ generator_casted_assignment
 						{
 						  GError *error = NULL;
 						  FilterXExpr *func = filterx_function_lookup(configuration, $5, NULL, &error);
-						  CHECK_ERROR_GERROR(func, @5, error, "function lookup failed: %s()", $5);
+						  CHECK_FUNCTION_ERROR(func, @5, $5, error);
 
 						  FilterXExpr *setattr = filterx_setattr_new($1, $3, func);
 						  filterx_generator_set_fillable($7, filterx_getattr_new(filterx_expr_ref($1), $3));
@@ -243,7 +255,7 @@ generator_casted_assignment
 						{
 						  GError *error = NULL;
 						  FilterXExpr *func = filterx_function_lookup(configuration, $6, NULL, &error);
-						  CHECK_ERROR_GERROR(func, @6, error, "function lookup failed: %s()", $6);
+						  CHECK_FUNCTION_ERROR(func, @6, $6, error);
 
 						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, $3, func);
 						  filterx_generator_set_fillable($8, filterx_get_subscript_new(filterx_expr_ref($1), filterx_expr_ref($3)));
@@ -259,7 +271,7 @@ generator_casted_assignment
 						{
 						  GError *error = NULL;
 						  FilterXExpr *func = filterx_function_lookup(configuration, $5, NULL, &error);
-						  CHECK_ERROR_GERROR(func, @5, error, "function lookup failed: %s()", $5);
+						  CHECK_FUNCTION_ERROR(func, @5, $5, error);
 
 						  FilterXExpr *minus_one = filterx_literal_new(filterx_config_freeze_object(configuration, filterx_integer_new(-1)));
 						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, NULL, func);
@@ -333,7 +345,7 @@ function_call
 	: LL_IDENTIFIER '(' arguments ')'	{
 						  GError *error = NULL;
 						  FilterXExpr *res = filterx_function_lookup(configuration, $1, $3, &error);
-						  CHECK_ERROR_GERROR(res, @$, error, "function lookup failed: %s()", $1);
+						  CHECK_FUNCTION_ERROR(res, @$, $1, error);
 						  free($1);
 						  $$ = res;
 						}

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -28,6 +28,7 @@
 
 typedef struct _FilterXType FilterXType;
 typedef struct _FilterXObject FilterXObject;
+typedef struct _FilterXExpr FilterXExpr;
 
 struct _FilterXType
 {

--- a/lib/filterx/func-istype.c
+++ b/lib/filterx/func-istype.c
@@ -128,7 +128,8 @@ filterx_function_istype_new(const gchar *function_name, FilterXFunctionArgs *arg
   self->super.super.eval = _eval;
   self->super.super.free_fn = _free;
 
-  if (!_extract_args(self, args, error))
+  if (!_extract_args(self, args, error) ||
+      !filterx_function_args_check(args, error))
     goto error;
 
   filterx_function_args_free(args);

--- a/lib/filterx/func-len.c
+++ b/lib/filterx/func-len.c
@@ -36,11 +36,6 @@ filterx_simple_function_len(GPtrArray *args)
     }
 
   FilterXObject *object = g_ptr_array_index(args, 0);
-  if (!object)
-    {
-      msg_error("FilterX: len: invalid argument: object." FILTERX_FUNC_LEN_USAGE);
-      return NULL;
-    }
 
   guint64 len;
   gboolean success = filterx_object_len(object, &len);

--- a/lib/filterx/func-len.c
+++ b/lib/filterx/func-len.c
@@ -23,15 +23,16 @@
 
 #include "filterx/func-len.h"
 #include "filterx/object-primitive.h"
+#include "filterx/filterx-eval.h"
 
 #define FILTERX_FUNC_LEN_USAGE "Usage: len(object)"
 
 FilterXObject *
-filterx_simple_function_len(GPtrArray *args)
+filterx_simple_function_len(FilterXExpr *s, GPtrArray *args)
 {
   if (args == NULL || args->len != 1)
     {
-      msg_error("FilterX: len: invalid number of arguments. " FILTERX_FUNC_LEN_USAGE);
+      filterx_simple_function_argument_error(s, "Requires exactly one argument", FALSE);
       return NULL;
     }
 
@@ -41,8 +42,7 @@ filterx_simple_function_len(GPtrArray *args)
   gboolean success = filterx_object_len(object, &len);
   if (!success)
     {
-      msg_error("FilterX: len: object type is not supported",
-                evt_tag_str("type", object->type->name));
+      filterx_eval_push_error("Object does not support len()", s, object);
       return NULL;
     }
 

--- a/lib/filterx/func-len.h
+++ b/lib/filterx/func-len.h
@@ -26,6 +26,6 @@
 
 #include "filterx/expr-function.h"
 
-FilterXObject *filterx_simple_function_len(GPtrArray *args);
+FilterXObject *filterx_simple_function_len(FilterXExpr *s, GPtrArray *args);
 
 #endif

--- a/lib/filterx/func-vars.c
+++ b/lib/filterx/func-vars.c
@@ -47,11 +47,11 @@ _add_to_dict(FilterXVariable *variable, gpointer user_data)
 }
 
 FilterXObject *
-filterx_simple_function_vars(GPtrArray *args)
+filterx_simple_function_vars(FilterXExpr *s, GPtrArray *args)
 {
   if (args && args->len != 0)
     {
-      msg_error("filterx: vars() function does not take any arguments");
+      filterx_simple_function_argument_error(s, "Incorrect number of arguments", FALSE);
       return NULL;
     }
 

--- a/lib/filterx/func-vars.h
+++ b/lib/filterx/func-vars.h
@@ -26,6 +26,6 @@
 
 #include "filterx/expr-function.h"
 
-FilterXObject *filterx_simple_function_vars(GPtrArray *args);
+FilterXObject *filterx_simple_function_vars(FilterXExpr *s, GPtrArray *args);
 
 #endif

--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -368,7 +368,8 @@ filterx_function_strptime_new(const gchar *function_name, FilterXFunctionArgs *a
   self->super.super.eval = _strptime_eval;
   self->super.super.free_fn = _strptime_free;
 
-  if (!_extract_args(self, args, error))
+  if (!_extract_args(self, args, error) ||
+      !filterx_function_args_check(args, error))
     goto error;
 
   filterx_function_args_free(args);

--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -115,11 +115,9 @@ filterx_datetime_get_value(FilterXObject *s)
 
 
 FilterXObject *
-filterx_typecast_datetime(GPtrArray *args)
+filterx_typecast_datetime(FilterXExpr *s, GPtrArray *args)
 {
-  FilterXObject *object = filterx_typecast_get_arg(args,
-                                                   "FilterX: Failed to create datetime object: invalid number of arguments. "
-                                                   "Usage: datetime($isodate_str), datetime($unix_int_ms) or datetime($unix_float_s)");
+  FilterXObject *object = filterx_typecast_get_arg(s, args);
   if (!object)
     return NULL;
 
@@ -144,7 +142,7 @@ filterx_typecast_datetime(GPtrArray *args)
     }
   else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(string)))
     {
-      return filterx_typecast_datetime_isodate(args);
+      return filterx_typecast_datetime_isodate(s, args);
     }
   msg_error("filterx: invalid typecast",
             evt_tag_str("from", object->type->name),
@@ -153,11 +151,9 @@ filterx_typecast_datetime(GPtrArray *args)
 }
 
 FilterXObject *
-filterx_typecast_datetime_isodate(GPtrArray *args)
+filterx_typecast_datetime_isodate(FilterXExpr *s, GPtrArray *args)
 {
-  FilterXObject *object = filterx_typecast_get_arg(args,
-                                                   "FilterX: Failed to create datetime object: invalid number of arguments. "
-                                                   "Usage: datetime($isodate_str), datetime($unix_int_ms) or datetime($unix_float_s)");
+  FilterXObject *object = filterx_typecast_get_arg(s, args);
   if (!object)
     return NULL;
 

--- a/lib/filterx/object-datetime.h
+++ b/lib/filterx/object-datetime.h
@@ -32,8 +32,8 @@ FILTERX_DECLARE_TYPE(datetime);
 
 FilterXObject *filterx_datetime_new(const UnixTime *ut);
 UnixTime filterx_datetime_get_value(FilterXObject *s);
-FilterXObject *filterx_typecast_datetime(GPtrArray *args);
-FilterXObject *filterx_typecast_datetime_isodate(GPtrArray *args);
+FilterXObject *filterx_typecast_datetime(FilterXExpr *s, GPtrArray *args);
+FilterXObject *filterx_typecast_datetime_isodate(FilterXExpr *, GPtrArray *args);
 FilterXFunction *filterx_function_strptime_new(const gchar *function_name, FilterXFunctionArgs *args, GError **error);
 
 gboolean datetime_repr(const UnixTime *ut, GString *repr);

--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -27,6 +27,8 @@
 #include "filterx/object-message-value.h"
 #include "filterx/filterx-weakrefs.h"
 #include "filterx/object-list-interface.h"
+#include "filterx/expr-function.h"
+#include "filterx/filterx-eval.h"
 
 #include "scanner/list-scanner/list-scanner.h"
 #include "str-repr/encode.h"
@@ -304,15 +306,14 @@ filterx_json_array_new_from_syslog_ng_list(const gchar *repr, gssize repr_len)
 }
 
 FilterXObject *
-filterx_json_array_new_from_args(GPtrArray *args)
+filterx_json_array_new_from_args(FilterXExpr *s, GPtrArray *args)
 {
   if (!args || args->len == 0)
     return filterx_json_array_new_empty();
 
   if (args->len != 1)
     {
-      msg_error("FilterX: Failed to create JSON array: invalid number of arguments. "
-                "Usage: json_array() or json_array($raw_json_string) or json_array($existing_json_array)");
+      filterx_simple_function_argument_error(s, "Requires zero or one argument", FALSE);
       return NULL;
     }
 
@@ -338,10 +339,8 @@ filterx_json_array_new_from_args(GPtrArray *args)
     return filterx_json_array_new_from_repr(repr, repr_len);
 
 error:
-  msg_error("FilterX: Failed to create JSON object: invalid argument type. "
-            "Usage: json_array() or json_array($raw_json_string) or json_array($syslog_ng_list) or "
-            "json_array($existing_json_array)",
-            evt_tag_str("type", arg->type->name));
+  filterx_eval_push_error_info("Argument must be a json array, a string or a syslog-ng list", s,
+                               g_strdup_printf("got \"%s\" instead", arg->type->name), TRUE);
   return NULL;
 }
 

--- a/lib/filterx/object-json.c
+++ b/lib/filterx/object-json.c
@@ -219,7 +219,8 @@ filterx_json_new_from_args(FilterXExpr *s, GPtrArray *args)
     return filterx_json_new_from_repr(repr, repr_len);
 
 error:
-  filterx_eval_push_error_info("Argument must be a json, a string or a syslog-ng list", s, g_strdup_printf("got \"%s\" instead", arg->type->name), TRUE);
+  filterx_eval_push_error_info("Argument must be a json, a string or a syslog-ng list", s,
+                               g_strdup_printf("got \"%s\" instead", arg->type->name), TRUE);
   return NULL;
 }
 

--- a/lib/filterx/object-json.c
+++ b/lib/filterx/object-json.c
@@ -162,15 +162,14 @@ filterx_json_new_from_repr(const gchar *repr, gssize repr_len)
 }
 
 FilterXObject *
-filterx_json_new_from_args(GPtrArray *args)
+filterx_json_new_from_args(FilterXExpr *s, GPtrArray *args)
 {
   if (!args || args->len == 0)
     return filterx_json_object_new_empty();
 
   if (args->len != 1)
     {
-      msg_error("FilterX: Failed to create JSON object: invalid number of arguments. "
-                "Usage: json() or json($raw_json_string) or json($existing_json)");
+      filterx_eval_push_error("Too many arguments", s, NULL);
       return NULL;
     }
 
@@ -220,9 +219,7 @@ filterx_json_new_from_args(GPtrArray *args)
     return filterx_json_new_from_repr(repr, repr_len);
 
 error:
-  msg_error("FilterX: Failed to create JSON object: invalid argument type. "
-            "Usage: json() or json($raw_json_string) or json($syslog_ng_list) or json($existing_json)",
-            evt_tag_str("type", arg->type->name));
+  filterx_eval_push_error_info("Argument must be a json, a string or a syslog-ng list", s, g_strdup_printf("got \"%s\" instead", arg->type->name), TRUE);
   return NULL;
 }
 

--- a/lib/filterx/object-json.h
+++ b/lib/filterx/object-json.h
@@ -41,8 +41,8 @@ FilterXObject *filterx_json_array_new_from_syslog_ng_list(const gchar *repr, gss
 FilterXObject *filterx_json_object_new_empty(void);
 FilterXObject *filterx_json_array_new_empty(void);
 
-FilterXObject *filterx_json_new_from_args(GPtrArray *args);
-FilterXObject *filterx_json_array_new_from_args(GPtrArray *args);
+FilterXObject *filterx_json_new_from_args(FilterXExpr *s, GPtrArray *args);
+FilterXObject *filterx_json_array_new_from_args(FilterXExpr *s, GPtrArray *args);
 
 FilterXObject *filterx_json_new_from_object(struct json_object *object);
 

--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -231,9 +231,9 @@ filterx_primitive_get_value(FilterXObject *s)
 }
 
 FilterXObject *
-filterx_typecast_boolean(GPtrArray *args)
+filterx_typecast_boolean(FilterXExpr *s, GPtrArray *args)
 {
-  FilterXObject *object = filterx_typecast_get_arg(args, NULL);
+  FilterXObject *object = filterx_typecast_get_arg(s, args);
   if (!object)
     return NULL;
 
@@ -247,9 +247,9 @@ filterx_typecast_boolean(GPtrArray *args)
 }
 
 FilterXObject *
-filterx_typecast_integer(GPtrArray *args)
+filterx_typecast_integer(FilterXExpr *s, GPtrArray *args)
 {
-  FilterXObject *object = filterx_typecast_get_arg(args, NULL);
+  FilterXObject *object = filterx_typecast_get_arg(s, args);
   if (!object)
     return NULL;
 
@@ -281,9 +281,9 @@ filterx_typecast_integer(GPtrArray *args)
 }
 
 FilterXObject *
-filterx_typecast_double(GPtrArray *args)
+filterx_typecast_double(FilterXExpr *s, GPtrArray *args)
 {
-  FilterXObject *object = filterx_typecast_get_arg(args, NULL);
+  FilterXObject *object = filterx_typecast_get_arg(s, args);
   if (!object)
     return NULL;
 

--- a/lib/filterx/object-primitive.h
+++ b/lib/filterx/object-primitive.h
@@ -48,9 +48,9 @@ FilterXObject *filterx_boolean_new(gboolean value);
 FilterXObject *filterx_enum_new(GlobalConfig *cfg, const gchar *namespace_name, const gchar *enum_name);
 GenericNumber filterx_primitive_get_value(FilterXObject *s);
 
-FilterXObject *filterx_typecast_boolean(GPtrArray *args);
-FilterXObject *filterx_typecast_integer(GPtrArray *args);
-FilterXObject *filterx_typecast_double(GPtrArray *args);
+FilterXObject *filterx_typecast_boolean(FilterXExpr *s, GPtrArray *args);
+FilterXObject *filterx_typecast_integer(FilterXExpr *s, GPtrArray *args);
+FilterXObject *filterx_typecast_double(FilterXExpr *s, GPtrArray *args);
 
 gboolean bool_repr(gboolean bool_val, GString *repr);
 gboolean double_repr(double val, GString *repr);

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -209,9 +209,9 @@ filterx_protobuf_new(const gchar *mem, gssize mem_len)
 }
 
 FilterXObject *
-filterx_typecast_string(GPtrArray *args)
+filterx_typecast_string(FilterXExpr *s, GPtrArray *args)
 {
-  FilterXObject *object = filterx_typecast_get_arg(args, NULL);
+  FilterXObject *object = filterx_typecast_get_arg(s, args);
   if (!object)
     return NULL;
 
@@ -235,9 +235,9 @@ filterx_typecast_string(GPtrArray *args)
 }
 
 FilterXObject *
-filterx_typecast_bytes(GPtrArray *args)
+filterx_typecast_bytes(FilterXExpr *s, GPtrArray *args)
 {
-  FilterXObject *object = filterx_typecast_get_arg(args, NULL);
+  FilterXObject *object = filterx_typecast_get_arg(s, args);
   if (!object)
     return NULL;
 
@@ -268,9 +268,9 @@ filterx_typecast_bytes(GPtrArray *args)
 }
 
 FilterXObject *
-filterx_typecast_protobuf(GPtrArray *args)
+filterx_typecast_protobuf(FilterXExpr *s, GPtrArray *args)
 {
-  FilterXObject *object = filterx_typecast_get_arg(args, NULL);
+  FilterXObject *object = filterx_typecast_get_arg(s, args);
   if (!object)
     return NULL;
 

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -32,9 +32,9 @@ FILTERX_DECLARE_TYPE(protobuf);
 const gchar *filterx_string_get_value(FilterXObject *s, gsize *length);
 const gchar *filterx_bytes_get_value(FilterXObject *s, gsize *length);
 const gchar *filterx_protobuf_get_value(FilterXObject *s, gsize *length);
-FilterXObject *filterx_typecast_string(GPtrArray *args);
-FilterXObject *filterx_typecast_bytes(GPtrArray *args);
-FilterXObject *filterx_typecast_protobuf(GPtrArray *args);
+FilterXObject *filterx_typecast_string(FilterXExpr *s, GPtrArray *args);
+FilterXObject *filterx_typecast_bytes(FilterXExpr *s, GPtrArray *args);
+FilterXObject *filterx_typecast_protobuf(FilterXExpr *s, GPtrArray *args);
 
 FilterXObject *filterx_string_new(const gchar *str, gssize str_len);
 FilterXObject *filterx_bytes_new(const gchar *str, gssize str_len);

--- a/lib/filterx/tests/test_builtin_functions.c
+++ b/lib/filterx/tests/test_builtin_functions.c
@@ -46,7 +46,7 @@
 #define TEST_BUILTIN_FUNCTION_NAME "TEST_BUILTIN_DUMMY_KEY"
 
 FilterXObject *
-test_builtin_simple_dummy_function(GPtrArray *args)
+test_builtin_simple_dummy_function(FilterXExpr *s, GPtrArray *args)
 {
   return filterx_string_new("test-builtin-functions", -1);
 }
@@ -82,7 +82,7 @@ Test(builtin_functions, test_builtin_simple_functions_lookup)
   cr_assert(func != NULL);
 
   // check dummy function as result
-  FilterXObject *res = func(NULL);
+  FilterXObject *res = func(NULL, NULL);
   cr_assert(res != NULL);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
   gsize len;

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -346,7 +346,7 @@ Test(expr_condition, test_condition_do_not_allow_to_add_else_into_else, .signal=
 }
 
 FilterXObject *
-_fail_func(GPtrArray *args)
+_fail_func(FilterXExpr *s, GPtrArray *args)
 {
   return NULL;
 }
@@ -365,7 +365,7 @@ Test(expr_condition, test_condition_return_null_on_illegal_expr)
 }
 
 FilterXObject *
-_dummy_func(GPtrArray *args)
+_dummy_func(FilterXExpr *s, GPtrArray *args)
 {
   return filterx_string_new("foobar", -1);
 }

--- a/lib/filterx/tests/test_expr_function.c
+++ b/lib/filterx/tests/test_expr_function.c
@@ -43,7 +43,7 @@
 #include "apphook.h"
 #include "scratch-buffers.h"
 
-FilterXObject *test_dummy_function(GPtrArray *args)
+FilterXObject *test_dummy_function(FilterXExpr *s, GPtrArray *args)
 {
   GString *repr = scratch_buffers_alloc();
   GString *out = scratch_buffers_alloc();

--- a/lib/filterx/tests/test_object_boolean.c
+++ b/lib/filterx/tests/test_object_boolean.c
@@ -65,7 +65,7 @@ Test(filterx_boolean, test_filterx_boolean_typecast_null_args)
 {
   GPtrArray *args = NULL;
 
-  FilterXObject *obj = filterx_typecast_boolean(args);
+  FilterXObject *obj = filterx_typecast_boolean(NULL, args);
   cr_assert_null(obj);
 }
 
@@ -73,7 +73,7 @@ Test(filterx_boolean, test_filterx_boolean_typecast_empty_args)
 {
   GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
 
-  FilterXObject *obj = filterx_typecast_boolean(args);
+  FilterXObject *obj = filterx_typecast_boolean(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -85,7 +85,7 @@ Test(filterx_boolean, test_filterx_boolean_typecast_null_arg)
 
   g_ptr_array_add(args, NULL);
 
-  FilterXObject *obj = filterx_typecast_boolean(args);
+  FilterXObject *obj = filterx_typecast_boolean(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -97,7 +97,7 @@ Test(filterx_boolean, test_filterx_boolean_typecast_null_object_arg)
   FilterXObject *in = filterx_null_new();
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_boolean(args);
+  FilterXObject *obj = filterx_typecast_boolean(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(boolean)));
 
@@ -113,7 +113,7 @@ Test(filterx_boolean, test_filterx_boolean_typecast_from_boolean)
   FilterXObject *in = filterx_boolean_new(TRUE);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_boolean(args);
+  FilterXObject *obj = filterx_typecast_boolean(NULL, args);
   cr_assert_eq(in, obj);
 
   g_ptr_array_free(args, TRUE);

--- a/lib/filterx/tests/test_object_bytes.c
+++ b/lib/filterx/tests/test_object_bytes.c
@@ -31,7 +31,7 @@ Test(filterx_bytes, test_filterx_bytes_typecast_null_args)
 {
   GPtrArray *args = NULL;
 
-  FilterXObject *obj = filterx_typecast_bytes(args);
+  FilterXObject *obj = filterx_typecast_bytes(NULL, args);
   cr_assert_null(obj);
 }
 
@@ -39,7 +39,7 @@ Test(filterx_bytes, test_filterx_bytes_typecast_empty_args)
 {
   GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
 
-  FilterXObject *obj = filterx_typecast_bytes(args);
+  FilterXObject *obj = filterx_typecast_bytes(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -51,7 +51,7 @@ Test(filterx_bytes, test_filterx_bytes_typecast_null_arg)
 
   g_ptr_array_add(args, NULL);
 
-  FilterXObject *obj = filterx_typecast_bytes(args);
+  FilterXObject *obj = filterx_typecast_bytes(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -63,7 +63,7 @@ Test(filterx_bytes, test_filterx_bytes_typecast_null_object_arg)
   FilterXObject *in = filterx_null_new();
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_bytes(args);
+  FilterXObject *obj = filterx_typecast_bytes(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -76,7 +76,7 @@ Test(filterx_bytes, test_filterx_bytes_typecast_from_bytes)
   FilterXObject *in = filterx_bytes_new("byte \0sequence", 14);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_bytes(args);
+  FilterXObject *obj = filterx_typecast_bytes(NULL, args);
 
   cr_assert_eq(in, obj);
 
@@ -90,7 +90,7 @@ Test(filterx_bytes, test_filterx_bytes_typecast_from_string)
   FilterXObject *in = filterx_string_new("string whatever", -1);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_bytes(args);
+  FilterXObject *obj = filterx_typecast_bytes(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(bytes)));
 
@@ -109,7 +109,7 @@ Test(filterx_bytes, test_filterx_bytes_typecast_from_protobuf)
   FilterXObject *in = filterx_protobuf_new("not a valid \0protobuf!", 22);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_bytes(args);
+  FilterXObject *obj = filterx_typecast_bytes(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(bytes)));
 

--- a/lib/filterx/tests/test_object_datetime.c
+++ b/lib/filterx/tests/test_object_datetime.c
@@ -57,7 +57,7 @@ Test(filterx_datetime, test_filterx_datetime_typecast_null_args)
 {
   GPtrArray *args = NULL;
 
-  FilterXObject *obj = filterx_typecast_datetime(args);
+  FilterXObject *obj = filterx_typecast_datetime(NULL, args);
   cr_assert_null(obj);
 }
 
@@ -65,7 +65,7 @@ Test(filterx_datetime, test_filterx_datetime_typecast_empty_args)
 {
   GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
 
-  FilterXObject *obj = filterx_typecast_datetime(args);
+  FilterXObject *obj = filterx_typecast_datetime(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -76,7 +76,7 @@ Test(filterx_datetime, test_filterx_datetime_typecast_null_arg)
   GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
   g_ptr_array_add(args, NULL);
 
-  FilterXObject *obj = filterx_typecast_datetime(args);
+  FilterXObject *obj = filterx_typecast_datetime(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -88,7 +88,7 @@ Test(filterx_datetime, test_filterx_datetime_typecast_null_object_arg)
   FilterXObject *in = filterx_null_new();
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_datetime(args);
+  FilterXObject *obj = filterx_typecast_datetime(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -101,7 +101,7 @@ Test(filterx_datetime, test_filterx_datetime_typecast_from_int)
   FilterXObject *in = filterx_integer_new(1710762325395194);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_datetime(args);
+  FilterXObject *obj = filterx_typecast_datetime(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(datetime)));
 
@@ -121,7 +121,7 @@ Test(filterx_datetime, test_filterx_datetime_typecast_from_double)
   FilterXObject *in = filterx_double_new(1710762325.395194);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_datetime(args);
+  FilterXObject *obj = filterx_typecast_datetime(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(datetime)));
 
@@ -141,7 +141,7 @@ Test(filterx_datetime, test_filterx_datetime_typecast_from_string)
   FilterXObject *in = filterx_string_new("2024-03-18T12:34:00Z", -1);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_datetime(args);
+  FilterXObject *obj = filterx_typecast_datetime(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(datetime)));
 
@@ -162,7 +162,7 @@ Test(filterx_datetime, test_filterx_datetime_typecast_from_datetime)
   FilterXObject *in = filterx_datetime_new(&ut);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_datetime(args);
+  FilterXObject *obj = filterx_typecast_datetime(NULL, args);
 
   cr_assert_eq(in, obj);
 
@@ -176,7 +176,7 @@ Test(filterx_datetime, test_filterx_datetime_repr)
   FilterXObject *in = filterx_string_new("2024-03-18T12:34:13+0900", -1);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_datetime(args);
+  FilterXObject *obj = filterx_typecast_datetime(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(datetime)));
 
@@ -198,7 +198,7 @@ Test(filterx_datetime, test_filterx_datetime_repr_isodate_Z)
   FilterXObject *in = filterx_string_new(test_time_str, -1);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_datetime(args);
+  FilterXObject *obj = filterx_typecast_datetime(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(datetime)));
 

--- a/lib/filterx/tests/test_object_double.c
+++ b/lib/filterx/tests/test_object_double.c
@@ -61,7 +61,7 @@ Test(filterx_double, test_filterx_double_typecast_null_args)
 {
   GPtrArray *args = NULL;
 
-  FilterXObject *obj = filterx_typecast_double(args);
+  FilterXObject *obj = filterx_typecast_double(NULL, args);
   cr_assert_null(obj);
 }
 
@@ -69,7 +69,7 @@ Test(filterx_double, test_filterx_double_typecast_empty_args)
 {
   GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
 
-  FilterXObject *obj = filterx_typecast_double(args);
+  FilterXObject *obj = filterx_typecast_double(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -81,7 +81,7 @@ Test(filterx_double, test_filterx_double_typecast_null_arg)
 
   g_ptr_array_add(args, NULL);
 
-  FilterXObject *obj = filterx_typecast_double(args);
+  FilterXObject *obj = filterx_typecast_double(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -93,7 +93,7 @@ Test(filterx_double, test_filterx_double_typecast_null_object_arg)
   FilterXObject *in = filterx_null_new();
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_double(args);
+  FilterXObject *obj = filterx_typecast_double(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -106,7 +106,7 @@ Test(filterx_double, test_filterx_double_typecast_from_double)
   FilterXObject *in = filterx_double_new(3.14);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_double(args);
+  FilterXObject *obj = filterx_typecast_double(NULL, args);
   cr_assert_eq(in, obj);
 
   g_ptr_array_free(args, TRUE);
@@ -119,7 +119,7 @@ Test(filterx_double, test_filterx_double_typecast_from_integer)
   FilterXObject *in = filterx_integer_new(443);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_double(args);
+  FilterXObject *obj = filterx_typecast_double(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(double)));
 
@@ -137,7 +137,7 @@ Test(filterx_double, test_filterx_double_typecast_from_string)
   FilterXObject *in = filterx_string_new("443.117", -1);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_double(args);
+  FilterXObject *obj = filterx_typecast_double(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(double)));
 

--- a/lib/filterx/tests/test_object_integer.c
+++ b/lib/filterx/tests/test_object_integer.c
@@ -63,7 +63,7 @@ Test(filterx_integer, test_filterx_integer_typecast_null_args)
 {
   GPtrArray *args = NULL;
 
-  FilterXObject *obj = filterx_typecast_integer(args);
+  FilterXObject *obj = filterx_typecast_integer(NULL, args);
   cr_assert_null(obj);
 }
 
@@ -71,7 +71,7 @@ Test(filterx_integer, test_filterx_integer_typecast_empty_args)
 {
   GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
 
-  FilterXObject *obj = filterx_typecast_integer(args);
+  FilterXObject *obj = filterx_typecast_integer(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -83,7 +83,7 @@ Test(filterx_integer, test_filterx_integer_typecast_null_arg)
 
   g_ptr_array_add(args, NULL);
 
-  FilterXObject *obj = filterx_typecast_integer(args);
+  FilterXObject *obj = filterx_typecast_integer(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -96,7 +96,7 @@ Test(filterx_integer, test_filterx_integer_typecast_null_object_arg)
   FilterXObject *in = filterx_null_new();
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_integer(args);
+  FilterXObject *obj = filterx_typecast_integer(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -108,7 +108,7 @@ Test(filterx_integer, test_filterx_integer_typecast_from_integer)
   FilterXObject *in = filterx_integer_new(443);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_integer(args);
+  FilterXObject *obj = filterx_typecast_integer(NULL, args);
   cr_assert_eq(in, obj);
 
   g_ptr_array_free(args, TRUE);
@@ -121,7 +121,7 @@ Test(filterx_integer, test_filterx_integer_typecast_from_double)
   FilterXObject *in = filterx_double_new(171.443);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_integer(args);
+  FilterXObject *obj = filterx_typecast_integer(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(integer)));
 
@@ -141,7 +141,7 @@ Test(filterx_integer, test_filterx_integer_typecast_from_double_roundup)
   FilterXObject *in = filterx_double_new(171.743);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_integer(args);
+  FilterXObject *obj = filterx_typecast_integer(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(integer)));
 
@@ -159,7 +159,7 @@ Test(filterx_integer, test_filterx_integer_typecast_from_string)
   FilterXObject *in = filterx_string_new("443", -1);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_integer(args);
+  FilterXObject *obj = filterx_typecast_integer(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(integer)));
 
@@ -177,7 +177,7 @@ Test(filterx_integer, test_filterx_integer_typecast_from_string_very_very_zero)
   FilterXObject *in = filterx_string_new("000", -1);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_integer(args);
+  FilterXObject *obj = filterx_typecast_integer(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(integer)));
 
@@ -195,7 +195,7 @@ Test(filterx_integer, test_filterx_integer_typecast_from_double_string)
   FilterXObject *in = filterx_string_new("443.117", -1);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_integer(args);
+  FilterXObject *obj = filterx_typecast_integer(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);

--- a/lib/filterx/tests/test_object_json.c
+++ b/lib/filterx/tests/test_object_json.c
@@ -69,11 +69,11 @@ static FilterXObject *
 _exec_func(FilterXSimpleFunctionProto func, FilterXObject *arg)
 {
   if (!arg)
-    return func(NULL);
+    return func(NULL, NULL);
 
   GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
   g_ptr_array_add(args, arg);
-  FilterXObject *result = func(args);
+  FilterXObject *result = func(NULL, args);
   g_ptr_array_unref(args);
   return result;
 }

--- a/lib/filterx/tests/test_object_protobuf.c
+++ b/lib/filterx/tests/test_object_protobuf.c
@@ -31,7 +31,7 @@ Test(filterx_protobuf, test_filterx_protobuf_typecast_null_args)
 {
   GPtrArray *args = NULL;
 
-  FilterXObject *obj = filterx_typecast_protobuf(args);
+  FilterXObject *obj = filterx_typecast_protobuf(NULL, args);
   cr_assert_null(obj);
 }
 
@@ -39,7 +39,7 @@ Test(filterx_protobuf, test_filterx_protobuf_typecast_empty_args)
 {
   GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
 
-  FilterXObject *obj = filterx_typecast_protobuf(args);
+  FilterXObject *obj = filterx_typecast_protobuf(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -51,7 +51,7 @@ Test(filterx_protobuf, test_filterx_protobuf_typecast_null_arg)
 
   g_ptr_array_add(args, NULL);
 
-  FilterXObject *obj = filterx_typecast_protobuf(args);
+  FilterXObject *obj = filterx_typecast_protobuf(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -63,7 +63,7 @@ Test(filterx_protobuf, test_filterx_protobuf_typecast_null_object_arg)
   FilterXObject *in = filterx_null_new();
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_protobuf(args);
+  FilterXObject *obj = filterx_typecast_protobuf(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -75,7 +75,7 @@ Test(filterx_protobuf, test_filterx_protobuf_typecast_from_bytes)
   FilterXObject *in = filterx_bytes_new("not valid \0protobuf!", 20);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_protobuf(args);
+  FilterXObject *obj = filterx_typecast_protobuf(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(protobuf)));
 
@@ -94,7 +94,7 @@ Test(filterx_protobuf, test_filterx_protobuf_typecast_from_protobuf)
   FilterXObject *in = filterx_protobuf_new("not valid \0protobuf!", 20);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_protobuf(args);
+  FilterXObject *obj = filterx_typecast_protobuf(NULL, args);
   cr_assert_eq(in, obj);
 
   g_ptr_array_free(args, TRUE);

--- a/lib/filterx/tests/test_object_string.c
+++ b/lib/filterx/tests/test_object_string.c
@@ -47,7 +47,7 @@ Test(filterx_string, test_filterx_string_typecast_null_args)
 {
   GPtrArray *args = NULL;
 
-  FilterXObject *obj = filterx_typecast_string(args);
+  FilterXObject *obj = filterx_typecast_string(NULL, args);
   cr_assert_null(obj);
 }
 
@@ -55,7 +55,7 @@ Test(filterx_string, test_filterx_string_typecast_empty_args)
 {
   GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
 
-  FilterXObject *obj = filterx_typecast_string(args);
+  FilterXObject *obj = filterx_typecast_string(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -67,7 +67,7 @@ Test(filterx_string, test_filterx_string_typecast_null_arg)
 
   g_ptr_array_add(args, NULL);
 
-  FilterXObject *obj = filterx_typecast_string(args);
+  FilterXObject *obj = filterx_typecast_string(NULL, args);
   cr_assert_null(obj);
 
   g_ptr_array_free(args, TRUE);
@@ -79,7 +79,7 @@ Test(filterx_string, test_filterx_string_typecast_null_object_arg)
   FilterXObject *in = filterx_null_new();
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_string(args);
+  FilterXObject *obj = filterx_typecast_string(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)));
 
@@ -98,7 +98,7 @@ Test(filterx_string, test_filterx_string_typecast_from_string)
   FilterXObject *in = filterx_string_new("foobar", -1);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_string(args);
+  FilterXObject *obj = filterx_typecast_string(NULL, args);
 
   cr_assert_eq(in, obj);
 
@@ -112,7 +112,7 @@ Test(filterx_string, test_filterx_string_typecast_from_bytes)
   FilterXObject *in = filterx_bytes_new("\x00\x1f byte \\sequence \x7f \xff", 21);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_string(args);
+  FilterXObject *obj = filterx_typecast_string(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)));
 
@@ -131,7 +131,7 @@ Test(filterx_string, test_filterx_string_typecast_from_protobuf)
   FilterXObject *in = filterx_protobuf_new("\xffnot a valid protobuf! \xd9", 23);
   g_ptr_array_add(args, in);
 
-  FilterXObject *obj = filterx_typecast_string(args);
+  FilterXObject *obj = filterx_typecast_string(NULL, args);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)));
 

--- a/modules/csvparser/filterx-func-format-csv.c
+++ b/modules/csvparser/filterx-func-format-csv.c
@@ -237,7 +237,8 @@ filterx_function_format_csv_new(const gchar *function_name, FilterXFunctionArgs 
   self->super.super.free_fn = _free;
   self->delimiter = ',';
 
-  if (!_extract_arguments(self, args, error))
+  if (!_extract_arguments(self, args, error) ||
+      !filterx_function_args_check(args, error))
     goto error;
 
   filterx_function_args_free(args);

--- a/modules/csvparser/filterx-func-parse-csv.c
+++ b/modules/csvparser/filterx-func-parse-csv.c
@@ -331,7 +331,8 @@ filterx_function_parse_csv_new(const gchar *function_name, FilterXFunctionArgs *
   csv_scanner_options_set_flags(&self->options, CSV_SCANNER_STRIP_WHITESPACE);
   csv_scanner_options_set_dialect(&self->options, CSV_SCANNER_ESCAPE_NONE);
 
-  if (!_extract_args(self, args, error))
+  if (!_extract_args(self, args, error) ||
+      !filterx_function_args_check(args, error))
     goto error;
 
   filterx_function_args_free(args);

--- a/modules/examples/example-plugins.c
+++ b/modules/examples/example-plugins.c
@@ -85,11 +85,7 @@ static Plugin example_plugins[] =
     .name = "example_destination",
     .parser = &example_destination_parser
   },
-  {
-    .type = LL_CONTEXT_FILTERX_SIMPLE_FUNC,
-    .name = "example_echo",
-    .construct = example_filterx_simple_func_construct_echo,
-  },
+  FILTERX_SIMPLE_FUNCTION_PLUGIN(example_echo),
 };
 
 gboolean

--- a/modules/examples/filterx/example-filterx-func/example-filterx-func-plugin.c
+++ b/modules/examples/filterx/example-filterx-func/example-filterx-func-plugin.c
@@ -54,8 +54,4 @@ exit:
   return filterx_boolean_new(FALSE);
 }
 
-gpointer
-example_filterx_simple_func_construct_echo(Plugin *self)
-{
-  return (gpointer) &echo;
-}
+FILTERX_SIMPLE_FUNCTION(example_echo, echo);

--- a/modules/examples/filterx/example-filterx-func/example-filterx-func-plugin.c
+++ b/modules/examples/filterx/example-filterx-func/example-filterx-func-plugin.c
@@ -29,7 +29,7 @@
 #include "filterx/object-primitive.h"
 
 static FilterXObject *
-echo(GPtrArray *args)
+echo(FilterXExpr *s, GPtrArray *args)
 {
   GString *buf = scratch_buffers_alloc();
   LogMessageValueType t;

--- a/modules/examples/filterx/example-filterx-func/example-filterx-func-plugin.h
+++ b/modules/examples/filterx/example-filterx-func/example-filterx-func-plugin.h
@@ -23,6 +23,8 @@
 #ifndef EXAMPLE_FILTERX_FUNC_PLUGIN_H_INCLUDED
 #define EXAMPLE_FILTERX_FUNC_PLUGIN_H_INCLUDED
 
-gpointer example_filterx_simple_func_construct_echo(Plugin *self);
+#include "filterx/expr-function.h"
+
+FILTERX_SIMPLE_FUNCTION_DECLARE(example_echo);
 
 #endif

--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -244,7 +244,7 @@ _filterx_otel_array_clone(FilterXObject *s)
 }
 
 FilterXObject *
-filterx_otel_array_new_from_args(GPtrArray *args)
+filterx_otel_array_new_from_args(FilterXExpr *s, GPtrArray *args)
 {
   FilterXOtelArray *self = g_new0(FilterXOtelArray, 1);
   _init_instance(self);

--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -295,11 +295,7 @@ _new_borrowed(ArrayValue *array)
   return &self->super.super;
 }
 
-gpointer
-grpc_otel_filterx_array_construct_new(Plugin *self)
-{
-  return (gpointer) &filterx_otel_array_new_from_args;
-}
+FILTERX_SIMPLE_FUNCTION(otel_array, filterx_otel_array_new_from_args);
 
 FilterXObject *
 OtelArrayField::FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors)

--- a/modules/grpc/otel/filterx/object-otel-kvlist.cpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.cpp
@@ -343,7 +343,7 @@ _filterx_otel_kvlist_clone(FilterXObject *s)
 }
 
 FilterXObject *
-filterx_otel_kvlist_new_from_args(GPtrArray *args)
+filterx_otel_kvlist_new_from_args(FilterXExpr *s, GPtrArray *args)
 {
   FilterXOtelKVList *self = g_new0(FilterXOtelKVList, 1);
   _init_instance(self);

--- a/modules/grpc/otel/filterx/object-otel-kvlist.cpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.cpp
@@ -394,11 +394,7 @@ _new_borrowed(RepeatedPtrField<KeyValue> *kvlist)
   return &self->super.super;
 }
 
-gpointer
-grpc_otel_filterx_kvlist_construct_new(Plugin *self)
-{
-  return (gpointer) &filterx_otel_kvlist_new_from_args;
-}
+FILTERX_SIMPLE_FUNCTION(otel_kvlist, filterx_otel_kvlist_new_from_args);
 
 FilterXObject *
 OtelKVListField::FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors)

--- a/modules/grpc/otel/filterx/object-otel-logrecord.cpp
+++ b/modules/grpc/otel/filterx/object-otel-logrecord.cpp
@@ -277,7 +277,7 @@ _filterx_otel_logrecord_clone(FilterXObject *s)
 }
 
 FilterXObject *
-filterx_otel_logrecord_new_from_args(GPtrArray *args)
+filterx_otel_logrecord_new_from_args(FilterXExpr *s, GPtrArray *args)
 {
   FilterXOtelLogRecord *self = g_new0(FilterXOtelLogRecord, 1);
   _init_instance(self);

--- a/modules/grpc/otel/filterx/object-otel-logrecord.cpp
+++ b/modules/grpc/otel/filterx/object-otel-logrecord.cpp
@@ -166,11 +166,6 @@ LogRecord::get_value() const
 
 /* C Wrappers */
 
-gpointer
-grpc_otel_filterx_logrecord_contruct_new(Plugin *self)
-{
-  return (gpointer) &filterx_otel_logrecord_new_from_args;
-}
 
 static void
 _free(FilterXObject *s)
@@ -321,6 +316,8 @@ filterx_otel_logrecord_new_from_args(GPtrArray *args)
 
   return &self->super.super;
 }
+
+FILTERX_SIMPLE_FUNCTION(otel_logrecord, filterx_otel_logrecord_new_from_args);
 
 FILTERX_DEFINE_TYPE(otel_logrecord, FILTERX_TYPE_NAME(dict),
                     .is_mutable = TRUE,

--- a/modules/grpc/otel/filterx/object-otel-resource.cpp
+++ b/modules/grpc/otel/filterx/object-otel-resource.cpp
@@ -303,11 +303,8 @@ filterx_otel_resource_new_from_args(GPtrArray *args)
   return &self->super.super;
 }
 
-gpointer
-grpc_otel_filterx_resource_construct_new(Plugin *self)
-{
-  return (gpointer) &filterx_otel_resource_new_from_args;
-}
+FILTERX_SIMPLE_FUNCTION(otel_resource, filterx_otel_resource_new_from_args);
+
 
 FILTERX_DEFINE_TYPE(otel_resource, FILTERX_TYPE_NAME(dict),
                     .is_mutable = TRUE,

--- a/modules/grpc/otel/filterx/object-otel-resource.cpp
+++ b/modules/grpc/otel/filterx/object-otel-resource.cpp
@@ -263,7 +263,7 @@ _filterx_otel_resource_clone(FilterXObject *s)
 }
 
 FilterXObject *
-filterx_otel_resource_new_from_args(GPtrArray *args)
+filterx_otel_resource_new_from_args(FilterXExpr *s, GPtrArray *args)
 {
   FilterXOtelResource *self = g_new0(FilterXOtelResource, 1);
   _init_instance(self);

--- a/modules/grpc/otel/filterx/object-otel-resource.cpp
+++ b/modules/grpc/otel/filterx/object-otel-resource.cpp
@@ -265,27 +265,27 @@ _filterx_otel_resource_clone(FilterXObject *s)
 FilterXObject *
 filterx_otel_resource_new_from_args(GPtrArray *args)
 {
-  FilterXOtelResource *s = g_new0(FilterXOtelResource, 1);
-  _init_instance(s);
+  FilterXOtelResource *self = g_new0(FilterXOtelResource, 1);
+  _init_instance(self);
 
   try
     {
       if (!args || args->len == 0)
         {
-          s->cpp = new Resource(s);
+          self->cpp = new Resource(self);
         }
       else if (args->len == 1)
         {
           FilterXObject *arg = (FilterXObject *) g_ptr_array_index(args, 0);
           if (filterx_object_is_type(arg, &FILTERX_TYPE_NAME(dict)))
             {
-              s->cpp = new Resource(s);
-              if (!filterx_dict_merge(&s->super.super, arg))
+              self->cpp = new Resource(self);
+              if (!filterx_dict_merge(&self->super.super, arg))
                 throw std::runtime_error("Failed to merge dict");
             }
           else
             {
-              s->cpp = new Resource(s, arg);
+              self->cpp = new Resource(self, arg);
             }
         }
       else
@@ -296,11 +296,11 @@ filterx_otel_resource_new_from_args(GPtrArray *args)
   catch (const std::runtime_error &e)
     {
       msg_error("FilterX: Failed to create OTel Resource object", evt_tag_str("error", e.what()));
-      filterx_object_unref(&s->super.super);
+      filterx_object_unref(&self->super.super);
       return NULL;
     }
 
-  return &s->super.super;
+  return &self->super.super;
 }
 
 gpointer

--- a/modules/grpc/otel/filterx/object-otel-scope.cpp
+++ b/modules/grpc/otel/filterx/object-otel-scope.cpp
@@ -265,27 +265,27 @@ _filterx_otel_scope_clone(FilterXObject *s)
 FilterXObject *
 filterx_otel_scope_new_from_args(GPtrArray *args)
 {
-  FilterXOtelScope *s = g_new0(FilterXOtelScope, 1);
-  _init_instance(s);
+  FilterXOtelScope *self = g_new0(FilterXOtelScope, 1);
+  _init_instance(self);
 
   try
     {
       if (!args || args->len == 0)
         {
-          s->cpp = new Scope(s);
+          self->cpp = new Scope(self);
         }
       else if (args->len == 1)
         {
           FilterXObject *arg = (FilterXObject *) g_ptr_array_index(args, 0);
           if (filterx_object_is_type(arg, &FILTERX_TYPE_NAME(dict)))
             {
-              s->cpp = new Scope(s);
-              if (!filterx_dict_merge(&s->super.super, arg))
+              self->cpp = new Scope(self);
+              if (!filterx_dict_merge(&self->super.super, arg))
                 throw std::runtime_error("Failed to merge dict");
             }
           else
             {
-              s->cpp = new Scope(s, arg);
+              self->cpp = new Scope(self, arg);
             }
         }
       else
@@ -296,11 +296,11 @@ filterx_otel_scope_new_from_args(GPtrArray *args)
   catch (const std::runtime_error &e)
     {
       msg_error("FilterX: Failed to create OTel Scope object", evt_tag_str("error", e.what()));
-      filterx_object_unref(&s->super.super);
+      filterx_object_unref(&self->super.super);
       return NULL;
     }
 
-  return &s->super.super;
+  return &self->super.super;
 }
 
 gpointer

--- a/modules/grpc/otel/filterx/object-otel-scope.cpp
+++ b/modules/grpc/otel/filterx/object-otel-scope.cpp
@@ -263,7 +263,7 @@ _filterx_otel_scope_clone(FilterXObject *s)
 }
 
 FilterXObject *
-filterx_otel_scope_new_from_args(GPtrArray *args)
+filterx_otel_scope_new_from_args(FilterXExpr *s, GPtrArray *args)
 {
   FilterXOtelScope *self = g_new0(FilterXOtelScope, 1);
   _init_instance(self);

--- a/modules/grpc/otel/filterx/object-otel-scope.cpp
+++ b/modules/grpc/otel/filterx/object-otel-scope.cpp
@@ -303,11 +303,8 @@ filterx_otel_scope_new_from_args(GPtrArray *args)
   return &self->super.super;
 }
 
-gpointer
-grpc_otel_filterx_scope_construct_new(Plugin *self)
-{
-  return (gpointer) &filterx_otel_scope_new_from_args;
-}
+FILTERX_SIMPLE_FUNCTION(otel_scope, filterx_otel_scope_new_from_args);
+
 
 FILTERX_DEFINE_TYPE(otel_scope, FILTERX_TYPE_NAME(dict),
                     .is_mutable = TRUE,

--- a/modules/grpc/otel/filterx/object-otel.h
+++ b/modules/grpc/otel/filterx/object-otel.h
@@ -27,18 +27,19 @@
 
 #include "compat/cpp-start.h"
 #include "filterx/filterx-object.h"
-#include "plugin.h"
+#include "filterx/expr-function.h"
 
-gpointer grpc_otel_filterx_logrecord_contruct_new(Plugin *self);
+FILTERX_SIMPLE_FUNCTION_DECLARE(otel_logrecord);
+FILTERX_SIMPLE_FUNCTION_DECLARE(otel_resource);
+FILTERX_SIMPLE_FUNCTION_DECLARE(otel_scope);
+FILTERX_SIMPLE_FUNCTION_DECLARE(otel_kvlist);
+FILTERX_SIMPLE_FUNCTION_DECLARE(otel_array);
 FilterXObject *filterx_otel_logrecord_new_from_args(GPtrArray *args);
 
-gpointer grpc_otel_filterx_resource_construct_new(Plugin *self);
 FilterXObject *filterx_otel_resource_new_from_args(GPtrArray *args);
 
-gpointer grpc_otel_filterx_scope_construct_new(Plugin *self);
 FilterXObject *filterx_otel_scope_new_from_args(GPtrArray *args);
 
-gpointer grpc_otel_filterx_kvlist_construct_new(Plugin *self);
 FilterXObject *filterx_otel_kvlist_new_from_args(GPtrArray *args);
 
 static inline FilterXObject *
@@ -47,7 +48,6 @@ filterx_otel_kvlist_new(void)
   return filterx_otel_kvlist_new_from_args(NULL);
 }
 
-gpointer grpc_otel_filterx_array_construct_new(Plugin *self);
 FilterXObject *filterx_otel_array_new_from_args(GPtrArray *args);
 
 static inline FilterXObject *

--- a/modules/grpc/otel/filterx/object-otel.h
+++ b/modules/grpc/otel/filterx/object-otel.h
@@ -34,21 +34,36 @@ FILTERX_SIMPLE_FUNCTION_DECLARE(otel_resource);
 FILTERX_SIMPLE_FUNCTION_DECLARE(otel_scope);
 FILTERX_SIMPLE_FUNCTION_DECLARE(otel_kvlist);
 FILTERX_SIMPLE_FUNCTION_DECLARE(otel_array);
+
 FilterXObject *filterx_otel_logrecord_new_from_args(GPtrArray *args);
-
 FilterXObject *filterx_otel_resource_new_from_args(GPtrArray *args);
-
 FilterXObject *filterx_otel_scope_new_from_args(GPtrArray *args);
-
 FilterXObject *filterx_otel_kvlist_new_from_args(GPtrArray *args);
+FilterXObject *filterx_otel_array_new_from_args(GPtrArray *args);
+
+static inline FilterXObject *
+filterx_otel_logrecord_new(void)
+{
+  return filterx_otel_logrecord_new_from_args(NULL);
+}
+
+static inline FilterXObject *
+filterx_otel_resource_new(void)
+{
+  return filterx_otel_resource_new_from_args(NULL);
+}
+
+static inline FilterXObject *
+filterx_otel_scope_new(void)
+{
+  return filterx_otel_scope_new_from_args(NULL);
+}
 
 static inline FilterXObject *
 filterx_otel_kvlist_new(void)
 {
   return filterx_otel_kvlist_new_from_args(NULL);
 }
-
-FilterXObject *filterx_otel_array_new_from_args(GPtrArray *args);
 
 static inline FilterXObject *
 filterx_otel_array_new(void)

--- a/modules/grpc/otel/filterx/object-otel.h
+++ b/modules/grpc/otel/filterx/object-otel.h
@@ -35,40 +35,41 @@ FILTERX_SIMPLE_FUNCTION_DECLARE(otel_scope);
 FILTERX_SIMPLE_FUNCTION_DECLARE(otel_kvlist);
 FILTERX_SIMPLE_FUNCTION_DECLARE(otel_array);
 
-FilterXObject *filterx_otel_logrecord_new_from_args(GPtrArray *args);
-FilterXObject *filterx_otel_resource_new_from_args(GPtrArray *args);
-FilterXObject *filterx_otel_scope_new_from_args(GPtrArray *args);
-FilterXObject *filterx_otel_kvlist_new_from_args(GPtrArray *args);
-FilterXObject *filterx_otel_array_new_from_args(GPtrArray *args);
+
+FilterXObject *filterx_otel_logrecord_new_from_args(FilterXExpr *s, GPtrArray *args);
+FilterXObject *filterx_otel_resource_new_from_args(FilterXExpr *s, GPtrArray *args);
+FilterXObject *filterx_otel_scope_new_from_args(FilterXExpr *s, GPtrArray *args);
+FilterXObject *filterx_otel_kvlist_new_from_args(FilterXExpr *s, GPtrArray *args);
+FilterXObject *filterx_otel_array_new_from_args(FilterXExpr *s, GPtrArray *args);
 
 static inline FilterXObject *
 filterx_otel_logrecord_new(void)
 {
-  return filterx_otel_logrecord_new_from_args(NULL);
+  return filterx_otel_logrecord_new_from_args(NULL, NULL);
 }
 
 static inline FilterXObject *
 filterx_otel_resource_new(void)
 {
-  return filterx_otel_resource_new_from_args(NULL);
+  return filterx_otel_resource_new_from_args(NULL, NULL);
 }
 
 static inline FilterXObject *
 filterx_otel_scope_new(void)
 {
-  return filterx_otel_scope_new_from_args(NULL);
+  return filterx_otel_scope_new_from_args(NULL, NULL);
 }
 
 static inline FilterXObject *
 filterx_otel_kvlist_new(void)
 {
-  return filterx_otel_kvlist_new_from_args(NULL);
+  return filterx_otel_kvlist_new_from_args(NULL, NULL);
 }
 
 static inline FilterXObject *
 filterx_otel_array_new(void)
 {
-  return filterx_otel_array_new_from_args(NULL);
+  return filterx_otel_array_new_from_args(NULL, NULL);
 }
 
 gpointer grpc_otel_filterx_enum_construct(Plugin *self);

--- a/modules/grpc/otel/otel-plugin.c
+++ b/modules/grpc/otel/otel-plugin.c
@@ -63,31 +63,11 @@ static Plugin otel_plugins[] =
     .name = "otel",
     .construct = grpc_otel_filterx_enum_construct,
   },
-  {
-    .type = LL_CONTEXT_FILTERX_SIMPLE_FUNC,
-    .name = "otel_logrecord",
-    .construct = grpc_otel_filterx_logrecord_contruct_new,
-  },
-  {
-    .type = LL_CONTEXT_FILTERX_SIMPLE_FUNC,
-    .name = "otel_resource",
-    .construct = grpc_otel_filterx_resource_construct_new,
-  },
-  {
-    .type = LL_CONTEXT_FILTERX_SIMPLE_FUNC,
-    .name = "otel_scope",
-    .construct = grpc_otel_filterx_scope_construct_new,
-  },
-  {
-    .type = LL_CONTEXT_FILTERX_SIMPLE_FUNC,
-    .name = "otel_kvlist",
-    .construct = grpc_otel_filterx_kvlist_construct_new,
-  },
-  {
-    .type = LL_CONTEXT_FILTERX_SIMPLE_FUNC,
-    .name = "otel_array",
-    .construct = grpc_otel_filterx_array_construct_new,
-  },
+  FILTERX_SIMPLE_FUNCTION_PLUGIN(otel_logrecord),
+  FILTERX_SIMPLE_FUNCTION_PLUGIN(otel_resource),
+  FILTERX_SIMPLE_FUNCTION_PLUGIN(otel_scope),
+  FILTERX_SIMPLE_FUNCTION_PLUGIN(otel_kvlist),
+  FILTERX_SIMPLE_FUNCTION_PLUGIN(otel_array),
 };
 
 gboolean

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -173,7 +173,7 @@ Test(otel_filterx, logrecord_from_protobuf)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new(serialized_log_record.c_str(), serialized_log_record.length()));
 
-  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(args);
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(NULL, args);
   cr_assert(filterx_otel_logrecord);
 
   const LogRecord &log_record_from_filterx = filterx_otel_logrecord->cpp->get_value();
@@ -188,7 +188,7 @@ Test(otel_filterx, logrecord_from_protobuf_invalid_arg)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_string_new("", 0));
 
-  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(args);
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_logrecord);
 
   g_ptr_array_free(args, TRUE);
@@ -199,7 +199,7 @@ Test(otel_filterx, logrecord_from_protobuf_malformed_data)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new("1234", 4));
 
-  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(args);
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_logrecord);
 
   g_ptr_array_free(args, TRUE);
@@ -211,7 +211,7 @@ Test(otel_filterx, logrecord_too_many_args)
   g_ptr_array_insert(args, 0, filterx_string_new("foo", 3));
   g_ptr_array_insert(args, 1, filterx_protobuf_new("bar", 3));
 
-  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(args);
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_logrecord);
 
   g_ptr_array_free(args, TRUE);
@@ -322,7 +322,7 @@ Test(otel_filterx, resource_from_protobuf)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new(serialized_resource.c_str(), serialized_resource.length()));
 
-  FilterXOtelResource *filterx_otel_resource = (FilterXOtelResource *) filterx_otel_resource_new_from_args(args);
+  FilterXOtelResource *filterx_otel_resource = (FilterXOtelResource *) filterx_otel_resource_new_from_args(NULL, args);
   cr_assert(filterx_otel_resource);
 
   const opentelemetry::proto::resource::v1::Resource &resource_from_filterx = filterx_otel_resource->cpp->get_value();
@@ -337,7 +337,7 @@ Test(otel_filterx, resource_from_protobuf_invalid_arg)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_string_new("", 0));
 
-  FilterXOtelResource *filterx_otel_resource = (FilterXOtelResource *) filterx_otel_resource_new_from_args(args);
+  FilterXOtelResource *filterx_otel_resource = (FilterXOtelResource *) filterx_otel_resource_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_resource);
 
   g_ptr_array_free(args, TRUE);
@@ -348,7 +348,7 @@ Test(otel_filterx, resource_from_protobuf_malformed_data)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new("1234", 4));
 
-  FilterXOtelResource *filterx_otel_resource = (FilterXOtelResource *) filterx_otel_resource_new_from_args(args);
+  FilterXOtelResource *filterx_otel_resource = (FilterXOtelResource *) filterx_otel_resource_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_resource);
 
   g_ptr_array_free(args, TRUE);
@@ -360,7 +360,7 @@ Test(otel_filterx, resource_too_many_args)
   g_ptr_array_insert(args, 0, filterx_string_new("foo", 3));
   g_ptr_array_insert(args, 1, filterx_protobuf_new("bar", 3));
 
-  FilterXOtelResource *filterx_otel_resource = (FilterXOtelResource *) filterx_otel_resource_new_from_args(args);
+  FilterXOtelResource *filterx_otel_resource = (FilterXOtelResource *) filterx_otel_resource_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_resource);
 
   g_ptr_array_free(args, TRUE);
@@ -378,7 +378,7 @@ Test(otel_filterx, resource_get_field)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new(serialized_resource.c_str(), serialized_resource.length()));
 
-  FilterXObject *filterx_otel_resource = (FilterXObject *) filterx_otel_resource_new_from_args(args);
+  FilterXObject *filterx_otel_resource = (FilterXObject *) filterx_otel_resource_new_from_args(NULL, args);
   cr_assert(filterx_otel_resource);
 
   _assert_filterx_integer_attribute(filterx_otel_resource, "dropped_attributes_count", 42);
@@ -407,7 +407,7 @@ Test(otel_filterx, resource_set_field)
   GPtrArray *attributes_kvlist_args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(attributes_kvlist_args, 0, filterx_protobuf_new(serialized_attributes.c_str(),
                      serialized_attributes.length()));
-  FilterXObject *filterx_kvlist = filterx_otel_kvlist_new_from_args(attributes_kvlist_args);
+  FilterXObject *filterx_kvlist = filterx_otel_kvlist_new_from_args(NULL, attributes_kvlist_args);
   cr_assert(filterx_object_setattr_string(filterx_otel_resource, "attributes", &filterx_kvlist));
 
   cr_assert_not(filterx_object_setattr_string(filterx_otel_resource, "invalid_attr", &filterx_integer));
@@ -479,7 +479,7 @@ Test(otel_filterx, resource_iter)
 
 Test(otel_filterx, scope_empty)
 {
-  FilterXOtelScope *filterx_otel_scope = (FilterXOtelScope *) filterx_otel_scope_new_from_args(NULL);
+  FilterXOtelScope *filterx_otel_scope = (FilterXOtelScope *) filterx_otel_scope_new();
   cr_assert(filterx_otel_scope);
 
   cr_assert(MessageDifferencer::Equals(opentelemetry::proto::common::v1::InstrumentationScope(),
@@ -502,7 +502,7 @@ Test(otel_filterx, scope_from_protobuf)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new(serialized_scope.c_str(), serialized_scope.length()));
 
-  FilterXOtelScope *filterx_otel_scope = (FilterXOtelScope *) filterx_otel_scope_new_from_args(args);
+  FilterXOtelScope *filterx_otel_scope = (FilterXOtelScope *) filterx_otel_scope_new_from_args(NULL, args);
   cr_assert(filterx_otel_scope);
 
   const opentelemetry::proto::common::v1::InstrumentationScope &scope_from_filterx = filterx_otel_scope->cpp->get_value();
@@ -517,7 +517,7 @@ Test(otel_filterx, scope_from_protobuf_invalid_arg)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_string_new("", 0));
 
-  FilterXOtelScope *filterx_otel_scope = (FilterXOtelScope *) filterx_otel_scope_new_from_args(args);
+  FilterXOtelScope *filterx_otel_scope = (FilterXOtelScope *) filterx_otel_scope_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_scope);
 
   g_ptr_array_free(args, TRUE);
@@ -528,7 +528,7 @@ Test(otel_filterx, scope_from_protobuf_malformed_data)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new("1234", 4));
 
-  FilterXOtelScope *filterx_otel_scope = (FilterXOtelScope *) filterx_otel_scope_new_from_args(args);
+  FilterXOtelScope *filterx_otel_scope = (FilterXOtelScope *) filterx_otel_scope_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_scope);
 
   g_ptr_array_free(args, TRUE);
@@ -540,7 +540,7 @@ Test(otel_filterx, scope_too_many_args)
   g_ptr_array_insert(args, 0, filterx_string_new("foo", 3));
   g_ptr_array_insert(args, 1, filterx_protobuf_new("bar", 3));
 
-  FilterXOtelScope *filterx_otel_scope = (FilterXOtelScope *) filterx_otel_scope_new_from_args(args);
+  FilterXOtelScope *filterx_otel_scope = (FilterXOtelScope *) filterx_otel_scope_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_scope);
 
   g_ptr_array_free(args, TRUE);
@@ -559,7 +559,7 @@ Test(otel_filterx, scope_get_field)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new(serialized_scope.c_str(), serialized_scope.length()));
 
-  FilterXObject *filterx_otel_scope = (FilterXObject *) filterx_otel_scope_new_from_args(args);
+  FilterXObject *filterx_otel_scope = (FilterXObject *) filterx_otel_scope_new_from_args(NULL, args);
   cr_assert(filterx_otel_scope);
 
   _assert_filterx_integer_attribute(filterx_otel_scope, "dropped_attributes_count", 42);
@@ -592,7 +592,7 @@ Test(otel_filterx, scope_set_field)
   GPtrArray *attributes_kvlist_args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(attributes_kvlist_args, 0, filterx_protobuf_new(serialized_attributes.c_str(),
                      serialized_attributes.length()));
-  FilterXObject *filterx_kvlist = filterx_otel_kvlist_new_from_args(attributes_kvlist_args);
+  FilterXObject *filterx_kvlist = filterx_otel_kvlist_new_from_args(NULL, attributes_kvlist_args);
   cr_assert(filterx_object_setattr_string(filterx_otel_scope, "attributes", &filterx_kvlist));
 
   cr_assert_not(filterx_object_setattr_string(filterx_otel_scope, "invalid_attr", &filterx_integer));
@@ -643,7 +643,7 @@ Test(otel_filterx, kvlist_from_protobuf)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new(serialized_kvlist.c_str(), serialized_kvlist.length()));
 
-  FilterXOtelKVList *filterx_otel_kvlist = (FilterXOtelKVList *) filterx_otel_kvlist_new_from_args(args);
+  FilterXOtelKVList *filterx_otel_kvlist = (FilterXOtelKVList *) filterx_otel_kvlist_new_from_args(NULL, args);
   cr_assert(filterx_otel_kvlist);
 
   _assert_repeated_kvs(filterx_otel_kvlist->cpp->get_value(), kvlist.values());
@@ -657,7 +657,7 @@ Test(otel_filterx, kvlist_from_protobuf_invalid_arg)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_string_new("", 0));
 
-  FilterXOtelKVList *filterx_otel_kvlist = (FilterXOtelKVList *) filterx_otel_kvlist_new_from_args(args);
+  FilterXOtelKVList *filterx_otel_kvlist = (FilterXOtelKVList *) filterx_otel_kvlist_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_kvlist);
 
   g_ptr_array_free(args, TRUE);
@@ -668,7 +668,7 @@ Test(otel_filterx, kvlist_from_protobuf_malformed_data)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new("1234", 4));
 
-  FilterXOtelKVList *filterx_otel_kvlist = (FilterXOtelKVList *) filterx_otel_kvlist_new_from_args(args);
+  FilterXOtelKVList *filterx_otel_kvlist = (FilterXOtelKVList *) filterx_otel_kvlist_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_kvlist);
 
   g_ptr_array_free(args, TRUE);
@@ -680,7 +680,7 @@ Test(otel_filterx, kvlist_too_many_args)
   g_ptr_array_insert(args, 0, filterx_string_new("foo", 3));
   g_ptr_array_insert(args, 1, filterx_protobuf_new("bar", 3));
 
-  FilterXOtelKVList *filterx_otel_kvlist = (FilterXOtelKVList *) filterx_otel_kvlist_new_from_args(args);
+  FilterXOtelKVList *filterx_otel_kvlist = (FilterXOtelKVList *) filterx_otel_kvlist_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_kvlist);
 
   g_ptr_array_free(args, TRUE);
@@ -711,7 +711,7 @@ Test(otel_filterx, kvlist_get_subscript)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new(serialized_kvlist.c_str(), serialized_kvlist.length()));
 
-  FilterXObject *filterx_otel_kvlist = (FilterXObject *) filterx_otel_kvlist_new_from_args(args);
+  FilterXObject *filterx_otel_kvlist = (FilterXObject *) filterx_otel_kvlist_new_from_args(NULL, args);
   cr_assert(filterx_otel_kvlist);
 
   FilterXObject *element_1_key = filterx_string_new("element_1_key", -1);
@@ -972,7 +972,7 @@ Test(otel_filterx, array_from_protobuf)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new(serialized_array.c_str(), serialized_array.length()));
 
-  FilterXOtelArray *filterx_otel_array = (FilterXOtelArray *) filterx_otel_array_new_from_args(args);
+  FilterXOtelArray *filterx_otel_array = (FilterXOtelArray *) filterx_otel_array_new_from_args(NULL, args);
   cr_assert(filterx_otel_array);
 
   const opentelemetry::proto::common::v1::ArrayValue &array_from_filterx = filterx_otel_array->cpp->get_value();
@@ -987,7 +987,7 @@ Test(otel_filterx, array_from_protobuf_invalid_arg)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_string_new("", 0));
 
-  FilterXOtelArray *filterx_otel_array = (FilterXOtelArray *) filterx_otel_array_new_from_args(args);
+  FilterXOtelArray *filterx_otel_array = (FilterXOtelArray *) filterx_otel_array_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_array);
 
   g_ptr_array_free(args, TRUE);
@@ -998,7 +998,7 @@ Test(otel_filterx, array_from_protobuf_malformed_data)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new("1234", 4));
 
-  FilterXOtelArray *filterx_otel_array = (FilterXOtelArray *) filterx_otel_array_new_from_args(args);
+  FilterXOtelArray *filterx_otel_array = (FilterXOtelArray *) filterx_otel_array_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_array);
 
   g_ptr_array_free(args, TRUE);
@@ -1010,7 +1010,7 @@ Test(otel_filterx, array_too_many_args)
   g_ptr_array_insert(args, 0, filterx_string_new("foo", 3));
   g_ptr_array_insert(args, 1, filterx_protobuf_new("bar", 3));
 
-  FilterXOtelArray *filterx_otel_array = (FilterXOtelArray *) filterx_otel_array_new_from_args(args);
+  FilterXOtelArray *filterx_otel_array = (FilterXOtelArray *) filterx_otel_array_new_from_args(NULL, args);
   cr_assert_not(filterx_otel_array);
 
   g_ptr_array_free(args, TRUE);
@@ -1037,7 +1037,7 @@ Test(otel_filterx, array_get_subscript)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new(serialized_array.c_str(), serialized_array.length()));
 
-  FilterXObject *filterx_otel_array = (FilterXObject *) filterx_otel_array_new_from_args(args);
+  FilterXObject *filterx_otel_array = (FilterXObject *) filterx_otel_array_new_from_args(NULL, args);
   cr_assert(filterx_otel_array);
 
   FilterXObject *element_1_index = filterx_integer_new(0);

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -173,7 +173,8 @@ Test(otel_filterx, logrecord_from_protobuf)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new(serialized_log_record.c_str(), serialized_log_record.length()));
 
-  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(NULL, args);
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(NULL,
+                                                 args);
   cr_assert(filterx_otel_logrecord);
 
   const LogRecord &log_record_from_filterx = filterx_otel_logrecord->cpp->get_value();
@@ -188,7 +189,8 @@ Test(otel_filterx, logrecord_from_protobuf_invalid_arg)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_string_new("", 0));
 
-  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(NULL, args);
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(NULL,
+                                                 args);
   cr_assert_not(filterx_otel_logrecord);
 
   g_ptr_array_free(args, TRUE);
@@ -199,7 +201,8 @@ Test(otel_filterx, logrecord_from_protobuf_malformed_data)
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new("1234", 4));
 
-  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(NULL, args);
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(NULL,
+                                                 args);
   cr_assert_not(filterx_otel_logrecord);
 
   g_ptr_array_free(args, TRUE);
@@ -211,7 +214,8 @@ Test(otel_filterx, logrecord_too_many_args)
   g_ptr_array_insert(args, 0, filterx_string_new("foo", 3));
   g_ptr_array_insert(args, 1, filterx_protobuf_new("bar", 3));
 
-  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(NULL, args);
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(NULL,
+                                                 args);
   cr_assert_not(filterx_otel_logrecord);
 
   g_ptr_array_free(args, TRUE);

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -152,7 +152,7 @@ _assert_filterx_otel_array_element(FilterXObject *obj, FilterXObject *key,
 
 Test(otel_filterx, logrecord_empty)
 {
-  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new_from_args(NULL);
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) filterx_otel_logrecord_new();
   cr_assert(filterx_otel_logrecord);
 
   cr_assert(MessageDifferencer::Equals(LogRecord(), filterx_otel_logrecord->cpp->get_value()));
@@ -219,7 +219,7 @@ Test(otel_filterx, logrecord_too_many_args)
 
 Test(otel_filterx, logrecord_len_and_unset_and_is_key_set)
 {
-  FilterXObject *logrecord = filterx_otel_logrecord_new_from_args(NULL);
+  FilterXObject *logrecord = filterx_otel_logrecord_new();
   FilterXObject *body = filterx_string_new("body", -1);
   FilterXObject *body_val = filterx_string_new("body_val", -1);
   FilterXObject *time_unix_nano = filterx_string_new("time_unix_nano", -1);
@@ -274,7 +274,7 @@ _append_to_str(FilterXObject *key, FilterXObject *value, gpointer user_data)
 
 Test(otel_filterx, logrecord_iter)
 {
-  FilterXObject *logrecord = filterx_otel_logrecord_new_from_args(NULL);
+  FilterXObject *logrecord = filterx_otel_logrecord_new();
   FilterXObject *body = filterx_string_new("body", -1);
   FilterXObject *body_val = filterx_string_new("body_val", -1);
   FilterXObject *time_unix_nano = filterx_string_new("time_unix_nano", -1);
@@ -301,7 +301,7 @@ Test(otel_filterx, logrecord_iter)
 
 Test(otel_filterx, resource_empty)
 {
-  FilterXOtelResource *filterx_otel_resource = (FilterXOtelResource *) filterx_otel_resource_new_from_args(NULL);
+  FilterXOtelResource *filterx_otel_resource = (FilterXOtelResource *) filterx_otel_resource_new();
   cr_assert(filterx_otel_resource);
 
   cr_assert(MessageDifferencer::Equals(opentelemetry::proto::resource::v1::Resource(),
@@ -393,7 +393,7 @@ Test(otel_filterx, resource_get_field)
 
 Test(otel_filterx, resource_set_field)
 {
-  FilterXObject *filterx_otel_resource = (FilterXObject *) filterx_otel_resource_new_from_args(NULL);
+  FilterXObject *filterx_otel_resource = (FilterXObject *) filterx_otel_resource_new();
   cr_assert(filterx_otel_resource);
 
   FilterXObject *filterx_integer = filterx_integer_new(42);
@@ -431,7 +431,7 @@ Test(otel_filterx, resource_set_field)
 
 Test(otel_filterx, resource_len_and_unset_and_is_key_set)
 {
-  FilterXObject *resource = filterx_otel_resource_new_from_args(NULL);
+  FilterXObject *resource = filterx_otel_resource_new();
   FilterXObject *dropped_attributes_count = filterx_string_new("dropped_attributes_count", -1);
   FilterXObject *dropped_attributes_count_val = filterx_integer_new(42);
 
@@ -457,7 +457,7 @@ Test(otel_filterx, resource_len_and_unset_and_is_key_set)
 
 Test(otel_filterx, resource_iter)
 {
-  FilterXObject *resource = filterx_otel_resource_new_from_args(NULL);
+  FilterXObject *resource = filterx_otel_resource_new();
   FilterXObject *dropped_attributes_count = filterx_string_new("dropped_attributes_count", -1);
   FilterXObject *dropped_attributes_count_val = filterx_integer_new(42);
 
@@ -575,7 +575,7 @@ Test(otel_filterx, scope_get_field)
 
 Test(otel_filterx, scope_set_field)
 {
-  FilterXObject *filterx_otel_scope = (FilterXObject *) filterx_otel_scope_new_from_args(NULL);
+  FilterXObject *filterx_otel_scope = (FilterXObject *) filterx_otel_scope_new();
   cr_assert(filterx_otel_scope);
 
   FilterXObject *filterx_integer = filterx_integer_new(42);
@@ -621,7 +621,7 @@ Test(otel_filterx, scope_set_field)
 
 Test(otel_filterx, kvlist_empty)
 {
-  FilterXOtelKVList *filterx_otel_kvlist = (FilterXOtelKVList *) filterx_otel_kvlist_new_from_args(NULL);
+  FilterXOtelKVList *filterx_otel_kvlist = (FilterXOtelKVList *) filterx_otel_kvlist_new();
   cr_assert(filterx_otel_kvlist);
 
   cr_assert_eq(filterx_otel_kvlist->cpp->get_value().size(), 0);
@@ -733,7 +733,7 @@ Test(otel_filterx, kvlist_get_subscript)
 
 Test(otel_filterx, kvlist_set_subscript)
 {
-  FilterXObject *filterx_otel_kvlist = (FilterXObject *) filterx_otel_kvlist_new_from_args(NULL);
+  FilterXObject *filterx_otel_kvlist = (FilterXObject *) filterx_otel_kvlist_new();
   cr_assert(filterx_otel_kvlist);
 
   FilterXObject *element_1_key = filterx_string_new("element_1_key", -1);
@@ -741,9 +741,9 @@ Test(otel_filterx, kvlist_set_subscript)
   FilterXObject *element_2_key = filterx_string_new("element_2_key", -1);
   FilterXObject *element_2_value = filterx_string_new("foobar", -1);
   FilterXObject *element_3_key = filterx_string_new("element_3_key", -1);
-  FilterXObject *element_3_value = filterx_otel_kvlist_new_from_args(NULL);
+  FilterXObject *element_3_value = filterx_otel_kvlist_new();
   FilterXObject *element_4_key = filterx_string_new("element_4_key", -1);
-  FilterXObject *element_4_value = filterx_otel_array_new_from_args(NULL);
+  FilterXObject *element_4_value = filterx_otel_array_new();
   cr_assert(filterx_object_set_subscript(filterx_otel_kvlist, element_1_key, &element_1_value));
   cr_assert(filterx_object_set_subscript(filterx_otel_kvlist, element_2_key, &element_2_value));
   cr_assert(filterx_object_set_subscript(filterx_otel_kvlist, element_3_key, &element_3_value));
@@ -783,8 +783,8 @@ Test(otel_filterx, kvlist_set_subscript)
 
 Test(otel_filterx, kvlist_through_logrecord)
 {
-  FilterXObject *fx_logrecord = filterx_otel_logrecord_new_from_args(NULL);
-  FilterXObject *fx_kvlist = filterx_otel_kvlist_new_from_args(NULL);
+  FilterXObject *fx_logrecord = filterx_otel_logrecord_new();
+  FilterXObject *fx_kvlist = filterx_otel_kvlist_new();
 
   FilterXObject *fx_key_0 = filterx_string_new("key_0", -1);
   FilterXObject *fx_key_1 = filterx_string_new("key_1", -1);
@@ -795,7 +795,7 @@ Test(otel_filterx, kvlist_through_logrecord)
   FilterXObject *fx_bar = filterx_string_new("bar", -1);
   FilterXObject *fx_baz = filterx_string_new("baz", -1);
 
-  FilterXObject *fx_inner_kvlist = filterx_otel_kvlist_new_from_args(NULL);
+  FilterXObject *fx_inner_kvlist = filterx_otel_kvlist_new();
 
   /* objects for storing the result of getattr() and get_subscript() */
   FilterXObject *fx_get_1 = nullptr;
@@ -883,7 +883,7 @@ Test(otel_filterx, kvlist_through_logrecord)
 
 Test(otel_filterx, scope_len_and_unset_and_is_key_set)
 {
-  FilterXObject *scope = filterx_otel_scope_new_from_args(NULL);
+  FilterXObject *scope = filterx_otel_scope_new();
   FilterXObject *name = filterx_string_new("name", -1);
   FilterXObject *name_val = filterx_string_new("name_val", -1);
   FilterXObject *version = filterx_string_new("version", -1);
@@ -924,7 +924,7 @@ Test(otel_filterx, scope_len_and_unset_and_is_key_set)
 
 Test(otel_filterx, scope_iter)
 {
-  FilterXObject *scope = filterx_otel_scope_new_from_args(NULL);
+  FilterXObject *scope = filterx_otel_scope_new();
   FilterXObject *name = filterx_string_new("name", -1);
   FilterXObject *name_val = filterx_string_new("name_val", -1);
   FilterXObject *version = filterx_string_new("version", -1);
@@ -951,7 +951,7 @@ Test(otel_filterx, scope_iter)
 
 Test(otel_filterx, array_empty)
 {
-  FilterXOtelArray *filterx_otel_kvlist = (FilterXOtelArray *) filterx_otel_array_new_from_args(NULL);
+  FilterXOtelArray *filterx_otel_kvlist = (FilterXOtelArray *) filterx_otel_array_new();
   cr_assert(filterx_otel_kvlist);
 
   cr_assert(MessageDifferencer::Equals(opentelemetry::proto::common::v1::ArrayValue(),
@@ -1064,13 +1064,13 @@ Test(otel_filterx, array_get_subscript)
 
 Test(otel_filterx, array_set_subscript)
 {
-  FilterXObject *filterx_otel_array = (FilterXObject *) filterx_otel_array_new_from_args(NULL);
+  FilterXObject *filterx_otel_array = (FilterXObject *) filterx_otel_array_new();
   cr_assert(filterx_otel_array);
 
   FilterXObject *element_1_value = filterx_integer_new(42);
   FilterXObject *element_2_value = filterx_string_new("foobar", -1);
-  FilterXObject *element_3_value = filterx_otel_kvlist_new_from_args(NULL);
-  FilterXObject *element_4_value = filterx_otel_array_new_from_args(NULL);
+  FilterXObject *element_3_value = filterx_otel_kvlist_new();
+  FilterXObject *element_4_value = filterx_otel_array_new();
   cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, &element_1_value));
   cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, &element_2_value));
   cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, &element_3_value));
@@ -1106,8 +1106,8 @@ Test(otel_filterx, array_set_subscript)
 
 Test(otel_filterx, array_through_logrecord)
 {
-  FilterXObject *fx_logrecord = filterx_otel_logrecord_new_from_args(NULL);
-  FilterXObject *fx_array = filterx_otel_array_new_from_args(NULL);
+  FilterXObject *fx_logrecord = filterx_otel_logrecord_new();
+  FilterXObject *fx_array = filterx_otel_array_new();
 
   FilterXObject *fx_2 = filterx_integer_new(2);
 
@@ -1115,7 +1115,7 @@ Test(otel_filterx, array_through_logrecord)
   FilterXObject *fx_bar = filterx_string_new("bar", -1);
   FilterXObject *fx_baz = filterx_string_new("baz", -1);
 
-  FilterXObject *fx_inner_array = filterx_otel_array_new_from_args(NULL);
+  FilterXObject *fx_inner_array = filterx_otel_array_new();
 
   /* objects for storing the result of getattr() and get_subscript() */
   FilterXObject *fx_get_1 = nullptr;

--- a/modules/json/filterx-cache-json-file.c
+++ b/modules/json/filterx-cache-json-file.c
@@ -215,6 +215,9 @@ filterx_function_cache_json_file_new(const gchar *function_name, FilterXFunction
   if (!self->cached_json)
     goto error;
 
+  if (!filterx_function_args_check(args, error))
+    goto error;
+
   _deep_freeze(self, self->cached_json);
 
   filterx_function_args_free(args);

--- a/modules/json/filterx-format-json.c
+++ b/modules/json/filterx-format-json.c
@@ -316,7 +316,7 @@ exit:
 }
 
 FilterXObject *
-filterx_format_json_new(GPtrArray *args)
+filterx_format_json_call(FilterXExpr *s, GPtrArray *args)
 {
   if (!args || args->len != 1)
     {
@@ -329,4 +329,4 @@ filterx_format_json_new(GPtrArray *args)
   return _format_json(arg);
 }
 
-FILTERX_SIMPLE_FUNCTION(format_json, filterx_format_json_new);
+FILTERX_SIMPLE_FUNCTION(format_json, filterx_format_json_call);

--- a/modules/json/filterx-format-json.c
+++ b/modules/json/filterx-format-json.c
@@ -329,8 +329,4 @@ filterx_format_json_new(GPtrArray *args)
   return _format_json(arg);
 }
 
-gpointer
-filterx_format_json_new_construct(Plugin *self)
-{
-  return (gpointer) &filterx_format_json_new;
-}
+FILTERX_SIMPLE_FUNCTION(format_json, filterx_format_json_new);

--- a/modules/json/filterx-format-json.h
+++ b/modules/json/filterx-format-json.h
@@ -24,7 +24,7 @@
 #include "filterx/filterx-object.h"
 #include "filterx/expr-function.h"
 
-FilterXObject *filterx_format_json_new(GPtrArray *args);
+FilterXObject *filterx_format_json_call(FilterXExpr *s, GPtrArray *args);
 
 FILTERX_SIMPLE_FUNCTION_DECLARE(format_json);
 

--- a/modules/json/filterx-format-json.h
+++ b/modules/json/filterx-format-json.h
@@ -22,9 +22,10 @@
 #define FILTERX_FORMAT_JSON_H_INCLUDED
 
 #include "filterx/filterx-object.h"
-#include "plugin.h"
+#include "filterx/expr-function.h"
 
 FilterXObject *filterx_format_json_new(GPtrArray *args);
-gpointer filterx_format_json_new_construct(Plugin *self);
+
+FILTERX_SIMPLE_FUNCTION_DECLARE(format_json);
 
 #endif

--- a/modules/json/json-plugin.c
+++ b/modules/json/json-plugin.c
@@ -38,11 +38,7 @@ static Plugin json_plugins[] =
   },
   TEMPLATE_FUNCTION_PLUGIN(tf_json, "format_json"),
   TEMPLATE_FUNCTION_PLUGIN(tf_flat_json, "format_flat_json"),
-  {
-    .type = LL_CONTEXT_FILTERX_SIMPLE_FUNC,
-    .name = "format_json",
-    .construct = filterx_format_json_new_construct,
-  },
+  FILTERX_SIMPLE_FUNCTION_PLUGIN(format_json),
   {
     .type = LL_CONTEXT_FILTERX_FUNC,
     .name = "cache_json_file",

--- a/modules/json/tests/test_filterx_format_json.c
+++ b/modules/json/tests/test_filterx_format_json.c
@@ -44,7 +44,7 @@ _exec_format_json_and_unref(FilterXObject *arg)
   GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
   g_ptr_array_add(args, arg);
 
-  FilterXObject *result = filterx_format_json_new(args);
+  FilterXObject *result = filterx_format_json_call(NULL, args);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
 
   g_ptr_array_unref(args);

--- a/modules/kvformat/filterx-func-format-kv.c
+++ b/modules/kvformat/filterx-func-format-kv.c
@@ -218,7 +218,8 @@ filterx_function_format_kv_new(const gchar *function_name, FilterXFunctionArgs *
   self->value_separator = '=';
   self->pair_separator = g_strdup(", ");
 
-  if (!_extract_arguments(self, args, error))
+  if (!_extract_arguments(self, args, error) ||
+      !filterx_function_args_check(args, error))
     goto error;
 
   filterx_function_args_free(args);

--- a/modules/kvformat/filterx-func-parse-kv.c
+++ b/modules/kvformat/filterx-func-parse-kv.c
@@ -261,7 +261,8 @@ filterx_function_parse_kv_new(const gchar *function_name, FilterXFunctionArgs *a
   self->value_separator = '=';
   self->pair_separator = g_strdup(", ");
 
-  if (!_extract_args(self, args, error))
+  if (!_extract_args(self, args, error) ||
+      !filterx_function_args_check(args, error))
     goto error;
 
   filterx_function_args_free(args);

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -1466,7 +1466,7 @@ def test_parse_csv_optional_arg_strip_whitespace(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
     custom_message = " foo   ,  bar  ,  baz, tik,   tak,    toe   ";
-    $MSG = parse_csv(custom_message, delimiter=",", strip_whitespace=true);
+    $MSG = parse_csv(custom_message, delimiter=",", strip_whitespaces=true);
     """,
     )
     syslog_ng.start(config)


### PR DESCRIPTION
This branch implements the handling of incorrect filterx function arguments, and also improves error handling aesthetics in multiple ways.

Here's a list of user-visible changes:
  * in some cases, the documentation/contact links were not printed on syntax errors, this was fixed
  * the primary error upon syntax error was easily lost in the log/error output, make it stand out
  * errors in function arguments are reported nicely, both when detected at compile time and at runtime

Internal changes:
  * it is now possible to set a filterx error condition where the extra info is a string and not a filterx object. Sometimes the filterx object is not available and creating one just for reporting an error would be an overhead. This should make it easier to report errors via the filterx error mechanism, instead of msg_error()
  * improve argument handling performance, use a GPtrArray to represent arg expressions, instead of a GList, which is iterated by index
