### PR TITLE
wildcard-file: fix race between EOF and file deletion detection 

### DIFF
--- a/modules/affile/poll-file-changes.c
+++ b/modules/affile/poll-file-changes.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2002-2013 Balabit
+ * Copyright (c) 2024 Axoflow
  * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2024 László Várady
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -61,6 +63,10 @@ poll_file_changes_on_eof(PollFileChanges *self)
   if (self->on_eof)
     result = self->on_eof(self);
   log_pipe_notify(self->control, NC_FILE_EOF, self);
+
+  if (self->stop_on_eof)
+    return FALSE;
+
   return result;
 }
 
@@ -212,6 +218,14 @@ poll_file_changes_update_watches(PollEvents *s, GIOCondition cond)
 
   if (check_again)
     poll_file_changes_rearm_timer(self);
+}
+
+void
+poll_file_changes_stop_on_eof(PollEvents *s)
+{
+  PollFileChanges *self = (PollFileChanges *) s;
+
+  self->stop_on_eof = TRUE;
 }
 
 void

--- a/modules/affile/poll-file-changes.h
+++ b/modules/affile/poll-file-changes.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2002-2013 Balabit
+ * Copyright (c) 2024 Axoflow
  * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2024 László Várady
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -39,6 +41,7 @@ struct _PollFileChanges
   struct iv_timer follow_timer;
   LogPipe *control;
 
+  gboolean stop_on_eof;
   void (*on_read)(PollFileChanges *);
   gboolean (*on_eof)(PollFileChanges *);
   void (*on_file_moved)(PollFileChanges *);
@@ -50,6 +53,7 @@ void poll_file_changes_init_instance(PollFileChanges *self, gint fd, const gchar
                                      LogPipe *control);
 void poll_file_changes_update_watches(PollEvents *s, GIOCondition cond);
 void poll_file_changes_stop_watches(PollEvents *s);
+void poll_file_changes_stop_on_eof(PollEvents *s);
 void poll_file_changes_free(PollEvents *s);
 
 #endif

--- a/modules/affile/tests/Makefile.am
+++ b/modules/affile/tests/Makefile.am
@@ -29,8 +29,9 @@ modules_affile_tests_test_file_opener_LDADD	= $(TEST_LDADD) \
 	-dlpreopen $(top_builddir)/modules/affile/libaffile.la
 
 modules_affile_tests_test_wildcard_file_reader_CFLAGS = $(TEST_CFLAGS) -I$(top_srcdir)/modules/affile
-modules_affile_tests_test_wildcard_file_reader_LDADD	= $(TEST_LDADD)
-modules_affile_tests_test_wildcard_file_reader_SOURCES = modules/affile/tests/test_wildcard_file_reader.c modules/affile/wildcard-file-reader.c
+modules_affile_tests_test_wildcard_file_reader_LDADD	= $(TEST_LDADD) \
+	-dlpreopen $(top_builddir)/modules/affile/libaffile.la
+modules_affile_tests_test_wildcard_file_reader_SOURCES = modules/affile/tests/test_wildcard_file_reader.c
 
 modules_affile_tests_test_file_list_CFLAGS = $(TEST_CFLAGS) -I$(top_srcdir)/modules/affile
 modules_affile_tests_test_file_list_LDADD	= $(TEST_LDADD) \

--- a/modules/affile/wildcard-file-reader.h
+++ b/modules/affile/wildcard-file-reader.h
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2018 Balabit
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 László Várady
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -40,7 +42,7 @@ typedef struct _FileStateEvent
 typedef struct _FileState
 {
   gboolean deleted;
-  gboolean eof;
+  gboolean last_eof;
 } FileState;
 
 

--- a/news/bugfix-160.md
+++ b/news/bugfix-160.md
@@ -1,0 +1,1 @@
+`wildcard-file()`: fix crash when a deleted file is concurrently written


### PR DESCRIPTION
This patch fixes a "race condition" between the EOF and file deletion
detection of AxoSyslog when wildcard-file() is used.

If a file is written after being deleted (an application keeps an fd
open), or if these two events occur concurrently, nearly at the same
time, the file poller mechanism might schedule another read cycle while
the file has already been marked as fully read and deleted.

To avoid scheduling issues between the two checks, the following is done
from now on: We do not track the EOF state in the WildcardFileReader,
instead, when a file deletion notification is received, the poller will
be instructed to stop after reaching the next EOF, and only then will
AxoSyslog actually delete the reader instance.

Fixxes syslog-ng/syslog-ng#4989