### PR TITLE
filterx: cleanup `message_value` handling

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -19,6 +19,7 @@ set(FILTERX_HEADERS
     filterx/filterx-pipe.h
     filterx/filterx-scope.h
     filterx/filterx-weakrefs.h
+    filterx/object-extractor.h
     filterx/object-datetime.h
     filterx/object-json.h
     filterx/object-json-internal.h
@@ -68,6 +69,7 @@ set(FILTERX_SOURCES
     filterx/filterx-pipe.c
     filterx/filterx-scope.c
     filterx/filterx-weakrefs.c
+    filterx/object-extractor.c
     filterx/object-datetime.c
     filterx/object-json.c
     filterx/object-json-object.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -20,6 +20,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/object-primitive.h		\
 	lib/filterx/filterx-scope.h		\
 	lib/filterx/filterx-eval.h		\
+	lib/filterx/object-extractor.h		\
 	lib/filterx/object-json.h		\
 	lib/filterx/object-json-internal.h		\
 	lib/filterx/object-string.h		\
@@ -68,6 +69,7 @@ filterx_sources = 				\
 	lib/filterx/object-primitive.c		\
 	lib/filterx/filterx-scope.c		\
 	lib/filterx/filterx-eval.c		\
+	lib/filterx/object-extractor.c		\
 	lib/filterx/object-json.c		\
 	lib/filterx/object-json-object.c		\
 	lib/filterx/object-json-array.c		\

--- a/lib/filterx/expr-comparison.c
+++ b/lib/filterx/expr-comparison.c
@@ -65,8 +65,8 @@ _convert_filterx_object_to_generic_number(FilterXObject *obj, GenericNumber *gn)
   UnixTime utime;
   if (filterx_object_extract_datetime(obj, &utime))
     {
-      uint64_t unix_epoch = unix_time_to_unix_epoch(utime);
-      gn_set_int64(gn, (uint64_t) unix_epoch);
+      guint64 unix_epoch = unix_time_to_unix_epoch(utime);
+      gn_set_int64(gn, (gint64) MIN(unix_epoch, G_MAXINT64));
       return;
     }
 

--- a/lib/filterx/expr-comparison.c
+++ b/lib/filterx/expr-comparison.c
@@ -24,6 +24,7 @@
 #include "filterx/expr-comparison.h"
 #include "filterx/object-datetime.h"
 #include "filterx/filterx-globals.h"
+#include "filterx/object-extractor.h"
 #include "filterx/object-primitive.h"
 #include "filterx/object-null.h"
 #include "filterx/object-string.h"
@@ -44,43 +45,43 @@ typedef struct _FilterXComparison
 static void
 _convert_filterx_object_to_generic_number(FilterXObject *obj, GenericNumber *gn)
 {
-  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(integer)) ||
-      filterx_object_is_type(obj, &FILTERX_TYPE_NAME(double)) ||
-      filterx_object_is_type(obj, &FILTERX_TYPE_NAME(boolean)))
-    *gn = filterx_primitive_get_value(obj);
-  else if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)))
+  if (filterx_object_extract_generic_number(obj, gn))
+    return;
+
+  const gchar *str;
+  if (filterx_object_extract_string(obj, &str, NULL))
     {
-      if (!parse_generic_number(filterx_string_get_value(obj, NULL), gn))
+      if (!parse_generic_number(str, gn))
         gn_set_nan(gn);
+      return;
     }
-  else if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(null)))
-    gn_set_int64(gn, 0);
-  else if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(datetime)))
+
+  if (filterx_object_extract_null(obj))
     {
-      const UnixTime utime = filterx_datetime_get_value(obj);
+      gn_set_int64(gn, 0);
+      return;
+    }
+
+  UnixTime utime;
+  if (filterx_object_extract_datetime(obj, &utime))
+    {
       uint64_t unix_epoch = unix_time_to_unix_epoch(utime);
-      gn_set_int64(gn, (uint64_t)unix_epoch);
+      gn_set_int64(gn, (uint64_t) unix_epoch);
+      return;
     }
-  else
-    {
-      gn_set_nan(gn);
-    }
+
+  gn_set_nan(gn);
 }
 
 static const gchar *
 _convert_filterx_object_to_string(FilterXObject *obj, gsize *len)
 {
-  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)))
+  const gchar *str;
+  if (filterx_object_extract_string(obj, &str, len) ||
+      filterx_object_extract_bytes(obj, &str, len) ||
+      filterx_object_extract_protobuf(obj, &str, len))
     {
-      return filterx_string_get_value(obj, len);
-    }
-  else if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(bytes)))
-    {
-      return filterx_bytes_get_value(obj, len);
-    }
-  else if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(protobuf)))
-    {
-      return filterx_protobuf_get_value(obj, len);
+      return str;
     }
 
   GString *buffer = scratch_buffers_alloc();
@@ -183,19 +184,22 @@ _eval(FilterXExpr *s)
 {
   FilterXComparison *self = (FilterXComparison *) s;
 
-  FilterXObject *lhs_object = filterx_expr_eval_typed(self->super.lhs);
+  gint compare_mode = self->operator & FCMPX_MODE_MASK;
+  gint operator = self->operator & FCMPX_OP_MASK;
+  gboolean typed_eval_needed = compare_mode & FCMPX_TYPE_AWARE || compare_mode & FCMPX_TYPE_AND_VALUE_BASED;
+
+  FilterXObject *lhs_object = typed_eval_needed ? filterx_expr_eval_typed(self->super.lhs) : filterx_expr_eval(
+                                self->super.lhs);
   if (!lhs_object)
     return NULL;
 
-  FilterXObject *rhs_object = filterx_expr_eval_typed(self->super.rhs);
+  FilterXObject *rhs_object = typed_eval_needed ? filterx_expr_eval_typed(self->super.rhs) : filterx_expr_eval(
+                                self->super.rhs);
   if (!rhs_object)
     {
       filterx_object_unref(lhs_object);
       return NULL;
     }
-
-  gint compare_mode = self->operator & FCMPX_MODE_MASK;
-  gint operator = self->operator & FCMPX_OP_MASK;
 
   gboolean result = TRUE;
   if (compare_mode & FCMPX_TYPE_AWARE)

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -267,6 +267,7 @@ _get_literal_string_from_expr(FilterXExpr *expr, gsize *len)
   if (!obj)
     goto error;
 
+  /* Literal message values don't exist, so we don't need to use the extractor. */
   str = filterx_string_get_value(obj, len);
 
   /*

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -40,7 +40,7 @@ _eval(FilterXExpr *s)
   if (!variable)
     return NULL;
 
-  FilterXObject *key = filterx_expr_eval_typed(self->key);
+  FilterXObject *key = filterx_expr_eval(self->key);
   if (!key)
     goto exit;
   result = filterx_object_get_subscript(variable, key);

--- a/lib/filterx/expr-literal-generator.c
+++ b/lib/filterx/expr-literal-generator.c
@@ -78,12 +78,12 @@ _eval_elements(FilterXObject *fillable, GList *elements)
       FilterXObject *key = NULL;
       if (elem->key)
         {
-          key = filterx_expr_eval_typed(elem->key);
+          key = filterx_expr_eval(elem->key);
           if (!key)
             return FALSE;
         }
 
-      FilterXObject *value = filterx_expr_eval_typed(elem->value);
+      FilterXObject *value = filterx_expr_eval(elem->value);
       if (!value)
         {
           filterx_object_unref(key);

--- a/lib/filterx/expr-plus.c
+++ b/lib/filterx/expr-plus.c
@@ -35,11 +35,11 @@ _eval(FilterXExpr *s)
 {
   FilterXOperatorPlus *self = (FilterXOperatorPlus *) s;
 
-  FilterXObject *lhs_object = filterx_expr_eval_typed(self->super.lhs);
+  FilterXObject *lhs_object = filterx_expr_eval(self->super.lhs);
   if (!lhs_object)
     return NULL;
 
-  FilterXObject *rhs_object = filterx_expr_eval_typed(self->super.rhs);
+  FilterXObject *rhs_object = filterx_expr_eval(self->super.rhs);
   if (!rhs_object)
     {
       filterx_object_unref(lhs_object);

--- a/lib/filterx/expr-regexp.c
+++ b/lib/filterx/expr-regexp.c
@@ -23,8 +23,8 @@
 
 #include "filterx/expr-regexp.h"
 #include "filterx/object-primitive.h"
+#include "filterx/object-extractor.h"
 #include "filterx/object-string.h"
-#include "filterx/object-message-value.h"
 #include "filterx/object-list-interface.h"
 #include "filterx/object-dict-interface.h"
 #include "compat/pcre.h"
@@ -142,21 +142,7 @@ _match(FilterXExpr *lhs_expr, pcre2_code_8 *pattern, FilterXReMatchState *state)
   if (!state->lhs_obj)
     goto error;
 
-  if (filterx_object_is_type(state->lhs_obj, &FILTERX_TYPE_NAME(message_value)))
-    {
-      if (filterx_message_value_get_type(state->lhs_obj) != LM_VT_STRING)
-        {
-          msg_error("FilterX: Regexp matching left hand side must be string type",
-                    evt_tag_str("type", state->lhs_obj->type->name));
-          goto error;
-        }
-      state->lhs_str = filterx_message_value_get_value(state->lhs_obj, &state->lhs_str_len);
-    }
-  else if (filterx_object_is_type(state->lhs_obj, &FILTERX_TYPE_NAME(string)))
-    {
-      state->lhs_str = filterx_string_get_value(state->lhs_obj, &state->lhs_str_len);
-    }
-  else
+  if (!filterx_object_extract_string(state->lhs_obj, &state->lhs_str, &state->lhs_str_len))
     {
       msg_error("FilterX: Regexp matching left hand side must be string type",
                 evt_tag_str("type", state->lhs_obj->type->name));

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -46,7 +46,7 @@ _eval(FilterXExpr *s)
 
   if (self->key)
     {
-      key = filterx_expr_eval_typed(self->key);
+      key = filterx_expr_eval(self->key);
       if (!key)
         goto exit;
     }
@@ -62,7 +62,7 @@ _eval(FilterXExpr *s)
       goto exit;
     }
 
-  new_value = filterx_expr_eval_typed(self->new_value);
+  new_value = filterx_expr_eval(self->new_value);
   if (!new_value)
     goto exit;
 

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -50,7 +50,7 @@ _eval(FilterXExpr *s)
       goto exit;
     }
 
-  FilterXObject *new_value = filterx_expr_eval_typed(self->new_value);
+  FilterXObject *new_value = filterx_expr_eval(self->new_value);
   if (!new_value)
     goto exit;
 

--- a/lib/filterx/func-str-transform.c
+++ b/lib/filterx/func-str-transform.c
@@ -23,6 +23,7 @@
  */
 
 #include "filterx/func-str-transform.h"
+#include "filterx/object-extractor.h"
 #include "filterx/object-string.h"
 #include "filterx/filterx-eval.h"
 
@@ -35,10 +36,11 @@ _extract_str_arg(FilterXExpr *s, GPtrArray *args, gssize *len)
       return NULL;
     }
 
+  const gchar *str;
   gsize inner_len;
   FilterXObject *object = g_ptr_array_index(args, 0);
-  const gchar *str = filterx_string_get_value(object, &inner_len);
-  if (!str)
+
+  if (!filterx_object_extract_string(object, &str, &inner_len))
     {
       filterx_simple_function_argument_error(s, "Object must be string", FALSE);
       return NULL;

--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -22,6 +22,7 @@
  */
 
 #include "filterx/func-unset-empties.h"
+#include "filterx/object-extractor.h"
 #include "filterx/object-string.h"
 #include "filterx/object-primitive.h"
 #include "filterx/object-null.h"
@@ -45,13 +46,13 @@ static gboolean _process_list(FilterXFunctionUnsetEmpties *self, FilterXObject *
 static gboolean
 _should_unset(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
 {
-  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)))
+  gsize str_len;
+  const gchar *str;
+  if (filterx_object_extract_string(obj, &str, &str_len))
     {
-      gsize len;
-      const gchar *value = filterx_string_get_value(obj, &len);
-      return len == 0 ||
-             strcasecmp(value, "n/a") == 0 ||
-             strcmp(value, "-") == 0;
+      return str_len == 0 ||
+             strcasecmp(str, "n/a") == 0 ||
+             strcmp(str, "-") == 0;
     }
 
   if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(null)))

--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -131,7 +131,7 @@ filterx_typecast_datetime(FilterXExpr *s, GPtrArray *args)
   gint64 i;
   if (filterx_object_extract_integer(object, &i))
     {
-      UnixTime ut = unix_time_from_unix_epoch(i);
+      UnixTime ut = unix_time_from_unix_epoch((guint64) MAX(i, 0));
       return filterx_datetime_new(&ut);
     }
 

--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -104,6 +104,7 @@ filterx_datetime_new(const UnixTime *ut)
   return &self->super;
 }
 
+/* NOTE: Consider using filterx_object_extract_datetime() to also support message_value. */
 UnixTime
 filterx_datetime_get_value(FilterXObject *s)
 {

--- a/lib/filterx/object-dict-interface.c
+++ b/lib/filterx/object-dict-interface.c
@@ -22,8 +22,10 @@
  */
 
 #include "filterx/object-dict-interface.h"
+#include "filterx/object-extractor.h"
 #include "filterx/object-string.h"
 #include "filterx/object-json.h"
+#include "str-utils.h"
 
 gboolean
 filterx_dict_iter(FilterXObject *s, FilterXDictIterFunc func, gpointer user_data)
@@ -153,10 +155,12 @@ _add_elem_to_json_object(FilterXObject *key_obj, FilterXObject *value_obj, gpoin
 {
   struct json_object *object = (struct json_object *) user_data;
 
-  /* FilterX strings are always NUL terminated. */
-  const gchar *key = filterx_string_get_value(key_obj, NULL);
-  if (!key)
+  const gchar *key;
+  gsize len;
+  if (!filterx_object_extract_string(key_obj, &key, &len))
     return FALSE;
+
+  APPEND_ZERO(key, key, len);
 
   struct json_object *value = NULL;
   FilterXObject *assoc_object = NULL;

--- a/lib/filterx/object-extractor.c
+++ b/lib/filterx/object-extractor.c
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "filterx/object-extractor.h"
+#include "filterx/object-message-value.h"
+#include "filterx/object-string.h"
+#include "filterx/object-primitive.h"
+#include "filterx/object-datetime.h"
+#include "filterx/object-null.h"
+#include "filterx/object-json.h"
+
+gboolean
+filterx_object_extract_string(FilterXObject *obj, const gchar **value, gsize *len)
+{
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
+    return filterx_message_value_get_string(obj, value, len);
+
+  *value = filterx_string_get_value(obj, len);
+  return !!(*value);
+}
+
+gboolean
+filterx_object_extract_bytes(FilterXObject *obj, const gchar **value, gsize *len)
+{
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
+    return filterx_message_value_get_bytes(obj, value, len);
+
+  *value = filterx_bytes_get_value(obj, len);
+  return !!(*value);
+}
+
+gboolean
+filterx_object_extract_protobuf(FilterXObject *obj, const gchar **value, gsize *len)
+{
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
+    return filterx_message_value_get_protobuf(obj, value, len);
+
+  *value = filterx_protobuf_get_value(obj, len);
+  return !!(*value);
+}
+
+gboolean
+filterx_object_extract_boolean(FilterXObject *obj, gboolean *value)
+{
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
+    return filterx_message_value_get_boolean(obj, value);
+
+  return filterx_boolean_unwrap(obj, value);
+}
+
+gboolean
+filterx_object_extract_integer(FilterXObject *obj, gint64 *value)
+{
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
+    return filterx_message_value_get_integer(obj, value);
+
+  return filterx_integer_unwrap(obj, value);
+}
+
+gboolean
+filterx_object_extract_double(FilterXObject *obj, gdouble *value)
+{
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
+    return filterx_message_value_get_double(obj, value);
+
+  return filterx_double_unwrap(obj, value);
+}
+
+gboolean
+filterx_object_extract_generic_number(FilterXObject *obj, GenericNumber *value)
+{
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(primitive)))
+    {
+      *value = filterx_primitive_get_value(obj);
+      return TRUE;
+    }
+
+  if (!filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
+    return FALSE;
+
+  gint64 i;
+  if (filterx_message_value_get_integer(obj, &i))
+    {
+      gn_set_int64(value, i);
+      return TRUE;
+    }
+
+  gdouble d;
+  if (filterx_message_value_get_double(obj, &d))
+    {
+      gn_set_double(value, d, -1);
+      return TRUE;
+    }
+
+  gboolean b;
+  if (filterx_message_value_get_boolean(obj, &b))
+    {
+      gn_set_int64(value, (gint64) b);
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
+gboolean
+filterx_object_extract_datetime(FilterXObject *obj, UnixTime *value)
+{
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
+    return filterx_message_value_get_datetime(obj, value);
+
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(datetime)))
+    {
+      *value = filterx_datetime_get_value(obj);
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
+gboolean
+filterx_object_extract_null(FilterXObject *obj)
+{
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
+    return filterx_message_value_get_null(obj);
+
+  return filterx_object_is_type(obj, &FILTERX_TYPE_NAME(null));
+}
+
+gboolean
+filterx_object_extract_json_array(FilterXObject *obj, struct json_object **value)
+{
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
+    {
+      if (!filterx_message_value_get_json(obj, value))
+        return FALSE;
+
+      if (json_object_is_type(*value, json_type_array))
+        return TRUE;
+
+      json_object_put(*value);
+      *value = NULL;
+      return FALSE;
+    }
+
+  *value = filterx_json_array_get_value(obj);
+  return !!(*value);
+}
+
+gboolean
+filterx_object_extract_json_object(FilterXObject *obj, struct json_object **value)
+{
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
+    return filterx_message_value_get_json(obj, value);
+
+  *value = filterx_json_object_get_value(obj);
+  return !!(*value);
+}

--- a/lib/filterx/object-extractor.h
+++ b/lib/filterx/object-extractor.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef FILTERX_OBJECT_EXTRACTOR_H_INCLUDED
+#define FILTERX_OBJECT_EXTRACTOR_H_INCLUDED
+
+#include "filterx/filterx-object.h"
+#include "generic-number.h"
+#include "compat/json.h"
+
+gboolean filterx_object_extract_string(FilterXObject *obj, const gchar **value, gsize *len);
+gboolean filterx_object_extract_bytes(FilterXObject *obj, const gchar **value, gsize *len);
+gboolean filterx_object_extract_protobuf(FilterXObject *obj, const gchar **value, gsize *len);
+gboolean filterx_object_extract_boolean(FilterXObject *obj, gboolean *value);
+gboolean filterx_object_extract_integer(FilterXObject *obj, gint64 *value);
+gboolean filterx_object_extract_double(FilterXObject *obj, gdouble *value);
+gboolean filterx_object_extract_generic_number(FilterXObject *obj, GenericNumber *value);
+gboolean filterx_object_extract_datetime(FilterXObject *obj, UnixTime *value);
+gboolean filterx_object_extract_null(FilterXObject *obj);
+gboolean filterx_object_extract_json_array(FilterXObject *obj, struct json_object **value);
+gboolean filterx_object_extract_json_object(FilterXObject *obj, struct json_object **value);
+
+#endif

--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -30,7 +30,7 @@
 #include "filterx/expr-function.h"
 #include "filterx/filterx-eval.h"
 
-#include "scanner/list-scanner/list-scanner.h"
+#include "logmsg/type-hinting.h"
 #include "str-repr/encode.h"
 
 #define JSON_ARRAY_MAX_SIZE 65536
@@ -262,19 +262,8 @@ _free(FilterXObject *s)
 FilterXObject *
 filterx_json_array_new_from_repr(const gchar *repr, gssize repr_len)
 {
-  struct json_tokener *tokener = json_tokener_new();
   struct json_object *jso;
-
-  jso = json_tokener_parse_ex(tokener, repr, repr_len < 0 ? strlen(repr) : repr_len);
-  if (repr_len >= 0 && json_tokener_get_error(tokener) == json_tokener_continue)
-    {
-      /* pass the closing NUL character */
-      jso = json_tokener_parse_ex(tokener, "", 1);
-    }
-
-  json_tokener_free(tokener);
-
-  if (!jso)
+  if (!type_cast_to_json(repr, repr_len, &jso, NULL))
     return NULL;
 
   if (!json_object_is_type(jso, json_type_array))
@@ -289,18 +278,9 @@ filterx_json_array_new_from_repr(const gchar *repr, gssize repr_len)
 FilterXObject *
 filterx_json_array_new_from_syslog_ng_list(const gchar *repr, gssize repr_len)
 {
-  struct json_object *jso = json_object_new_array();
-
-  ListScanner scanner;
-  list_scanner_init(&scanner);
-  list_scanner_input_string(&scanner, repr, repr_len);
-  for (gint i = 0; list_scanner_scan_next(&scanner); i++)
-    {
-      json_object_array_put_idx(jso, i,
-                                json_object_new_string_len(list_scanner_get_current_value(&scanner),
-                                                           list_scanner_get_current_value_len(&scanner)));
-    }
-  list_scanner_deinit(&scanner);
+  struct json_object *jso;
+  if (!type_cast_to_json_from_list(repr, repr_len, &jso, NULL))
+    return NULL;
 
   return filterx_json_array_new_sub(jso, NULL);
 }

--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -340,6 +340,7 @@ filterx_json_array_to_json_literal(FilterXObject *s)
   return json_object_to_json_string_ext(self->jso, JSON_C_TO_STRING_PLAIN);
 }
 
+/* NOTE: Consider using filterx_object_extract_json_array() to also support message_value. */
 struct json_object *
 filterx_json_array_get_value(FilterXObject *s)
 {

--- a/lib/filterx/object-json-object.c
+++ b/lib/filterx/object-json-object.c
@@ -253,6 +253,7 @@ filterx_json_object_to_json_literal(FilterXObject *s)
   return json_object_to_json_string_ext(self->jso, JSON_C_TO_STRING_PLAIN);
 }
 
+/* NOTE: Consider using filterx_object_extract_json_object() to also support message_value. */
 struct json_object *
 filterx_json_object_get_value(FilterXObject *s)
 {

--- a/lib/filterx/object-json-object.c
+++ b/lib/filterx/object-json-object.c
@@ -26,6 +26,7 @@
 #include "filterx/object-string.h"
 #include "filterx/filterx-weakrefs.h"
 #include "filterx/object-dict-interface.h"
+#include "logmsg/type-hinting.h"
 
 struct FilterXJsonObject_
 {
@@ -229,18 +230,11 @@ _free(FilterXObject *s)
 FilterXObject *
 filterx_json_object_new_from_repr(const gchar *repr, gssize repr_len)
 {
-  struct json_tokener *tokener = json_tokener_new();
   struct json_object *jso;
+  if (!type_cast_to_json(repr, repr_len, &jso, NULL))
+    return NULL;
 
-  jso = json_tokener_parse_ex(tokener, repr, repr_len < 0 ? strlen(repr) : repr_len);
-  if (repr_len >= 0 && json_tokener_get_error(tokener) == json_tokener_continue)
-    {
-      /* pass the closing NUL character */
-      jso = json_tokener_parse_ex(tokener, "", 1);
-    }
-
-  json_tokener_free(tokener);
-  return jso ? filterx_json_object_new_sub(jso, NULL) : NULL;
+  return filterx_json_object_new_sub(jso, NULL);
 }
 
 FilterXObject *

--- a/lib/filterx/object-json-object.c
+++ b/lib/filterx/object-json-object.c
@@ -21,11 +21,13 @@
  *
  */
 #include "filterx/object-json-internal.h"
+#include "filterx/object-extractor.h"
 #include "filterx/object-null.h"
 #include "filterx/object-primitive.h"
 #include "filterx/object-string.h"
 #include "filterx/filterx-weakrefs.h"
 #include "filterx/object-dict-interface.h"
+#include "str-utils.h"
 #include "logmsg/type-hinting.h"
 
 struct FilterXJsonObject_
@@ -91,9 +93,12 @@ _get_subscript(FilterXDict *s, FilterXObject *key)
 {
   FilterXJsonObject *self = (FilterXJsonObject *) s;
 
-  const gchar *key_str = filterx_string_get_value(key, NULL);
-  if (!key_str)
+  const gchar *key_str;
+  gsize len;
+  if (!filterx_object_extract_string(key, &key_str, &len))
     return NULL;
+
+  APPEND_ZERO(key_str, key_str, len);
 
   struct json_object *jso = NULL;
   if (!json_object_object_get_ex(self->jso, key_str, &jso))
@@ -107,9 +112,12 @@ _set_subscript(FilterXDict *s, FilterXObject *key, FilterXObject **new_value)
 {
   FilterXJsonObject *self = (FilterXJsonObject *) s;
 
-  const gchar *key_str = filterx_string_get_value(key, NULL);
-  if (!key_str)
+  const gchar *key_str;
+  gsize len;
+  if (!filterx_object_extract_string(key, &key_str, &len))
     return FALSE;
+
+  APPEND_ZERO(key_str, key_str, len);
 
   struct json_object *jso = NULL;
   FilterXObject *assoc_object = NULL;
@@ -144,9 +152,12 @@ _unset_key(FilterXDict *s, FilterXObject *key)
 {
   FilterXJsonObject *self = (FilterXJsonObject *) s;
 
-  const gchar *key_str = filterx_string_get_value(key, NULL);
-  if (!key_str)
+  const gchar *key_str;
+  gsize len;
+  if (!filterx_object_extract_string(key, &key_str, &len))
     return FALSE;
+
+  APPEND_ZERO(key_str, key_str, len);
 
   json_object_object_del(self->jso, key_str);
 

--- a/lib/filterx/object-message-value.c
+++ b/lib/filterx/object-message-value.c
@@ -41,6 +41,111 @@ typedef struct _FilterXMessageValue
 } FilterXMessageValue;
 
 gboolean
+filterx_message_value_get_string(FilterXObject *s, const gchar **value, gsize *len)
+{
+  FilterXMessageValue *self = (FilterXMessageValue *) s;
+
+  if (self->type != LM_VT_STRING)
+    return FALSE;
+
+  *value = self->repr;
+  *len = self->repr_len;
+  return TRUE;
+}
+
+gboolean
+filterx_message_value_get_bytes(FilterXObject *s, const gchar **value, gsize *len)
+{
+  FilterXMessageValue *self = (FilterXMessageValue *) s;
+
+  if (self->type != LM_VT_BYTES)
+    return FALSE;
+
+  *value = self->repr;
+  *len = self->repr_len;
+  return TRUE;
+}
+
+gboolean
+filterx_message_value_get_protobuf(FilterXObject *s, const gchar **value, gsize *len)
+{
+  FilterXMessageValue *self = (FilterXMessageValue *) s;
+
+  if (self->type != LM_VT_PROTOBUF)
+    return FALSE;
+
+  *value = self->repr;
+  *len = self->repr_len;
+  return TRUE;
+}
+
+gboolean
+filterx_message_value_get_boolean(FilterXObject *s, gboolean *value)
+{
+  FilterXMessageValue *self = (FilterXMessageValue *) s;
+
+  if (self->type != LM_VT_BOOLEAN)
+    return FALSE;
+
+  return type_cast_to_boolean(self->repr, self->repr_len, value, NULL);
+}
+
+gboolean
+filterx_message_value_get_integer(FilterXObject *s, gint64 *value)
+{
+  FilterXMessageValue *self = (FilterXMessageValue *) s;
+
+  if (self->type != LM_VT_INTEGER)
+    return FALSE;
+
+  return type_cast_to_int64(self->repr, self->repr_len, value, NULL);
+}
+
+gboolean
+filterx_message_value_get_double(FilterXObject *s, gdouble *value)
+{
+  FilterXMessageValue *self = (FilterXMessageValue *) s;
+
+  if (self->type != LM_VT_DOUBLE)
+    return FALSE;
+
+  return type_cast_to_double(self->repr, self->repr_len, value, NULL);
+}
+
+gboolean
+filterx_message_value_get_datetime(FilterXObject *s, UnixTime *value)
+{
+  FilterXMessageValue *self = (FilterXMessageValue *) s;
+
+  if (self->type != LM_VT_DATETIME)
+    return FALSE;
+
+  return type_cast_to_datetime_unixtime(self->repr, self->repr_len, value, NULL);
+}
+
+gboolean
+filterx_message_value_get_null(FilterXObject *s)
+{
+  FilterXMessageValue *self = (FilterXMessageValue *) s;
+
+  return self->type == LM_VT_NULL;
+}
+
+gboolean
+filterx_message_value_get_json(FilterXObject *s, struct json_object **value)
+{
+  FilterXMessageValue *self = (FilterXMessageValue *) s;
+
+  if (self->type == LM_VT_JSON)
+    return type_cast_to_json(self->repr, self->repr_len, value, NULL);
+
+  if (self->type == LM_VT_LIST)
+    return type_cast_to_json_from_list(self->repr, self->repr_len, value, NULL);
+
+  return FALSE;
+}
+
+gboolean
 _is_value_type_pair_truthy(const gchar  *repr, gssize repr_len, LogMessageValueType type)
 {
   gboolean b;

--- a/lib/filterx/object-message-value.h
+++ b/lib/filterx/object-message-value.h
@@ -34,4 +34,14 @@ FilterXObject *filterx_message_value_new(const gchar *repr, gssize repr_len, Log
 LogMessageValueType filterx_message_value_get_type(FilterXObject *s);
 const gchar *filterx_message_value_get_value(FilterXObject *s, gsize *len);
 
+gboolean filterx_message_value_get_string(FilterXObject *s, const gchar **value, gsize *len);
+gboolean filterx_message_value_get_bytes(FilterXObject *s, const gchar **value, gsize *len);
+gboolean filterx_message_value_get_protobuf(FilterXObject *s, const gchar **value, gsize *len);
+gboolean filterx_message_value_get_boolean(FilterXObject *s, gboolean *value);
+gboolean filterx_message_value_get_integer(FilterXObject *s, gint64 *value);
+gboolean filterx_message_value_get_double(FilterXObject *s, gdouble *value);
+gboolean filterx_message_value_get_datetime(FilterXObject *s, UnixTime *value);
+gboolean filterx_message_value_get_null(FilterXObject *s);
+gboolean filterx_message_value_get_json(FilterXObject *s, struct json_object **value);
+
 #endif

--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -257,6 +257,7 @@ filterx_enum_new(GlobalConfig *cfg, const gchar *namespace_name, const gchar *en
   return &self->super;
 }
 
+/* NOTE: Consider using filterx_object_extract_generic_number() to also support message_value. */
 GenericNumber
 filterx_primitive_get_value(FilterXObject *s)
 {

--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -66,19 +66,18 @@ _integer_map_to_json(FilterXObject *s, struct json_object **object, FilterXObjec
 }
 
 static FilterXObject *
-_integer_add(FilterXObject *self, FilterXObject *object)
+_integer_add(FilterXObject *s, FilterXObject *object)
 {
-  GenericNumber base = filterx_primitive_get_value(self);
-  if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(integer)))
-    {
-      GenericNumber add = filterx_primitive_get_value(object);
-      return filterx_integer_new(gn_as_int64(&base) + gn_as_int64(&add));
-    }
-  if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(double)))
-    {
-      GenericNumber add = filterx_primitive_get_value(object);
-      return filterx_double_new(gn_as_int64(&base) + gn_as_double(&add));
-    }
+  FilterXPrimitive *self = (FilterXPrimitive *) s;
+
+  gint64 i;
+  if (filterx_object_extract_integer(object, &i))
+    return filterx_integer_new(gn_as_int64(&self->value) + i);
+
+  gdouble d;
+  if (filterx_object_extract_double(object, &d))
+    return filterx_double_new(gn_as_int64(&self->value) + d);
+
   return NULL;
 }
 
@@ -123,19 +122,18 @@ _double_map_to_json(FilterXObject *s, struct json_object **object, FilterXObject
 }
 
 static FilterXObject *
-_double_add(FilterXObject *self, FilterXObject *object)
+_double_add(FilterXObject *s, FilterXObject *object)
 {
-  GenericNumber base = filterx_primitive_get_value(self);
-  if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(integer)))
-    {
-      GenericNumber add = filterx_primitive_get_value(object);
-      return filterx_double_new(gn_as_double(&base) + gn_as_int64(&add));
-    }
-  else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(double)))
-    {
-      GenericNumber add = filterx_primitive_get_value(object);
-      return filterx_double_new(gn_as_double(&base) + gn_as_double(&add));
-    }
+  FilterXPrimitive *self = (FilterXPrimitive *) s;
+
+  gint64 i;
+  if (filterx_object_extract_integer(object, &i))
+    return filterx_double_new(gn_as_double(&self->value) + i);
+
+  gdouble d;
+  if (filterx_object_extract_double(object, &d))
+    return filterx_double_new(gn_as_double(&self->value) + d);
+
   return NULL;
 }
 

--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -355,27 +355,26 @@ _repr(FilterXObject *s, GString *repr)
   return filterx_object_marshal_append(s, repr, &t);
 }
 
-FILTERX_DEFINE_TYPE(integer, FILTERX_TYPE_NAME(object),
+FILTERX_DEFINE_TYPE(primitive, FILTERX_TYPE_NAME(object),
                     .truthy = _truthy,
+                    .repr = _repr,
+                   );
+
+FILTERX_DEFINE_TYPE(integer, FILTERX_TYPE_NAME(primitive),
                     .marshal = _integer_marshal,
                     .map_to_json = _integer_map_to_json,
-                    .repr = _repr,
                     .add = _integer_add,
                    );
 
-FILTERX_DEFINE_TYPE(double, FILTERX_TYPE_NAME(object),
-                    .truthy = _truthy,
+FILTERX_DEFINE_TYPE(double, FILTERX_TYPE_NAME(primitive),
                     .marshal = _double_marshal,
                     .map_to_json = _double_map_to_json,
-                    .repr = _repr,
                     .add = _double_add,
                    );
 
-FILTERX_DEFINE_TYPE(boolean, FILTERX_TYPE_NAME(object),
-                    .truthy = _truthy,
+FILTERX_DEFINE_TYPE(boolean, FILTERX_TYPE_NAME(primitive),
                     .marshal = _bool_marshal,
                     .map_to_json = _bool_map_to_json,
-                    .repr = _repr,
                    );
 
 void

--- a/lib/filterx/object-primitive.h
+++ b/lib/filterx/object-primitive.h
@@ -26,6 +26,7 @@
 #include "filterx/filterx-object.h"
 #include "generic-number.h"
 
+FILTERX_DECLARE_TYPE(primitive);
 FILTERX_DECLARE_TYPE(integer);
 FILTERX_DECLARE_TYPE(double);
 FILTERX_DECLARE_TYPE(boolean);

--- a/lib/filterx/object-primitive.h
+++ b/lib/filterx/object-primitive.h
@@ -57,6 +57,7 @@ gboolean bool_repr(gboolean bool_val, GString *repr);
 gboolean double_repr(double val, GString *repr);
 gboolean integer_repr(gint64 val, GString *repr);
 
+/* NOTE: Consider using filterx_object_extract_integer() to also support message_value. */
 static inline gboolean
 filterx_integer_unwrap(FilterXObject *s, gint64 *value)
 {
@@ -68,6 +69,7 @@ filterx_integer_unwrap(FilterXObject *s, gint64 *value)
   return TRUE;
 }
 
+/* NOTE: Consider using filterx_object_extract_double() to also support message_value. */
 static inline gboolean
 filterx_double_unwrap(FilterXObject *s, gdouble *value)
 {
@@ -79,6 +81,7 @@ filterx_double_unwrap(FilterXObject *s, gdouble *value)
   return TRUE;
 }
 
+/* NOTE: Consider using filterx_object_extract_boolean() to also support message_value. */
 static inline gboolean
 filterx_boolean_unwrap(FilterXObject *s, gboolean *value)
 {

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -34,6 +34,7 @@ typedef struct _FilterXString
   gchar str[];
 } FilterXString;
 
+/* NOTE: Consider using filterx_object_extract_string() to also support message_value. */
 const gchar *
 filterx_string_get_value(FilterXObject *s, gsize *length)
 {
@@ -49,6 +50,7 @@ filterx_string_get_value(FilterXObject *s, gsize *length)
   return self->str;
 }
 
+/* NOTE: Consider using filterx_object_extract_bytes() to also support message_value. */
 const gchar *
 filterx_bytes_get_value(FilterXObject *s, gsize *length)
 {
@@ -63,6 +65,7 @@ filterx_bytes_get_value(FilterXObject *s, gsize *length)
   return self->str;
 }
 
+/* NOTE: Consider using filterx_object_extract_protobuf() to also support message_value. */
 const gchar *
 filterx_protobuf_get_value(FilterXObject *s, gsize *length)
 {

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -126,23 +126,20 @@ _string_repr(FilterXObject *s, GString *repr)
 }
 
 static FilterXObject *
-_string_add(FilterXObject *self, FilterXObject *object)
+_string_add(FilterXObject *s, FilterXObject *object)
 {
+  FilterXString *self = (FilterXString *) s;
 
-  if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(string)))
-    {
-      gsize lhs_len, rhs_len;
-      const gchar *lhs_value = filterx_string_get_value(self, &lhs_len);
-      const gchar *rhs_value = filterx_string_get_value(object, &rhs_len);
-      GString *buffer = scratch_buffers_alloc();
+  const gchar *other_str;
+  gsize other_str_len;
+  if (!filterx_object_extract_string(object, &other_str, &other_str_len))
+    return NULL;
 
-      g_string_append_len(buffer, lhs_value, lhs_len);
-      g_string_append_len(buffer, rhs_value, rhs_len);
-      /* FIXME: support taking over the already allocated space */
-      return filterx_string_new(buffer->str, buffer->len);
-    }
-
-  return NULL;
+  GString *buffer = scratch_buffers_alloc();
+  g_string_append_len(buffer, self->str, self->str_len);
+  g_string_append_len(buffer, other_str, other_str_len);
+  /* FIXME: support taking over the already allocated space */
+  return filterx_string_new(buffer->str, buffer->len);
 }
 
 FilterXObject *
@@ -216,23 +213,20 @@ _bytes_repr(FilterXObject *s, GString *repr)
 }
 
 static FilterXObject *
-_bytes_add(FilterXObject *self, FilterXObject *object)
+_bytes_add(FilterXObject *s, FilterXObject *object)
 {
+  FilterXString *self = (FilterXString *) s;
 
-  if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(bytes)))
-    {
-      gsize lhs_len, rhs_len;
-      const gchar *lhs_value = filterx_bytes_get_value(self, &lhs_len);
-      const gchar *rhs_value = filterx_bytes_get_value(object, &rhs_len);
-      GString *buffer = scratch_buffers_alloc();
+  const gchar *other_str;
+  gsize other_str_len;
+  if (!filterx_object_extract_bytes(object, &other_str, &other_str_len))
+    return NULL;
 
-      g_string_append_len(buffer, lhs_value, lhs_len);
-      g_string_append_len(buffer, rhs_value, rhs_len);
-      /* FIXME: support taking over the already allocated space */
-      return filterx_bytes_new(buffer->str, buffer->len);
-    }
-
-  return NULL;
+  GString *buffer = scratch_buffers_alloc();
+  g_string_append_len(buffer, self->str, self->str_len);
+  g_string_append_len(buffer, other_str, other_str_len);
+  /* FIXME: support taking over the already allocated space */
+  return filterx_bytes_new(buffer->str, buffer->len);
 }
 
 FilterXObject *

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -259,10 +259,7 @@ filterx_typecast_string(FilterXExpr *s, GPtrArray *args)
     return NULL;
 
   if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(string)))
-    {
-      filterx_object_ref(object);
-      return object;
-    }
+    return filterx_object_ref(object);
 
   GString *buf = scratch_buffers_alloc();
 
@@ -285,10 +282,7 @@ filterx_typecast_bytes(FilterXExpr *s, GPtrArray *args)
     return NULL;
 
   if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(bytes)))
-    {
-      filterx_object_ref(object);
-      return object;
-    }
+    return filterx_object_ref(object);
 
   if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(string)))
     {

--- a/lib/logmsg/type-hinting.h
+++ b/lib/logmsg/type-hinting.h
@@ -27,6 +27,7 @@
 
 #include "syslog-ng.h"
 #include "logmsg/logmsg.h"
+#include "compat/json.h"
 
 #define TYPE_HINTING_ERROR type_hinting_error_quark()
 
@@ -49,6 +50,8 @@ gboolean type_cast_to_int64(const gchar *value, gssize value_len, gint64 *out, G
 gboolean type_cast_to_double(const gchar *value, gssize value_len, gdouble *out, GError **error);
 gboolean type_cast_to_datetime_msec(const gchar *value, gssize value_len, gint64 *out, GError **error);
 gboolean type_cast_to_datetime_unixtime(const gchar *value, gssize value_len, UnixTime *ut, GError **error);
+gboolean type_cast_to_json(const gchar *value, gssize value_len, struct json_object **out, GError **error);
+gboolean type_cast_to_json_from_list(const gchar *value, gssize value_len, struct json_object **out, GError **error);
 
 gboolean type_cast_validate(const gchar *value, gssize value_len, LogMessageValueType type, GError **error);
 

--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -24,6 +24,7 @@
 #include "otel-field.hpp"
 
 #include "compat/cpp-start.h"
+#include "filterx/object-extractor.h"
 #include "filterx/object-primitive.h"
 #include "filterx/object-string.h"
 #include "compat/cpp-end.h"
@@ -63,10 +64,9 @@ Array::Array(FilterXOtelArray *s, FilterXObject *protobuf_object) :
   array(new ArrayValue()),
   borrowed(false)
 {
+  const gchar *value;
   gsize length;
-  const gchar *value = filterx_protobuf_get_value(protobuf_object, &length);
-
-  if (!value)
+  if (!filterx_object_extract_protobuf(protobuf_object, &value, &length))
     {
       delete array;
       throw std::runtime_error("Argument is not a protobuf object");

--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -27,6 +27,7 @@
 #include "filterx/object-extractor.h"
 #include "filterx/object-primitive.h"
 #include "filterx/object-string.h"
+#include "filterx/object-message-value.h"
 #include "compat/cpp-end.h"
 
 #include <google/protobuf/reflection.h>
@@ -363,6 +364,15 @@ OtelArrayField::FilterXObjectSetter(google::protobuf::Message *message, ProtoRef
     {
       if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(list)))
         return _set_array_field_from_list(message, reflectors, object, assoc_object);
+
+      if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(message_value)))
+        {
+          FilterXObject *unmarshalled = filterx_object_unmarshal(object);
+          bool success = filterx_object_is_type(unmarshalled, &FILTERX_TYPE_NAME(list)) &&
+                         _set_array_field_from_list(message, reflectors, unmarshalled, assoc_object);
+          filterx_object_unref(unmarshalled);
+          return success;
+        }
 
       msg_error("otel-array: Failed to convert field, type is unsupported",
                 evt_tag_str("field", reflectors.fieldDescriptor->name().c_str()),

--- a/modules/grpc/otel/filterx/object-otel-kvlist.cpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.cpp
@@ -24,6 +24,7 @@
 #include "otel-field.hpp"
 
 #include "compat/cpp-start.h"
+#include "filterx/object-extractor.h"
 #include "filterx/object-string.h"
 #include "filterx/object-null.h"
 #include "compat/cpp-end.h"
@@ -59,10 +60,9 @@ KVList::KVList(FilterXOtelKVList *s, FilterXObject *protobuf_object) :
   repeated_kv(new RepeatedPtrField<KeyValue>()),
   borrowed(false)
 {
+  const gchar *value;
   gsize length;
-  const gchar *value = filterx_protobuf_get_value(protobuf_object, &length);
-
-  if (!value)
+  if (!filterx_object_extract_protobuf(protobuf_object, &value, &length))
     {
       delete repeated_kv;
       throw std::runtime_error("Argument is not a protobuf object");

--- a/modules/grpc/otel/filterx/object-otel-kvlist.cpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.cpp
@@ -27,6 +27,7 @@
 #include "filterx/object-extractor.h"
 #include "filterx/object-string.h"
 #include "filterx/object-null.h"
+#include "filterx/object-message-value.h"
 #include "compat/cpp-end.h"
 
 #include <google/protobuf/reflection.h>
@@ -101,7 +102,7 @@ KVList::marshal(void)
 }
 
 KeyValue *
-KVList::get_mutable_kv_for_key(const char *key) const
+KVList::get_mutable_kv_for_key(const std::string &key) const
 {
   for (int i = 0; i < repeated_kv->size(); i++)
     {
@@ -117,8 +118,12 @@ KVList::get_mutable_kv_for_key(const char *key) const
 bool
 KVList::set_subscript(FilterXObject *key, FilterXObject **value)
 {
-  const gchar *key_c_str = filterx_string_get_value(key, NULL);
-  if (!key_c_str)
+  std::string key_str;
+  try
+    {
+      key_str = extract_string_from_object(key);
+    }
+  catch (const std::runtime_error &)
     {
       msg_error("FilterX: Failed to set OTel KVList element",
                 evt_tag_str("error", "Key must be string type"));
@@ -127,11 +132,11 @@ KVList::set_subscript(FilterXObject *key, FilterXObject **value)
 
   ProtobufField *converter = otel_converter_by_type(FieldDescriptor::TYPE_MESSAGE);
 
-  KeyValue *kv = get_mutable_kv_for_key(key_c_str);
+  KeyValue *kv = get_mutable_kv_for_key(key_str);
   if (!kv)
     {
       kv = repeated_kv->Add();
-      kv->set_key(key_c_str);
+      kv->set_key(key_str);
     }
 
   FilterXObject *assoc_object = NULL;
@@ -146,18 +151,22 @@ KVList::set_subscript(FilterXObject *key, FilterXObject **value)
 FilterXObject *
 KVList::get_subscript(FilterXObject *key)
 {
-  const gchar *key_c_str = filterx_string_get_value(key, NULL);
-  if (!key_c_str)
+  std::string key_str;
+  try
     {
-      msg_error("FilterX: Failed to get OTel KVList element",
+      key_str = extract_string_from_object(key);
+    }
+  catch (const std::runtime_error &)
+    {
+      msg_error("FilterX: Failed to set OTel KVList element",
                 evt_tag_str("error", "Key must be string type"));
-      return NULL;
+      return nullptr;
     }
 
   ProtobufField *converter = otel_converter_by_type(FieldDescriptor::TYPE_MESSAGE);
-  KeyValue *kv = get_mutable_kv_for_key(key_c_str);
+  KeyValue *kv = get_mutable_kv_for_key(key_str);
   if (!kv)
-    return NULL;
+    return nullptr;
 
   return converter->Get(kv, "value");
 }
@@ -165,24 +174,29 @@ KVList::get_subscript(FilterXObject *key)
 bool
 KVList::is_key_set(FilterXObject *key) const
 {
-  const gchar *key_c_str = filterx_string_get_value(key, NULL);
-  if (!key_c_str)
+  try
     {
-      msg_error("FilterX: Failed to check OTel KVList key",
+      return !!get_mutable_kv_for_key(extract_string_from_object(key));
+    }
+  catch (const std::runtime_error &)
+    {
+      msg_error("FilterX: Failed to set OTel KVList element",
                 evt_tag_str("error", "Key must be string type"));
       return false;
     }
-
-  return !!get_mutable_kv_for_key(key_c_str);
 }
 
 bool
 KVList::unset_key(FilterXObject *key)
 {
-  const gchar *key_c_str = filterx_string_get_value(key, NULL);
-  if (!key_c_str)
+  std::string key_str;
+  try
     {
-      msg_error("FilterX: Failed to unset OTel KVList element",
+      key_str = extract_string_from_object(key);
+    }
+  catch (const std::runtime_error &)
+    {
+      msg_error("FilterX: Failed to set OTel KVList element",
                 evt_tag_str("error", "Key must be string type"));
       return false;
     }
@@ -190,7 +204,7 @@ KVList::unset_key(FilterXObject *key)
   for (int i = 0; i < repeated_kv->size(); i++)
     {
       KeyValue &possible_kv = repeated_kv->at(i);
-      if (possible_kv.key().compare(key_c_str) == 0)
+      if (possible_kv.key().compare(key_str) == 0)
         {
           repeated_kv->DeleteSubrange(i, 1);
           return true;
@@ -458,13 +472,13 @@ _add_elem_to_repeated_kv(FilterXObject *key_obj, FilterXObject *value_obj, gpoin
 {
   RepeatedPtrField<KeyValue> *repeated_kv = (RepeatedPtrField<KeyValue> *) user_data;
 
-  /* FilterX strings are always NUL terminated. */
-  const gchar *key = filterx_string_get_value(key_obj, NULL);
-  if (!key)
-    return FALSE;
+  const gchar *key;
+  gsize key_len;
+  if (!filterx_object_extract_string(key_obj, &key, &key_len))
+    return false;
 
   KeyValue *kv = repeated_kv->Add();
-  kv->set_key(key);
+  kv->set_key(key, key_len);
 
   FilterXObject *assoc_object = NULL;
   if (!syslogng::grpc::otel::any_field_converter.FilterXObjectDirectSetter(kv->mutable_value(), value_obj, &assoc_object))
@@ -494,6 +508,15 @@ OtelKVListField::FilterXObjectSetter(google::protobuf::Message *message, ProtoRe
     {
       if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(dict)))
         return _set_kvlist_field_from_dict(message, reflectors, object, assoc_object);
+
+      if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(message_value)))
+        {
+          FilterXObject *unmarshalled = filterx_object_unmarshal(object);
+          bool success = filterx_object_is_type(unmarshalled, &FILTERX_TYPE_NAME(dict)) &&
+                         _set_kvlist_field_from_dict(message, reflectors, unmarshalled, assoc_object);
+          filterx_object_unref(unmarshalled);
+          return success;
+        }
 
       msg_error("otel-kvlist: Failed to convert field, type is unsupported",
                 evt_tag_str("field", reflectors.fieldDescriptor->name().c_str()),

--- a/modules/grpc/otel/filterx/object-otel-kvlist.hpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.hpp
@@ -68,7 +68,7 @@ public:
 private:
   KVList(const KVList &o, FilterXOtelKVList *s);
   friend FilterXObject *::_filterx_otel_kvlist_clone(FilterXObject *s);
-  KeyValue *get_mutable_kv_for_key(const char *key) const;
+  KeyValue *get_mutable_kv_for_key(const std::string &key) const;
 
 private:
   FilterXOtelKVList *super;

--- a/modules/grpc/otel/filterx/object-otel-logrecord.cpp
+++ b/modules/grpc/otel/filterx/object-otel-logrecord.cpp
@@ -26,6 +26,7 @@
 
 #include "compat/cpp-start.h"
 
+#include "filterx/object-extractor.h"
 #include "filterx/object-string.h"
 #include "filterx/object-datetime.h"
 #include "filterx/object-primitive.h"
@@ -50,10 +51,9 @@ LogRecord::LogRecord(FilterXOtelLogRecord *super_) : super(super_)
 
 LogRecord::LogRecord(FilterXOtelLogRecord *super_, FilterXObject *protobuf_object) : super(super_)
 {
+  const gchar *value;
   gsize length;
-  const gchar *value = filterx_protobuf_get_value(protobuf_object, &length);
-
-  if (!value)
+  if (!filterx_object_extract_protobuf(protobuf_object, &value, &length))
     throw std::runtime_error("Argument is not a protobuf object");
 
   if (!logRecord.ParsePartialFromArray(value, length))

--- a/modules/grpc/otel/filterx/object-otel-resource.cpp
+++ b/modules/grpc/otel/filterx/object-otel-resource.cpp
@@ -24,6 +24,7 @@
 #include "otel-field.hpp"
 
 #include "compat/cpp-start.h"
+#include "filterx/object-extractor.h"
 #include "filterx/object-string.h"
 #include "compat/cpp-end.h"
 
@@ -39,10 +40,9 @@ Resource::Resource(FilterXOtelResource *s) : super(s)
 
 Resource::Resource(FilterXOtelResource *s, FilterXObject *protobuf_object) : super(s)
 {
+  const gchar *value;
   gsize length;
-  const gchar *value = filterx_protobuf_get_value(protobuf_object, &length);
-
-  if (!value)
+  if (!filterx_object_extract_protobuf(protobuf_object, &value, &length))
     throw std::runtime_error("Argument is not a protobuf object");
 
   if (!resource.ParsePartialFromArray(value, length))

--- a/modules/grpc/otel/filterx/object-otel-scope.cpp
+++ b/modules/grpc/otel/filterx/object-otel-scope.cpp
@@ -24,6 +24,7 @@
 #include "otel-field.hpp"
 
 #include "compat/cpp-start.h"
+#include "filterx/object-extractor.h"
 #include "filterx/object-string.h"
 #include "compat/cpp-end.h"
 
@@ -39,10 +40,9 @@ Scope::Scope(FilterXOtelScope *s) : super(s)
 
 Scope::Scope(FilterXOtelScope *s, FilterXObject *protobuf_object) : super(s)
 {
+  const gchar *value;
   gsize length;
-  const gchar *value = filterx_protobuf_get_value(protobuf_object, &length);
-
-  if (!value)
+  if (!filterx_object_extract_protobuf(protobuf_object, &value, &length))
     throw std::runtime_error("Argument is not a protobuf object");
 
   if (!scope.ParsePartialFromArray(value, length))


### PR DESCRIPTION
A common coding error we introduce is to forget to handle `message_value` types in our functions.

This PR introduces object-extractor which handles the value extraction for all built-in types and their `message_value` counterparts. I also replaced nearly every occurrence of getting an object's value.

The code change fixes some missing `message_value` handlings implicitly.

Also I think we improve the performance and add more functionality in some cases, e.g.:
* in some places we now skip calling `unmarshal()`/`eval_typed()` for creating a temporary object that we immediately unref (notably in subscript, attr and add expressions)
* now we support `message_value`s in subscript expression keys