### PR TITLE
filterx/expr-conditional: refactor 

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -28,7 +28,7 @@ set(FILTERX_HEADERS
     filterx/object-string.h
     filterx/object-list-interface.h
     filterx/object-dict-interface.h
-    filterx/expr-condition.h
+    filterx/expr-conditional.h
     filterx/expr-isset.h
     filterx/expr-unset.h
     filterx/expr-shorthand.h
@@ -77,7 +77,7 @@ set(FILTERX_SOURCES
     filterx/object-string.c
     filterx/object-list-interface.c
     filterx/object-dict-interface.c
-    filterx/expr-condition.c
+    filterx/expr-conditional.c
     filterx/expr-isset.c
     filterx/expr-unset.c
     filterx/expr-shorthand.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -31,7 +31,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/filterx-config.h		\
 	lib/filterx/filterx-pipe.h		\
 	lib/filterx/expr-function.h	\
-	lib/filterx/expr-condition.h \
+	lib/filterx/expr-conditional.h \
 	lib/filterx/expr-isset.h \
 	lib/filterx/expr-unset.h		\
 	lib/filterx/expr-shorthand.h		\
@@ -79,7 +79,7 @@ filterx_sources = 				\
 	lib/filterx/filterx-config.c		\
 	lib/filterx/filterx-pipe.c		\
 	lib/filterx/expr-function.c		\
-	lib/filterx/expr-condition.c		\
+	lib/filterx/expr-conditional.c		\
 	lib/filterx/expr-isset.c		\
 	lib/filterx/expr-unset.c		\
 	lib/filterx/expr-shorthand.c		\

--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -51,7 +51,7 @@ _eval_condition(FilterXConditional *c)
           if (c->false_branch == NULL)
             result = filterx_boolean_new(TRUE);
           else
-            result = _eval_condition(c->false_branch);
+            result = filterx_expr_eval(&self->false_branch->super);
           goto exit;
         }
     }

--- a/lib/filterx/expr-conditional.c
+++ b/lib/filterx/expr-conditional.c
@@ -23,7 +23,7 @@
  *
  */
 
-#include "filterx/expr-condition.h"
+#include "filterx/expr-conditional.h"
 #include "filterx/object-primitive.h"
 
 static FilterXConditional *

--- a/lib/filterx/expr-conditional.h
+++ b/lib/filterx/expr-conditional.h
@@ -21,8 +21,8 @@
  *
  */
 
-#ifndef FILTERX_CONDITION_H_INCLUDED
-#define FILTERX_CONDITION_H_INCLUDED
+#ifndef FILTERX_CONDITIONAL_H_INCLUDED
+#define FILTERX_CONDITIONAL_H_INCLUDED
 
 #include "filterx/filterx-expr.h"
 

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -46,7 +46,7 @@
 #include "filterx/object-string.h"
 #include "filterx/filterx-config.h"
 #include "filterx/expr-function.h"
-#include "filterx/expr-condition.h"
+#include "filterx/expr-conditional.h"
 #include "filterx/expr-isset.h"
 #include "filterx/expr-unset.h"
 #include "filterx/expr-literal-generator.h"

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ add_unit_test(LIBTEST CRITERION TARGET test_object_null DEPENDS json-plugin ${JS
 add_unit_test(LIBTEST CRITERION TARGET test_object_primitive DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_string DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_expr_comparison DEPENDS json-plugin ${JSONC_LIBRARY})
-add_unit_test(LIBTEST CRITERION TARGET test_expr_condition DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_expr_conditional DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_builtin_functions DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_bytes DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_protobuf DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -13,7 +13,7 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_filterx_expr	\
 		lib/filterx/tests/test_expr_function	\
 		lib/filterx/tests/test_expr_comparison \
-		lib/filterx/tests/test_expr_condition \
+		lib/filterx/tests/test_expr_conditional \
 		lib/filterx/tests/test_expr_function \
 		lib/filterx/tests/test_builtin_functions \
 		lib/filterx/tests/test_type_registry \
@@ -50,8 +50,8 @@ lib_filterx_tests_test_filterx_expr_LDADD   = $(TEST_LDADD) $(PREOPEN_SYSLOGFORM
 lib_filterx_tests_test_expr_comparison_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_expr_comparison_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
-lib_filterx_tests_test_expr_condition_CFLAGS = $(TEST_CFLAGS)
-lib_filterx_tests_test_expr_condition_LDADD	 = $(TEST_LDADD) $(JSON_LIBS)
+lib_filterx_tests_test_expr_conditional_CFLAGS = $(TEST_CFLAGS)
+lib_filterx_tests_test_expr_conditional_LDADD	 = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_builtin_functions_CFLAGS = $(TEST_CFLAGS)
 lib_filterx_tests_test_builtin_functions_LDADD = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/test_builtin_functions.c
+++ b/lib/filterx/tests/test_builtin_functions.c
@@ -27,7 +27,7 @@
 #include "filterx/filterx-object.h"
 #include "filterx/object-primitive.h"
 #include "filterx/expr-comparison.h"
-#include "filterx/expr-condition.h"
+#include "filterx/expr-conditional.h"
 #include "filterx/filterx-expr.h"
 #include "filterx/expr-literal.h"
 #include "filterx/object-string.h"

--- a/lib/filterx/tests/test_expr_conditional.c
+++ b/lib/filterx/tests/test_expr_conditional.c
@@ -27,7 +27,7 @@
 #include "filterx/filterx-eval.h"
 #include "filterx/object-primitive.h"
 #include "filterx/expr-comparison.h"
-#include "filterx/expr-condition.h"
+#include "filterx/expr-conditional.h"
 #include "filterx/filterx-expr.h"
 #include "filterx/expr-literal.h"
 #include "filterx/object-string.h"
@@ -94,7 +94,7 @@ _assert_get_test_variable(const char *var_name)
 
 //// Actual tests
 
-Test(expr_condition, test_control_variable_set_get)
+Test(expr_conditional, test_control_variable_set_get)
 {
   FilterXObject *control_value = _assert_get_test_variable("$control-value");
 
@@ -104,7 +104,7 @@ Test(expr_condition, test_control_variable_set_get)
 }
 
 
-Test(expr_condition, test_condition_with_null_expr_must_evaluated)
+Test(expr_conditional, test_condition_with_null_expr_must_evaluated)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
 
@@ -121,7 +121,7 @@ Test(expr_condition, test_condition_with_null_expr_must_evaluated)
   filterx_object_unref(cond_eval);
 }
 
-Test(expr_condition, test_condition_matching_expression)
+Test(expr_conditional, test_condition_matching_expression)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
 
@@ -140,7 +140,7 @@ Test(expr_condition, test_condition_matching_expression)
 }
 
 
-Test(expr_condition, test_condition_non_matching_expression)
+Test(expr_conditional, test_condition_non_matching_expression)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
 
@@ -159,7 +159,7 @@ Test(expr_condition, test_condition_non_matching_expression)
 }
 
 
-Test(expr_condition, test_condition_matching_elif_expression)
+Test(expr_conditional, test_condition_matching_elif_expression)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
   GList *elif_stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("elif-matching")));
@@ -183,7 +183,7 @@ Test(expr_condition, test_condition_matching_elif_expression)
 }
 
 
-Test(expr_condition, test_condition_non_matching_elif_expression)
+Test(expr_conditional, test_condition_non_matching_elif_expression)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
   GList *elif_stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("elif-matching")));
@@ -206,7 +206,7 @@ Test(expr_condition, test_condition_non_matching_elif_expression)
   filterx_object_unref(cond_eval);
 }
 
-Test(expr_condition, test_condition_matching_else_expression)
+Test(expr_conditional, test_condition_matching_else_expression)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
   GList *elif_stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("elif-matching")));
@@ -233,7 +233,7 @@ Test(expr_condition, test_condition_matching_else_expression)
   filterx_object_unref(cond_eval);
 }
 
-Test(expr_condition, test_condition_subsequent_conditions_must_create_nested_condition)
+Test(expr_conditional, test_condition_subsequent_conditions_must_create_nested_condition)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
   GList *elif_stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("elif-matching")));
@@ -262,7 +262,7 @@ Test(expr_condition, test_condition_subsequent_conditions_must_create_nested_con
   filterx_expr_unref(cond);
 }
 
-Test(expr_condition, test_condition_all_the_statements_must_executed)
+Test(expr_conditional, test_condition_all_the_statements_must_executed)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
   stmts = g_list_append(stmts, _assert_assign_var("$control-value2", _string_to_filterXExpr("matching2")));
@@ -290,7 +290,7 @@ Test(expr_condition, test_condition_all_the_statements_must_executed)
 }
 
 
-Test(expr_condition, test_condition_must_return_last_expression_from_evaluated_codeblock)
+Test(expr_conditional, test_condition_must_return_last_expression_from_evaluated_codeblock)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
   stmts = g_list_append(stmts, _assert_assign_var("$control-value2", _string_to_filterXExpr("matching2")));
@@ -308,7 +308,7 @@ Test(expr_condition, test_condition_must_return_last_expression_from_evaluated_c
 }
 
 
-Test(expr_condition, test_condition_falsey_statement_must_interrupt_sequential_code_execution)
+Test(expr_conditional, test_condition_falsey_statement_must_interrupt_sequential_code_execution)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
   stmts = g_list_append(stmts, filterx_literal_new(filterx_boolean_new(false)));
@@ -332,7 +332,7 @@ Test(expr_condition, test_condition_falsey_statement_must_interrupt_sequential_c
   filterx_object_unref(cond_eval);
 }
 
-Test(expr_condition, test_condition_error_statement_must_return_null)
+Test(expr_conditional, test_condition_error_statement_must_return_null)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
   stmts = g_list_append(stmts, filterx_dummy_error_new(""));
@@ -355,7 +355,7 @@ Test(expr_condition, test_condition_error_statement_must_return_null)
   filterx_object_unref(cond_eval);
 }
 
-Test(expr_condition, test_condition_do_not_allow_to_add_else_into_else, .signal=SIGABRT)
+Test(expr_conditional, test_condition_do_not_allow_to_add_else_into_else, .signal=SIGABRT)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
   GList *stmts2 = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
@@ -373,7 +373,7 @@ _fail_func(FilterXExpr *s, GPtrArray *args)
   return NULL;
 }
 
-Test(expr_condition, test_condition_return_null_on_illegal_expr)
+Test(expr_conditional, test_condition_return_null_on_illegal_expr)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
 
@@ -392,7 +392,7 @@ _dummy_func(FilterXExpr *s, GPtrArray *args)
   return filterx_string_new("foobar", -1);
 }
 
-Test(expr_condition, test_condition_return_expr_result_on_missing_stmts)
+Test(expr_conditional, test_condition_return_expr_result_on_missing_stmts)
 {
   FilterXExpr *func = filterx_simple_function_new("test_fn", filterx_function_args_new(NULL, NULL), _dummy_func);
 
@@ -407,7 +407,7 @@ Test(expr_condition, test_condition_return_expr_result_on_missing_stmts)
   filterx_object_unref(res);
 }
 
-Test(expr_condition, test_condition_must_not_fail_on_empty_else_block)
+Test(expr_conditional, test_condition_must_not_fail_on_empty_else_block)
 {
   FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(FALSE)),
                       NULL);
@@ -422,7 +422,7 @@ Test(expr_condition, test_condition_must_not_fail_on_empty_else_block)
   filterx_object_unref(res);
 }
 
-Test(expr_condition, test_condition_with_complex_expression_to_check_memory_leaks)
+Test(expr_conditional, test_condition_with_complex_expression_to_check_memory_leaks)
 {
   GList *stmts = NULL;
   stmts = g_list_append(stmts, filterx_literal_new(filterx_string_new("foobar", -1)));
@@ -457,4 +457,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(expr_condition, .init = setup, .fini = teardown);
+TestSuite(expr_conditional, .init = setup, .fini = teardown);

--- a/lib/filterx/tests/test_expr_function.c
+++ b/lib/filterx/tests/test_expr_function.c
@@ -27,7 +27,7 @@
 #include "filterx/filterx-object.h"
 #include "filterx/object-primitive.h"
 #include "filterx/expr-comparison.h"
-#include "filterx/expr-condition.h"
+#include "filterx/expr-conditional.h"
 #include "filterx/filterx-expr.h"
 #include "filterx/expr-literal.h"
 #include "filterx/object-string.h"


### PR DESCRIPTION
Although the original version is shorter it is a bit difficult for me to understand its flow.

For example the using or freeing of conditional_value or the "fallthrough"-like implementation of the evaluation of statements.

In some places it was hard to wrap my head around why we are returning something, and it was caused by the same code handling the basic if-elif-else code and ternary as well.

Hopefully the new version makes it easier to read and is less error-prone.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>