### PR TITLE
ci: set write permissions explicitly for jobs

### DIFF
--- a/.github/workflows/axosyslog-charts-release.yml
+++ b/.github/workflows/axosyslog-charts-release.yml
@@ -1,5 +1,7 @@
 name: AxoSyslog charts release
 
+permissions: write-all
+
 on:
   push:
     paths:

--- a/.github/workflows/axosyslog-docker.yml
+++ b/.github/workflows/axosyslog-docker.yml
@@ -1,5 +1,7 @@
 name: AxoSyslog Docker image builder
 
+permissions: write-all
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/axosyslog-image-snapshot.yml
+++ b/.github/workflows/axosyslog-image-snapshot.yml
@@ -42,6 +42,7 @@ jobs:
           path: dbld/build/*.tar.*
 
   publish-image:
+    permissions: write-all
     uses: ./.github/workflows/axosyslog-docker.yml
     needs: tarball
     with:

--- a/.github/workflows/axosyslog-nightly.yml
+++ b/.github/workflows/axosyslog-nightly.yml
@@ -1,5 +1,7 @@
 name: AxoSyslog nightly
 
+permissions: write-all
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/axosyslog-stable.yml
+++ b/.github/workflows/axosyslog-stable.yml
@@ -4,6 +4,8 @@
 
 name: AxoSyslog stable
 
+permissions: write-all
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/comment-on-version-bump-pr.yml
+++ b/.github/workflows/comment-on-version-bump-pr.yml
@@ -8,6 +8,8 @@
 
 name: Comment on version bump PR
 
+permissions: write-all
+
 on:
   push:
     branches:

--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -1,5 +1,7 @@
 name: Compile dbld-images
 
+permissions: write-all
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -14,6 +14,7 @@
 
 name: Draft release
 
+permissions: write-all
 
 on:
   workflow_dispatch:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -23,6 +23,8 @@
 
 name: Version bump
 
+permissions: write-all
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
> For each of the available scopes, shown in the table below, you can assign one of the permissions: read, write, or none. If you specify the access for any of these scopes, all of those that are not specified are set to none.

I used `write-all` for the above reason (to avoid specifying all scopes one by one for each job), but if needed, I can fine-grain them. Note that the current permissions are stricter (even with `write-all`) than the previous defaults.