### PR TITLE
Tarball fixes

### DIFF
--- a/cmake/Makefile.am
+++ b/cmake/Makefile.am
@@ -13,6 +13,7 @@ EXTRA_DIST +=	\
 	cmake/Modules/FindFLEX.cmake	\
 	cmake/Modules/FindGettext.cmake	\
 	cmake/Modules/FindGLIB.cmake	\
+	cmake/Modules/FindGperf.cmake	\
 	cmake/Modules/FindGradle.cmake	\
 	cmake/Modules/FindgRPC.cmake	\
 	cmake/Modules/FindHiredis.cmake	\
@@ -36,4 +37,5 @@ EXTRA_DIST +=	\
 	cmake/Modules/ProtobufGenerateCpp.cmake	\
 	cmake/module_switch.cmake		\
 	cmake/openssl_functions.cmake \
-	cmake/print_config_summary.cmake
+	cmake/print_config_summary.cmake \
+	cmake/python_build_venv.cmake

--- a/dbld/pkg-tarball
+++ b/dbld/pkg-tarball
@@ -14,7 +14,7 @@ rm -rf $SYSLOGNG_DIR
 tar xfz $SYSLOGNG_TARBALL
 cd $SYSLOGNG_DIR
 
-echo ${VERSION} > VERSION
+echo ${VERSION} > VERSION.txt
 
 /dbld/generate-debian-directory $MODE
 /dbld/generate-rpm-specfile $MODE

--- a/modules/afmongodb/Makefile.am
+++ b/modules/afmongodb/Makefile.am
@@ -41,7 +41,8 @@ BUILT_SOURCES					+=	\
 
 EXTRA_DIST					+=	\
 	modules/afmongodb/afmongodb-grammar.ym \
-	modules/afmongodb/CMakeLists.txt
+	modules/afmongodb/CMakeLists.txt \
+	modules/afmongodb/tests/CMakeLists.txt
 
 
 .PHONY: modules/afmongodb/ mod-afmongodb mod-mongodb


### PR DESCRIPTION
Patches were cherry-picked from syslog-ng/syslog-ng#5041 by @HofiOne.

(The PR also contains a fix for the VERSION file naming inconsistency that was worked around in the original PR.)