### PR TITLE
[dbld] Handle already exist USER_ID in docker environment

### DIFF
--- a/dbld/images/entrypoint.sh
+++ b/dbld/images/entrypoint.sh
@@ -25,10 +25,14 @@ function create_user() {
 if [[ "$USER_ID" -eq 0 ]]; then
     "$@"
 else
-    if ! getent passwd $USER_ID > /dev/null
+    if getent passwd $USER_ID > /dev/null
     then
+        echo "USER_ID: $USER_ID already exist in passwd database, performing cleanup"
+        userdel --remove $(getent passwd $USER_ID | cut -d":" -f1)
+	create_user
+    else
         create_user
     fi
-
+    echo "Added new user: $USER_NAME"
     exec sudo --preserve-env -Hu "${USER_NAME}" "$@"
 fi

--- a/dbld/images/entrypoint.sh
+++ b/dbld/images/entrypoint.sh
@@ -8,22 +8,26 @@ USER_ID=`stat -c '%u' $SOURCE_DIR`
 GROUP_NAME=$USER_NAME
 GROUP_ID=`stat -c '%g' $SOURCE_DIR`
 
+function create_user() {
+    groupadd --gid $GROUP_ID $GROUP_NAME &>/dev/null || \
+        groupadd --gid $GROUP_ID dockerguest &>/dev/null || \
+        echo "Failed to add group $GROUP_NAME/$GROUP_ID in docker entrypoint-debian.sh";
+    useradd $USER_NAME --uid=$USER_ID --gid=$GROUP_ID &>/dev/null || \
+        useradd dockerguest --uid=$USER_ID --gid=$GROUP_ID &>/dev/null || \
+        echo "Failed to add user $USER_NAME/$USER_ID in docker entrypoint-debian.sh";
+    usermod -a -G sudo $USER_NAME || usermod -a -G wheel $USER_NAME
+    sed -i -e '/^%sudo\s\+ALL=/s,ALL$,NOPASSWD: ALL,' /etc/sudoers
+    sed -i -e '/^%wheel\s\+ALL=/s,ALL$,NOPASSWD: ALL,' /etc/sudoers
+    mkdir -p /home/$USER_NAME
+    chown $USER_NAME:$GROUP_ID /home/$USER_NAME
+}
+
 if [[ "$USER_ID" -eq 0 ]]; then
     "$@"
 else
     if ! getent passwd $USER_ID > /dev/null
     then
-        groupadd --gid $GROUP_ID $GROUP_NAME &>/dev/null || \
-            groupadd --gid $GROUP_ID dockerguest &>/dev/null || \
-            echo "Failed to add group $GROUP_NAME/$GROUP_ID in docker entrypoint-debian.sh";
-        useradd $USER_NAME --uid=$USER_ID --gid=$GROUP_ID &>/dev/null || \
-            useradd dockerguest --uid=$USER_ID --gid=$GROUP_ID &>/dev/null || \
-            echo "Failed to add user $USER_NAME/$USER_ID in docker entrypoint-debian.sh";
-	usermod -a -G sudo $USER_NAME || usermod -a -G wheel $USER_NAME
-	sed -i -e '/^%sudo\s\+ALL=/s,ALL$,NOPASSWD: ALL,' /etc/sudoers
-	sed -i -e '/^%wheel\s\+ALL=/s,ALL$,NOPASSWD: ALL,' /etc/sudoers
-        mkdir -p /home/$USER_NAME
-        chown $USER_NAME:$GROUP_ID /home/$USER_NAME
+        create_user
     fi
 
     exec sudo --preserve-env -Hu "${USER_NAME}" "$@"


### PR DESCRIPTION
Original issue:
 - While going through the local dbld dev environment creation with:
   - `dbld/rules image`
   - `dbld/rules bootstrap`
 - I've got the following error:
```
...
sudo: unknown user micek
sudo: error initializing audit plugin sudoers_audit
make: *** [dbld/rules:101: bootstrap-ubuntu-noble] Error 1
```

Root cause:
 - After ubuntu:kinetic general "ubuntu" user was added to the base image with USER_ID: 1000
```
micek@DESKTOP-0E9OKG3:~$ docker run -it ubuntu:jammy bash -c "grep 1000 /etc/passwd"
micek@DESKTOP-0E9OKG3:~$ docker run -it ubuntu:kinetic bash -c "grep 1000 /etc/passwd"
micek@DESKTOP-0E9OKG3:~$ docker run -it ubuntu:lunar bash -c "grep 1000 /etc/passwd"
ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
micek@DESKTOP-0E9OKG3:~$ docker run -it ubuntu:mantic bash -c "grep 1000 /etc/passwd"
ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
micek@DESKTOP-0E9OKG3:~$ docker run -it ubuntu:noble bash -c "grep 1000 /etc/passwd"
ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
```
 - The else branch was not handled while checking the USER_ID exitance in `dbld/images/entrypoint.sh`  before the user creation and based on this own user can not be created.
 - This line causes the error: `exec sudo --preserve-env -Hu "${USER_NAME}" "$@"`

Solution:
 - With removing the unused 'ubuntu' user we can add our own user with id 1000
