### PR TITLE
csvparser: properly append the delimiter character to the resulting stirng in format_csv()

### DIFF
--- a/modules/csvparser/filterx-func-format-csv.c
+++ b/modules/csvparser/filterx-func-format-csv.c
@@ -63,7 +63,7 @@ _append_to_buffer(FilterXObject *key, FilterXObject *value, gpointer user_data)
     }
 
   if (buffer->len)
-    g_string_append(buffer, &self->delimiter);
+    g_string_append_c(buffer, self->delimiter);
 
   gsize len_before_value = buffer->len;
   if (!filterx_object_repr_append(value, buffer))


### PR DESCRIPTION
The delimiter is a single character and is not a null terminated string, so don't handle it as such.
