### PR TITLE
filterx: use a single compound expr to represent list of expressions

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -782,7 +782,7 @@ log_item
         | KW_SOURCE '{' source_content '}'      { $$ = log_expr_node_new_source(NULL, $3, &@$); }
         | KW_FILTER '(' string ')'		{ $$ = log_expr_node_new_filter_reference($3, &@$); free($3); }
         | KW_FILTER '{' filter_content '}'      { $$ = log_expr_node_new_filter(NULL, $3, &@$); }
-        | KW_FILTERX '{' filterx_content '}'    { $$ = log_expr_node_new_filter(NULL, $3, &@$); }
+        | KW_FILTERX filterx_content            { $$ = log_expr_node_new_filter(NULL, $2, &@$); }
         | KW_PARSER '(' string ')'              { $$ = log_expr_node_new_parser_reference($3, &@$); free($3); }
         | KW_PARSER '{' parser_content '}'      { $$ = log_expr_node_new_parser(NULL, $3, &@$); }
         | KW_REWRITE '(' string ')'             { $$ = log_expr_node_new_rewrite_reference($3, &@$); free($3); }

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -709,11 +709,11 @@ filter_content
 
 filterx_content
         : _filterx_context_push <ptr>{
-            GList *filterx_stmts = NULL;
+            FilterXExpr *filterx_block = NULL;
 
-	    CHECK_ERROR_WITHOUT_MESSAGE(cfg_parser_parse(&filterx_parser, lexer, (gpointer *) &filterx_stmts, NULL), @$);
+	    CHECK_ERROR_WITHOUT_MESSAGE(cfg_parser_parse(&filterx_parser, lexer, (gpointer *) &filterx_block, NULL), @$);
 
-            $$ = log_expr_node_new_pipe(log_filterx_pipe_new(filterx_stmts, configuration), &@$);
+            $$ = log_expr_node_new_pipe(log_filterx_pipe_new(filterx_block, configuration), &@$);
 	  } _filterx_context_pop			{ $$ = $2; }
 	;
 

--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -31,7 +31,7 @@ set(FILTERX_HEADERS
     filterx/expr-condition.h
     filterx/expr-isset.h
     filterx/expr-unset.h
-    filterx/expr-shorthand.h
+    filterx/expr-compound.h
     filterx/expr-generator.h
     filterx/expr-literal-generator.h
     filterx/expr-regexp.h
@@ -80,7 +80,7 @@ set(FILTERX_SOURCES
     filterx/expr-condition.c
     filterx/expr-isset.c
     filterx/expr-unset.c
-    filterx/expr-shorthand.c
+    filterx/expr-compound.c
     filterx/expr-generator.c
     filterx/expr-literal-generator.c
     filterx/expr-regexp.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -34,7 +34,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/expr-condition.h \
 	lib/filterx/expr-isset.h \
 	lib/filterx/expr-unset.h		\
-	lib/filterx/expr-shorthand.h		\
+	lib/filterx/expr-compound.h		\
 	lib/filterx/expr-generator.h		\
 	lib/filterx/expr-literal-generator.h		\
 	lib/filterx/expr-regexp.h		\
@@ -82,7 +82,7 @@ filterx_sources = 				\
 	lib/filterx/expr-condition.c		\
 	lib/filterx/expr-isset.c		\
 	lib/filterx/expr-unset.c		\
-	lib/filterx/expr-shorthand.c		\
+	lib/filterx/expr-compound.c		\
 	lib/filterx/expr-generator.c		\
 	lib/filterx/expr-literal-generator.c		\
 	lib/filterx/expr-regexp.c		\

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -36,6 +36,19 @@ typedef struct _FilterXCompoundExpr
   GList *exprs;
 } FilterXCompoundExpr;
 
+static gboolean
+_expr_eval(FilterXExpr *expr, FilterXObject **result)
+{
+  *result = filterx_expr_eval(expr);
+
+  if (!(*result))
+    return FALSE;
+
+  if (!expr->ignore_falsy_result && filterx_object_falsy(*result))
+    return FALSE;
+  return TRUE;
+}
+
 gboolean
 filterx_expr_list_eval(GList *expressions, FilterXObject **result)
 {
@@ -45,10 +58,7 @@ filterx_expr_list_eval(GList *expressions, FilterXObject **result)
       filterx_object_unref(*result);
 
       FilterXExpr *expr = elem->data;
-      *result = filterx_expr_eval(expr);
-
-      if (!(*result) ||
-          (!expr->ignore_falsy_result && filterx_object_falsy(*result)))
+      if (!_expr_eval(expr, result))
         return FALSE;
     }
 

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -24,6 +24,8 @@
 #include "filterx/expr-compound.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/object-primitive.h"
+#include "scratch-buffers.h"
+
 #include <stdarg.h>
 
 typedef struct _FilterXCompoundExpr
@@ -33,6 +35,25 @@ typedef struct _FilterXCompoundExpr
   gboolean return_value_of_last_expr;
   GList *exprs;
 } FilterXCompoundExpr;
+
+gboolean
+filterx_expr_list_eval(GList *expressions, FilterXObject **result)
+{
+  *result = NULL;
+  for (GList *elem = expressions; elem; elem = elem->next)
+    {
+      filterx_object_unref(*result);
+
+      FilterXExpr *expr = elem->data;
+      *result = filterx_expr_eval(expr);
+
+      if (!(*result) ||
+          (!expr->ignore_falsy_result && filterx_object_falsy(*result)))
+        return FALSE;
+    }
+
+  return TRUE;
+}
 
 static FilterXObject *
 _eval(FilterXExpr *s)

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -21,18 +21,18 @@
  *
  */
 
-#include "filterx/expr-shorthand.h"
+#include "filterx/expr-compound.h"
 
-typedef struct _FilterXShorthand
+typedef struct _FilterXCompoundExpr
 {
   FilterXExpr super;
   GList *exprs;
-} FilterXShorthand;
+} FilterXCompoundExpr;
 
 static FilterXObject *
 _eval(FilterXExpr *s)
 {
-  FilterXShorthand *self = (FilterXShorthand *) s;
+  FilterXCompoundExpr *self = (FilterXCompoundExpr *) s;
   FilterXObject *result = NULL;
 
   filterx_expr_list_eval(self->exprs, &result);
@@ -42,7 +42,7 @@ _eval(FilterXExpr *s)
 static void
 _free(FilterXExpr *s)
 {
-  FilterXShorthand *self = (FilterXShorthand *) s;
+  FilterXCompoundExpr *self = (FilterXCompoundExpr *) s;
 
   g_list_free_full(self->exprs, (GDestroyNotify) filterx_expr_unref);
   filterx_expr_free_method(s);
@@ -50,17 +50,17 @@ _free(FilterXExpr *s)
 
 /* Takes reference of expr */
 void
-filterx_shorthand_add(FilterXExpr *s, FilterXExpr *expr)
+filterx_compound_expr_add(FilterXExpr *s, FilterXExpr *expr)
 {
-  FilterXShorthand *self = (FilterXShorthand *) s;
+  FilterXCompoundExpr *self = (FilterXCompoundExpr *) s;
 
   self->exprs = g_list_append(self->exprs, expr);
 }
 
 FilterXExpr *
-filterx_shorthand_new(void)
+filterx_compound_expr_new(void)
 {
-  FilterXShorthand *self = g_new0(FilterXShorthand, 1);
+  FilterXCompoundExpr *self = g_new0(FilterXCompoundExpr, 1);
 
   filterx_expr_init_instance(&self->super);
   self->super.eval = _eval;
@@ -68,4 +68,3 @@ filterx_shorthand_new(void)
 
   return &self->super;
 }
-

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -47,7 +47,7 @@ _eval_expr(FilterXExpr *expr, FilterXObject **result)
 
   gboolean success = expr->ignore_falsy_result || filterx_object_truthy(res);
 
-  if (!success || trace_flag)
+  if ((!success || trace_flag) && !expr->suppress_from_trace)
     {
       ScratchBuffersMarker mark;
       GString *buf = scratch_buffers_alloc_and_mark(&mark);

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -28,6 +28,8 @@
 typedef struct _FilterXCompoundExpr
 {
   FilterXExpr super;
+  /* whether this is a statement expression */
+  gboolean return_value_of_last_expr;
   GList *exprs;
 } FilterXCompoundExpr;
 
@@ -48,9 +50,12 @@ _eval(FilterXExpr *s)
     }
   else
     {
-      if (!result)
+      if (!result || !self->return_value_of_last_expr)
         {
-          /* result NULL means an empty block, implicitly TRUE */
+          filterx_object_unref(result);
+
+          /* an empty list of statements, or a compound statement where the
+           * result is ignored.  implicitly TRUE */
           result = filterx_boolean_new(TRUE);
         }
     }
@@ -85,13 +90,14 @@ filterx_compound_expr_add_list(FilterXExpr *s, GList *expr_list)
 }
 
 FilterXExpr *
-filterx_compound_expr_new(void)
+filterx_compound_expr_new(gboolean return_value_of_last_expr)
 {
   FilterXCompoundExpr *self = g_new0(FilterXCompoundExpr, 1);
 
   filterx_expr_init_instance(&self->super);
   self->super.eval = _eval;
   self->super.free_fn = _free;
+  self->return_value_of_last_expr = return_value_of_last_expr;
 
   return &self->super;
 }

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -24,6 +24,7 @@
 #include "filterx/expr-compound.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/object-primitive.h"
+#include <stdarg.h>
 
 typedef struct _FilterXCompoundExpr
 {
@@ -100,4 +101,21 @@ filterx_compound_expr_new(gboolean return_value_of_last_expr)
   self->return_value_of_last_expr = return_value_of_last_expr;
 
   return &self->super;
+}
+
+FilterXExpr *
+filterx_compound_expr_new_va(gboolean return_value_of_last_expr, FilterXExpr *first, ...)
+{
+  FilterXExpr *s = filterx_compound_expr_new(return_value_of_last_expr);
+  va_list va;
+
+  va_start(va, first);
+  FilterXExpr *arg = first;
+  while (arg)
+    {
+      filterx_compound_expr_add(s, arg);
+      arg = va_arg(va, FilterXExpr *);
+    }
+  va_end(va);
+  return s;
 }

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -57,6 +57,14 @@ filterx_compound_expr_add(FilterXExpr *s, FilterXExpr *expr)
   self->exprs = g_list_append(self->exprs, expr);
 }
 
+void
+filterx_compound_expr_add_list(FilterXExpr *s, GList *expr_list)
+{
+  FilterXCompoundExpr *self = (FilterXCompoundExpr *) s;
+
+  self->exprs = g_list_concat(self->exprs, expr_list);
+}
+
 FilterXExpr *
 filterx_compound_expr_new(void)
 {

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -22,6 +22,8 @@
  */
 
 #include "filterx/expr-compound.h"
+#include "filterx/filterx-eval.h"
+#include "filterx/object-primitive.h"
 
 typedef struct _FilterXCompoundExpr
 {
@@ -35,7 +37,24 @@ _eval(FilterXExpr *s)
   FilterXCompoundExpr *self = (FilterXCompoundExpr *) s;
   FilterXObject *result = NULL;
 
-  filterx_expr_list_eval(self->exprs, &result);
+  if (!filterx_expr_list_eval(self->exprs, &result))
+    {
+      if (result)
+        {
+          filterx_eval_push_error("bailing out due to a falsy expr", s, result);
+          filterx_object_unref(result);
+          result = NULL;
+        }
+    }
+  else
+    {
+      if (!result)
+        {
+          /* result NULL means an empty block, implicitly TRUE */
+          result = filterx_boolean_new(TRUE);
+        }
+    }
+
   return result;
 }
 

--- a/lib/filterx/expr-compound.h
+++ b/lib/filterx/expr-compound.h
@@ -25,7 +25,8 @@
 
 #include "filterx/filterx-expr.h"
 
-FilterXExpr *filterx_compound_expr_new(void);
 void filterx_compound_expr_add(FilterXExpr *s, FilterXExpr *expr);
+void filterx_compound_expr_add_list(FilterXExpr *s, GList *expr_list);
+FilterXExpr *filterx_compound_expr_new(void);
 
 #endif

--- a/lib/filterx/expr-compound.h
+++ b/lib/filterx/expr-compound.h
@@ -20,12 +20,12 @@
  * COPYING for details.
  *
  */
-#ifndef FILTERX_SHORTHAND_H_INCLUDED
-#define FILTERX_SHORTHAND_H_INCLUDED
+#ifndef FILTERX_COMPOUND_H_INCLUDED
+#define FILTERX_COMPOUND_H_INCLUDED
 
 #include "filterx/filterx-expr.h"
 
-FilterXExpr *filterx_shorthand_new(void);
-void filterx_shorthand_add(FilterXExpr *s, FilterXExpr *expr);
+FilterXExpr *filterx_compound_expr_new(void);
+void filterx_compound_expr_add(FilterXExpr *s, FilterXExpr *expr);
 
 #endif

--- a/lib/filterx/expr-compound.h
+++ b/lib/filterx/expr-compound.h
@@ -27,6 +27,6 @@
 
 void filterx_compound_expr_add(FilterXExpr *s, FilterXExpr *expr);
 void filterx_compound_expr_add_list(FilterXExpr *s, GList *expr_list);
-FilterXExpr *filterx_compound_expr_new(void);
+FilterXExpr *filterx_compound_expr_new(gboolean return_value_of_last_expr);
 
 #endif

--- a/lib/filterx/expr-compound.h
+++ b/lib/filterx/expr-compound.h
@@ -28,5 +28,6 @@
 void filterx_compound_expr_add(FilterXExpr *s, FilterXExpr *expr);
 void filterx_compound_expr_add_list(FilterXExpr *s, GList *expr_list);
 FilterXExpr *filterx_compound_expr_new(gboolean return_value_of_last_expr);
+FilterXExpr *filterx_compound_expr_new_va(gboolean return_value_of_last_expr, FilterXExpr *first, ...);
 
 #endif

--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -24,62 +24,24 @@
 #include "filterx/expr-condition.h"
 #include "filterx/object-primitive.h"
 
-static FilterXConditional *
-_tail_condition(FilterXConditional *c)
+typedef struct _FilterXConditional FilterXConditional;
+
+struct _FilterXConditional
 {
-  g_assert(c != NULL);
-  if (c->false_branch != NULL)
-    return _tail_condition(c->false_branch);
-  else
-    return c;
-}
-
-static FilterXObject *
-_eval_condition(FilterXConditional *c)
-{
-  FilterXObject *result = NULL;
-  FilterXObject *condition_value = NULL;
-  if (c->condition != FILTERX_CONDITIONAL_NO_CONDITION)
-    {
-      condition_value = filterx_expr_eval(c->condition);
-      if (!condition_value)
-        return NULL;
-      if (filterx_object_falsy(condition_value))
-        {
-          // no condition-expression match, no elif or else case
-          // returning true to avoid filterx failure on non matching if's
-          if (c->false_branch == NULL)
-            result = filterx_boolean_new(TRUE);
-          else
-            result = _eval_condition(c->false_branch);
-          goto exit;
-        }
-    }
-
-  if (!c->statements)
-    {
-      if (c->condition)
-        return condition_value;
-      // returning true to avoid filterx failure on empty else block
-      result = filterx_boolean_new(TRUE);
-      goto exit;
-    }
-
-  filterx_expr_list_eval(c->statements, &result);
-exit:
-  filterx_object_unref(condition_value);
-  return result;
-}
+  FilterXExpr super;
+  FilterXExpr *condition;
+  FilterXExpr *true_branch;
+  FilterXExpr *false_branch;
+};
 
 static void
-_free (FilterXExpr *s)
+_free(FilterXExpr *s)
 {
   FilterXConditional *self = (FilterXConditional *) s;
 
   filterx_expr_unref(self->condition);
-  g_list_free_full(self->statements, (GDestroyNotify) filterx_expr_unref);
-  if (self->false_branch != NULL)
-    filterx_expr_unref(&self->false_branch->super);
+  filterx_expr_unref(self->true_branch);
+  filterx_expr_unref(self->false_branch);
   filterx_expr_free_method(s);
 }
 
@@ -87,37 +49,76 @@ static FilterXObject *
 _eval(FilterXExpr *s)
 {
   FilterXConditional *self = (FilterXConditional *) s;
-  return _eval_condition(self);
+  FilterXObject *condition_value = filterx_expr_eval(self->condition);
+  FilterXObject *result = NULL;
+
+  if (!condition_value)
+    return NULL;
+
+  if (filterx_object_truthy(condition_value))
+    {
+      if (self->true_branch)
+        result = filterx_expr_eval(self->true_branch);
+      else
+        result = filterx_object_ref(condition_value);
+    }
+  else
+    {
+      if (self->false_branch)
+        result = filterx_expr_eval(self->false_branch);
+      else
+        result = filterx_boolean_new(TRUE);
+    }
+
+  filterx_object_unref(condition_value);
+  return result;
+}
+
+void
+filterx_conditional_set_true_branch(FilterXExpr *s, FilterXExpr *true_branch)
+{
+  FilterXConditional *self = (FilterXConditional *) s;
+
+  filterx_expr_unref(self->true_branch);
+  self->true_branch = true_branch;
+}
+
+void
+filterx_conditional_set_false_branch(FilterXExpr *s, FilterXExpr *false_branch)
+{
+  FilterXConditional *self = (FilterXConditional *) s;
+
+  filterx_expr_unref(self->false_branch);
+  self->false_branch = false_branch;
 }
 
 FilterXExpr *
-filterx_conditional_new_conditional_codeblock(FilterXExpr *condition, GList *stmts)
+filterx_conditional_new(FilterXExpr *condition)
 {
   FilterXConditional *self = g_new0(FilterXConditional, 1);
   filterx_expr_init_instance(&self->super);
   self->super.eval = _eval;
   self->super.free_fn = _free;
   self->condition = condition;
-  self->statements = stmts;
   return &self->super;
 }
 
 FilterXExpr *
-filterx_conditional_new_codeblock(GList *stmts)
+filterx_conditional_find_tail(FilterXExpr *s)
 {
-  return filterx_conditional_new_conditional_codeblock(FILTERX_CONDITIONAL_NO_CONDITION, stmts);
-}
+  /* check if this is a FilterXConditional instance */
+  if (s->eval != _eval)
+    return NULL;
 
-
-FilterXExpr *
-filterx_conditional_add_false_branch(FilterXConditional *s, FilterXConditional *false_branch)
-{
-  g_assert(s != NULL);
-  FilterXConditional *last_condition = _tail_condition(s);
-
-  // avoid to create nested elses (if () {} else {} else {} else {})
-  g_assert(last_condition->condition);
-
-  last_condition->false_branch = false_branch;
-  return &s->super;
+  FilterXConditional *self = (FilterXConditional *) s;
+  if (self->false_branch)
+    {
+      FilterXConditional *tail = (FilterXConditional *) filterx_conditional_find_tail(self->false_branch);
+      if (tail)
+        {
+          g_assert(tail->false_branch == NULL);
+          return &tail->super;
+        }
+    }
+  return s;
 }

--- a/lib/filterx/expr-condition.h
+++ b/lib/filterx/expr-condition.h
@@ -26,20 +26,9 @@
 
 #include "filterx/filterx-expr.h"
 
-typedef struct _FilterXConditional FilterXConditional;
-
-struct _FilterXConditional
-{
-  FilterXExpr super;
-  FilterXExpr *condition;
-  GList *statements;
-  FilterXConditional *false_branch;
-};
-
-#define FILTERX_CONDITIONAL_NO_CONDITION NULL
-
-FilterXExpr *filterx_conditional_new_conditional_codeblock(FilterXExpr *condition, GList *stmts);
-FilterXExpr *filterx_conditional_new_codeblock(GList *stmts);
-FilterXExpr *filterx_conditional_add_false_branch(FilterXConditional *s, FilterXConditional *fail_branch);
+void filterx_conditional_set_true_branch(FilterXExpr *s, FilterXExpr *true_branch);
+void filterx_conditional_set_false_branch(FilterXExpr *s, FilterXExpr *false_branch);
+FilterXExpr *filterx_conditional_find_tail(FilterXExpr *s);
+FilterXExpr *filterx_conditional_new(FilterXExpr *condition);
 
 #endif

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -198,6 +198,9 @@ filterx_eval_expr(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *ms
   FilterXObject *res = filterx_expr_eval(expr);
   if (!res)
     {
+      msg_debug("FILTERX ERROR",
+                filterx_format_last_error_location(),
+                filterx_format_last_error());
       filterx_eval_clear_errors();
       goto fail;
     }

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -189,7 +189,7 @@ filterx_eval_store_weak_ref(FilterXObject *object)
 }
 
 gboolean
-filterx_eval_expr(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *msg)
+filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *msg)
 {
   context->msgs = &msg;
   context->num_msg = 1;

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -149,6 +149,14 @@ filterx_format_last_error(void)
                         extra_info ? : "");
 }
 
+EVTTAG *
+filterx_format_last_error_location(void)
+{
+  FilterXEvalContext *context = filterx_eval_get_context();
+
+  return filterx_expr_format_location_tag(context->error.expr);
+}
+
 
 /*
  * This is not a real weakref implementation as we will never get rid off

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -188,7 +188,6 @@ filterx_eval_store_weak_ref(FilterXObject *object)
     }
 }
 
-
 static gboolean
 _evaluate_statement(FilterXExpr *expr)
 {

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -188,66 +188,22 @@ filterx_eval_store_weak_ref(FilterXObject *object)
     }
 }
 
-static gboolean
-_evaluate_statement(FilterXExpr *expr)
-{
-  FilterXObject *res = filterx_expr_eval(expr);
-  gboolean success = FALSE;
-
-  if (!res)
-    {
-      msg_debug("FILTERX ERROR",
-                filterx_expr_format_location_tag(expr),
-                filterx_format_last_error());
-      return FALSE;
-    }
-  filterx_eval_clear_errors();
-
-  success = expr->ignore_falsy_result || filterx_object_truthy(res);
-  if (!success || trace_flag)
-    {
-      GString *buf = scratch_buffers_alloc();
-
-      if (!filterx_object_repr(res, buf))
-        {
-          LogMessageValueType t;
-          if (!filterx_object_marshal(res, buf, &t))
-            g_assert_not_reached();
-        }
-
-      if (!success)
-        msg_debug("FILTERX FALSY",
-                  filterx_expr_format_location_tag(expr),
-                  evt_tag_mem("value", buf->str, buf->len),
-                  evt_tag_str("type", res->type->name));
-      else
-        msg_trace("FILTERX ESTEP",
-                  filterx_expr_format_location_tag(expr),
-                  evt_tag_mem("value", buf->str, buf->len),
-                  evt_tag_int("truthy", filterx_object_truthy(res)),
-                  evt_tag_str("type", res->type->name));
-    }
-
-  filterx_object_unref(res);
-  return success;
-}
-
 gboolean
-filterx_eval_exec_statements(FilterXEvalContext *context, GList *statements, LogMessage *msg)
+filterx_eval_expr(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *msg)
 {
   context->msgs = &msg;
   context->num_msg = 1;
   gboolean success = FALSE;
-  for (GList *l = statements; l; l = l->next)
+
+  FilterXObject *res = filterx_expr_eval(expr);
+  if (!res)
     {
-      FilterXExpr *expr = l->data;
-      if (!_evaluate_statement(expr))
-        {
-          goto fail;
-        }
+      filterx_eval_clear_errors();
+      goto fail;
     }
+  success = filterx_object_truthy(res);
+  filterx_object_unref(res);
   /* NOTE: we only store the results into the message if the entire evaluation was successful */
-  success = TRUE;
 fail:
   filterx_scope_set_dirty(context->scope);
   return success;

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -53,7 +53,7 @@ FilterXScope *filterx_eval_get_scope(void);
 void filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObject *object);
 void filterx_eval_push_error_info(const gchar *message, FilterXExpr *expr, gchar *info, gboolean free_info);
 void filterx_eval_set_context(FilterXEvalContext *context);
-gboolean filterx_eval_expr(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *msg);
+gboolean filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *msg);
 void filterx_eval_sync_scope_and_message(FilterXScope *scope, LogMessage *msg);
 const gchar *filterx_eval_get_last_error(void);
 EVTTAG *filterx_format_last_error(void);

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -53,7 +53,7 @@ FilterXScope *filterx_eval_get_scope(void);
 void filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObject *object);
 void filterx_eval_push_error_info(const gchar *message, FilterXExpr *expr, gchar *info, gboolean free_info);
 void filterx_eval_set_context(FilterXEvalContext *context);
-gboolean filterx_eval_exec_statements(FilterXEvalContext *context, GList *statements, LogMessage *msg);
+gboolean filterx_eval_expr(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *msg);
 void filterx_eval_sync_scope_and_message(FilterXScope *scope, LogMessage *msg);
 const gchar *filterx_eval_get_last_error(void);
 EVTTAG *filterx_format_last_error(void);

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -57,6 +57,7 @@ gboolean filterx_eval_exec_statements(FilterXEvalContext *context, GList *statem
 void filterx_eval_sync_scope_and_message(FilterXScope *scope, LogMessage *msg);
 const gchar *filterx_eval_get_last_error(void);
 EVTTAG *filterx_format_last_error(void);
+EVTTAG *filterx_format_last_error_location(void);
 void filterx_eval_clear_errors(void);
 
 void filterx_eval_store_weak_ref(FilterXObject *object);

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -137,22 +137,3 @@ filterx_binary_op_init_instance(FilterXBinaryOp *self, FilterXExpr *lhs, FilterX
   self->lhs = lhs;
   self->rhs = rhs;
 }
-
-gboolean
-filterx_expr_list_eval(GList *expressions, FilterXObject **result)
-{
-  *result = NULL;
-  for (GList *elem = expressions; elem; elem = elem->next)
-    {
-      filterx_object_unref(*result);
-
-      FilterXExpr *expr = elem->data;
-      *result = filterx_expr_eval(expr);
-
-      if (!(*result) ||
-          (!expr->ignore_falsy_result && filterx_object_falsy(*result)))
-        return FALSE;
-    }
-
-  return TRUE;
-}

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -49,7 +49,7 @@ EVTTAG *
 filterx_expr_format_location_tag(FilterXExpr *self)
 {
   if (self)
-    return evt_tag_printf("expr", "%s:%d:%d| %s",
+    return evt_tag_printf("expr", "%s:%d:%d|\t%s",
                           self->lloc.name, self->lloc.first_line, self->lloc.first_column,
                           self->expr_text ? : "n/a");
   else

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -26,6 +26,14 @@
 #include "messages.h"
 
 void
+filterx_expr_set_location_with_text(FilterXExpr *self, CfgLexer *lexer, CFG_LTYPE *lloc, const gchar *text)
+{
+  self->lloc = *lloc;
+  if (debug_flag)
+    self->expr_text = g_strdup(text);
+}
+
+void
 filterx_expr_set_location(FilterXExpr *self, CfgLexer *lexer, CFG_LTYPE *lloc)
 {
   self->lloc = *lloc;

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -157,6 +157,4 @@ typedef struct _FilterXBinaryOp
 void filterx_binary_op_free_method(FilterXExpr *s);
 void filterx_binary_op_init_instance(FilterXBinaryOp *self, FilterXExpr *lhs, FilterXExpr *rhs);
 
-gboolean filterx_expr_list_eval(GList *expressions, FilterXObject **result);
-
 #endif

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -31,7 +31,7 @@ struct _FilterXExpr
 {
   guint32 ref_cnt;
   const gchar *type;
-  guint32 ignore_falsy_result:1;
+  guint32 ignore_falsy_result:1, suppress_from_trace:1;
 
   /* evaluate expression */
   FilterXObject *(*eval)(FilterXExpr *self);

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -131,6 +131,7 @@ filterx_expr_unset(FilterXExpr *self)
 }
 
 void filterx_expr_set_location(FilterXExpr *self, CfgLexer *lexer, CFG_LTYPE *lloc);
+void filterx_expr_set_location_with_text(FilterXExpr *self, CfgLexer *lexer, CFG_LTYPE *lloc, const gchar *text);
 EVTTAG *filterx_expr_format_location_tag(FilterXExpr *self);
 void filterx_expr_init_instance(FilterXExpr *self);
 FilterXExpr *filterx_expr_new(void);

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -50,7 +50,7 @@
 #include "filterx/expr-isset.h"
 #include "filterx/expr-unset.h"
 #include "filterx/expr-literal-generator.h"
-#include "filterx/expr-shorthand.h"
+#include "filterx/expr-compound.h"
 #include "filterx/expr-regexp.h"
 #include "filterx/expr-plus.h"
 #include "filterx/expr-null-coalesce.h"
@@ -186,23 +186,23 @@ generator_assignment
 						  FilterXExpr *setattr = filterx_setattr_new($1, $3, filterx_generator_create_container_new($5, $1));
 						  filterx_generator_set_fillable($5, filterx_getattr_new(filterx_expr_ref($1), $3));
 
-						  FilterXExpr *shorthand = filterx_shorthand_new();
-						  filterx_shorthand_add(shorthand, setattr);
-						  filterx_shorthand_add(shorthand, $5);
+						  FilterXExpr *block = filterx_compound_expr_new();
+						  filterx_compound_expr_add(block, setattr);
+						  filterx_compound_expr_add(block, $5);
 
 						  free($3);
-						  $$ = shorthand;
+						  $$ = block;
 						}
 	| expr '[' expr ']' KW_ASSIGN expr_generator
 						{
 						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, $3, filterx_generator_create_container_new($6, $1));
 						  filterx_generator_set_fillable($6, filterx_get_subscript_new(filterx_expr_ref($1), filterx_expr_ref($3)));
 
-						  FilterXExpr *shorthand = filterx_shorthand_new();
-						  filterx_shorthand_add(shorthand, set_subscript);
-						  filterx_shorthand_add(shorthand, $6);
+						  FilterXExpr *block = filterx_compound_expr_new();
+						  filterx_compound_expr_add(block, set_subscript);
+						  filterx_compound_expr_add(block, $6);
 
-						  $$ = shorthand;
+						  $$ = block;
 						}
 	| expr '[' ']' KW_ASSIGN expr_generator
 						{
@@ -210,11 +210,11 @@ generator_assignment
 						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, NULL, filterx_generator_create_container_new($5, $1));
 						  filterx_generator_set_fillable($5, filterx_get_subscript_new(filterx_expr_ref($1), minus_one));
 
-						  FilterXExpr *shorthand = filterx_shorthand_new();
-						  filterx_shorthand_add(shorthand, set_subscript);
-						  filterx_shorthand_add(shorthand, $5);
+						  FilterXExpr *block = filterx_compound_expr_new();
+						  filterx_compound_expr_add(block, set_subscript);
+						  filterx_compound_expr_add(block, $5);
 
-						  $$ = shorthand;
+						  $$ = block;
 						}
 	| expr KW_PLUS_ASSIGN expr_generator	{ $$ = $3; filterx_generator_set_fillable($3, $1); }
 	| generator_casted_assignment
@@ -230,12 +230,12 @@ generator_casted_assignment
 						  FilterXExpr *assign = filterx_assign_new($1, func);
 						  filterx_generator_set_fillable($5, filterx_expr_ref($1));
 
-						  FilterXExpr *shorthand = filterx_shorthand_new();
-						  filterx_shorthand_add(shorthand, assign);
-						  filterx_shorthand_add(shorthand, $5);
+						  FilterXExpr *block = filterx_compound_expr_new();
+						  filterx_compound_expr_add(block, assign);
+						  filterx_compound_expr_add(block, $5);
 						  free($3);
 
-						  $$ = shorthand;
+						  $$ = block;
 						}
 	| expr '.' LL_IDENTIFIER KW_ASSIGN LL_IDENTIFIER '(' expr_generator ')'
 						{
@@ -246,12 +246,12 @@ generator_casted_assignment
 						  FilterXExpr *setattr = filterx_setattr_new($1, $3, func);
 						  filterx_generator_set_fillable($7, filterx_getattr_new(filterx_expr_ref($1), $3));
 
-						  FilterXExpr *shorthand = filterx_shorthand_new();
-						  filterx_shorthand_add(shorthand, setattr);
-						  filterx_shorthand_add(shorthand, $7);
+						  FilterXExpr *block = filterx_compound_expr_new();
+						  filterx_compound_expr_add(block, setattr);
+						  filterx_compound_expr_add(block, $7);
 						  free($3);
 
-						  $$ = shorthand;
+						  $$ = block;
 						}
 	| expr '[' expr ']' KW_ASSIGN LL_IDENTIFIER '(' expr_generator ')'
 						{
@@ -262,12 +262,12 @@ generator_casted_assignment
 						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, $3, func);
 						  filterx_generator_set_fillable($8, filterx_get_subscript_new(filterx_expr_ref($1), filterx_expr_ref($3)));
 
-						  FilterXExpr *shorthand = filterx_shorthand_new();
-						  filterx_shorthand_add(shorthand, set_subscript);
-						  filterx_shorthand_add(shorthand, $8);
+						  FilterXExpr *block = filterx_compound_expr_new();
+						  filterx_compound_expr_add(block, set_subscript);
+						  filterx_compound_expr_add(block, $8);
 						  free($6);
 
-						  $$ = shorthand;
+						  $$ = block;
 						}
 	| expr '[' ']' KW_ASSIGN LL_IDENTIFIER '(' expr_generator ')'
 						{
@@ -279,12 +279,12 @@ generator_casted_assignment
 						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, NULL, func);
 						  filterx_generator_set_fillable($7, filterx_get_subscript_new(filterx_expr_ref($1), minus_one));
 
-						  FilterXExpr *shorthand = filterx_shorthand_new();
-						  filterx_shorthand_add(shorthand, set_subscript);
-						  filterx_shorthand_add(shorthand, $7);
+						  FilterXExpr *block = filterx_compound_expr_new();
+						  filterx_compound_expr_add(block, set_subscript);
+						  filterx_compound_expr_add(block, $7);
 						  free($5);
 
-						  $$ = shorthand;
+						  $$ = block;
 						}
 	;
 

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -94,7 +94,7 @@ construct_template_expr(LogTemplate *template)
 %define api.prefix {filterx_}
 %lex-param {CfgLexer *lexer}
 %parse-param {CfgLexer *lexer}
-%parse-param {GList **result}
+%parse-param {FilterXExpr **result}
 %parse-param {gpointer arg}
 
 /* INCLUDE_DECLS */
@@ -107,6 +107,7 @@ construct_template_expr(LogTemplate *template)
 %token KW_DECLARE
 %token KW_REGEXP_SEARCH
 
+%type <ptr> block
 %type <ptr> stmts
 %type <node> stmt
 %type <node> stmt_expr
@@ -147,7 +148,16 @@ construct_template_expr(LogTemplate *template)
 %%
 
 start
-        : stmts					{ *result = $1; if (yychar != FILTERX_EMPTY) { cfg_lexer_unput_token(lexer, &yylval); } YYACCEPT; }
+        : block					{ *result = $1; if (yychar != FILTERX_EMPTY) { cfg_lexer_unput_token(lexer, &yylval); } YYACCEPT; }
+	;
+
+block
+	: stmts					{
+                                                  FilterXExpr *block = filterx_compound_expr_new(FALSE);
+                                                  filterx_compound_expr_add_list(block, $1);
+						  filterx_expr_set_location_with_text(block, lexer, &@1, "{ ... }");
+                                                  $$ = block;
+                                                }
 	;
 
 stmts

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -186,7 +186,7 @@ generator_assignment
 						  FilterXExpr *setattr = filterx_setattr_new($1, $3, filterx_generator_create_container_new($5, $1));
 						  filterx_generator_set_fillable($5, filterx_getattr_new(filterx_expr_ref($1), $3));
 
-						  FilterXExpr *block = filterx_compound_expr_new();
+						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
 						  filterx_compound_expr_add(block, setattr);
 						  filterx_compound_expr_add(block, $5);
 
@@ -198,7 +198,7 @@ generator_assignment
 						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, $3, filterx_generator_create_container_new($6, $1));
 						  filterx_generator_set_fillable($6, filterx_get_subscript_new(filterx_expr_ref($1), filterx_expr_ref($3)));
 
-						  FilterXExpr *block = filterx_compound_expr_new();
+						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
 						  filterx_compound_expr_add(block, set_subscript);
 						  filterx_compound_expr_add(block, $6);
 
@@ -210,7 +210,7 @@ generator_assignment
 						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, NULL, filterx_generator_create_container_new($5, $1));
 						  filterx_generator_set_fillable($5, filterx_get_subscript_new(filterx_expr_ref($1), minus_one));
 
-						  FilterXExpr *block = filterx_compound_expr_new();
+						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
 						  filterx_compound_expr_add(block, set_subscript);
 						  filterx_compound_expr_add(block, $5);
 
@@ -230,7 +230,7 @@ generator_casted_assignment
 						  FilterXExpr *assign = filterx_assign_new($1, func);
 						  filterx_generator_set_fillable($5, filterx_expr_ref($1));
 
-						  FilterXExpr *block = filterx_compound_expr_new();
+						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
 						  filterx_compound_expr_add(block, assign);
 						  filterx_compound_expr_add(block, $5);
 						  free($3);
@@ -246,7 +246,7 @@ generator_casted_assignment
 						  FilterXExpr *setattr = filterx_setattr_new($1, $3, func);
 						  filterx_generator_set_fillable($7, filterx_getattr_new(filterx_expr_ref($1), $3));
 
-						  FilterXExpr *block = filterx_compound_expr_new();
+						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
 						  filterx_compound_expr_add(block, setattr);
 						  filterx_compound_expr_add(block, $7);
 						  free($3);
@@ -262,7 +262,7 @@ generator_casted_assignment
 						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, $3, func);
 						  filterx_generator_set_fillable($8, filterx_get_subscript_new(filterx_expr_ref($1), filterx_expr_ref($3)));
 
-						  FilterXExpr *block = filterx_compound_expr_new();
+						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
 						  filterx_compound_expr_add(block, set_subscript);
 						  filterx_compound_expr_add(block, $8);
 						  free($6);
@@ -279,7 +279,7 @@ generator_casted_assignment
 						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, NULL, func);
 						  filterx_generator_set_fillable($7, filterx_get_subscript_new(filterx_expr_ref($1), minus_one));
 
-						  FilterXExpr *block = filterx_compound_expr_new();
+						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
 						  filterx_compound_expr_add(block, set_subscript);
 						  filterx_compound_expr_add(block, $7);
 						  free($5);

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -482,6 +482,7 @@ conditional
 if
 	: KW_IF '(' expr ')' codeblock
 	  {
+            filterx_expr_set_location($3, lexer, &@3);
 	    $$ = filterx_conditional_new($3);
             filterx_conditional_set_true_branch($$, $5);
 	  }
@@ -489,6 +490,7 @@ if
 	  {
             FilterXExpr *tailing_if = filterx_conditional_find_tail($1);
 
+            filterx_expr_set_location($4, lexer, &@4);
 	    /* create new conditional */
 	    FilterXExpr *elif_expr = filterx_conditional_new($4);
             filterx_conditional_set_true_branch(elif_expr, $6);
@@ -508,12 +510,14 @@ codeblock
 ternary
 	: expr '?' expr ':' expr
 	  {
+            filterx_expr_set_location($1, lexer, &@1);
 	    $$ = filterx_conditional_new($1);
             filterx_conditional_set_true_branch($$, $3);
             filterx_conditional_set_false_branch($$, $5);
 	  }
 	| expr '?' ':' expr
 	  {
+            filterx_expr_set_location($1, lexer, &@1);
 	    $$ = filterx_conditional_new($1);
 	    filterx_conditional_set_false_branch($$, $4);
 	  }

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -141,7 +141,6 @@ construct_template_expr(LogTemplate *template)
 %type <ptr> conditional
 %type <ptr> condition
 %type <ptr> if
-%type <ptr> codeblock
 %type <ptr> ternary
 %type <ptr> default
 
@@ -152,10 +151,10 @@ start
 	;
 
 block
-	: stmts					{
+	: '{' stmts '}'				{
                                                   FilterXExpr *block = filterx_compound_expr_new(FALSE);
-                                                  filterx_compound_expr_add_list(block, $1);
-						  filterx_expr_set_location_with_text(block, lexer, &@1, "{ ... }");
+                                                  filterx_compound_expr_add_list(block, $2);
+						  filterx_expr_set_location_with_text(block, lexer, &@$, "{ ... }");
                                                   $$ = block;
                                                 }
 	;
@@ -471,7 +470,7 @@ regexp_match
 
 conditional
 	: if					{ $$ = $1; }
-	| if KW_ELSE codeblock
+	| if KW_ELSE block
 	  {
             FilterXExpr *tailing_if = filterx_conditional_find_tail($1);
 	    filterx_conditional_set_false_branch(tailing_if, $3);
@@ -480,13 +479,13 @@ conditional
 	;
 
 if
-	: KW_IF '(' expr ')' codeblock
+	: KW_IF '(' expr ')' block
 	  {
             filterx_expr_set_location($3, lexer, &@3);
 	    $$ = filterx_conditional_new($3);
             filterx_conditional_set_true_branch($$, $5);
 	  }
-	| if KW_ELIF '(' expr ')' codeblock
+	| if KW_ELIF '(' expr ')' block
 	  {
             FilterXExpr *tailing_if = filterx_conditional_find_tail($1);
 
@@ -502,10 +501,6 @@ if
 	  }
 	;
 
-
-codeblock
-	: '{' block '}'				{ $$ = $2; }
-	;
 
 ternary
 	: expr '?' expr ':' expr

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -473,36 +473,49 @@ conditional
 	: if					{ $$ = $1; }
 	| if KW_ELSE codeblock
 	  {
-	    $$ = filterx_conditional_add_false_branch((FilterXConditional*)$1, (FilterXConditional*)filterx_conditional_new_codeblock($3));
+            FilterXExpr *tailing_if = filterx_conditional_find_tail($1);
+	    filterx_conditional_set_false_branch(tailing_if, $3);
+	    $$ = $1;
 	  }
 	;
 
 if
 	: KW_IF '(' expr ')' codeblock
 	  {
-	    $$ = filterx_conditional_new_conditional_codeblock($3, $5);
+	    $$ = filterx_conditional_new($3);
+            filterx_conditional_set_true_branch($$, $5);
 	  }
 	| if KW_ELIF '(' expr ')' codeblock
 	  {
-	    $$ = filterx_conditional_add_false_branch((FilterXConditional*)$1, (FilterXConditional*)filterx_conditional_new_conditional_codeblock($4, $6));
+            FilterXExpr *tailing_if = filterx_conditional_find_tail($1);
+
+	    /* create new conditional */
+	    FilterXExpr *elif_expr = filterx_conditional_new($4);
+            filterx_conditional_set_true_branch(elif_expr, $6);
+
+	    /* link it into the else branch of the last if */
+	    filterx_conditional_set_false_branch(tailing_if, elif_expr);
+	
+	    $$ = $1;
 	  }
 	;
 
 
 codeblock
-	: '{' stmts '}'				{ $$ = $2; }
+	: '{' block '}'				{ $$ = $2; }
 	;
 
 ternary
 	: expr '?' expr ':' expr
 	  {
-	    FilterXConditional *cond = (FilterXConditional*)filterx_conditional_new_conditional_codeblock($1, g_list_append(NULL, $3));
-	    $$ = filterx_conditional_add_false_branch(cond, (FilterXConditional*)filterx_conditional_new_codeblock(g_list_append(NULL, $5)));
+	    $$ = filterx_conditional_new($1);
+            filterx_conditional_set_true_branch($$, $3);
+            filterx_conditional_set_false_branch($$, $5);
 	  }
 	| expr '?' ':' expr
 	  {
-	    FilterXConditional *cond = (FilterXConditional*)filterx_conditional_new_conditional_codeblock($1, NULL);
-	    $$ = filterx_conditional_add_false_branch(cond, (FilterXConditional*)filterx_conditional_new_codeblock(g_list_append(NULL, $4)));
+	    $$ = filterx_conditional_new($1);
+	    filterx_conditional_set_false_branch($$, $4);
 	  }
 	;
 

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -192,38 +192,35 @@ assignment
 generator_assignment
 	: expr '.' LL_IDENTIFIER KW_ASSIGN expr_generator
 						{
-						  FilterXExpr *setattr = filterx_setattr_new($1, $3, filterx_generator_create_container_new($5, $1));
 						  filterx_generator_set_fillable($5, filterx_getattr_new(filterx_expr_ref($1), $3));
 
-						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
-						  filterx_compound_expr_add(block, setattr);
-						  filterx_compound_expr_add(block, $5);
-
+						  $$ = filterx_compound_expr_new_va(TRUE,
+						    filterx_setattr_new($1, $3, filterx_generator_create_container_new($5, $1)),
+						    $5,
+						    NULL
+                                                  );
 						  free($3);
-						  $$ = block;
 						}
 	| expr '[' expr ']' KW_ASSIGN expr_generator
 						{
-						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, $3, filterx_generator_create_container_new($6, $1));
 						  filterx_generator_set_fillable($6, filterx_get_subscript_new(filterx_expr_ref($1), filterx_expr_ref($3)));
 
-						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
-						  filterx_compound_expr_add(block, set_subscript);
-						  filterx_compound_expr_add(block, $6);
-
-						  $$ = block;
+						  $$ = filterx_compound_expr_new_va(TRUE,
+						    filterx_set_subscript_new($1, $3, filterx_generator_create_container_new($6, $1)),
+						    $6,
+						    NULL
+						  );
 						}
 	| expr '[' ']' KW_ASSIGN expr_generator
 						{
 						  FilterXExpr *minus_one = filterx_literal_new(filterx_config_freeze_object(configuration, filterx_integer_new(-1)));
-						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, NULL, filterx_generator_create_container_new($5, $1));
 						  filterx_generator_set_fillable($5, filterx_get_subscript_new(filterx_expr_ref($1), minus_one));
 
-						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
-						  filterx_compound_expr_add(block, set_subscript);
-						  filterx_compound_expr_add(block, $5);
-
-						  $$ = block;
+						  $$ = filterx_compound_expr_new_va(TRUE,
+						    filterx_set_subscript_new($1, NULL, filterx_generator_create_container_new($5, $1)),
+						    $5,
+						    NULL
+						  );
 						}
 	| expr KW_PLUS_ASSIGN expr_generator	{ $$ = $3; filterx_generator_set_fillable($3, $1); }
 	| generator_casted_assignment
@@ -236,15 +233,14 @@ generator_casted_assignment
 						  FilterXExpr *func = filterx_function_lookup(configuration, $3, NULL, &error);
 						  CHECK_FUNCTION_ERROR(func, @3, $3, error);
 
-						  FilterXExpr *assign = filterx_assign_new($1, func);
 						  filterx_generator_set_fillable($5, filterx_expr_ref($1));
 
-						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
-						  filterx_compound_expr_add(block, assign);
-						  filterx_compound_expr_add(block, $5);
+						  $$ = filterx_compound_expr_new_va(TRUE,
+						    filterx_assign_new($1, func),
+						    $5,
+						    NULL
+						  );
 						  free($3);
-
-						  $$ = block;
 						}
 	| expr '.' LL_IDENTIFIER KW_ASSIGN LL_IDENTIFIER '(' expr_generator ')'
 						{
@@ -252,15 +248,14 @@ generator_casted_assignment
 						  FilterXExpr *func = filterx_function_lookup(configuration, $5, NULL, &error);
 						  CHECK_FUNCTION_ERROR(func, @5, $5, error);
 
-						  FilterXExpr *setattr = filterx_setattr_new($1, $3, func);
 						  filterx_generator_set_fillable($7, filterx_getattr_new(filterx_expr_ref($1), $3));
 
-						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
-						  filterx_compound_expr_add(block, setattr);
-						  filterx_compound_expr_add(block, $7);
+						  $$ = filterx_compound_expr_new_va(TRUE,
+						    filterx_setattr_new($1, $3, func),
+						    $7,
+						    NULL
+						  );
 						  free($3);
-
-						  $$ = block;
 						}
 	| expr '[' expr ']' KW_ASSIGN LL_IDENTIFIER '(' expr_generator ')'
 						{
@@ -268,15 +263,14 @@ generator_casted_assignment
 						  FilterXExpr *func = filterx_function_lookup(configuration, $6, NULL, &error);
 						  CHECK_FUNCTION_ERROR(func, @6, $6, error);
 
-						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, $3, func);
 						  filterx_generator_set_fillable($8, filterx_get_subscript_new(filterx_expr_ref($1), filterx_expr_ref($3)));
 
-						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
-						  filterx_compound_expr_add(block, set_subscript);
-						  filterx_compound_expr_add(block, $8);
+						  $$ = filterx_compound_expr_new_va(TRUE,
+						    filterx_set_subscript_new($1, $3, func),
+						    $8,
+						    NULL
+						  );
 						  free($6);
-
-						  $$ = block;
 						}
 	| expr '[' ']' KW_ASSIGN LL_IDENTIFIER '(' expr_generator ')'
 						{
@@ -285,15 +279,14 @@ generator_casted_assignment
 						  CHECK_FUNCTION_ERROR(func, @5, $5, error);
 
 						  FilterXExpr *minus_one = filterx_literal_new(filterx_config_freeze_object(configuration, filterx_integer_new(-1)));
-						  FilterXExpr *set_subscript = filterx_set_subscript_new($1, NULL, func);
 						  filterx_generator_set_fillable($7, filterx_get_subscript_new(filterx_expr_ref($1), minus_one));
 
-						  FilterXExpr *block = filterx_compound_expr_new(TRUE);
-						  filterx_compound_expr_add(block, set_subscript);
-						  filterx_compound_expr_add(block, $7);
+						  $$ = filterx_compound_expr_new_va(TRUE,
+						    filterx_set_subscript_new($1, NULL, func),
+						    $7,
+						    NULL
+						  );
 						  free($5);
-
-						  $$ = block;
 						}
 	;
 

--- a/lib/filterx/filterx-parser.c
+++ b/lib/filterx/filterx-parser.c
@@ -25,7 +25,7 @@
 #include "filterx/filterx-grammar.h"
 
 extern int filterx_debug;
-int filterx_parse(CfgLexer *lexer, GList **node, gpointer arg);
+int filterx_parse(CfgLexer *lexer, FilterXExpr **expr, gpointer arg);
 
 static CfgLexerKeyword filterx_keywords[] =
 {
@@ -69,4 +69,4 @@ CfgParser filterx_parser =
   .parse = (gint (*)(CfgLexer *, gpointer *, gpointer)) filterx_parse,
 };
 
-CFG_PARSER_IMPLEMENT_LEXER_BINDING(filterx_, FILTERX_, GList **)
+CFG_PARSER_IMPLEMENT_LEXER_BINDING(filterx_, FILTERX_, FilterXExpr **)

--- a/lib/filterx/filterx-parser.h
+++ b/lib/filterx/filterx-parser.h
@@ -25,9 +25,10 @@
 #define FILTERX_EXPR_PARSER_H_INCLUDED
 
 #include "cfg-parser.h"
+#include "filterx/filterx-expr.h"
 
 extern CfgParser filterx_parser;
 
-CFG_PARSER_DECLARE_LEXER_BINDING(filterx_, FILTERX_, GList **)
+CFG_PARSER_DECLARE_LEXER_BINDING(filterx_, FILTERX_, FilterXExpr **)
 
 #endif

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -29,7 +29,7 @@ typedef struct _LogFilterXPipe
 {
   LogPipe super;
   gchar *name;
-  GList *stmts;
+  FilterXExpr *block;
 } LogFilterXPipe;
 
 static gboolean
@@ -62,7 +62,7 @@ log_filterx_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_o
             evt_tag_msg_reference(msg));
 
   NVTable *payload = nv_table_ref(msg->payload);
-  res = filterx_eval_exec_statements(&eval_context, self->stmts, msg);
+  res = filterx_eval_expr(&eval_context, self->block, msg);
 
   msg_trace("<<<<<< filterx rule evaluation result",
             evt_tag_str("result", res ? "matched" : "unmatched"),
@@ -91,9 +91,9 @@ static LogPipe *
 log_filterx_pipe_clone(LogPipe *s)
 {
   LogFilterXPipe *self = (LogFilterXPipe *) s;
-  GList *cloned_stmts = g_list_copy_deep(self->stmts, (GCopyFunc) filterx_expr_ref, NULL);
+  FilterXExpr *cloned_block = filterx_expr_ref(self->block);
 
-  LogPipe *cloned = log_filterx_pipe_new(cloned_stmts, s->cfg);
+  LogPipe *cloned = log_filterx_pipe_new(cloned_block, s->cfg);
   ((LogFilterXPipe *)cloned)->name = g_strdup(self->name);
   return cloned;
 }
@@ -104,12 +104,12 @@ log_filterx_pipe_free(LogPipe *s)
   LogFilterXPipe *self = (LogFilterXPipe *) s;
 
   g_free(self->name);
-  g_list_free_full(self->stmts, (GDestroyNotify) filterx_expr_unref);
+  filterx_expr_unref(self->block);
   log_pipe_free_method(s);
 }
 
 LogPipe *
-log_filterx_pipe_new(GList *stmts, GlobalConfig *cfg)
+log_filterx_pipe_new(FilterXExpr *block, GlobalConfig *cfg)
 {
   LogFilterXPipe *self = g_new0(LogFilterXPipe, 1);
 
@@ -119,6 +119,6 @@ log_filterx_pipe_new(GList *stmts, GlobalConfig *cfg)
   self->super.queue = log_filterx_pipe_queue;
   self->super.free_fn = log_filterx_pipe_free;
   self->super.clone = log_filterx_pipe_clone;
-  self->stmts = stmts;
+  self->block = block;
   return &self->super;
 }

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -62,7 +62,7 @@ log_filterx_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_o
             evt_tag_msg_reference(msg));
 
   NVTable *payload = nv_table_ref(msg->payload);
-  res = filterx_eval_expr(&eval_context, self->block, msg);
+  res = filterx_eval_exec(&eval_context, self->block, msg);
 
   msg_trace("<<<<<< filterx rule evaluation result",
             evt_tag_str("result", res ? "matched" : "unmatched"),

--- a/lib/filterx/filterx-pipe.h
+++ b/lib/filterx/filterx-pipe.h
@@ -27,6 +27,6 @@
 #include "filterx/filterx-expr.h"
 #include "logpipe.h"
 
-LogPipe *log_filterx_pipe_new(GList *stmts, GlobalConfig *cfg);
+LogPipe *log_filterx_pipe_new(FilterXExpr *expr, GlobalConfig *cfg);
 
 #endif

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_unit_test(LIBTEST CRITERION TARGET test_object_primitive DEPENDS json-plugin
 add_unit_test(LIBTEST CRITERION TARGET test_object_string DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_expr_comparison DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_expr_condition DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_expr_compound DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_builtin_functions DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_bytes DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_protobuf DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -14,6 +14,7 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_expr_function	\
 		lib/filterx/tests/test_expr_comparison \
 		lib/filterx/tests/test_expr_condition \
+		lib/filterx/tests/test_expr_compound \
 		lib/filterx/tests/test_expr_function \
 		lib/filterx/tests/test_builtin_functions \
 		lib/filterx/tests/test_type_registry \
@@ -52,6 +53,9 @@ lib_filterx_tests_test_expr_comparison_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_expr_condition_CFLAGS = $(TEST_CFLAGS)
 lib_filterx_tests_test_expr_condition_LDADD	 = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_expr_compound_CFLAGS = $(TEST_CFLAGS)
+lib_filterx_tests_test_expr_compound_LDADD	 = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_builtin_functions_CFLAGS = $(TEST_CFLAGS)
 lib_filterx_tests_test_builtin_functions_LDADD = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/test_expr_compound.c
+++ b/lib/filterx/tests/test_expr_compound.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2023 shifter <shifter@axoflow.com>
+ * Copyright (c) 2024 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/filterx-lib.h"
+
+#include "filterx/object-string.h"
+#include "filterx/expr-compound.h"
+#include "filterx/expr-variable.h"
+#include "filterx/expr-assign.h"
+#include "filterx/expr-literal.h"
+#include "apphook.h"
+#include "scratch-buffers.h"
+
+/* FIXME: these were copied from test_expr_condition and should be moved to libtest */
+FilterXExpr *
+_assert_assign_var(const char *var_name, FilterXExpr *value)
+{
+  FilterXExpr *control_variable = filterx_msg_variable_expr_new(var_name);
+  cr_assert(control_variable != NULL);
+
+  return filterx_assign_new(control_variable, value);
+}
+
+FilterXExpr *
+_string_to_filterXExpr(const gchar *str)
+{
+  return filterx_literal_new(filterx_string_new(str, -1));
+}
+
+gint
+_assert_cmp_string_to_filterx_object(const char *str, FilterXObject *obj)
+{
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)));
+  gsize string_len;
+  const gchar *string = filterx_string_get_value(obj, &string_len);
+  return strcmp(string, str);
+}
+
+void
+_assert_set_test_variable(const char *var_name, FilterXExpr *expr)
+{
+  FilterXExpr *assign = _assert_assign_var(var_name, expr);
+  cr_assert(assign != NULL);
+
+  FilterXObject *assign_eval_res = filterx_expr_eval(assign);
+  cr_assert(assign_eval_res != NULL);
+  cr_assert(filterx_object_truthy(assign_eval_res));
+
+  filterx_expr_unref(assign);
+  filterx_object_unref(assign_eval_res);
+}
+
+FilterXObject *
+_assert_get_test_variable(const char *var_name)
+{
+  FilterXExpr *control_variable = filterx_msg_variable_expr_new(var_name);
+  cr_assert(control_variable != NULL);
+  FilterXObject *result = filterx_expr_eval(control_variable);
+  filterx_expr_unref(control_variable);
+  return result;
+}
+
+
+Test(expr_compound, test_compound_all_the_statements_must_execute_and_return_truthy)
+{
+  FilterXExpr *compound = filterx_compound_expr_new_va(FALSE,
+                                                       _assert_assign_var("$control-value", _string_to_filterXExpr("matching")),
+                                                       _assert_assign_var("$control-value2", _string_to_filterXExpr("matching2")),
+                                                       _assert_assign_var("$control-value3", _string_to_filterXExpr("matching3")),
+                                                       NULL);
+
+
+  FilterXObject *res = filterx_expr_eval(compound);
+  cr_assert(res != NULL);
+  cr_assert(filterx_object_truthy(res));
+  filterx_object_unref(res);
+
+  FilterXObject *control_value = _assert_get_test_variable("$control-value");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching", control_value));
+  filterx_object_unref(control_value);
+  control_value = _assert_get_test_variable("$control-value2");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching2", control_value));
+  filterx_object_unref(control_value);
+  control_value = _assert_get_test_variable("$control-value3");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching3", control_value));
+  filterx_object_unref(control_value);
+
+  filterx_expr_unref(compound);
+}
+
+Test(expr_compound, test_compound_all_the_statements_must_execute_and_return_the_last_value_if_instructed)
+{
+  FilterXExpr *compound = filterx_compound_expr_new_va(TRUE,
+                                                       _assert_assign_var("$control-value", _string_to_filterXExpr("matching")),
+                                                       _assert_assign_var("$control-value2", _string_to_filterXExpr("matching2")),
+                                                       _assert_assign_var("$control-value3", _string_to_filterXExpr("matching3")),
+                                                       NULL);
+
+
+  FilterXObject *res = filterx_expr_eval(compound);
+  cr_assert(res != NULL);
+  cr_assert(filterx_object_truthy(res));
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching3", res));
+  filterx_object_unref(res);
+
+  FilterXObject *control_value = _assert_get_test_variable("$control-value");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching", control_value));
+  filterx_object_unref(control_value);
+  control_value = _assert_get_test_variable("$control-value2");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching2", control_value));
+  filterx_object_unref(control_value);
+  control_value = _assert_get_test_variable("$control-value3");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching3", control_value));
+  filterx_object_unref(control_value);
+
+  filterx_expr_unref(compound);
+}
+
+
+static void
+setup(void)
+{
+  app_startup();
+  init_libtest_filterx();
+  _assert_set_test_variable("$control-value", _string_to_filterXExpr("default"));
+  _assert_set_test_variable("$control-value3", _string_to_filterXExpr("default3"));
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  deinit_libtest_filterx();
+  app_shutdown();
+}
+
+TestSuite(expr_compound, .init = setup, .fini = teardown);

--- a/libtest/filterx-lib.c
+++ b/libtest/filterx-lib.c
@@ -26,7 +26,7 @@
 #include "cr_template.h"
 #include "filterx/object-json.h"
 #include "filterx/object-string.h"
-#include "filterx/expr-shorthand.h"
+#include "filterx/expr-compound.h"
 #include "filterx/expr-literal.h"
 #include "filterx/filterx-eval.h"
 
@@ -134,9 +134,9 @@ filterx_test_unknown_object_new(void)
 FilterXExpr *
 filterx_non_literal_new(FilterXObject *object)
 {
-  FilterXExpr *shorthand = filterx_shorthand_new();
-  filterx_shorthand_add(shorthand, filterx_literal_new(object));
-  return shorthand;
+  FilterXExpr *block = filterx_compound_expr_new();
+  filterx_compound_expr_add(block, filterx_literal_new(object));
+  return block;
 }
 
 typedef struct _FilterXDummyError FilterXDummyError;

--- a/libtest/filterx-lib.c
+++ b/libtest/filterx-lib.c
@@ -134,7 +134,7 @@ filterx_test_unknown_object_new(void)
 FilterXExpr *
 filterx_non_literal_new(FilterXObject *object)
 {
-  FilterXExpr *block = filterx_compound_expr_new();
+  FilterXExpr *block = filterx_compound_expr_new(TRUE);
   filterx_compound_expr_add(block, filterx_literal_new(object));
   return block;
 }

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -487,6 +487,15 @@ def test_simple_true_condition(config, syslog_ng):
     assert file_true.read_log() == "foobar\n"
 
 
+def test_empty_block(config, syslog_ng):
+    (file_true, file_false) = create_config(config, """ """)
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "foobar\n"
+
+
 def test_simple_false_condition(config, syslog_ng):
     (file_true, file_false) = create_config(config, """ false; """)
     syslog_ng.start(config)

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -953,6 +953,8 @@ def test_if_condition_matching_elif_condition(config, syslog_ng):
         $out = "matched";
     } elif (true) {
         $out = "elif-matched";
+    } elif (true) {
+        $out = "elif2-matched";
     } else {
         $out = "else-matched";
     };


### PR DESCRIPTION
This merges various forms of expression lists into a single FilterXExpr instance:
* true and false branches of conditions
* top-level expression list of filterx blocks
* expression lists generated by our grammar (e.g. generator expressions)

It also implements expression tracing at all of these levels, so instead of only tracing top level statements, it also steps into the true/false branches of if statements.

It also fixes a few other issues:
* the requirement of having to add a "true" as the last statement in ifs to avoid dropping the entire message.
* 