### PR TITLE
github-actions: fix bucket name in upload-packages again

### DIFF
--- a/.github/workflows/upload-packages.yml
+++ b/.github/workflows/upload-packages.yml
@@ -59,6 +59,6 @@ jobs:
           find * -type f -exec \
             aws s3api put-object \
               --endpoint-url https://${{ secrets.r2-account-id }}.r2.cloudflarestorage.com \
-              --bucket axoflow-packages-build-wnam \
+              --bucket axoflow-packages-build \
               --key ${{ inputs.pkg-type }}/${{ github.run_id }}/{} \
               --body {} \;


### PR DESCRIPTION
wnam is not in the bucket name, it was a user error by me.

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
