### PR TITLE
cfg-lexer: fix KW_PLUS_ASSIGN preference

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -205,8 +205,7 @@ main_location_print (FILE *yyo, YYLTYPE const * const yylocp)
 %left   ';'
 
 /* operators in the filter language, the order of this determines precedence */
-%right KW_ASSIGN 9000
-%right KW_PLUS_ASSIGN 9001
+%right KW_ASSIGN 9000, KW_PLUS_ASSIGN 9001
 %right '?' ':'
 %right KW_NULL_COALESCING
 %left  KW_OR 9010


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
