### PR TITLE
Format csv refinement changes

### DIFF
--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -306,6 +306,25 @@ filterx_function_args_get_named_object(FilterXFunctionArgs *self, const gchar *n
   return obj;
 }
 
+FilterXObject *
+filterx_function_args_get_named_literal_object(FilterXFunctionArgs *self, const gchar *name, gboolean *exists)
+{
+  FilterXObject *obj = NULL;
+  FilterXExpr *expr = filterx_function_args_get_named_expr(self, name);
+  *exists = !!expr;
+  if (!expr)
+    return NULL;
+
+  if (!filterx_expr_is_literal(expr))
+    goto error;
+
+  obj = filterx_expr_eval(expr);
+error:
+  filterx_expr_unref(expr);
+  return obj;
+}
+
+
 const gchar *
 filterx_function_args_get_named_literal_string(FilterXFunctionArgs *self, const gchar *name, gsize *len,
                                                gboolean *exists)

--- a/lib/filterx/expr-function.h
+++ b/lib/filterx/expr-function.h
@@ -65,6 +65,8 @@ const gchar *filterx_function_args_get_literal_string(FilterXFunctionArgs *self,
 gboolean filterx_function_args_is_literal_null(FilterXFunctionArgs *self, guint64 index);
 FilterXExpr *filterx_function_args_get_named_expr(FilterXFunctionArgs *self, const gchar *name);
 FilterXObject *filterx_function_args_get_named_object(FilterXFunctionArgs *self, const gchar *name, gboolean *exists);
+FilterXObject *filterx_function_args_get_named_literal_object(FilterXFunctionArgs *self, const gchar *name,
+    gboolean *exists);
 const gchar *filterx_function_args_get_named_literal_string(FilterXFunctionArgs *self, const gchar *name,
                                                             gsize *len, gboolean *exists);
 gboolean filterx_function_args_get_named_literal_boolean(FilterXFunctionArgs *self, const gchar *name,

--- a/modules/csvparser/filterx-func-format-csv.h
+++ b/modules/csvparser/filterx-func-format-csv.h
@@ -29,6 +29,7 @@
 
 #define FILTERX_FUNC_FORMAT_CSV_ARG_NAME_COLUMNS "columns"
 #define FILTERX_FUNC_FORMAT_CSV_ARG_NAME_DELIMITER "delimiter"
+#define FILTERX_FUNC_FORMAT_CSV_ARG_NAME_DEFAULT_VALUE "default_value"
 
 FilterXFunction *filterx_function_format_csv_new(const gchar *function_name, FilterXFunctionArgs *args, GError **error);
 gpointer filterx_function_construct_format_csv(Plugin *self);

--- a/modules/csvparser/tests/test_filterx_func_format_csv.c
+++ b/modules/csvparser/tests/test_filterx_func_format_csv.c
@@ -202,6 +202,60 @@ Test(filterx_func_format_csv, test_escape_existing_double_quotes_in_case_of_addi
   _assert_format_csv(args, "\"\\\"fo;o\\\"\";\"b;ar\";\"baz\"");
 }
 
+Test(filterx_func_format_csv, test_dict_mode_fills_remaining_cols_with_default_default_value)
+{
+  FilterXExpr *csv_data = filterx_literal_new(
+                            filterx_json_object_new_from_repr("{\"col1\":\"foo\",\"col2\":\"bar\",\"col3\":\"baz\"}", -1));
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL, csv_data));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_FORMAT_CSV_ARG_NAME_COLUMNS,
+                                                      filterx_non_literal_new(filterx_json_array_new_from_repr("[\"col1\",\"col2\",\"col3\",\"more\",\"cols\"]", -1))));
+
+  _assert_format_csv(args, "foo,bar,baz,,");
+}
+
+Test(filterx_func_format_csv, test_dict_mode_fills_remaining_cols_with_non_default_default_value)
+{
+  FilterXExpr *csv_data = filterx_literal_new(
+                            filterx_json_object_new_from_repr("{\"col1\":\"foo\",\"col2\":\"bar\",\"col3\":\"baz\"}", -1));
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL, csv_data));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_FORMAT_CSV_ARG_NAME_COLUMNS,
+                                                      filterx_non_literal_new(filterx_json_array_new_from_repr("[\"col1\",\"col2\",\"col3\",\"more\",\"cols\"]", -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_FORMAT_CSV_ARG_NAME_DEFAULT_VALUE,
+                                                      filterx_literal_new(filterx_string_new("null", -1))));
+
+  _assert_format_csv(args, "foo,bar,baz,null,null");
+}
+
+Test(filterx_func_format_csv, test_dict_mode_default_value_repr_must_be_literal)
+{
+  FilterXExpr *csv_data = filterx_literal_new(
+                            filterx_json_object_new_from_repr("{\"col1\":\"foo\",\"col2\":\"bar\",\"col3\":\"baz\"}", -1));
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL, csv_data));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_FORMAT_CSV_ARG_NAME_COLUMNS,
+                                                      filterx_non_literal_new(filterx_json_array_new_from_repr("[\"col1\",\"col2\",\"col3\",\"more\",\"cols\"]", -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_FORMAT_CSV_ARG_NAME_DEFAULT_VALUE,
+                                                      filterx_non_literal_new(filterx_string_new("null", -1))));
+
+  _assert_format_csv_init_fail(args);
+}
+
+Test(filterx_func_format_csv, test_dict_mode_default_value_repr_must_be_string)
+{
+  FilterXExpr *csv_data = filterx_literal_new(
+                            filterx_json_object_new_from_repr("{\"col1\":\"foo\",\"col2\":\"bar\",\"col3\":\"baz\"}", -1));
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL, csv_data));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_FORMAT_CSV_ARG_NAME_COLUMNS,
+                                                      filterx_non_literal_new(filterx_json_array_new_from_repr("[\"col1\",\"col2\",\"col3\",\"more\",\"cols\"]", -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_FORMAT_CSV_ARG_NAME_DEFAULT_VALUE,
+                                                      filterx_literal_new(filterx_null_new())));
+
+  _assert_format_csv_init_fail(args);
+}
+
 
 static void
 setup(void)


### PR DESCRIPTION
- format function now renders additional columns as default value // ["foo","bar","baz","",""]
- introduce "default_value" named argument to change the value of default value
- sets the default of default_value to "" on construct 