### PR TITLE
scl: add elasticsearch-datastream destination

### DIFF
--- a/news/feature-178.md
+++ b/news/feature-178.md
@@ -1,0 +1,12 @@
+### Send log messages to Elasticsearch data stream
+The `elasticsearch-datastream()` destination can be used to feed Elasticsearch [data streams](https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams.html).
+
+Example config:
+
+```
+elasticsearch-datastream(
+  url("https://elastic-endpoint:9200/my-data-stream/_bulk")
+  user("elastic")
+  password("ba3DI8u5qX61We7EP748V8RZ") 
+);
+```

--- a/scl/elasticsearch/elastic-datastream.conf
+++ b/scl/elasticsearch/elastic-datastream.conf
@@ -1,0 +1,50 @@
+#############################################################################
+# Copyright (c) 2024 Axoflow
+# Copyright (c) 2024 <szilard.parrag@axoflow.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+@requires json-plugin
+
+block destination elasticsearch-datastream(
+  url()
+  workers(4)
+  batch_lines(100)
+  timeout(10)
+  record("--scope rfc5424 --exclude DATE --key ISODATE @timestamp=${ISODATE}")
+  headers("Content-Type: application/x-ndjson")
+  body_suffix("\n")
+  ...)
+{
+
+@requires http "The elasticsearch-datastream() driver depends on the AxoSyslog http module, please install the axosyslog-mod-http (Debian & derivatives) or the axosyslog-http (RHEL & co) package"
+
+    http(
+        url(`url`)
+        headers(`headers`)
+        workers(`workers`)
+        batch_lines(`batch_lines`)
+        timeout(`timeout`)
+        body_suffix(`body_suffix`)
+        body("{\"create\":{ }}\n$(format-json --scope none `record`)")
+        method("PUT")
+        `__VARARGS__`
+    );
+};

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -221,6 +221,7 @@ modules/json/filterx-cache-json-file\.[ch]$
 modules/json/tests/test_filterx_format_json\.c$
 scl/fortigate/.*\.conf$
 scl/cee/.*\.conf$
+scl/elasticsearch/elastic-datastream.conf$
 scl/logscale/logscale\.conf$
 scl/mariadb/.*\.conf$
 scl/python/python-modules\.conf$


### PR DESCRIPTION
See https://www.elastic.co/guide/en/elasticsearch/reference/current/use-a-data-stream.html#add-documents-to-a-data-stream for details.

Sample trace log:
```
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='data_out', data='{"create":{ }}.{"PROGRAM":"prg00000","PRIORITY":"info","PID":"1234","MESSAGE":"seq: 0000000000, thread: 0000, runid: 1719322110, stamp: 2024-06-25T15:28:30 PADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADD","ISODATE":"2024-06-25T15:28:30+02:00","HOST":"localhost","FACILITY":"auth","@timestamp":"2024-06-25T15:28:30+02:00"}.'
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='ssl_data_in', data='.....'
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='ssl_data_in', data='.'
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='text', data='TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):.'
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='ssl_data_in', data='.'
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='ssl_data_in', data='.....'
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='ssl_data_in', data='.'
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='header_in', data='HTTP/1.1 200 OK..'
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='header_in', data='X-elastic-product: Elasticsearch..'
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='header_in', data='content-type: application/json..'
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='header_in', data='Transfer-Encoding: chunked..'
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='header_in', data='..'
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='data_in', data='190..{.  "errors" : false,.  "took" : 2,.  "items" : [.    {.      "create" : {.        "_index" : "ds-lo",.        "_id" : "kO2VT5ABNjqgUaS3aGHT",.        "_version" : 1,.        "result" : "created",.        "_shards" : {.          "total" : 2,.          "successful" : 1,.          "failed" : 0.        },.        "_seq_no" : 56,.        "_primary_term" : 1,.        "status" : 201.      }.    }.  ].}...0....'
[2024-06-25T15:28:30.157427] cURL debug; worker='0', type='text', data='Connection #0 to host localhost left intact.'
[2024-06-25T15:28:30.157427] http: HTTP response received; url='https://localhost:9200/ds-lo/_bulk?pretty', status_code='200', body_size='403', batch_size='1', redirected='0', total_time='0.009', worker_index='0', driver='output_quickstart_elasticsearch#0', location='syslog-ng.conf:45:5'
```
