### PR TITLE
Null-pointer fixes

### DIFF
--- a/lib/cfg-block.c
+++ b/lib/cfg-block.c
@@ -138,7 +138,7 @@ _validate_spurious_args(CfgArgs *self, CfgArgs *defs, const gchar *reference)
 static gboolean
 _validate_args(CfgArgs *self, CfgArgs *defs, const gchar *reference)
 {
-  return _validate_mandatory_options(defs, self, reference) && _validate_spurious_args(self, defs, reference);
+  return defs && _validate_mandatory_options(defs, self, reference) && _validate_spurious_args(self, defs, reference);
 }
 
 /*

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -389,7 +389,7 @@ log_reader_work_finished(void *s, gpointer arg)
       self->notify_code = 0;
       log_pipe_notify(self->control, notify_code, self);
     }
-  if (self->super.super.flags & PIF_INITIALIZED)
+  if ((self->super.super.flags & PIF_INITIALIZED) && self->proto)
     {
       /* reenable polling the source assuming that we're still in
        * business (e.g. the reader hasn't been uninitialized) */

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -380,7 +380,7 @@ plugin_load_module(PluginContext *context, const gchar *module_name, CfgArgs *ar
   g_module_make_resident(mod);
   module_info = _get_module_info(mod);
 
-  if (module_info->canonical_name)
+  if (module_info && module_info->canonical_name)
     {
       g_free(module_init_func);
       module_init_func = _format_module_init_name(module_info->canonical_name ? : module_name);

--- a/lib/template/repr.c
+++ b/lib/template/repr.c
@@ -63,6 +63,7 @@ _setup_function_call(LogTemplate *template, Plugin *p, LogTemplateElem *e,
 
   g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
   e->func.ops = plugin_construct(p);
+  g_return_val_if_fail(e->func.ops != NULL, FALSE);
   e->func.state = e->func.ops->size_of_state > 0 ? g_malloc0(e->func.ops->size_of_state) : NULL;
 
   /* prepare may modify the argv array: remove and rearrange elements */

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -305,6 +305,15 @@ affile_dw_queue(LogPipe *s, LogMessage *lm, const LogPathOptions *path_options)
 }
 
 static void
+affile_dw_unset_owner(AFFileDestWriter *self)
+{
+  if (self->owner)
+    log_pipe_unref(&self->owner->super.super.super);
+
+  self->owner = NULL;
+}
+
+static void
 affile_dw_set_owner(AFFileDestWriter *self, AFFileDestDriver *owner)
 {
   GlobalConfig *cfg = log_pipe_get_config(&owner->super.super.super);
@@ -512,7 +521,7 @@ affile_dd_reuse_writer(gpointer key, gpointer value, gpointer user_data)
   affile_dw_set_owner(writer, self);
   if (!log_pipe_init(&writer->super))
     {
-      affile_dw_set_owner(writer, NULL);
+      affile_dw_unset_owner(writer);
       log_pipe_unref(&writer->super);
       g_hash_table_remove(self->writer_hash, key);
     }

--- a/news/bugfix-216.md
+++ b/news/bugfix-216.md
@@ -1,0 +1,3 @@
+Fixed potential null pointer deref issues
+
+TODO Add Dmitry Levin @nivelus to the NEWS file as a thank you for finding these


### PR DESCRIPTION
Patches are originally coming from syslog-ng/syslog-ng#4132 (@OverOrion do you want to close that PR?)

Fixes syslog-ng/syslog-ng#5025
Fixes syslog-ng/syslog-ng#5026

(Contains an alternative implementation of syslog-ng/syslog-ng#5032 and syslog-ng/syslog-ng#5031)