### PR TITLE
cfg-lex: implement "Leave the backslash alone" for slash_string

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -386,7 +386,7 @@ filterx_word	[^ \#'"/\(\)\{\}\[\]\\;\r\n\t,|\.@:]
 <slash_string>\\f		        { g_string_append_c(yyextra->string_buffer, 12); }
 <slash_string>\\\\	                { g_string_append_c(yyextra->string_buffer, '\\'); }
 <slash_string>\\\/	                { g_string_append_c(yyextra->string_buffer, '/'); }
-<slash_string>\\[^anrtvbfox]	        { g_string_append_c(yyextra->string_buffer, yytext[1]); }
+<slash_string>\\[^anrtvbfox]	        { g_string_append(yyextra->string_buffer, yytext); }
 <slash_string>[^\/\\\r\n]+              { g_string_append(yyextra->string_buffer, yytext); }
 <slash_string>\/	                {
 			                        yy_pop_state(yyscanner);

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -1695,6 +1695,7 @@ bar/;
             $MSG.escaped_slash = /foo\/bar/;
             $MSG.non_escaped_single_quotes = /foo'bar/;
             $MSG.non_escaped_double_quotes = /foo"bar/;
+            $MSG.escaped_non_special = /foo\dbar/;
 
             ## special characters
             $MSG.new_line = /foo\nbar/;
@@ -1725,6 +1726,7 @@ bar/;
         r""""escaped_slash":"foo\/bar","""
         r""""non_escaped_single_quotes":"foo'bar","""
         r""""non_escaped_double_quotes":"foo\"bar","""
+        r""""escaped_non_special":"foo\\dbar","""
         r""""new_line":"foo\nbar","""
         r""""tab":"foo\tbar","""
         r""""carrige_return":"foo\rbar","""


### PR DESCRIPTION
From the awk docs:
https://www.gnu.org/software/gawk/manual/html_node/Escape-Sequences.html#index-mawk-utility

> Backslash Before Regular Characters
>
> If you place a backslash in a string constant before something
> that is not one of the characters previously listed, POSIX awk
> purposely leaves what happens as undefined.
>
> There are two choices:
>
> Strip the backslash out
> This is what BWK awk and gawk both do. For example, "a\qc"
> is the same as "aqc". (Because this is such an easy bug both
> to introduce and to miss, gawk warns you about it.) Consider
> ‘FS = "[ \t]+\|[ \t]+"’ to use vertical bars surrounded by
> whitespace as the field separator. There should be two
> backslashes in the string: ‘FS = "[ \t]+\\|[ \t]+"’.)
>
> Leave the backslash alone
> Some other awk implementations do this. In such implementations,
> typing "a\qc" is the same as typing "a\\qc".

AxoSyslog uses PCRE regexps, where \d, \w, etc are supported. The whole point of the slash strings was to make it easier to write regexp patterns. I believe it is easier for the user to write such patterns if we choose the "Leave the backslash alone" solution.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>