### PR TITLE
Filterx datetime in json should be represented as epoch

### DIFF
--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -54,13 +54,12 @@ _truthy(FilterXObject *s)
 
 /* FIXME: delegate formatting and parsing to UnixTime */
 static void
-_convert_unix_time_to_string(const UnixTime *ut, GString *result)
+_convert_unix_time_to_string(const UnixTime *ut, GString *result, gboolean include_tzofs)
 {
-
   format_int64_padded(result, -1, ' ', 10, ut->ut_sec);
   g_string_append_c(result, '.');
   format_uint64_padded(result, 6, '0', 10, ut->ut_usec);
-  if (ut->ut_gmtoff != -1)
+  if (include_tzofs && ut->ut_gmtoff != -1)
     {
       if (ut->ut_gmtoff >= 0)
         g_string_append_c(result, '+');
@@ -79,7 +78,7 @@ _marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
   FilterXDateTime *self = (FilterXDateTime *) s;
 
   *t = LM_VT_DATETIME;
-  _convert_unix_time_to_string(&self->ut, repr);
+  _convert_unix_time_to_string(&self->ut, repr, TRUE);
   return TRUE;
 }
 
@@ -89,7 +88,7 @@ _map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **asso
   FilterXDateTime *self = (FilterXDateTime *) s;
   GString *time_stamp = scratch_buffers_alloc();
 
-  _convert_unix_time_to_string(&self->ut, time_stamp);
+  _convert_unix_time_to_string(&self->ut, time_stamp, FALSE);
 
   *object = json_object_new_string_len(time_stamp->str, time_stamp->len);
   return TRUE;

--- a/lib/filterx/tests/test_object_datetime.c
+++ b/lib/filterx/tests/test_object_datetime.c
@@ -49,7 +49,7 @@ Test(filterx_datetime, test_filterx_object_datetime_maps_to_the_right_json_value
 {
   UnixTime ut = { .ut_sec = 1701350398, .ut_usec = 123000, .ut_gmtoff = 3600 };
   FilterXObject *fobj = filterx_datetime_new(&ut);
-  assert_object_json_equals(fobj, "\"1701350398.123000+01:00\"");
+  assert_object_json_equals(fobj, "\"1701350398.123000\"");
   filterx_object_unref(fobj);
 }
 

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -388,7 +388,7 @@ def test_otel_resource_scope_log_to_json(config, syslog_ng):
                 "version": "ceta",
             },
             "log": {
-                "time_unix_nano": "123.456789+00:00",
+                "time_unix_nano": "123.456789",
                 "body": "fit",
                 "attributes": {
                     "answer": 42,
@@ -407,7 +407,7 @@ def test_otel_resource_scope_log_to_json(config, syslog_ng):
                 "version": "ceta",
             },
             "log": {
-                "time_unix_nano": "123.456789+00:00",
+                "time_unix_nano": "123.456789",
                 "body": "fit",
                 "attributes": {
                     "answer": 42,
@@ -468,7 +468,7 @@ def test_json_to_otel_resource_scope_log(config, syslog_ng):
             "version": "ceta",
         },
         "log": {
-            "time_unix_nano": "123.456789+00:00",
+            "time_unix_nano": "123.456789",
             "body": "fit",
             "attributes": {
                 "answer": 42,


### PR DESCRIPTION
Whenever a datetime object is to be represented in JSON, we should not add the timezone value.