### PR TITLE
macros: extract type information from MESSAGE, PROGRAM and HOST 

### DIFF
--- a/news/bugfix-162.md
+++ b/news/bugfix-162.md
@@ -1,0 +1,3 @@
+macros: Fixed a bug which always set certain macros to string type
+
+The affected macros are `$PROGRAM`, `$HOST` and `$MESSAGE`.


### PR DESCRIPTION
`MESSAGE` in particular can contain not just string data, but for example JSON as well.

This is necessary for the `$(format-json)` function to work properly with a json type `MESSAGE`.

Kudos to b1oodborne from Discord for finding this issue.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>