### PR TITLE
compat, grpc: fix C++ build warnings

### DIFF
--- a/lib/compat/cpp-start.h
+++ b/lib/compat/cpp-start.h
@@ -91,6 +91,10 @@
 
 #ifdef __cplusplus
 
+#ifndef __STDC_VERSION__
+#define __STDC_VERSION__ 0
+#endif
+
 #define this this_
 
 extern "C" {

--- a/modules/grpc/otel/filterx/object-otel-kvlist.cpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.cpp
@@ -31,6 +31,9 @@
 #include <google/protobuf/reflection.h>
 #include <stdexcept>
 
+/* The deprecated MutableRepeatedPtrField() does not have a proper alternative. */
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 using namespace syslogng::grpc::otel::filterx;
 using opentelemetry::proto::common::v1::KeyValueList;
 using opentelemetry::proto::common::v1::AnyValue;

--- a/modules/grpc/protos/CMakeLists.txt
+++ b/modules/grpc/protos/CMakeLists.txt
@@ -91,5 +91,5 @@ target_include_directories(grpc-protos
   PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
 )
 
-target_compile_options(grpc-protos PRIVATE -Wno-switch-default)
+target_compile_options(grpc-protos PRIVATE -Wno-switch-default -Wno-deprecated-declarations)
 install(TARGETS grpc-protos LIBRARY DESTINATION lib/syslog-ng COMPONENT grpc-protos)

--- a/modules/grpc/protos/Makefile.am
+++ b/modules/grpc/protos/Makefile.am
@@ -117,6 +117,7 @@ modules_grpc_protos_libgrpc_protos_la_CXXFLAGS = \
   $(AM_CXXFLAGS) \
   $(PROTOBUF_CFLAGS) \
   $(GRPCPP_CFLAGS) \
+  -Wno-deprecated-declarations \
   -I$(GOOGLEAPIS_PROTO_SRCDIR) \
   -I$(GOOGLEAPIS_PROTO_BUILDDIR) \
   -I$(OPENTELEMETRY_PROTO_SRCDIR) \


### PR DESCRIPTION
```
/usr/include/json-c/json_object.h:473:55: warning: "__STDC_VERSION__" is not defined, evaluates to 0 [-Wundef]
```
---
```
./modules/grpc/protos/google-proto/google/api/client.pb.cc: In member function ‘virtual google::protobuf::uint8* google::api::CommonLanguageSettings::_InternalSerialize(google::protobuf::uint8*, google::protobuf::io::EpsCopyOutputStream*) const’:
./modules/grpc/protos/google-proto/google/api/client.pb.cc:801:31: warning: ‘const string& google::api::CommonLanguageSettings::reference_docs_uri() const’ is deprecated [-Wdeprecated-declarations]
  801 |   if (this->reference_docs_uri().size() > 0) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from ./modules/grpc/protos/google-proto/google/api/client.pb.cc:4:
./modules/grpc/protos/google-proto/google/api/client.pb.h:2915:27: note: declared here
 2915 | inline const std::string& CommonLanguageSettings::reference_docs_uri() const {
      |                           ^~~~~~~~~~~~~~~~~~~~~~
./modules/grpc/protos/google-proto/google/api/client.pb.cc: In member function ‘virtual size_t google::api::CommonLanguageSettings::ByteSizeLong() const’:
./modules/grpc/protos/google-proto/google/api/client.pb.cc:854:31: warning: ‘const string& google::api::CommonLanguageSettings::reference_docs_uri() const’ is deprecated [-Wdeprecated-declarations]
  854 |   if (this->reference_docs_uri().size() > 0) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from ./modules/grpc/protos/google-proto/google/api/client.pb.cc:4:
./modules/grpc/protos/google-proto/google/api/client.pb.h:2915:27: note: declared here
 2915 | inline const std::string& CommonLanguageSettings::reference_docs_uri() const {
      |                           ^~~~~~~~~~~~~~~~~~~~~~
./modules/grpc/protos/google-proto/google/api/client.pb.cc: In member function ‘void google::api::CommonLanguageSettings::MergeFrom(const google::api::CommonLanguageSettings&)’:
./modules/grpc/protos/google-proto/google/api/client.pb.cc:892:30: warning: ‘const string& google::api::CommonLanguageSettings::reference_docs_uri() const’ is deprecated [-Wdeprecated-declarations]
  892 |   if (from.reference_docs_uri().size() > 0) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from ./modules/grpc/protos/google-proto/google/api/client.pb.cc:4:
./modules/grpc/protos/google-proto/google/api/client.pb.h:2915:27: note: declared here
 2915 | inline const std::string& CommonLanguageSettings::reference_docs_uri() const {
```