### PR TITLE
Filterx regexp subst

### DIFF
--- a/lib/filterx/expr-regexp.h
+++ b/lib/filterx/expr-regexp.h
@@ -26,8 +26,11 @@
 
 #include "filterx/filterx-expr.h"
 #include "filterx/expr-generator.h"
+#include "filterx/expr-function.h"
 
 FilterXExpr *filterx_expr_regexp_match_new(FilterXExpr *lhs, const gchar *pattern);
 FilterXExpr *filterx_expr_regexp_search_generator_new(FilterXExpr *lhs, const gchar *pattern);
+FilterXFunction *filterx_function_regexp_subst_new(const gchar *function_name, FilterXFunctionArgs *args,
+                                                   GError **error);
 
 #endif

--- a/lib/filterx/expr-regexp.h
+++ b/lib/filterx/expr-regexp.h
@@ -28,9 +28,25 @@
 #include "filterx/expr-generator.h"
 #include "filterx/expr-function.h"
 
+#define FILTERX_FUNC_REGEXP_SUBST_FLAG_JIT_NAME "jit"
+#define FILTERX_FUNC_REGEXP_SUBST_FLAG_GLOBAL_NAME "global"
+#define FILTERX_FUNC_REGEXP_SUBST_FLAG_UTF8_NAME "utf8"
+#define FILTERX_FUNC_REGEXP_SUBST_FLAG_IGNORECASE_NAME "ignorecase"
+#define FILTERX_FUNC_REGEXP_SUBST_FLAG_NEWLINE_NAME "newline"
+
+typedef struct FilterXFuncRegexpSubstOpts_
+{
+  gboolean global;
+  gboolean jit;
+  gboolean utf8;
+  gboolean ignorecase;
+  gboolean newline;
+} FilterXFuncRegexpSubstOpts;
+
 FilterXExpr *filterx_expr_regexp_match_new(FilterXExpr *lhs, const gchar *pattern);
 FilterXExpr *filterx_expr_regexp_search_generator_new(FilterXExpr *lhs, const gchar *pattern);
 FilterXFunction *filterx_function_regexp_subst_new(const gchar *function_name, FilterXFunctionArgs *args,
                                                    GError **error);
+gboolean filterx_regexp_subst_is_jit_enabled(FilterXFunction *s);
 
 #endif

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -35,6 +35,7 @@
 #include "filterx/func-vars.h"
 #include "filterx/func-unset-empties.h"
 #include "filterx/func-str-transform.h"
+#include "filterx/expr-regexp.h"
 #include "filterx/filterx-eval.h"
 
 static GHashTable *filterx_builtin_simple_functions = NULL;
@@ -115,6 +116,7 @@ _ctors_init(void)
   g_assert(filterx_builtin_function_ctor_register("strptime", filterx_function_strptime_new));
   g_assert(filterx_builtin_function_ctor_register("istype", filterx_function_istype_new));
   g_assert(filterx_builtin_function_ctor_register("unset_empties", filterx_function_unset_empties_new));
+  g_assert(filterx_builtin_function_ctor_register("regexp_subst", filterx_function_regexp_subst_new));
 }
 
 static void

--- a/lib/filterx/tests/test_expr_regexp.c
+++ b/lib/filterx/tests/test_expr_regexp.c
@@ -32,6 +32,7 @@
 #include "filterx/object-list-interface.h"
 #include "apphook.h"
 #include "scratch-buffers.h"
+#include "compat/pcre.h"
 
 static gboolean
 _check_match(const gchar *lhs, const gchar *pattern)
@@ -236,35 +237,103 @@ Test(filterx_expr_regexp, regexp_search_init_error)
   _assert_search_init_error("foobarbaz", "(");
 }
 
-static FilterXObject *
-_sub(const gchar *pattern, const gchar *repr, const gchar *str)
+static FilterXFunction *
+_build_subst_func(const gchar *pattern, const gchar *repr, const gchar *str, FilterXFuncRegexpSubstOpts opts)
 {
   GList *args = NULL;
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_non_literal_new(filterx_string_new(str, -1))));
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(pattern, -1))));
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(repr, -1))));
+  if (opts.global)
+    args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_REGEXP_SUBST_FLAG_GLOBAL_NAME,
+                                                        filterx_literal_new(filterx_boolean_new(TRUE))));
+  if (!opts.jit)
+    args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_REGEXP_SUBST_FLAG_JIT_NAME,
+                                                        filterx_literal_new(filterx_boolean_new(FALSE))));
+  if (opts.ignorecase)
+    args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_REGEXP_SUBST_FLAG_IGNORECASE_NAME,
+                                                        filterx_literal_new(filterx_boolean_new(TRUE))));
+  if (opts.newline)
+    args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_REGEXP_SUBST_FLAG_NEWLINE_NAME,
+                                                        filterx_literal_new(filterx_boolean_new(TRUE))));
+  if (opts.utf8)
+    args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_REGEXP_SUBST_FLAG_UTF8_NAME,
+                                                        filterx_literal_new(filterx_boolean_new(TRUE))));
 
   GError *err = NULL;
   FilterXFunction *func = filterx_function_regexp_subst_new("test", filterx_function_args_new(args, NULL), &err);
   cr_assert_null(err);
+  return func;
+}
+
+static FilterXObject *
+_sub(const gchar *pattern, const gchar *repr, const gchar *str, FilterXFuncRegexpSubstOpts opts)
+{
+  FilterXFunction *func = _build_subst_func(pattern, repr, str, opts);
 
   FilterXObject *res = filterx_expr_eval(&func->super);
   filterx_expr_unref(&func->super);
   return res;
 }
 
+// disabling jit compiler since it confuses valgrind in some cases
+// in some test cases we test jit against non-jit, those tests will produce invalid reads in valgrind
+// further info: https://stackoverflow.com/questions/74777619/valgrind-conditional-jump-error-with-pcre2-jit-when-reading-from-file
+
 Test(filterx_expr_regexp, regexp_subst_single_replace)
 {
-  FilterXObject *result = _sub("oo", "X", "foobarbaz");
+  FilterXFuncRegexpSubstOpts opts = {};
+  FilterXObject *result = _sub("oo", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
   const gchar *res = filterx_string_get_value(result, NULL);
   cr_assert_str_eq(res, "fXbarbaz");
   filterx_object_unref(result);
 }
 
+Test(filterx_expr_regexp, regexp_subst_single_replace_with_global)
+{
+  FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
+  FilterXObject *result = _sub("oo", "X", "foobarbaz", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value(result, NULL);
+  cr_assert_str_eq(res, "fXbarbaz");
+  filterx_object_unref(result);
+}
+
+Test(filterx_expr_regexp, regexp_subst_multi_replace)
+{
+  FilterXFuncRegexpSubstOpts opts = {};
+  FilterXObject *result = _sub("a", "X", "foobarbaz", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value(result, NULL);
+  cr_assert_str_eq(res, "foobXrbaz");
+  filterx_object_unref(result);
+}
+
+Test(filterx_expr_regexp, regexp_subst_multi_replace_with_global)
+{
+  FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
+  FilterXObject *result = _sub("a", "X", "foobarbaz", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value(result, NULL);
+  cr_assert_str_eq(res, "foobXrbXz");
+  filterx_object_unref(result);
+}
+
 Test(filterx_expr_regexp, regexp_subst_zero_length_matches)
 {
-  FilterXObject *result = _sub("u*", "X", "foobarbaz");
+  FilterXFuncRegexpSubstOpts opts = {};
+  FilterXObject *result = _sub("u*", "X", "foobarbaz", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value(result, NULL);
+  cr_assert_str_eq(res, "XfoobarbazX");
+  filterx_object_unref(result);
+}
+
+Test(filterx_expr_regexp, regexp_subst_zero_length_matches_with_global)
+{
+  FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
+  FilterXObject *result = _sub("u*", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
   const gchar *res = filterx_string_get_value(result, NULL);
   cr_assert_str_eq(res, "XfXoXoXbXaXrXbXaXzX");
@@ -273,7 +342,18 @@ Test(filterx_expr_regexp, regexp_subst_zero_length_matches)
 
 Test(filterx_expr_regexp, regexp_subst_zero_length_matches_with_char_matches)
 {
-  FilterXObject *result = _sub("a*", "X", "foobarbaz");
+  FilterXFuncRegexpSubstOpts opts = {};
+  FilterXObject *result = _sub("a*", "X", "foobarbaz", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value(result, NULL);
+  cr_assert_str_eq(res, "XfoobarbazX");
+  filterx_object_unref(result);
+}
+
+Test(filterx_expr_regexp, regexp_subst_zero_length_matches_with_char_matches_with_global)
+{
+  FilterXFuncRegexpSubstOpts opts = {.global = TRUE, .jit=FALSE};
+  FilterXObject *result = _sub("a*", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
   const gchar *res = filterx_string_get_value(result, NULL);
   cr_assert_str_eq(res, "XfXoXoXbXXrXbXXzX");
@@ -282,7 +362,18 @@ Test(filterx_expr_regexp, regexp_subst_zero_length_matches_with_char_matches)
 
 Test(filterx_expr_regexp, regexp_subst_at_beginning)
 {
-  FilterXObject *result = _sub("fo", "X", "foobarbaz");
+  FilterXFuncRegexpSubstOpts opts = {};
+  FilterXObject *result = _sub("fo", "X", "foobarbaz", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value(result, NULL);
+  cr_assert_str_eq(res, "Xobarbaz");
+  filterx_object_unref(result);
+}
+
+Test(filterx_expr_regexp, regexp_subst_at_beginning_with_global)
+{
+  FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
+  FilterXObject *result = _sub("fo", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
   const gchar *res = filterx_string_get_value(result, NULL);
   cr_assert_str_eq(res, "Xobarbaz");
@@ -291,16 +382,38 @@ Test(filterx_expr_regexp, regexp_subst_at_beginning)
 
 Test(filterx_expr_regexp, regexp_subst_at_the_end)
 {
-  FilterXObject *result = _sub("az", "X", "foobarbaz");
+  FilterXFuncRegexpSubstOpts opts = {};
+  FilterXObject *result = _sub("az", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
   const gchar *res = filterx_string_get_value(result, NULL);
   cr_assert_str_eq(res, "foobarbX");
   filterx_object_unref(result);
 }
 
-Test(filterx_expr_regexp, regexp_subst_multi_replace)
+Test(filterx_expr_regexp, regexp_subst_at_the_end_with_global)
 {
-  FilterXObject *result = _sub("(a|o)", "X", "foobarbaz");
+  FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
+  FilterXObject *result = _sub("az", "X", "foobarbaz", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value(result, NULL);
+  cr_assert_str_eq(res, "foobarbX");
+  filterx_object_unref(result);
+}
+
+Test(filterx_expr_regexp, regexp_subst_multi_replace_multi_pattern)
+{
+  FilterXFuncRegexpSubstOpts opts = {};
+  FilterXObject *result = _sub("(a|o)", "X", "foobarbaz", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value(result, NULL);
+  cr_assert_str_eq(res, "fXobarbaz");
+  filterx_object_unref(result);
+}
+
+Test(filterx_expr_regexp, regexp_subst_multi_replace_multi_pattern_with_global)
+{
+  FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
+  FilterXObject *result = _sub("(a|o)", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
   const gchar *res = filterx_string_get_value(result, NULL);
   cr_assert_str_eq(res, "fXXbXrbXz");
@@ -309,7 +422,18 @@ Test(filterx_expr_regexp, regexp_subst_multi_replace)
 
 Test(filterx_expr_regexp, regexp_subst_accept_end_literal)
 {
-  FilterXObject *result = _sub("ba.$", "X", "foobarbaz");
+  FilterXFuncRegexpSubstOpts opts = {};
+  FilterXObject *result = _sub("ba.$", "X", "foobarbaz", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value(result, NULL);
+  cr_assert_str_eq(res, "foobarX");
+  filterx_object_unref(result);
+}
+
+Test(filterx_expr_regexp, regexp_subst_accept_end_literal_with_global)
+{
+  FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
+  FilterXObject *result = _sub("ba.$", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
   const gchar *res = filterx_string_get_value(result, NULL);
   cr_assert_str_eq(res, "foobarX");
@@ -318,11 +442,72 @@ Test(filterx_expr_regexp, regexp_subst_accept_end_literal)
 
 Test(filterx_expr_regexp, regexp_subst_accept_groups)
 {
-  FilterXObject *result = _sub("(o)*(ba)", "X", "foobarbaz");
+  FilterXFuncRegexpSubstOpts opts = {};
+  FilterXObject *result = _sub("(o)*(ba)", "X", "foobarbaz", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value(result, NULL);
+  cr_assert_str_eq(res, "fXrbaz");
+  filterx_object_unref(result);
+}
+
+Test(filterx_expr_regexp, regexp_subst_accept_groups_with_global)
+{
+  FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
+  FilterXObject *result = _sub("(o)*(ba)", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
   const gchar *res = filterx_string_get_value(result, NULL);
   cr_assert_str_eq(res, "fXrXz");
   filterx_object_unref(result);
+}
+
+Test(filterx_expr_regexp, regexp_subst_nojit_arg)
+{
+  FilterXFuncRegexpSubstOpts opts = {.jit = TRUE};
+  FilterXFunction *func = _build_subst_func("o", "X", "foobarbaz", opts);
+  cr_assert_not_null(func);
+  cr_assert(filterx_regexp_subst_is_jit_enabled(func));
+  filterx_expr_unref(&func->super);
+
+  FilterXFuncRegexpSubstOpts opts_nojit = {};
+  FilterXFunction *func_nojit = _build_subst_func("o", "X", "foobarbaz", opts_nojit);
+  cr_assert_not_null(func_nojit);
+  cr_assert(!filterx_regexp_subst_is_jit_enabled(func_nojit));
+  filterx_expr_unref(&func_nojit->super);
+}
+
+Test(filterx_expr_regexp, regexp_subst_match_opt_ignorecase)
+{
+  FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
+  FilterXObject *result = _sub("(O|A)", "X", "foobarbaz", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value(result, NULL);
+  cr_assert_str_eq(res, "foobarbaz");
+  filterx_object_unref(result);
+
+  FilterXFuncRegexpSubstOpts opts_alt = {.ignorecase = TRUE, .global = TRUE};
+  FilterXObject *result_alt = _sub("(O|A)", "X", "foobarbaz", opts_alt);
+  cr_assert(filterx_object_is_type(result_alt, &FILTERX_TYPE_NAME(string)));
+  const gchar *res_alt = filterx_string_get_value(result_alt, NULL);
+  cr_assert_str_eq(res_alt, "fXXbXrbXz");
+  filterx_object_unref(result_alt);
+}
+
+Test(filterx_expr_regexp, regexp_subst_match_opt_ignorecase_nojit)
+{
+  // check whether the CASELESS option applied with non-jit pattern
+  FilterXFuncRegexpSubstOpts opts = {.global=TRUE};
+  FilterXObject *result = _sub("(O|A)", "X", "foobarbaz", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value(result, NULL);
+  cr_assert_str_eq(res, "foobarbaz");
+  filterx_object_unref(result);
+
+  FilterXFuncRegexpSubstOpts opts_alt = {.ignorecase = TRUE, .global = TRUE, .jit = TRUE};
+  FilterXObject *result_alt = _sub("(O|A)", "X", "foobarbaz", opts_alt);
+  cr_assert(filterx_object_is_type(result_alt, &FILTERX_TYPE_NAME(string)));
+  const gchar *res_alt = filterx_string_get_value(result_alt, NULL);
+  cr_assert_str_eq(res_alt, "fXXbXrbXz");
+  filterx_object_unref(result_alt);
 }
 
 static void

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -1722,6 +1722,13 @@ def test_regexp_subst(config, syslog_ng):
         $MSG.empty_pattern = regexp_subst("foobarbaz","","!");
         $MSG.zero_length_match = regexp_subst("foobarbaz","u*","!");
         $MSG.orgrp = regexp_subst("foobarbaz", "(fo|az)", "!");
+        $MSG.single_global = regexp_subst("foobarbaz","o","", global=true);
+        $MSG.empty_string_global = regexp_subst("","a","!", global=true);
+        $MSG.empty_pattern_global = regexp_subst("foobarbaz","","!", global=true);
+        $MSG.zero_length_match_global = regexp_subst("foobarbaz","u*","!", global=true);
+        $MSG.orgrp_global = regexp_subst("foobarbaz", "(fo|az)", "!", global=true);
+        $MSG.ignore_case_control = regexp_subst("FoObArBaz", "(o|a)", "!", global=true);
+        $MSG.ignore_case = regexp_subst("FoObArBaz", "(o|a)", "!", ignorecase=true, global=true);
     """,
     )
     syslog_ng.start(config)
@@ -1729,11 +1736,18 @@ def test_regexp_subst(config, syslog_ng):
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
     exp = (
-        r"""{"single":"fbarbaz","""
+        r"""{"single":"fobarbaz","""
         r""""empty_string":"","""
-        r""""empty_pattern":"!f!o!o!b!a!r!b!a!z!","""
-        r""""zero_length_match":"!f!o!o!b!a!r!b!a!z!","""
-        r""""orgrp":"!obarb!"}""" + "\n"
+        r""""empty_pattern":"!foobarbaz!","""
+        r""""zero_length_match":"!foobarbaz!","""
+        r""""orgrp":"!obarbaz","""
+        r""""single_global":"fbarbaz","""
+        r""""empty_string_global":"","""
+        r""""empty_pattern_global":"!f!o!o!b!a!r!b!a!z!","""
+        r""""zero_length_match_global":"!f!o!o!b!a!r!b!a!z!","""
+        r""""orgrp_global":"!obarb!","""
+        r""""ignore_case_control":"F!ObArB!z","""
+        r""""ignore_case":"F!!b!rB!z"}""" + "\n"
     )
     assert file_true.read_log() == exp
 

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -79,19 +79,6 @@ log {{
     config.set_raw_config(preamble)
     return (file_true, file_false)
 
-# TODO: take care of _evaluate_statement methods result, to fix this test
-# def test_filterx_falsey_value_assign(config, syslog_ng):
-#     (file_true, file_false) = create_config(
-#         config, """
-#                     $myvar = 0;
-#                     $MSG = $myvar; """,
-#     )
-#     syslog_ng.start(config)
-
-#     assert file_true.get_stats()["processed"] == 1
-#     assert "processed" not in file_false.get_stats()
-#     assert file_true.read_log() == "0\n"
-
 
 def test_otel_logrecord_int32_setter_getter(config, syslog_ng):
     (file_true, file_false) = create_config(
@@ -219,21 +206,6 @@ def test_otel_logrecord_body_datetime_setter_getter(config, syslog_ng):
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
     assert file_true.read_log() == "1701353998123000\n"
-
-
-# TODO: figure out null type's proper behaviour
-# def test_otel_logrecord_body_null_setter_getter(config, syslog_ng):
-#     (file_true, file_false) = create_config(
-#         config, """
-#                                             $olr = otel_logrecord();
-#                                             $olr.body = ${values.null};
-#                                             $MSG = $olr.body; """,
-#     )
-#     syslog_ng.start(config)
-
-#     assert file_true.get_stats()["processed"] == 1
-#     assert "processed" not in file_false.get_stats()
-#     assert file_true.read_log() == "\n"
 
 
 def test_otel_logrecord_body_bytes_setter_getter(config, syslog_ng):


### PR DESCRIPTION
Complete implementation of regex_subst filterx function based on #195.
usage:
```
regexp_subst(string, pattern, replacement)
```

example:
```
filterx {
  $MSG = regexp_subst($MSG, "u*", "X");
}
```