### PR TITLE
cfg: treat non-versioned configs as `@version: current`

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -663,11 +663,7 @@ cfg_read_config(GlobalConfig *self, const gchar *fname, gchar *preprocess_into)
         }
 
       if (self->user_version == 0)
-        {
-          msg_error("ERROR: configuration files without a version number have become unsupported in " VERSION_3_13
-                    ", please specify a version number using @version as the first line in the configuration file");
-          return FALSE;
-        }
+        cfg_set_current_version(self);
 
       if (res)
         {


### PR DESCRIPTION
This allows configurations to skip the `@version` pragma, which allows AxoSyslog to be started even with an empty configuration file.
