### PR TITLE
Logproto remove handshake in progress

### DIFF
--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -73,8 +73,7 @@ struct _LogProtoClient
   LogProtoStatus (*process_in)(LogProtoClient *s);
   LogProtoStatus (*flush)(LogProtoClient *s);
   gboolean (*validate_options)(LogProtoClient *s);
-  gboolean (*handshake_in_progess)(LogProtoClient *s);
-  LogProtoStatus (*handshake)(LogProtoClient *s);
+  LogProtoStatus (*handshake)(LogProtoClient *s, gboolean *handshake_finished);
   gboolean (*restart_with_state)(LogProtoClient *s, PersistState *state, const gchar *persist_name);
   void (*free_fn)(LogProtoClient *s);
   LogProtoClientFlowControlFuncs flow_control_funcs;
@@ -113,23 +112,14 @@ log_proto_client_validate_options(LogProtoClient *self)
   return self->validate_options(self);
 }
 
-static inline gboolean
-log_proto_client_handshake_in_progress(LogProtoClient *s)
-{
-  if (s->handshake_in_progess)
-    {
-      return s->handshake_in_progess(s);
-    }
-  return FALSE;
-}
-
 static inline LogProtoStatus
-log_proto_client_handshake(LogProtoClient *s)
+log_proto_client_handshake(LogProtoClient *s, gboolean *handshake_finished)
 {
   if (s->handshake)
     {
-      return s->handshake(s);
+      return s->handshake(s, handshake_finished);
     }
+  *handshake_finished = TRUE;
   return LPS_SUCCESS;
 }
 

--- a/lib/logproto/logproto-proxied-text-server.c
+++ b/lib/logproto/logproto-proxied-text-server.c
@@ -524,13 +524,13 @@ log_proto_proxied_text_server_prepare(LogProtoServer *s, GIOCondition *cond, gin
 }
 
 static LogProtoStatus
-log_proto_proxied_text_server_handshake(LogProtoServer *s)
+log_proto_proxied_text_server_handshake(LogProtoServer *s, gboolean *handshake_finished)
 {
   LogProtoProxiedTextServer *self = (LogProtoProxiedTextServer *) s;
 
   LogProtoStatus status = _fetch_into_proxy_buffer(self);
 
-  self->handshake_done = (status == LPS_SUCCESS);
+  self->handshake_done = *handshake_finished = (status == LPS_SUCCESS);
   if (status != LPS_SUCCESS)
     return status;
 
@@ -556,13 +556,6 @@ log_proto_proxied_text_server_handshake(LogProtoServer *s)
       msg_error("Error parsing PROXY protocol header");
       return LPS_ERROR;
     }
-}
-
-static gboolean
-log_proto_proxied_text_server_handshake_in_progress(LogProtoServer *s)
-{
-  LogProtoProxiedTextServer *self = (LogProtoProxiedTextServer *) s;
-  return !self->handshake_done;
 }
 
 static void
@@ -626,7 +619,6 @@ log_proto_proxied_text_server_init(LogProtoProxiedTextServer *self, LogTransport
   log_proto_text_server_init(&self->super, transport, options);
 
   self->super.super.super.prepare = log_proto_proxied_text_server_prepare;
-  self->super.super.super.handshake_in_progess = log_proto_proxied_text_server_handshake_in_progress;
   self->super.super.super.handshake = log_proto_proxied_text_server_handshake;
   self->super.super.super.fetch = log_proto_proxied_text_server_fetch;
   self->super.super.super.free_fn = log_proto_proxied_text_server_free;

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -88,8 +88,7 @@ struct _LogProtoServer
   LogProtoStatus (*fetch)(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read,
                           LogTransportAuxData *aux, Bookmark *bookmark);
   gboolean (*validate_options)(LogProtoServer *s);
-  gboolean (*handshake_in_progess)(LogProtoServer *s);
-  LogProtoStatus (*handshake)(LogProtoServer *s);
+  LogProtoStatus (*handshake)(LogProtoServer *s, gboolean *handshake_finished);
   void (*free_fn)(LogProtoServer *s);
 };
 
@@ -99,23 +98,14 @@ log_proto_server_validate_options(LogProtoServer *self)
   return self->validate_options(self);
 }
 
-static inline gboolean
-log_proto_server_handshake_in_progress(LogProtoServer *s)
-{
-  if (s->handshake_in_progess)
-    {
-      return s->handshake_in_progess(s);
-    }
-  return FALSE;
-}
-
 static inline LogProtoStatus
-log_proto_server_handshake(LogProtoServer *s)
+log_proto_server_handshake(LogProtoServer *s, gboolean *handshake_finished)
 {
   if (s->handshake)
     {
-      return s->handshake(s);
+      return s->handshake(s, handshake_finished);
     }
+  *handshake_finished = TRUE;
   return LPS_SUCCESS;
 }
 

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -60,7 +60,7 @@ struct _LogReader
 {
   LogSource super;
   LogProtoServer *proto;
-  gboolean immediate_check;
+  gboolean immediate_check, handshake_in_progress;
   LogPipe *control;
   LogReaderOptions *options;
   PollEvents *poll_events;


### PR DESCRIPTION
The branch itself simplifies the LogProto handshake API and adds a unit test for the LogProtoAutoServer class (rfc6587)
