### PR TITLE
filterx: make unset() a function and allow multiple args

### DIFF
--- a/lib/filterx/expr-unset.h
+++ b/lib/filterx/expr-unset.h
@@ -23,8 +23,8 @@
 #ifndef FILTERX_UNSET_KEY_H_INCLUDED
 #define FILTERX_UNSET_KEY_H_INCLUDED
 
-#include "filterx/filterx-expr.h"
+#include "filterx/expr-function.h"
 
-FilterXExpr *filterx_unset_new(FilterXExpr *expr);
+FilterXFunction *filterx_function_unset_new(const gchar *function_name, FilterXFunctionArgs *args, GError **error);
 
 #endif

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -36,6 +36,7 @@
 #include "filterx/func-unset-empties.h"
 #include "filterx/func-str-transform.h"
 #include "filterx/expr-regexp.h"
+#include "filterx/expr-unset.h"
 #include "filterx/filterx-eval.h"
 
 static GHashTable *filterx_builtin_simple_functions = NULL;
@@ -117,6 +118,7 @@ _ctors_init(void)
   g_assert(filterx_builtin_function_ctor_register("istype", filterx_function_istype_new));
   g_assert(filterx_builtin_function_ctor_register("unset_empties", filterx_function_unset_empties_new));
   g_assert(filterx_builtin_function_ctor_register("regexp_subst", filterx_function_regexp_subst_new));
+  g_assert(filterx_builtin_function_ctor_register("unset", filterx_function_unset_new));
 }
 
 static void

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -103,7 +103,6 @@ construct_template_expr(LogTemplate *template)
 %token KW_NULL
 %token KW_ENUM
 %token KW_ISSET
-%token KW_UNSET
 %token KW_DECLARE
 %token KW_REGEXP_SEARCH
 
@@ -322,7 +321,6 @@ expr
 	| ternary				{ $$ = $1; }
 	| default				{ $$ = $1; }
 	| KW_ISSET '(' expr ')'			{ $$ = filterx_isset_new($3); }
-	| KW_UNSET '(' expr ')'			{ $$ = filterx_unset_new($3); }
 	| regexp_match				{ $$ = $1; }
 	;
 

--- a/lib/filterx/filterx-parser.c
+++ b/lib/filterx/filterx-parser.c
@@ -49,7 +49,6 @@ static CfgLexerKeyword filterx_keywords[] =
   { "elif",               KW_ELIF },
 
   { "isset",              KW_ISSET },
-  { "unset",              KW_UNSET },
   { "declare",            KW_DECLARE },
 
   /* TODO: This should be done via generator function. */

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -1149,11 +1149,7 @@ def test_unset(config, syslog_ng):
     $arr[] = "first";
     $arr[] = "second";
 
-    unset(${values.int});
-    unset($almafa);
-    unset($MSG["inner_key"]);
-    unset($MSG["almafa"]);
-    unset($arr[0]);
+    unset(${values.int}, $almafa, $MSG["inner_key"], $MSG["almafa"], $arr[0]);
 
     not isset(${values.int});
     not isset($almafa);


### PR DESCRIPTION
Now we can do:
```
  unset(foo, bar, baz);
```
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
