### PR TITLE
otel,loki,bigquery: add `headers()` option to dest 

### DIFF
--- a/modules/grpc/bigquery/bigquery-dest.cpp
+++ b/modules/grpc/bigquery/bigquery-dest.cpp
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
  * Copyright (c) 2023 László Várady
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -442,6 +444,13 @@ bigquery_dd_add_string_channel_arg(LogDriver *d, const gchar *name, const gchar 
 {
   BigQueryDestDriver *self = (BigQueryDestDriver *) d;
   self->cpp->add_extra_channel_arg(name, value);
+}
+
+void
+bigquery_dd_add_header(LogDriver *d, const gchar *name, const gchar *value)
+{
+  BigQueryDestDriver *self = (BigQueryDestDriver *) d;
+  self->cpp->add_header(name, value);
 }
 
 LogTemplateOptions *

--- a/modules/grpc/bigquery/bigquery-dest.h
+++ b/modules/grpc/bigquery/bigquery-dest.h
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
  * Copyright (c) 2023 László Várady
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -50,6 +52,8 @@ void bigquery_dd_set_keepalive_max_pings(LogDriver *d, gint p);
 
 void bigquery_dd_add_int_channel_arg(LogDriver *s, const gchar *name, glong value);
 void bigquery_dd_add_string_channel_arg(LogDriver *s, const gchar *name, const gchar *value);
+
+void bigquery_dd_add_header(LogDriver *s, const gchar *name, const gchar *value);
 
 LogTemplateOptions *bigquery_dd_get_template_options(LogDriver *d);
 

--- a/modules/grpc/bigquery/bigquery-dest.hpp
+++ b/modules/grpc/bigquery/bigquery-dest.hpp
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
  * Copyright (c) 2023 László Várady
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -150,6 +152,12 @@ public:
     this->string_extra_channel_args.push_back(std::pair<std::string, std::string> {name, value});
   }
 
+  void add_header(std::string name, std::string value)
+  {
+    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+    this->headers.push_back(std::pair<std::string, std::string> {name, value});
+  }
+
   const std::string &get_url()
   {
     return this->url;
@@ -213,6 +221,7 @@ private:
 
   std::list<std::pair<std::string, long>> int_extra_channel_args;
   std::list<std::pair<std::string, std::string>> string_extra_channel_args;
+  std::list<std::pair<std::string, std::string>> headers;
 
   DestDriverMetrics metrics;
 };

--- a/modules/grpc/bigquery/bigquery-grammar.ym
+++ b/modules/grpc/bigquery/bigquery-grammar.ym
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
  * Copyright (c) 2023 László Várady
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -63,6 +65,7 @@
 %token KW_MAX_PINGS_WITHOUT_DATA
 
 %token KW_CHANNEL_ARGS
+%token KW_HEADERS
 
 %type <ptr> bigquery_dest
 
@@ -107,6 +110,7 @@ bigquery_dest_option
     }
   | KW_KEEP_ALIVE '(' bigquery_keepalive_options ')'
   | KW_CHANNEL_ARGS '(' bigquery_dest_channel_args ')'
+  | KW_HEADERS '(' bigquery_dest_headers ')'
   | threaded_dest_driver_general_option
   | threaded_dest_driver_workers_option
   | threaded_dest_driver_batch_option
@@ -147,6 +151,15 @@ bigquery_dest_channel_args
 bigquery_dest_channel_arg
   : string LL_ARROW LL_NUMBER { bigquery_dd_add_int_channel_arg(last_driver, $1, $3); free($1); }
   | string LL_ARROW string { bigquery_dd_add_string_channel_arg(last_driver, $1, $3); free($1); free($3); }
+  ;
+
+bigquery_dest_headers
+  : bigquery_dest_header bigquery_dest_headers
+  |
+  ;
+
+bigquery_dest_header
+  : string LL_ARROW string { bigquery_dd_add_header(last_driver, $1, $3); free($1); free($3); }
   ;
 
 /* INCLUDE_RULES */

--- a/modules/grpc/bigquery/bigquery-parser.c
+++ b/modules/grpc/bigquery/bigquery-parser.c
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
  * Copyright (c) 2023 László Várady
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -44,6 +46,7 @@ static CfgLexerKeyword bigquery_keywords[] =
   { "timeout", KW_TIMEOUT },
   { "max_pings_without_data", KW_MAX_PINGS_WITHOUT_DATA },
   { "channel_args", KW_CHANNEL_ARGS },
+  { "headers", KW_HEADERS },
   { NULL }
 };
 

--- a/modules/grpc/bigquery/bigquery-worker.hpp
+++ b/modules/grpc/bigquery/bigquery-worker.hpp
@@ -65,6 +65,7 @@ public:
   LogThreadedResult flush(LogThreadedFlushMode mode);
 
 private:
+  void prepare_context(::grpc::ClientContext &ctx);
   std::shared_ptr<::grpc::Channel> create_channel();
   void construct_write_stream();
   void prepare_batch();

--- a/modules/grpc/loki/loki-dest.cpp
+++ b/modules/grpc/loki/loki-dest.cpp
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
  * Copyright (c) 2023 László Várady
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -251,6 +253,13 @@ loki_dd_add_string_channel_arg(LogDriver *d, const gchar *name, const gchar *val
 {
   LokiDestDriver *self = (LokiDestDriver *) d;
   self->cpp->add_extra_channel_arg(name, value);
+}
+
+void
+loki_dd_add_header(LogDriver *d, const gchar *name, const gchar *value)
+{
+  LokiDestDriver *self = (LokiDestDriver *) d;
+  self->cpp->add_header(name, value);
 }
 
 LogTemplateOptions *

--- a/modules/grpc/loki/loki-dest.h
+++ b/modules/grpc/loki/loki-dest.h
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
  * Copyright (c) 2023 László Várady
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -49,6 +51,8 @@ void loki_dd_set_keepalive_max_pings(LogDriver *d, gint p);
 
 void loki_dd_add_int_channel_arg(LogDriver *s, const gchar *name, glong value);
 void loki_dd_add_string_channel_arg(LogDriver *s, const gchar *name, const gchar *value);
+
+void loki_dd_add_header(LogDriver *s, const gchar *name, const gchar *value);
 
 LogTemplateOptions *loki_dd_get_template_options(LogDriver *d);
 

--- a/modules/grpc/loki/loki-dest.hpp
+++ b/modules/grpc/loki/loki-dest.hpp
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
  * Copyright (c) 2023 László Várady
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -141,6 +143,12 @@ public:
     this->string_extra_channel_args.push_back(std::pair<std::string, std::string> {name, value});
   }
 
+  void add_header(std::string name, std::string value)
+  {
+    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+    this->headers.push_back(std::pair<std::string, std::string> {name, value});
+  }
+
   const std::string &get_url()
   {
     return this->url;
@@ -169,6 +177,7 @@ private:
 
   std::list<std::pair<std::string, long>> int_extra_channel_args;
   std::list<std::pair<std::string, std::string>> string_extra_channel_args;
+  std::list<std::pair<std::string, std::string>> headers;
 
   DestDriverMetrics metrics;
 };

--- a/modules/grpc/loki/loki-grammar.ym
+++ b/modules/grpc/loki/loki-grammar.ym
@@ -71,6 +71,7 @@ GrpcClientCredentialsBuilderW *last_grpc_client_credentials_builder;
 %token KW_MAX_PINGS_WITHOUT_DATA
 
 %token KW_CHANNEL_ARGS
+%token KW_HEADERS
 
 %type <ptr> loki_dest
 
@@ -106,6 +107,7 @@ loki_dest_option
   | KW_TEMPLATE '(' template_name_or_content ')' { loki_dd_set_message_template_ref(last_driver, $3); }
   | KW_AUTH { last_grpc_client_credentials_builder = loki_dd_get_credentials_builder(last_driver); } '(' grpc_client_credentials_option ')'
   | KW_CHANNEL_ARGS '(' loki_dest_channel_args ')'
+  | KW_HEADERS '(' loki_dest_headers ')'
   | threaded_dest_driver_general_option
   | threaded_dest_driver_workers_option
   | threaded_dest_driver_batch_option
@@ -146,6 +148,16 @@ loki_dest_channel_arg
   : string LL_ARROW LL_NUMBER { loki_dd_add_int_channel_arg(last_driver, $1, $3); free($1); }
   | string LL_ARROW string { loki_dd_add_string_channel_arg(last_driver, $1, $3); free($1); free($3); }
   ;
+
+loki_dest_headers
+  : loki_dest_header loki_dest_headers
+  |
+  ;
+
+loki_dest_header
+  : string LL_ARROW string { loki_dd_add_header(last_driver, $1, $3); free($1); free($3); }
+  ;
+
 
 /*
  * gRPC Credentials Builders

--- a/modules/grpc/loki/loki-parser.c
+++ b/modules/grpc/loki/loki-parser.c
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
  * Copyright (c) 2023 László Várady
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -49,6 +51,7 @@ static CfgLexerKeyword loki_keywords[] =
   { "adc", KW_ADC },
   { "tenant_id", KW_TENANT_ID },
   { "channel_args", KW_CHANNEL_ARGS },
+  { "headers", KW_HEADERS },
   { NULL }
 };
 

--- a/modules/grpc/loki/loki-worker.cpp
+++ b/modules/grpc/loki/loki-worker.cpp
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
  * Copyright (c) 2023 László Várady
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -241,6 +243,8 @@ DestinationWorker::flush(LogThreadedFlushMode mode)
   logproto::PushResponse response{};
 
   ::grpc::ClientContext ctx;
+  for (auto nv : owner->headers)
+    ctx.AddMetadata(nv.first, nv.second);
 
   if (!owner->tenant_id.empty())
     ctx.AddMetadata("x-scope-orgid", owner->tenant_id);

--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2023 Attila Szakacs
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2023-2024 Attila Szakacs <attila.szakacs@axoflow.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -431,10 +432,19 @@ permanent_error:
   return LTR_DROP;
 }
 
+void
+DestWorker::prepare_context(::grpc::ClientContext &context)
+{
+  for (auto nv : owner.headers)
+    context.AddMetadata(nv.first, nv.second);
+}
+
 LogThreadedResult
 DestWorker::flush_log_records()
 {
   ::grpc::ClientContext client_context;
+  prepare_context(client_context);
+
   logs_service_response.Clear();
   ::grpc::Status status = logs_service_stub->Export(&client_context, logs_service_request,
                                                     &logs_service_response);
@@ -454,6 +464,8 @@ LogThreadedResult
 DestWorker::flush_metrics()
 {
   ::grpc::ClientContext client_context;
+  prepare_context(client_context);
+
   metrics_service_response.Clear();
   ::grpc::Status status = metrics_service_stub->Export(&client_context, metrics_service_request,
                                                        &metrics_service_response);
@@ -473,6 +485,8 @@ LogThreadedResult
 DestWorker::flush_spans()
 {
   ::grpc::ClientContext client_context;
+  prepare_context(client_context);
+
   trace_service_response.Clear();
   ::grpc::Status status = trace_service_stub->Export(&client_context, trace_service_request,
                                                      &trace_service_response);

--- a/modules/grpc/otel/otel-dest-worker.hpp
+++ b/modules/grpc/otel/otel-dest-worker.hpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2023 Attila Szakacs
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2023-2024 Attila Szakacs <attila.szakacs@axoflow.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -70,6 +71,8 @@ public:
   virtual LogThreadedResult flush(LogThreadedFlushMode mode);
 
 protected:
+  void prepare_context(::grpc::ClientContext &context);
+
   void clear_current_msg_metadata();
   void get_metadata_for_current_msg(LogMessage *msg);
 

--- a/modules/grpc/otel/otel-dest.cpp
+++ b/modules/grpc/otel/otel-dest.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2023 Attila Szakacs
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2023-2024 Attila Szakacs <attila.szakacs@axoflow.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -81,6 +82,13 @@ void
 DestDriver::add_extra_channel_arg(std::string name, std::string value)
 {
   string_extra_channel_args.push_back(std::pair<std::string, std::string> {name, value});
+}
+
+void
+DestDriver::add_header(std::string name, std::string value)
+{
+  std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+  headers.push_back(std::pair<std::string, std::string> {name, value});
 }
 
 const char *
@@ -183,6 +191,12 @@ void
 otel_dd_add_string_channel_arg(LogDriver *s, const gchar *name, const gchar *value)
 {
   get_DestDriver(s)->add_extra_channel_arg(name, value);
+}
+
+void
+otel_dd_add_header(LogDriver *s, const gchar *name, const gchar *value)
+{
+  get_DestDriver(s)->add_header(name, value);
 }
 
 GrpcClientCredentialsBuilderW *

--- a/modules/grpc/otel/otel-dest.h
+++ b/modules/grpc/otel/otel-dest.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2023 Attila Szakacs
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2023-2024 Attila Szakacs <attila.szakacs@axoflow.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -38,6 +39,7 @@ void otel_dd_set_compression(LogDriver *s, gboolean enable);
 void otel_dd_set_batch_bytes(LogDriver *s, glong b);
 void otel_dd_add_int_channel_arg(LogDriver *s, const gchar *name, glong value);
 void otel_dd_add_string_channel_arg(LogDriver *s, const gchar *name, const gchar *value);
+void otel_dd_add_header(LogDriver *s, const gchar *name, const gchar *value);
 GrpcClientCredentialsBuilderW *otel_dd_get_credentials_builder(LogDriver *s);
 
 #include "compat/cpp-end.h"

--- a/modules/grpc/otel/otel-dest.hpp
+++ b/modules/grpc/otel/otel-dest.hpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2023 Attila Szakacs
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2023-2024 Attila Szakacs <attila.szakacs@axoflow.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -58,6 +59,8 @@ public:
   void add_extra_channel_arg(std::string name, long value);
   void add_extra_channel_arg(std::string name, std::string value);
 
+  void add_header(std::string name, std::string value);
+
   virtual bool init();
   virtual bool deinit();
   virtual const char *format_stats_key(StatsClusterKeyBuilder *kb);
@@ -77,6 +80,7 @@ protected:
   size_t batch_bytes;
   std::list<std::pair<std::string, long>> int_extra_channel_args;
   std::list<std::pair<std::string, std::string>> string_extra_channel_args;
+  std::list<std::pair<std::string, std::string>> headers;
   GrpcClientCredentialsBuilderW credentials_builder_wrapper;
   DestDriverMetrics metrics;
 };

--- a/modules/grpc/otel/otel-grammar.ym
+++ b/modules/grpc/otel/otel-grammar.ym
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2023 Attila Szakacs
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2023-2024 Attila Szakacs <attila.szakacs@axoflow.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -74,6 +75,7 @@ GrpcClientCredentialsBuilderW *last_grpc_client_credentials_builder;
 %token KW_BATCH_BYTES
 %token KW_CONCURRENT_REQUESTS
 %token KW_CHANNEL_ARGS
+%token KW_HEADERS
 %token KW_SET_HOSTNAME
 
 %type <ptr> source_otel
@@ -166,6 +168,7 @@ destination_otel_option
   | KW_COMPRESSION '(' yesno ')' { otel_dd_set_compression(last_driver, $3); }
   | KW_BATCH_BYTES '(' positive_integer ')' { otel_dd_set_batch_bytes(last_driver, $3); }
   | KW_CHANNEL_ARGS '(' destination_otel_channel_args ')'
+  | KW_HEADERS '(' destination_otel_headers ')'
   | threaded_dest_driver_general_option
   | threaded_dest_driver_batch_option
   | threaded_dest_driver_workers_option
@@ -179,6 +182,15 @@ destination_otel_channel_args
 destination_otel_channel_arg
   : string LL_ARROW LL_NUMBER { otel_dd_add_int_channel_arg(last_driver, $1, $3); free($1); }
   | string LL_ARROW string { otel_dd_add_string_channel_arg(last_driver, $1, $3); free($1); free($3); }
+  ;
+
+destination_otel_headers
+  : destination_otel_header destination_otel_headers
+  |
+  ;
+
+destination_otel_header
+  : string LL_ARROW string { otel_dd_add_header(last_driver, $1, $3); free($1); free($3); }
   ;
 
 destination_syslog_ng_otlp

--- a/modules/grpc/otel/otel-parser.c
+++ b/modules/grpc/otel/otel-parser.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2023 Attila Szakacs
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2023-2024 Attila Szakacs <attila.szakacs@axoflow.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -53,6 +54,7 @@ static CfgLexerKeyword otel_keywords[] =
   { "batch_bytes",               KW_BATCH_BYTES },
   { "concurrent_requests",       KW_CONCURRENT_REQUESTS },
   { "channel_args",              KW_CHANNEL_ARGS },
+  { "headers",                   KW_HEADERS },
   { "set_hostname",              KW_SET_HOSTNAME },
   { NULL }
 };

--- a/news/feature-192.md
+++ b/news/feature-192.md
@@ -1,0 +1,14 @@
+`opentelemetry()`, `loki()`, `bigquery()` destination: Added `headers()` option
+
+With this option you can add gRPC headers to each RPC call.
+
+Example config:
+```
+opentelemetry(
+  ...
+  headers(
+    "organization" => "Axoflow"
+    "stream-name" => "axo-stream"
+  )
+);
+```


### PR DESCRIPTION
Example config:
```
opentelemetry(
  ...
  headers(
    "organization" => "Axoflow"
    "stream-name" => "axo-stream"
  )
);
```