### PR TITLE
Filterx expr plus operator for generators and += operator (part 2)

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -44,6 +44,7 @@ set(FILTERX_HEADERS
     filterx/func-flatten.h
     filterx/expr-plus.h
     filterx/expr-null-coalesce.h
+    filterx/expr-plus-generator.h
     PARENT_SCOPE
     )
 
@@ -94,6 +95,7 @@ set(FILTERX_SOURCES
     filterx/expr-plus.c
     filterx/filterx-private.c
     filterx/expr-null-coalesce.c
+    filterx/expr-plus-generator.c
     PARENT_SCOPE
     )
 

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -45,7 +45,8 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/func-str-transform.h		\
 	lib/filterx/func-flatten.h		\
 	lib/filterx/filterx-private.h			\
-	lib/filterx/expr-null-coalesce.h
+	lib/filterx/expr-null-coalesce.h	\
+	lib/filterx/expr-plus-generator.h
 
 
 filterx_sources = 				\
@@ -95,6 +96,7 @@ filterx_sources = 				\
 	lib/filterx/func-flatten.c		\
 	lib/filterx/filterx-private.c	\
 	lib/filterx/expr-null-coalesce.c	\
+	lib/filterx/expr-plus-generator.c	\
 	lib/filterx/filterx-grammar.y
 
 BUILT_SOURCES += 				\

--- a/lib/filterx/expr-generator.c
+++ b/lib/filterx/expr-generator.c
@@ -48,6 +48,12 @@ _eval(FilterXExpr *s)
   return NULL;
 }
 
+gboolean
+filterx_expr_is_generator(FilterXExpr *s)
+{
+  return s->eval == _eval;
+}
+
 void
 filterx_generator_init_instance(FilterXExpr *s)
 {

--- a/lib/filterx/expr-generator.h
+++ b/lib/filterx/expr-generator.h
@@ -38,6 +38,7 @@ struct FilterXExprGenerator_
 void filterx_generator_set_fillable(FilterXExpr *s, FilterXExpr *fillable);
 void filterx_generator_init_instance(FilterXExpr *s);
 void filterx_generator_free_method(FilterXExpr *s);
+gboolean filterx_expr_is_generator(FilterXExpr *s);
 
 FilterXExpr *filterx_generator_create_container_new(FilterXExpr *g, FilterXExpr *fillable_parent);
 

--- a/lib/filterx/expr-plus-generator.c
+++ b/lib/filterx/expr-plus-generator.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 shifter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "expr-plus.h"
+#include "object-string.h"
+#include "filterx-eval.h"
+#include "scratch-buffers.h"
+#include "expr-generator.h"
+#include "object-list-interface.h"
+#include "object-dict-interface.h"
+
+typedef struct FilterXOperatorPlusGenerator
+{
+  FilterXExprGenerator super;
+  FilterXExpr *lhs;
+  FilterXExpr *rhs;
+} FilterXOperatorPlusGenerator;
+
+static gboolean
+_generate_obj(FilterXOperatorPlusGenerator *self, FilterXObject *obj, FilterXObject *fillable)
+{
+  if (filterx_object_is_type(fillable, &FILTERX_TYPE_NAME(list)))
+    return filterx_list_merge(fillable, obj);
+
+  if (filterx_object_is_type(fillable, &FILTERX_TYPE_NAME(dict)))
+    return filterx_dict_merge(fillable, obj);
+
+  filterx_eval_push_error("Failed to merge objects, invalid fillable type", &self->super.super, fillable);
+
+  return FALSE;
+}
+
+static gboolean
+_handle_object_or_generator(FilterXOperatorPlusGenerator *self, FilterXExpr *expr, FilterXObject *fillable)
+{
+  FilterXObject *obj = NULL;
+  if (filterx_expr_is_generator(expr))
+    {
+      filterx_generator_set_fillable(expr, filterx_expr_ref(self->super.fillable));
+      obj = filterx_expr_eval(expr);
+      filterx_object_unref(obj);
+      return !!obj;
+    }
+
+  obj = filterx_expr_eval(expr);
+  if (!obj)
+    return FALSE;
+  if (!_generate_obj(self, obj, fillable))
+    {
+      filterx_object_unref(obj);
+      return FALSE;
+    }
+
+  filterx_object_unref(obj);
+  return TRUE;
+}
+
+static gboolean
+_expr_plus_generator_generate(FilterXExprGenerator *s, FilterXObject *fillable)
+{
+  FilterXOperatorPlusGenerator *self = (FilterXOperatorPlusGenerator *) s;
+
+  if (!_handle_object_or_generator(self, self->lhs, fillable))
+    return FALSE;
+  if (!_handle_object_or_generator(self, self->rhs, fillable))
+    return FALSE;
+  return TRUE;
+}
+
+static FilterXObject *
+_expr_plus_generator_create_container(FilterXExprGenerator *s, FilterXExpr *fillable_parent)
+{
+  FilterXOperatorPlusGenerator *self = (FilterXOperatorPlusGenerator *) s;
+  FilterXExprGenerator *generator = (FilterXExprGenerator *)(filterx_expr_is_generator(
+      self->rhs) ? self->rhs : self->lhs);
+  return generator->create_container(generator, fillable_parent);
+}
+
+static void
+_expr_plus_generator_free(FilterXExpr *s)
+{
+  FilterXOperatorPlusGenerator *self = (FilterXOperatorPlusGenerator *) s;
+  filterx_expr_unref(self->lhs);
+  filterx_expr_unref(self->rhs);
+  filterx_generator_free_method(s);
+}
+
+FilterXExpr *
+filterx_operator_plus_generator_new(FilterXExpr *lhs, FilterXExpr *rhs)
+{
+  FilterXOperatorPlusGenerator *self = g_new0(FilterXOperatorPlusGenerator, 1);
+  filterx_generator_init_instance(&self->super.super);
+  self->lhs = lhs;
+  self->rhs = rhs;
+  self->super.generate = _expr_plus_generator_generate;
+  self->super.super.free_fn = _expr_plus_generator_free;
+  self->super.create_container = _expr_plus_generator_create_container;
+
+  return &self->super.super;
+}

--- a/lib/filterx/expr-plus-generator.h
+++ b/lib/filterx/expr-plus-generator.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 shifter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef FILTERX_EXPR_PLUS_GENERATOR_H_INCLUDED
+#define FILTERX_EXPR_PLUS_GENERATOR_H_INCLUDED
+
+#include "filterx-expr.h"
+
+FilterXExpr *filterx_operator_plus_generator_new(FilterXExpr *lhs, FilterXExpr *rhs);
+
+#endif

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -112,6 +112,8 @@ construct_template_expr(LogTemplate *template)
 %type <node> stmt
 %type <node> stmt_expr
 %type <node> assignment
+%type <node> plus_assignment
+%type <node> generator_plus_assignment
 %type <node> generator_assignment
 %type <node> generator_casted_assignment
 %type <node> declaration
@@ -181,6 +183,17 @@ stmt_expr
 	| declaration 				{ $$ = $1; }
 	;
 
+plus_assignment
+	: variable KW_PLUS_ASSIGN expr		{ $$ = filterx_assign_new(filterx_expr_ref($1), filterx_operator_plus_new($1, $3)); }
+	| expr '[' expr ']' KW_PLUS_ASSIGN expr	{ $$ = filterx_set_subscript_new(filterx_expr_ref($1), filterx_expr_ref($3), filterx_operator_plus_new(filterx_get_subscript_new($1, $3), $6)); }
+	| expr '.' LL_IDENTIFIER KW_PLUS_ASSIGN expr
+						{
+							$$ = filterx_setattr_new(filterx_expr_ref($1), $3, filterx_operator_plus_new(filterx_getattr_new($1, $3), $5));
+							free($3);
+						}
+	;
+
+
 assignment
 	/* TODO extract lvalues */
 	: variable KW_ASSIGN expr			{ $$ = filterx_assign_new($1, $3); }
@@ -188,7 +201,10 @@ assignment
 	| expr '[' expr ']' KW_ASSIGN expr	{ $$ = filterx_set_subscript_new($1, $3, $6); }
 	| expr '[' ']' KW_ASSIGN expr  		{ $$ = filterx_set_subscript_new($1, NULL, $5); }
 	| generator_assignment
+	| plus_assignment			{ $$ = $1; }
 	;
+
+
 
 generator_assignment
 	/* TODO extract lvalues */
@@ -224,9 +240,14 @@ generator_assignment
 						    NULL
 						  );
 						}
-	| expr KW_PLUS_ASSIGN expr_generator	{ $$ = $3; filterx_generator_set_fillable($3, $1); }
+	| generator_plus_assignment
 	| generator_casted_assignment
 	;
+
+generator_plus_assignment
+	: variable KW_PLUS_ASSIGN expr_generator			{ $$ = $3; filterx_generator_set_fillable($3, $1); }
+	| expr '[' expr ']' KW_PLUS_ASSIGN expr_generator	{ $$ = $6; filterx_generator_set_fillable($6, filterx_get_subscript_new($1, $3)); }
+	| expr '.' LL_IDENTIFIER KW_PLUS_ASSIGN expr_generator	{ $$ = $5; filterx_generator_set_fillable($5, filterx_getattr_new($1, $3)); free($3);}
 
 generator_casted_assignment
 	/* TODO extract lvalues */

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -54,6 +54,7 @@
 #include "filterx/expr-regexp.h"
 #include "filterx/expr-plus.h"
 #include "filterx/expr-null-coalesce.h"
+#include "filterx/expr-plus-generator.h"
 
 #include "template/templates.h"
 
@@ -296,7 +297,6 @@ declaration
 	: KW_DECLARE filterx_variable KW_ASSIGN expr	{ filterx_variable_expr_declare($2); $$ = filterx_assign_new($2, $4); }
 	;
 
-
 expr
 	: expr_value				{ $$ = $1; }
 	| function_call				{ $$ = $1; }
@@ -346,6 +346,9 @@ expr_generator_unchecked
 	| list_generator
 	| regexp_search
 	| '(' expr_generator ')'		{ $$ = $2; }
+	| expr '+' expr_generator		{ $$ = filterx_operator_plus_generator_new($1, $3); }
+	| expr_generator '+' expr 		{ $$ = filterx_operator_plus_generator_new($1, $3); }
+	| expr_generator '+' expr_generator 	{ $$ = filterx_operator_plus_generator_new($1, $3); }
 	;
 
 function_call

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -22,3 +22,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_expr_function DEPENDS json-plugin ${
 add_unit_test(LIBTEST CRITERION TARGET test_expr_regexp DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_expr_null_coalesce DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_expr_plus DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_expr_plus_generator DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -23,7 +23,8 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_func_flatten \
 		lib/filterx/tests/test_expr_regexp	\
 		lib/filterx/tests/test_expr_null_coalesce	\
-		lib/filterx/tests/test_expr_plus
+		lib/filterx/tests/test_expr_plus	\
+		lib/filterx/tests/test_expr_plus_generator
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt
 
@@ -100,3 +101,6 @@ lib_filterx_tests_test_expr_null_coalesce_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_expr_plus_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_expr_plus_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_expr_plus_generator_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_expr_plus_generator_LDADD   = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/test_expr_plus_generator.c
+++ b/lib/filterx/tests/test_expr_plus_generator.c
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 shifter <shifter@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/cr_template.h"
+#include "libtest/filterx-lib.h"
+
+#include "filterx/filterx-object.h"
+#include "filterx/object-primitive.h"
+#include "filterx/expr-comparison.h"
+#include "filterx/filterx-expr.h"
+#include "filterx/expr-literal.h"
+#include "filterx/object-string.h"
+#include "filterx/object-null.h"
+#include "filterx/object-datetime.h"
+#include "filterx/object-message-value.h"
+#include "filterx/expr-null-coalesce.h"
+#include "filterx/func-istype.h"
+#include "filterx/filterx-eval.h"
+#include "filterx/func-len.h"
+#include "filterx/expr-function.h"
+#include "filterx/expr-plus-generator.h"
+#include "filterx/object-json.h"
+#include "filterx/object-list-interface.h"
+#include "filterx/object-dict-interface.h"
+#include "filterx/expr-generator.h"
+#include "filterx/expr-literal-generator.h"
+
+#include "apphook.h"
+#include "scratch-buffers.h"
+
+void
+_assert_cmp_lists(FilterXObject *expected, FilterXObject *provided)
+{
+  cr_assert(filterx_object_is_type(expected, &FILTERX_TYPE_NAME(list)));
+  cr_assert(filterx_object_is_type(provided, &FILTERX_TYPE_NAME(list)));
+  guint64 expected_len, provided_len;
+  cr_assert(filterx_object_len(expected, &expected_len));
+  cr_assert(filterx_object_len(provided, &provided_len));
+  cr_assert(expected_len == provided_len, "expected len:%lu provided len:%lu", expected_len, provided_len);
+  for (guint64 i = 0; i < expected_len; i ++)
+    {
+      FilterXObject *expected_value_obj = filterx_list_get_subscript(expected, i);
+      FilterXObject *provided_value_obj = filterx_list_get_subscript(provided, i);
+      cr_assert(expected_value_obj->type == provided_value_obj->type, "expected type:%s provided type:%s",
+                expected_value_obj->type->name, provided_value_obj->type->name);
+
+      GString *expected_val = scratch_buffers_alloc();
+      GString *provided_val = scratch_buffers_alloc();
+      cr_assert(filterx_object_repr(expected_value_obj, expected_val), "repr call failure on expected val");
+      cr_assert(filterx_object_repr(provided_value_obj, provided_val), "repr call failure on provided val");
+
+      cr_assert_str_eq(expected_val->str, provided_val->str, "values of nth(%lu) elt differs: expected:%s provided:%s", i,
+                       expected_val->str, provided_val->str);
+
+      filterx_object_unref(expected_value_obj);
+      filterx_object_unref(provided_value_obj);
+    }
+}
+
+Test(expr_plus_generator, test_list_add_two_generators_with_post_set_fillable)
+{
+  FilterXExpr *lhs = filterx_literal_list_generator_new();
+  GList *lhs_vals = NULL;
+  lhs_vals = g_list_append(lhs_vals,
+                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("foo", -1)), FALSE));
+  lhs_vals = g_list_append(lhs_vals,
+                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("bar", -1)), FALSE));
+  filterx_literal_generator_set_elements(lhs, lhs_vals);
+
+  FilterXExpr *rhs = filterx_literal_list_generator_new();
+  GList *rhs_vals = NULL;
+  rhs_vals = g_list_append(rhs_vals,
+                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("baz", -1)), FALSE));
+  rhs_vals = g_list_append(rhs_vals,
+                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("other", -1)), FALSE));
+  filterx_literal_generator_set_elements(rhs, rhs_vals);
+
+
+  FilterXExpr *expr = filterx_operator_plus_generator_new(lhs, rhs);
+  FilterXObject *json_array = filterx_json_array_new_empty();
+  FilterXExpr *fillable = filterx_literal_new(json_array);
+  filterx_generator_set_fillable(expr, filterx_expr_ref(fillable));
+
+  FilterXObject *res_object = filterx_expr_eval(expr);
+  cr_assert_not_null(res_object);
+  cr_assert(filterx_object_is_type(res_object, &FILTERX_TYPE_NAME(list)));
+
+  FilterXObject *expected = filterx_json_array_new_from_repr("[\"foo\",\"bar\",\"baz\",\"other\"]", -1);
+
+  _assert_cmp_lists(expected, res_object);
+
+  filterx_expr_unref(expr);
+  filterx_expr_unref(fillable);
+  filterx_object_unref(expected);
+  filterx_object_unref(json_array);
+}
+
+Test(expr_plus_generator, test_list_add_variable_to_generator_with_post_set_fillable)
+{
+  FilterXExpr *lhs = filterx_literal_list_generator_new();
+  GList *lhs_vals = NULL;
+  lhs_vals = g_list_append(lhs_vals,
+                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("foo", -1)), FALSE));
+  lhs_vals = g_list_append(lhs_vals,
+                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("bar", -1)), FALSE));
+  filterx_literal_generator_set_elements(lhs, lhs_vals);
+
+  FilterXExpr *rhs = filterx_non_literal_new(filterx_json_array_new_from_repr("[\"baz\", \"other\"]", -1));
+
+  FilterXExpr *expr = filterx_operator_plus_generator_new(lhs, rhs);
+  FilterXObject *json_array = filterx_json_array_new_empty();
+  FilterXExpr *fillable = filterx_literal_new(json_array);
+  filterx_generator_set_fillable(expr, filterx_expr_ref(fillable));
+
+  FilterXObject *res_object = filterx_expr_eval(expr);
+  cr_assert_not_null(res_object);
+  cr_assert(filterx_object_is_type(res_object, &FILTERX_TYPE_NAME(list)));
+
+  FilterXObject *expected = filterx_json_array_new_from_repr("[\"foo\",\"bar\",\"baz\",\"other\"]", -1);
+
+  _assert_cmp_lists(expected, res_object);
+
+  filterx_expr_unref(expr);
+  filterx_expr_unref(fillable);
+  filterx_object_unref(expected);
+  filterx_object_unref(json_array);
+}
+
+Test(expr_plus_generator, test_list_add_generator_to_variable_with_post_set_fillable)
+{
+  FilterXExpr *lhs = filterx_non_literal_new(filterx_json_array_new_from_repr("[\"foo\", \"bar\"]", -1));
+
+  FilterXExpr *rhs = filterx_literal_list_generator_new();
+  GList *rhs_vals = NULL;
+  rhs_vals = g_list_append(rhs_vals,
+                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("baz", -1)), FALSE));
+  rhs_vals = g_list_append(rhs_vals,
+                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("other", -1)), FALSE));
+  filterx_literal_generator_set_elements(rhs, rhs_vals);
+
+  FilterXExpr *expr = filterx_operator_plus_generator_new(lhs, rhs);
+  FilterXObject *json_array = filterx_json_array_new_empty();
+  FilterXExpr *fillable = filterx_literal_new(json_array);
+  filterx_generator_set_fillable(expr, filterx_expr_ref(fillable));
+
+  FilterXObject *res_object = filterx_expr_eval(expr);
+  cr_assert_not_null(res_object);
+  cr_assert(filterx_object_is_type(res_object, &FILTERX_TYPE_NAME(list)));
+
+  FilterXObject *expected = filterx_json_array_new_from_repr("[\"foo\",\"bar\",\"baz\",\"other\"]", -1);
+
+  _assert_cmp_lists(expected, res_object);
+
+  filterx_expr_unref(expr);
+  filterx_expr_unref(fillable);
+  filterx_object_unref(expected);
+  filterx_object_unref(json_array);
+}
+
+
+Test(expr_plus_generator, test_nested_dict_add_two_generators_with_post_set_fillable)
+{
+  FilterXExpr *lhs = filterx_literal_dict_generator_new();
+  GList *lhs_vals = NULL;
+  GList *lhs_inner = NULL;
+  lhs_inner = g_list_append(lhs_inner,
+                            filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("bar", -1)),
+                                filterx_literal_new(filterx_string_new("baz", -1)), TRUE));
+  lhs_vals = g_list_append(lhs_vals,
+                           filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("foo", -1)),
+                                                              filterx_literal_inner_dict_generator_new(lhs, lhs_inner), FALSE));
+  filterx_literal_generator_set_elements(lhs, lhs_vals);
+
+  FilterXExpr *rhs = filterx_literal_dict_generator_new();
+  GList *rhs_vals = NULL;
+  GList *rhs_inner = NULL;
+  rhs_inner = g_list_append(rhs_inner,
+                            filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("tak", -1)),
+                                filterx_literal_new(filterx_string_new("toe", -1)), TRUE));
+  rhs_vals = g_list_append(rhs_vals,
+                           filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("tik", -1)),
+                                                              filterx_literal_inner_dict_generator_new(rhs, rhs_inner), FALSE));
+  filterx_literal_generator_set_elements(rhs, rhs_vals);
+
+  FilterXExpr *expr = filterx_operator_plus_generator_new(lhs, rhs);
+  FilterXObject *json_dict = filterx_json_object_new_empty();
+  FilterXExpr *fillable = filterx_literal_new(json_dict);
+  filterx_generator_set_fillable(expr, filterx_expr_ref(fillable));
+
+  FilterXObject *res_object = filterx_expr_eval(expr);
+  cr_assert_not_null(res_object);
+  cr_assert(filterx_object_is_type(res_object, &FILTERX_TYPE_NAME(dict)));
+
+  struct json_object *jso = NULL;
+  FilterXObject *assoc_object = NULL;
+  cr_assert(filterx_object_map_to_json(res_object, &jso, &assoc_object));
+
+  const gchar *json_repr = json_object_to_json_string_ext(jso, JSON_C_TO_STRING_PLAIN);
+  cr_assert_str_eq(json_repr, "{\"foo\":{\"bar\":\"baz\"},\"tik\":{\"tak\":\"toe\"}}");
+  json_object_put(jso);
+  filterx_object_unref(assoc_object);
+
+  filterx_expr_unref(expr);
+  filterx_expr_unref(fillable);
+  filterx_object_unref(json_dict);
+}
+
+Test(expr_plus_generator, test_nested_dict_add_variable_to_generator_with_post_set_fillable)
+{
+  FilterXExpr *lhs = filterx_literal_dict_generator_new();
+  GList *lhs_vals = NULL;
+  GList *lhs_inner = NULL;
+  lhs_inner = g_list_append(lhs_inner,
+                            filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("bar", -1)),
+                                filterx_literal_new(filterx_string_new("baz", -1)), TRUE));
+  lhs_vals = g_list_append(lhs_vals,
+                           filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("foo", -1)),
+                                                              filterx_literal_inner_dict_generator_new(lhs, lhs_inner), FALSE));
+  filterx_literal_generator_set_elements(lhs, lhs_vals);
+
+  FilterXExpr *rhs = filterx_non_literal_new(filterx_json_object_new_from_repr("{\"tik\":{\"tak\":\"toe\"}}", -1));
+
+  FilterXExpr *expr = filterx_operator_plus_generator_new(lhs, rhs);
+  FilterXObject *json_dict = filterx_json_object_new_empty();
+  FilterXExpr *fillable = filterx_literal_new(json_dict);
+  filterx_generator_set_fillable(expr, filterx_expr_ref(fillable));
+
+  FilterXObject *res_object = filterx_expr_eval(expr);
+  cr_assert_not_null(res_object);
+  cr_assert(filterx_object_is_type(res_object, &FILTERX_TYPE_NAME(dict)));
+
+  struct json_object *jso = NULL;
+  FilterXObject *assoc_object = NULL;
+  cr_assert(filterx_object_map_to_json(res_object, &jso, &assoc_object));
+
+  const gchar *json_repr = json_object_to_json_string_ext(jso, JSON_C_TO_STRING_PLAIN);
+  cr_assert_str_eq(json_repr, "{\"foo\":{\"bar\":\"baz\"},\"tik\":{\"tak\":\"toe\"}}");
+  json_object_put(jso);
+  filterx_object_unref(assoc_object);
+
+  filterx_expr_unref(expr);
+  filterx_expr_unref(fillable);
+  filterx_object_unref(json_dict);
+}
+
+Test(expr_plus_generator, test_nested_dict_add_generator_to_variable_with_post_set_fillable)
+{
+
+  FilterXExpr *lhs = filterx_non_literal_new(filterx_json_object_new_from_repr("{\"foo\":{\"bar\":\"baz\"}}", -1));
+
+  FilterXExpr *rhs = filterx_literal_dict_generator_new();
+  GList *rhs_vals = NULL;
+  GList *rhs_inner = NULL;
+  rhs_inner = g_list_append(rhs_inner,
+                            filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("tak", -1)),
+                                filterx_literal_new(filterx_string_new("toe", -1)), TRUE));
+  rhs_vals = g_list_append(rhs_vals,
+                           filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("tik", -1)),
+                                                              filterx_literal_inner_dict_generator_new(rhs, rhs_inner), FALSE));
+  filterx_literal_generator_set_elements(rhs, rhs_vals);
+
+  FilterXExpr *expr = filterx_operator_plus_generator_new(lhs, rhs);
+  FilterXObject *json_dict = filterx_json_object_new_empty();
+  FilterXExpr *fillable = filterx_literal_new(json_dict);
+  filterx_generator_set_fillable(expr, filterx_expr_ref(fillable));
+
+  FilterXObject *res_object = filterx_expr_eval(expr);
+  cr_assert_not_null(res_object);
+  cr_assert(filterx_object_is_type(res_object, &FILTERX_TYPE_NAME(dict)));
+
+  struct json_object *jso = NULL;
+  FilterXObject *assoc_object = NULL;
+  cr_assert(filterx_object_map_to_json(res_object, &jso, &assoc_object));
+
+  const gchar *json_repr = json_object_to_json_string_ext(jso, JSON_C_TO_STRING_PLAIN);
+  cr_assert_str_eq(json_repr, "{\"foo\":{\"bar\":\"baz\"},\"tik\":{\"tak\":\"toe\"}}");
+  json_object_put(jso);
+  filterx_object_unref(assoc_object);
+
+  filterx_expr_unref(expr);
+  filterx_expr_unref(fillable);
+  filterx_object_unref(json_dict);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  init_libtest_filterx();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  deinit_libtest_filterx();
+  app_shutdown();
+}
+
+
+TestSuite(expr_plus_generator, .init = setup, .fini = teardown);


### PR DESCRIPTION
continue #217 with expr-plus-generator operator for handling mixed generator/variable operations

This commit continues the work from #217 by introducing the expr-plus-generator 
operator. This new operator is designed to handle plus operations over generators 
and mixed generator/variable operations, ensuring that both types of elements are 
processed seamlessly as a single generator.