### PR TITLE
Fix disappearing `metrics-probe()` counters

### DIFF
--- a/lib/cfg-grammar-internal.c
+++ b/lib/cfg-grammar-internal.c
@@ -50,4 +50,4 @@ LogRewrite *last_rewrite;
 CfgArgs *last_block_args;
 DNSCacheOptions *last_dns_cache_options;
 MultiLineOptions *last_multi_line_options;
-MetricsTemplate *last_metrics_template;
+DynMetricsTemplate *last_dyn_metrics_template;

--- a/lib/cfg-grammar-internal.h
+++ b/lib/cfg-grammar-internal.h
@@ -52,7 +52,7 @@
 #include "cfg-block.h"
 #include "cfg-path.h"
 #include "multi-line/multi-line-factory.h"
-#include "metrics/metrics-template.h"
+#include "metrics/dyn-metrics-template.h"
 
 #include "logthrsource/logthrfetcherdrv.h"
 #include "logthrdest/logthrdestdrv.h"
@@ -91,7 +91,7 @@ extern LogRewrite *last_rewrite;
 extern CfgArgs *last_block_args;
 extern DNSCacheOptions *last_dns_cache_options;
 extern MultiLineOptions *last_multi_line_options;
-extern MetricsTemplate *last_metrics_template;
+extern DynMetricsTemplate *last_dyn_metrics_template;
 
 
 #endif

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1674,25 +1674,25 @@ vp_rekey_option
 	| KW_LOWER '(' ')' { value_pairs_transform_set_add_func(last_vp_transset, value_pairs_new_transform_lower()); }
 	;
 
-metrics_template_opt
-        : KW_KEY '(' string ')' { metrics_template_set_key(last_metrics_template, $3); g_free($3); }
-        | KW_LABELS '(' metrics_template_labels_opts ')'
-        | KW_LEVEL '(' nonnegative_integer ')' { metrics_template_set_level(last_metrics_template, $3); }
+dyn_metrics_template_opt
+        : KW_KEY '(' string ')' { dyn_metrics_template_set_key(last_dyn_metrics_template, $3); g_free($3); }
+        | KW_LABELS '(' dyn_metrics_template_labels_opts ')'
+        | KW_LEVEL '(' nonnegative_integer ')' { dyn_metrics_template_set_level(last_dyn_metrics_template, $3); }
 
-metrics_template_labels_opts
-        : metrics_template_labels_opt metrics_template_labels_opts
+dyn_metrics_template_labels_opts
+        : dyn_metrics_template_labels_opt dyn_metrics_template_labels_opts
         |
         ;
 
-metrics_template_labels_opt
-        : metrics_template_label_template
-        | { last_value_pairs = metrics_template_get_value_pairs(last_metrics_template); } vp_option
+dyn_metrics_template_labels_opt
+        : dyn_metrics_template_label_template
+        | { last_value_pairs = dyn_metrics_template_get_value_pairs(last_dyn_metrics_template); } vp_option
         ;
 
-metrics_template_label_template
+dyn_metrics_template_label_template
         : string LL_ARROW template_content
           {
-            metrics_template_add_label_template(last_metrics_template, $1, $3);
+            dyn_metrics_template_add_label_template(last_dyn_metrics_template, $1, $3);
             free($1);
             log_template_unref($3);
           }

--- a/lib/filterx/filterx-metrics-labels.c
+++ b/lib/filterx/filterx-metrics-labels.c
@@ -28,7 +28,7 @@
 #include "expr-literal-generator.h"
 #include "object-string.h"
 #include "object-dict-interface.h"
-#include "metrics/metrics-tls-cache.h"
+#include "metrics/dyn-metrics-cache.h"
 #include "stats/stats-cluster-single.h"
 #include "scratch-buffers.h"
 
@@ -260,7 +260,7 @@ _format_label_to_cache(gpointer data, gpointer user_data)
 gboolean
 filterx_metrics_labels_format(FilterXMetricsLabels *self, StatsClusterLabel **labels, gsize *len)
 {
-  DynMetricsStore *cache = metrics_tls_cache();
+  DynMetricsStore *cache = dyn_metrics_cache();
 
   dyn_metrics_store_reset_labels_cache(cache);
 

--- a/lib/filterx/filterx-metrics-labels.c
+++ b/lib/filterx/filterx-metrics-labels.c
@@ -192,7 +192,7 @@ filterx_metrics_labels_is_const(FilterXMetricsLabels *self)
 static gboolean
 _format_dict_elem_to_cache(FilterXObject *key, FilterXObject *value, gpointer user_data)
 {
-  MetricsCache *cache = (MetricsCache *) user_data;
+  DynMetricsStore *cache = (DynMetricsStore *) user_data;
 
   const gchar *name_str = _format_str_obj(key);
   if (!name_str)
@@ -210,7 +210,7 @@ _format_dict_elem_to_cache(FilterXObject *key, FilterXObject *value, gpointer us
       return FALSE;
     }
 
-  StatsClusterLabel *label = metrics_cache_alloc_label(cache);
+  StatsClusterLabel *label = dyn_metrics_store_alloc_label(cache);
   label->name = name_str;
   label->value = value_str;
 
@@ -218,7 +218,7 @@ _format_dict_elem_to_cache(FilterXObject *key, FilterXObject *value, gpointer us
 }
 
 static gboolean
-_format_expr_to_cache(FilterXExpr *expr, MetricsCache *cache)
+_format_expr_to_cache(FilterXExpr *expr, DynMetricsStore *cache)
 {
   FilterXObject *obj = filterx_expr_eval_typed(expr);
   if (!obj)
@@ -237,7 +237,7 @@ _format_expr_to_cache(FilterXExpr *expr, MetricsCache *cache)
   if (!success)
     goto exit;
 
-  metrics_cache_sort_labels(cache);
+  dyn_metrics_store_sort_labels(cache);
 
 exit:
   filterx_object_unref(obj);
@@ -249,20 +249,20 @@ _format_label_to_cache(gpointer data, gpointer user_data)
 {
   FilterXMetricsLabel *label = (FilterXMetricsLabel *) data;
   gboolean *success = ((gpointer *) user_data)[0];
-  MetricsCache *cache = ((gpointer *) user_data)[1];
+  DynMetricsStore *cache = ((gpointer *) user_data)[1];
 
   if (!(*success))
     return;
 
-  *success = _label_format(label, metrics_cache_alloc_label(cache));
+  *success = _label_format(label, dyn_metrics_store_alloc_label(cache));
 }
 
 gboolean
 filterx_metrics_labels_format(FilterXMetricsLabels *self, StatsClusterLabel **labels, gsize *len)
 {
-  MetricsCache *cache = metrics_tls_cache();
+  DynMetricsStore *cache = metrics_tls_cache();
 
-  metrics_cache_reset_labels(cache);
+  dyn_metrics_store_reset_labels(cache);
 
   gboolean success;
   if (self->expr)
@@ -279,8 +279,8 @@ filterx_metrics_labels_format(FilterXMetricsLabels *self, StatsClusterLabel **la
   if (!success)
     return FALSE;
 
-  *labels = metrics_cache_get_labels(cache);
-  *len = metrics_cache_get_labels_len(cache);
+  *labels = dyn_metrics_store_get_labels(cache);
+  *len = dyn_metrics_store_get_labels_len(cache);
   return TRUE;
 }
 

--- a/lib/filterx/filterx-metrics-labels.c
+++ b/lib/filterx/filterx-metrics-labels.c
@@ -210,7 +210,7 @@ _format_dict_elem_to_cache(FilterXObject *key, FilterXObject *value, gpointer us
       return FALSE;
     }
 
-  StatsClusterLabel *label = dyn_metrics_store_alloc_label(cache);
+  StatsClusterLabel *label = dyn_metrics_store_cache_label(cache);
   label->name = name_str;
   label->value = value_str;
 
@@ -237,7 +237,7 @@ _format_expr_to_cache(FilterXExpr *expr, DynMetricsStore *cache)
   if (!success)
     goto exit;
 
-  dyn_metrics_store_sort_labels(cache);
+  dyn_metrics_store_sort_cached_labels(cache);
 
 exit:
   filterx_object_unref(obj);
@@ -254,7 +254,7 @@ _format_label_to_cache(gpointer data, gpointer user_data)
   if (!(*success))
     return;
 
-  *success = _label_format(label, dyn_metrics_store_alloc_label(cache));
+  *success = _label_format(label, dyn_metrics_store_cache_label(cache));
 }
 
 gboolean
@@ -262,7 +262,7 @@ filterx_metrics_labels_format(FilterXMetricsLabels *self, StatsClusterLabel **la
 {
   DynMetricsStore *cache = metrics_tls_cache();
 
-  dyn_metrics_store_reset_labels(cache);
+  dyn_metrics_store_reset_labels_cache(cache);
 
   gboolean success;
   if (self->expr)
@@ -279,8 +279,8 @@ filterx_metrics_labels_format(FilterXMetricsLabels *self, StatsClusterLabel **la
   if (!success)
     return FALSE;
 
-  *labels = dyn_metrics_store_get_labels(cache);
-  *len = dyn_metrics_store_get_labels_len(cache);
+  *labels = dyn_metrics_store_get_cached_labels(cache);
+  *len = dyn_metrics_store_get_cached_labels_len(cache);
   return TRUE;
 }
 

--- a/lib/filterx/filterx-metrics.c
+++ b/lib/filterx/filterx-metrics.c
@@ -173,7 +173,7 @@ filterx_metrics_get_stats_counter(FilterXMetrics *self, StatsCounterItem **count
   if (!_format_sck(self, &sck))
     goto exit;
 
-  *counter = metrics_cache_get_counter(metrics_tls_cache(), &sck, self->level);
+  *counter = dyn_metrics_store_get_counter(metrics_tls_cache(), &sck, self->level);
   success = TRUE;
 
 exit:

--- a/lib/filterx/filterx-metrics.c
+++ b/lib/filterx/filterx-metrics.c
@@ -173,7 +173,7 @@ filterx_metrics_get_stats_counter(FilterXMetrics *self, StatsCounterItem **count
   if (!_format_sck(self, &sck))
     goto exit;
 
-  *counter = dyn_metrics_store_get_counter(metrics_tls_cache(), &sck, self->level);
+  *counter = dyn_metrics_store_retrieve_counter(metrics_tls_cache(), &sck, self->level);
   success = TRUE;
 
 exit:

--- a/lib/filterx/filterx-metrics.c
+++ b/lib/filterx/filterx-metrics.c
@@ -30,7 +30,7 @@
 #include "filterx-eval.h"
 #include "stats/stats-cluster-single.h"
 #include "stats/stats-registry.h"
-#include "metrics/metrics-tls-cache.h"
+#include "metrics/dyn-metrics-cache.h"
 #include "scratch-buffers.h"
 #include "atomic.h"
 
@@ -173,7 +173,7 @@ filterx_metrics_get_stats_counter(FilterXMetrics *self, StatsCounterItem **count
   if (!_format_sck(self, &sck))
     goto exit;
 
-  *counter = dyn_metrics_store_retrieve_counter(metrics_tls_cache(), &sck, self->level);
+  *counter = dyn_metrics_store_retrieve_counter(dyn_metrics_cache(), &sck, self->level);
   success = TRUE;
 
 exit:

--- a/lib/metrics/CMakeLists.txt
+++ b/lib/metrics/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(METRICS_HEADERS
     metrics/metrics.h
-    metrics/metrics-cache.h
+    metrics/dyn-metrics-store.h
     metrics/metrics-tls-cache.h
     metrics/metrics-template.h
     metrics/label-template.h
@@ -8,7 +8,7 @@ set(METRICS_HEADERS
 
 set(METRICS_SOURCES
     metrics/metrics.c
-    metrics/metrics-cache.c
+    metrics/dyn-metrics-store.c
     metrics/metrics-tls-cache.c
     metrics/metrics-template.c
     metrics/label-template.c

--- a/lib/metrics/CMakeLists.txt
+++ b/lib/metrics/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(METRICS_HEADERS
     metrics/metrics.h
     metrics/dyn-metrics-store.h
-    metrics/metrics-tls-cache.h
+    metrics/dyn-metrics-cache.h
     metrics/metrics-template.h
     metrics/label-template.h
     PARENT_SCOPE)
@@ -9,7 +9,7 @@ set(METRICS_HEADERS
 set(METRICS_SOURCES
     metrics/metrics.c
     metrics/dyn-metrics-store.c
-    metrics/metrics-tls-cache.c
+    metrics/dyn-metrics-cache.c
     metrics/metrics-template.c
     metrics/label-template.c
     PARENT_SCOPE)

--- a/lib/metrics/CMakeLists.txt
+++ b/lib/metrics/CMakeLists.txt
@@ -2,7 +2,7 @@ set(METRICS_HEADERS
     metrics/metrics.h
     metrics/dyn-metrics-store.h
     metrics/dyn-metrics-cache.h
-    metrics/metrics-template.h
+    metrics/dyn-metrics-template.h
     metrics/label-template.h
     PARENT_SCOPE)
 
@@ -10,7 +10,7 @@ set(METRICS_SOURCES
     metrics/metrics.c
     metrics/dyn-metrics-store.c
     metrics/dyn-metrics-cache.c
-    metrics/metrics-template.c
+    metrics/dyn-metrics-template.c
     metrics/label-template.c
     PARENT_SCOPE)
 

--- a/lib/metrics/Makefile.am
+++ b/lib/metrics/Makefile.am
@@ -6,14 +6,14 @@ metricsinclude_HEADERS = \
 	lib/metrics/metrics.h	\
 	lib/metrics/dyn-metrics-store.h	\
 	lib/metrics/dyn-metrics-cache.h	\
-	lib/metrics/metrics-template.h	\
+	lib/metrics/dyn-metrics-template.h	\
 	lib/metrics/label-template.h
 
 metrics_sources = \
 	lib/metrics/metrics.c	\
 	lib/metrics/dyn-metrics-store.c	\
 	lib/metrics/dyn-metrics-cache.c	\
-	lib/metrics/metrics-template.c	\
+	lib/metrics/dyn-metrics-template.c	\
 	lib/metrics/label-template.c
 
 #include lib/metrics/tests/Makefile.am

--- a/lib/metrics/Makefile.am
+++ b/lib/metrics/Makefile.am
@@ -5,14 +5,14 @@ EXTRA_DIST += lib/metrics/CMakeLists.txt
 metricsinclude_HEADERS = \
 	lib/metrics/metrics.h	\
 	lib/metrics/dyn-metrics-store.h	\
-	lib/metrics/metrics-tls-cache.h	\
+	lib/metrics/dyn-metrics-cache.h	\
 	lib/metrics/metrics-template.h	\
 	lib/metrics/label-template.h
 
 metrics_sources = \
 	lib/metrics/metrics.c	\
 	lib/metrics/dyn-metrics-store.c	\
-	lib/metrics/metrics-tls-cache.c	\
+	lib/metrics/dyn-metrics-cache.c	\
 	lib/metrics/metrics-template.c	\
 	lib/metrics/label-template.c
 

--- a/lib/metrics/Makefile.am
+++ b/lib/metrics/Makefile.am
@@ -4,14 +4,14 @@ EXTRA_DIST += lib/metrics/CMakeLists.txt
 
 metricsinclude_HEADERS = \
 	lib/metrics/metrics.h	\
-	lib/metrics/metrics-cache.h	\
+	lib/metrics/dyn-metrics-store.h	\
 	lib/metrics/metrics-tls-cache.h	\
 	lib/metrics/metrics-template.h	\
 	lib/metrics/label-template.h
 
 metrics_sources = \
 	lib/metrics/metrics.c	\
-	lib/metrics/metrics-cache.c	\
+	lib/metrics/dyn-metrics-store.c	\
 	lib/metrics/metrics-tls-cache.c	\
 	lib/metrics/metrics-template.c	\
 	lib/metrics/label-template.c

--- a/lib/metrics/dyn-metrics-cache.c
+++ b/lib/metrics/dyn-metrics-cache.c
@@ -30,30 +30,31 @@
 
 TLS_BLOCK_START
 {
-  DynMetricsStore *dyn_metrics_store;
+  DynMetricsStore *metrics_cache;
 }
 TLS_BLOCK_END;
 
-#define dyn_metrics_store __tls_deref(dyn_metrics_store)
+
+#define metrics_cache __tls_deref(metrics_cache)
 
 static void
 _init_tls_cache(gpointer user_data)
 {
-  g_assert(!dyn_metrics_store);
+  g_assert(!metrics_cache);
 
-  dyn_metrics_store = dyn_metrics_store_new();
+  metrics_cache = dyn_metrics_store_new();
 }
 
 static void
 _deinit_tls_cache(gpointer user_data)
 {
-  dyn_metrics_store_free(dyn_metrics_store);
+  dyn_metrics_store_free(metrics_cache);
 }
 
 DynMetricsStore *
 dyn_metrics_cache(void)
 {
-  return dyn_metrics_store;
+  return metrics_cache;
 }
 
 void

--- a/lib/metrics/dyn-metrics-cache.h
+++ b/lib/metrics/dyn-metrics-cache.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2023-2024 Attila Szakacs <attila.szakacs@axoflow.com>
  * Copyright (c) 2024 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 László Várady
  * Copyright (c) 2024 Axoflow
  *
  * This library is free software; you can redistribute it and/or
@@ -23,49 +24,15 @@
  *
  */
 
-#include "metrics-tls-cache.h"
-#include "apphook.h"
-#include "tls-support.h"
+#ifndef DYN_METRICS_CACHE_H_INCLUDED
+#define DYN_METRICS_CACHE_H_INCLUDED
 
-TLS_BLOCK_START
-{
-  DynMetricsStore *dyn_metrics_store;
-}
-TLS_BLOCK_END;
+#include "stats/stats-registry.h"
+#include "dyn-metrics-store.h"
 
-#define dyn_metrics_store __tls_deref(dyn_metrics_store)
+DynMetricsStore *dyn_metrics_cache(void);
 
-static void
-_init_tls_cache(gpointer user_data)
-{
-  g_assert(!dyn_metrics_store);
+void dyn_metrics_cache_global_init(void);
+void dyn_metrics_cache_global_deinit(void);
 
-  dyn_metrics_store = dyn_metrics_store_new();
-}
-
-static void
-_deinit_tls_cache(gpointer user_data)
-{
-  dyn_metrics_store_free(dyn_metrics_store);
-}
-
-DynMetricsStore *
-metrics_tls_cache(void)
-{
-  return dyn_metrics_store;
-}
-
-void
-metrics_tls_cache_global_init(void)
-{
-  register_application_thread_init_hook(_init_tls_cache, NULL);
-  register_application_thread_deinit_hook(_deinit_tls_cache, NULL);
-
-  _init_tls_cache(NULL);
-}
-
-void
-metrics_tls_cache_global_deinit(void)
-{
-  _deinit_tls_cache(NULL);
-}
+#endif

--- a/lib/metrics/dyn-metrics-store.c
+++ b/lib/metrics/dyn-metrics-store.c
@@ -104,26 +104,26 @@ dyn_metrics_store_remove_counter(DynMetricsStore *self, StatsClusterKey *key)
 }
 
 void
-dyn_metrics_store_reset_labels(DynMetricsStore *self)
+dyn_metrics_store_reset_labels_cache(DynMetricsStore *self)
 {
   self->label_buffers = g_array_set_size(self->label_buffers, 0);
 }
 
 StatsClusterLabel *
-dyn_metrics_store_alloc_label(DynMetricsStore *self)
+dyn_metrics_store_cache_label(DynMetricsStore *self)
 {
   self->label_buffers = g_array_set_size(self->label_buffers, self->label_buffers->len + 1);
   return &g_array_index(self->label_buffers, StatsClusterLabel, self->label_buffers->len - 1);
 }
 
 StatsClusterLabel *
-dyn_metrics_store_get_labels(DynMetricsStore *self)
+dyn_metrics_store_get_cached_labels(DynMetricsStore *self)
 {
   return (StatsClusterLabel *) self->label_buffers->data;
 }
 
 guint
-dyn_metrics_store_get_labels_len(DynMetricsStore *self)
+dyn_metrics_store_get_cached_labels_len(DynMetricsStore *self)
 {
   return self->label_buffers->len;
 }
@@ -135,7 +135,7 @@ _label_cmp(StatsClusterLabel *lhs, StatsClusterLabel *rhs)
 }
 
 void
-dyn_metrics_store_sort_labels(DynMetricsStore *self)
+dyn_metrics_store_sort_cached_labels(DynMetricsStore *self)
 {
   g_array_sort(self->label_buffers, (GCompareFunc) _label_cmp);
 }

--- a/lib/metrics/dyn-metrics-store.c
+++ b/lib/metrics/dyn-metrics-store.c
@@ -104,6 +104,12 @@ dyn_metrics_store_remove_counter(DynMetricsStore *self, StatsClusterKey *key)
 }
 
 void
+dyn_metrics_store_reset(DynMetricsStore *self)
+{
+  g_hash_table_remove_all(self->clusters);
+}
+
+void
 dyn_metrics_store_merge(DynMetricsStore *self, DynMetricsStore *other)
 {
   GHashTableIter iter;

--- a/lib/metrics/dyn-metrics-store.c
+++ b/lib/metrics/dyn-metrics-store.c
@@ -104,6 +104,20 @@ dyn_metrics_store_remove_counter(DynMetricsStore *self, StatsClusterKey *key)
 }
 
 void
+dyn_metrics_store_merge(DynMetricsStore *self, DynMetricsStore *other)
+{
+  GHashTableIter iter;
+  g_hash_table_iter_init(&iter, other->clusters);
+
+  gpointer key, value;
+  while (g_hash_table_iter_next(&iter, &key, &value))
+    {
+      stats_cluster_track_counter(value, SC_TYPE_SINGLE_VALUE);
+      g_hash_table_insert(self->clusters, key, value);
+    }
+}
+
+void
 dyn_metrics_store_reset_labels_cache(DynMetricsStore *self)
 {
   self->label_buffers = g_array_set_size(self->label_buffers, 0);

--- a/lib/metrics/dyn-metrics-store.c
+++ b/lib/metrics/dyn-metrics-store.c
@@ -84,7 +84,7 @@ dyn_metrics_store_free(DynMetricsStore *self)
 }
 
 StatsCounterItem *
-dyn_metrics_store_get_counter(DynMetricsStore *self, StatsClusterKey *key, gint level)
+dyn_metrics_store_retrieve_counter(DynMetricsStore *self, StatsClusterKey *key, gint level)
 {
   StatsCluster *cluster = g_hash_table_lookup(self->clusters, key);
   if (!cluster)

--- a/lib/metrics/dyn-metrics-store.h
+++ b/lib/metrics/dyn-metrics-store.h
@@ -55,10 +55,11 @@ void dyn_metrics_store_free(DynMetricsStore *self);
 
 StatsCounterItem *dyn_metrics_store_retrieve_counter(DynMetricsStore *self, StatsClusterKey *key, gint level);
 gboolean dyn_metrics_store_remove_counter(DynMetricsStore *self, StatsClusterKey *key);
-void dyn_metrics_store_reset_labels(DynMetricsStore *self);
-StatsClusterLabel *dyn_metrics_store_alloc_label(DynMetricsStore *self);
-StatsClusterLabel *dyn_metrics_store_get_labels(DynMetricsStore *self);
-guint dyn_metrics_store_get_labels_len(DynMetricsStore *self);
-void dyn_metrics_store_sort_labels(DynMetricsStore *self);
+
+void dyn_metrics_store_reset_labels_cache(DynMetricsStore *self);
+StatsClusterLabel *dyn_metrics_store_cache_label(DynMetricsStore *self);
+StatsClusterLabel *dyn_metrics_store_get_cached_labels(DynMetricsStore *self);
+guint dyn_metrics_store_get_cached_labels_len(DynMetricsStore *self);
+void dyn_metrics_store_sort_cached_labels(DynMetricsStore *self);
 
 #endif

--- a/lib/metrics/dyn-metrics-store.h
+++ b/lib/metrics/dyn-metrics-store.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2023-2024 Attila Szakacs <attila.szakacs@axoflow.com>
  * Copyright (c) 2024 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 László Várady
  * Copyright (c) 2024 Axoflow
  *
  * This library is free software; you can redistribute it and/or
@@ -23,8 +24,8 @@
  *
  */
 
-#ifndef METRICS_CACHE_H_INCLUDED
-#define METRICS_CACHE_H_INCLUDED
+#ifndef DYN_METRICS_STORE_H_INCLUDED
+#define DYN_METRICS_STORE_H_INCLUDED
 
 #include "stats/stats-registry.h"
 
@@ -36,29 +37,28 @@
  * issue, as they are always stored on their call-site, binding their
  * lifecycle to the call-site.
  *
- * This class intends to solve this problem by providing a cache,
- * which keeps alive its counters until the cache is freed. On the
- * call-site you only need to keep the cache alive, to keep the
+ * This class intends to solve this problem by providing a store,
+ * which keeps alive its counters until the store is freed. On the
+ * call-site you only need to keep the store alive, to keep the
  * counters alive.
  *
  * It also grants a label cache for performance optimization needs.
  *
- * Note: The cache is NOT thread safe, make sure to eliminate
- * concurrency on the call site. If you need a cache that is bound
- * to the current thread, see metrics/metrics-tls-cache.h.
+ * Note: The store is NOT thread safe, make sure to eliminate
+ * concurrency on the call site.
  */
 
-typedef struct _MetricsCache MetricsCache;
+typedef struct _DynMetricsStore DynMetricsStore;
 
-MetricsCache *metrics_cache_new(void);
-void metrics_cache_free(MetricsCache *self);
+DynMetricsStore *dyn_metrics_store_new(void);
+void dyn_metrics_store_free(DynMetricsStore *self);
 
-StatsCounterItem *metrics_cache_get_counter(MetricsCache *self, StatsClusterKey *key, gint level);
-gboolean metrics_cache_remove_counter(MetricsCache *self, StatsClusterKey *key);
-void metrics_cache_reset_labels(MetricsCache *self);
-StatsClusterLabel *metrics_cache_alloc_label(MetricsCache *self);
-StatsClusterLabel *metrics_cache_get_labels(MetricsCache *self);
-guint metrics_cache_get_labels_len(MetricsCache *self);
-void metrics_cache_sort_labels(MetricsCache *self);
+StatsCounterItem *dyn_metrics_store_get_counter(DynMetricsStore *self, StatsClusterKey *key, gint level);
+gboolean dyn_metrics_store_remove_counter(DynMetricsStore *self, StatsClusterKey *key);
+void dyn_metrics_store_reset_labels(DynMetricsStore *self);
+StatsClusterLabel *dyn_metrics_store_alloc_label(DynMetricsStore *self);
+StatsClusterLabel *dyn_metrics_store_get_labels(DynMetricsStore *self);
+guint dyn_metrics_store_get_labels_len(DynMetricsStore *self);
+void dyn_metrics_store_sort_labels(DynMetricsStore *self);
 
 #endif

--- a/lib/metrics/dyn-metrics-store.h
+++ b/lib/metrics/dyn-metrics-store.h
@@ -55,6 +55,7 @@ void dyn_metrics_store_free(DynMetricsStore *self);
 
 StatsCounterItem *dyn_metrics_store_retrieve_counter(DynMetricsStore *self, StatsClusterKey *key, gint level);
 gboolean dyn_metrics_store_remove_counter(DynMetricsStore *self, StatsClusterKey *key);
+void dyn_metrics_store_merge(DynMetricsStore *self, DynMetricsStore *other);
 
 void dyn_metrics_store_reset_labels_cache(DynMetricsStore *self);
 StatsClusterLabel *dyn_metrics_store_cache_label(DynMetricsStore *self);

--- a/lib/metrics/dyn-metrics-store.h
+++ b/lib/metrics/dyn-metrics-store.h
@@ -55,6 +55,7 @@ void dyn_metrics_store_free(DynMetricsStore *self);
 
 StatsCounterItem *dyn_metrics_store_retrieve_counter(DynMetricsStore *self, StatsClusterKey *key, gint level);
 gboolean dyn_metrics_store_remove_counter(DynMetricsStore *self, StatsClusterKey *key);
+void dyn_metrics_store_reset(DynMetricsStore *self);
 void dyn_metrics_store_merge(DynMetricsStore *self, DynMetricsStore *other);
 
 void dyn_metrics_store_reset_labels_cache(DynMetricsStore *self);

--- a/lib/metrics/dyn-metrics-store.h
+++ b/lib/metrics/dyn-metrics-store.h
@@ -45,7 +45,9 @@
  * It also grants a label cache for performance optimization needs.
  *
  * Note: The store is NOT thread safe, make sure to eliminate
- * concurrency on the call site.
+ * concurrency on the call site. If you need a cache that is purged only
+ * during reload, use metrics/dyn-metrics-cache.h.
+ *
  */
 
 typedef struct _DynMetricsStore DynMetricsStore;

--- a/lib/metrics/dyn-metrics-store.h
+++ b/lib/metrics/dyn-metrics-store.h
@@ -53,7 +53,7 @@ typedef struct _DynMetricsStore DynMetricsStore;
 DynMetricsStore *dyn_metrics_store_new(void);
 void dyn_metrics_store_free(DynMetricsStore *self);
 
-StatsCounterItem *dyn_metrics_store_get_counter(DynMetricsStore *self, StatsClusterKey *key, gint level);
+StatsCounterItem *dyn_metrics_store_retrieve_counter(DynMetricsStore *self, StatsClusterKey *key, gint level);
 gboolean dyn_metrics_store_remove_counter(DynMetricsStore *self, StatsClusterKey *key);
 void dyn_metrics_store_reset_labels(DynMetricsStore *self);
 StatsClusterLabel *dyn_metrics_store_alloc_label(DynMetricsStore *self);

--- a/lib/metrics/dyn-metrics-template.c
+++ b/lib/metrics/dyn-metrics-template.c
@@ -22,32 +22,32 @@
  *
  */
 
-#include "metrics-template.h"
+#include "dyn-metrics-template.h"
 #include "label-template.h"
 #include "dyn-metrics-cache.h"
 #include "stats/stats-cluster-single.h"
 #include "scratch-buffers.h"
 
 void
-metrics_template_set_level(MetricsTemplate *self, gint level)
+dyn_metrics_template_set_level(DynMetricsTemplate *self, gint level)
 {
   self->level = level;
 }
 
 void
-metrics_template_add_label_template(MetricsTemplate *self, const gchar *label, LogTemplate *value_template)
+dyn_metrics_template_add_label_template(DynMetricsTemplate *self, const gchar *label, LogTemplate *value_template)
 {
   self->label_templates = g_list_append(self->label_templates, label_template_new(label, value_template));
 }
 
 ValuePairs *
-metrics_template_get_value_pairs(MetricsTemplate *self)
+dyn_metrics_template_get_value_pairs(DynMetricsTemplate *self)
 {
   return self->vp;
 }
 
 void
-metrics_template_set_key(MetricsTemplate *self, const gchar *key)
+dyn_metrics_template_set_key(DynMetricsTemplate *self, const gchar *key)
 {
   g_free(self->key);
   self->key = g_strdup(key);
@@ -72,20 +72,21 @@ _add_dynamic_labels_vp_helper(const gchar *name, LogMessageValueType type, const
 }
 
 static void
-_add_dynamic_labels(MetricsTemplate *self, LogTemplateOptions *template_options, LogMessage *msg, DynMetricsStore *cache)
+_add_dynamic_labels(DynMetricsTemplate *self, LogTemplateOptions *template_options, LogMessage *msg,
+                    DynMetricsStore *cache)
 {
   LogTemplateEvalOptions template_eval_options = { template_options, LTZ_SEND, 0, NULL, LM_VT_STRING };
   value_pairs_foreach(self->vp, _add_dynamic_labels_vp_helper, msg, &template_eval_options, cache);
 }
 
 gboolean
-metrics_template_is_enabled(MetricsTemplate *self)
+dyn_metrics_template_is_enabled(DynMetricsTemplate *self)
 {
   return stats_check_level(self->level);
 }
 
 static void
-_build_sck(MetricsTemplate *self, LogTemplateOptions *template_options, LogMessage *msg, DynMetricsStore *cache,
+_build_sck(DynMetricsTemplate *self, LogTemplateOptions *template_options, LogMessage *msg, DynMetricsStore *cache,
            StatsClusterKey *key)
 {
   dyn_metrics_store_reset_labels_cache(cache);
@@ -108,9 +109,9 @@ _build_sck(MetricsTemplate *self, LogTemplateOptions *template_options, LogMessa
 }
 
 StatsCounterItem *
-metrics_template_get_stats_counter(MetricsTemplate *self,
-                                   LogTemplateOptions *template_options,
-                                   LogMessage *msg)
+dyn_metrics_template_get_stats_counter(DynMetricsTemplate *self,
+                                       LogTemplateOptions *template_options,
+                                       LogMessage *msg)
 {
   DynMetricsStore *cache = dyn_metrics_cache();
 
@@ -127,23 +128,23 @@ metrics_template_get_stats_counter(MetricsTemplate *self,
 }
 
 gboolean
-metrics_template_init(MetricsTemplate *self)
+dyn_metrics_template_init(DynMetricsTemplate *self)
 {
   self->label_templates = g_list_sort(self->label_templates, (GCompareFunc) label_template_compare);
   return TRUE;
 }
 
-MetricsTemplate *
-metrics_template_new(GlobalConfig *cfg)
+DynMetricsTemplate *
+dyn_metrics_template_new(GlobalConfig *cfg)
 {
-  MetricsTemplate *self = g_new0(MetricsTemplate, 1);
+  DynMetricsTemplate *self = g_new0(DynMetricsTemplate, 1);
 
   self->vp = value_pairs_new(cfg);
   return self;
 }
 
 void
-metrics_template_free(MetricsTemplate *self)
+dyn_metrics_template_free(DynMetricsTemplate *self)
 {
   g_free(self->key);
   g_list_free_full(self->label_templates, (GDestroyNotify) label_template_free);
@@ -151,12 +152,12 @@ metrics_template_free(MetricsTemplate *self)
   g_free(self);
 }
 
-MetricsTemplate *
-metrics_template_clone(MetricsTemplate *self, GlobalConfig *cfg)
+DynMetricsTemplate *
+dyn_metrics_template_clone(DynMetricsTemplate *self, GlobalConfig *cfg)
 {
-  MetricsTemplate *cloned = metrics_template_new(cfg);
-  metrics_template_set_key(cloned, self->key);
-  metrics_template_set_level(cloned, self->level);
+  DynMetricsTemplate *cloned = dyn_metrics_template_new(cfg);
+  dyn_metrics_template_set_key(cloned, self->key);
+  dyn_metrics_template_set_level(cloned, self->level);
 
   for (GList *elem = g_list_first(self->label_templates); elem; elem = elem->next)
     {

--- a/lib/metrics/dyn-metrics-template.h
+++ b/lib/metrics/dyn-metrics-template.h
@@ -28,6 +28,11 @@
 #include "value-pairs/value-pairs.h"
 #include "stats/stats-cluster.h"
 
+/*
+ * DynMetricsTemplate utilizes dyn-metrics-cache to achieve better performance
+ * and to provide proper lifetime for dynamic counters.
+ */
+
 typedef struct _DynMetricsTemplate
 {
   gchar *key;

--- a/lib/metrics/dyn-metrics-template.h
+++ b/lib/metrics/dyn-metrics-template.h
@@ -21,33 +21,33 @@
  *
  */
 
-#ifndef METRICS_TEMPLATE_H_INCLUDED
-#define METRICS_TEMPLATE_H_INCLUDED
+#ifndef DYN_METRICS_TEMPLATE_H_INCLUDED
+#define DYN_METRICS_TEMPLATE_H_INCLUDED
 
 #include "template/templates.h"
 #include "value-pairs/value-pairs.h"
 #include "stats/stats-cluster.h"
 
-typedef struct _MetricsTemplate
+typedef struct _DynMetricsTemplate
 {
   gchar *key;
   GList *label_templates;
   ValuePairs *vp;
   gint level;
-} MetricsTemplate;
+} DynMetricsTemplate;
 
-void metrics_template_set_key(MetricsTemplate *s, const gchar *key);
-void metrics_template_add_label_template(MetricsTemplate *s, const gchar *label, LogTemplate *value_template);
-void metrics_template_set_level(MetricsTemplate *s, gint level);
-ValuePairs *metrics_template_get_value_pairs(MetricsTemplate *s);
-gboolean metrics_template_is_enabled(MetricsTemplate *self);
-StatsCounterItem *metrics_template_get_stats_counter(MetricsTemplate *self,
-                                                     LogTemplateOptions *template_options,
-                                                     LogMessage *msg);
-gboolean metrics_template_init(MetricsTemplate *self);
+void dyn_metrics_template_set_key(DynMetricsTemplate *s, const gchar *key);
+void dyn_metrics_template_add_label_template(DynMetricsTemplate *s, const gchar *label, LogTemplate *value_template);
+void dyn_metrics_template_set_level(DynMetricsTemplate *s, gint level);
+ValuePairs *dyn_metrics_template_get_value_pairs(DynMetricsTemplate *s);
+gboolean dyn_metrics_template_is_enabled(DynMetricsTemplate *self);
+StatsCounterItem *dyn_metrics_template_get_stats_counter(DynMetricsTemplate *self,
+                                                         LogTemplateOptions *template_options,
+                                                         LogMessage *msg);
+gboolean dyn_metrics_template_init(DynMetricsTemplate *self);
 
-MetricsTemplate *metrics_template_new(GlobalConfig *cfg);
-void metrics_template_free(MetricsTemplate *self);
-MetricsTemplate *metrics_template_clone(MetricsTemplate *self, GlobalConfig *cfg);
+DynMetricsTemplate *dyn_metrics_template_new(GlobalConfig *cfg);
+void dyn_metrics_template_free(DynMetricsTemplate *self);
+DynMetricsTemplate *dyn_metrics_template_clone(DynMetricsTemplate *self, GlobalConfig *cfg);
 
 #endif

--- a/lib/metrics/metrics-template.c
+++ b/lib/metrics/metrics-template.c
@@ -120,7 +120,7 @@ metrics_template_get_stats_counter(MetricsTemplate *self,
   scratch_buffers_mark(&marker);
   _build_sck(self, template_options, msg, cache, &key);
 
-  StatsCounterItem *counter = dyn_metrics_store_get_counter(cache, &key, self->level);
+  StatsCounterItem *counter = dyn_metrics_store_retrieve_counter(cache, &key, self->level);
 
   scratch_buffers_reclaim_marked(marker);
   return counter;

--- a/lib/metrics/metrics-template.c
+++ b/lib/metrics/metrics-template.c
@@ -64,7 +64,7 @@ _add_dynamic_labels_vp_helper(const gchar *name, LogMessageValueType type, const
   g_string_assign(name_buffer, name);
   g_string_append_len(value_buffer, value, value_len);
 
-  StatsClusterLabel *label = dyn_metrics_store_alloc_label(cache);
+  StatsClusterLabel *label = dyn_metrics_store_cache_label(cache);
   label->name = name_buffer->str;
   label->value = value_buffer->str;
 
@@ -88,7 +88,7 @@ static void
 _build_sck(MetricsTemplate *self, LogTemplateOptions *template_options, LogMessage *msg, DynMetricsStore *cache,
            StatsClusterKey *key)
 {
-  dyn_metrics_store_reset_labels(cache);
+  dyn_metrics_store_reset_labels_cache(cache);
 
   for (GList *elem = g_list_first(self->label_templates); elem; elem = elem->next)
     {
@@ -96,15 +96,15 @@ _build_sck(MetricsTemplate *self, LogTemplateOptions *template_options, LogMessa
       GString *value_buffer = scratch_buffers_alloc();
 
       label_template_format(label_template, template_options, msg, value_buffer,
-                            dyn_metrics_store_alloc_label(cache));
+                            dyn_metrics_store_cache_label(cache));
     }
 
   if (self->vp)
     _add_dynamic_labels(self, template_options, msg, cache);
 
   stats_cluster_single_key_set(key, self->key,
-                               dyn_metrics_store_get_labels(cache),
-                               dyn_metrics_store_get_labels_len(cache));
+                               dyn_metrics_store_get_cached_labels(cache),
+                               dyn_metrics_store_get_cached_labels_len(cache));
 }
 
 StatsCounterItem *

--- a/lib/metrics/metrics-template.c
+++ b/lib/metrics/metrics-template.c
@@ -24,7 +24,7 @@
 
 #include "metrics-template.h"
 #include "label-template.h"
-#include "metrics-tls-cache.h"
+#include "dyn-metrics-cache.h"
 #include "stats/stats-cluster-single.h"
 #include "scratch-buffers.h"
 
@@ -112,7 +112,7 @@ metrics_template_get_stats_counter(MetricsTemplate *self,
                                    LogTemplateOptions *template_options,
                                    LogMessage *msg)
 {
-  DynMetricsStore *cache = metrics_tls_cache();
+  DynMetricsStore *cache = dyn_metrics_cache();
 
   StatsClusterKey key;
   ScratchBuffersMarker marker;

--- a/lib/metrics/metrics-tls-cache.c
+++ b/lib/metrics/metrics-tls-cache.c
@@ -29,30 +29,30 @@
 
 TLS_BLOCK_START
 {
-  MetricsCache *metrics_cache;
+  DynMetricsStore *dyn_metrics_store;
 }
 TLS_BLOCK_END;
 
-#define metrics_cache __tls_deref(metrics_cache)
+#define dyn_metrics_store __tls_deref(dyn_metrics_store)
 
 static void
 _init_tls_cache(gpointer user_data)
 {
-  g_assert(!metrics_cache);
+  g_assert(!dyn_metrics_store);
 
-  metrics_cache = metrics_cache_new();
+  dyn_metrics_store = dyn_metrics_store_new();
 }
 
 static void
 _deinit_tls_cache(gpointer user_data)
 {
-  metrics_cache_free(metrics_cache);
+  dyn_metrics_store_free(dyn_metrics_store);
 }
 
-MetricsCache *
+DynMetricsStore *
 metrics_tls_cache(void)
 {
-  return metrics_cache;
+  return dyn_metrics_store;
 }
 
 void

--- a/lib/metrics/metrics-tls-cache.h
+++ b/lib/metrics/metrics-tls-cache.h
@@ -27,9 +27,9 @@
 #define METRICS_TLS_CACHE_H_INCLUDED
 
 #include "stats/stats-registry.h"
-#include "metrics-cache.h"
+#include "dyn-metrics-store.h"
 
-MetricsCache *metrics_tls_cache(void);
+DynMetricsStore *metrics_tls_cache(void);
 
 void metrics_tls_cache_global_init(void);
 void metrics_tls_cache_global_deinit(void);

--- a/lib/metrics/metrics.c
+++ b/lib/metrics/metrics.c
@@ -23,16 +23,16 @@
  */
 
 #include "metrics.h"
-#include "metrics-tls-cache.h"
+#include "dyn-metrics-cache.h"
 
 void
 metrics_global_init(void)
 {
-  metrics_tls_cache_global_init();
+  dyn_metrics_cache_global_init();
 }
 
 void
 metrics_global_deinit(void)
 {
-  metrics_tls_cache_global_deinit();
+  dyn_metrics_cache_global_deinit();
 }

--- a/modules/diskq/diskq-global-metrics.c
+++ b/modules/diskq/diskq-global-metrics.c
@@ -179,10 +179,10 @@ _set_abandoned_disk_buffer_file_metrics(const gchar *dir, const gchar *filename)
   _init_abandoned_disk_buffer_sc_keys(&queued_sc_key, &capacity_sc_key, &disk_allocated_sc_key, &disk_usage_sc_key,
                                       abs_filename, options.reliable);
 
-  queued = dyn_metrics_store_get_counter(diskq_global_metrics.cache, &queued_sc_key, STATS_LEVEL1);
-  capacity = dyn_metrics_store_get_counter(diskq_global_metrics.cache, &capacity_sc_key, STATS_LEVEL1);
-  disk_allocated = dyn_metrics_store_get_counter(diskq_global_metrics.cache, &disk_allocated_sc_key, STATS_LEVEL1);
-  disk_usage = dyn_metrics_store_get_counter(diskq_global_metrics.cache, &disk_usage_sc_key, STATS_LEVEL1);
+  queued = dyn_metrics_store_retrieve_counter(diskq_global_metrics.cache, &queued_sc_key, STATS_LEVEL1);
+  capacity = dyn_metrics_store_retrieve_counter(diskq_global_metrics.cache, &capacity_sc_key, STATS_LEVEL1);
+  disk_allocated = dyn_metrics_store_retrieve_counter(diskq_global_metrics.cache, &disk_allocated_sc_key, STATS_LEVEL1);
+  disk_usage = dyn_metrics_store_retrieve_counter(diskq_global_metrics.cache, &disk_usage_sc_key, STATS_LEVEL1);
 
   stats_counter_set(queued, log_queue_get_length(&queue->super));
   stats_counter_set(capacity, B_TO_KiB(qdisk_get_max_useful_space(queue->qdisk)));
@@ -289,8 +289,8 @@ _update_dir_metrics(gpointer key, gpointer value, gpointer user_data)
   StatsClusterKey available_bytes_sc_key;
   _init_dir_sc_keys(&available_bytes_sc_key, dir);
 
-  StatsCounterItem *counter = dyn_metrics_store_get_counter(diskq_global_metrics.cache, &available_bytes_sc_key,
-                                                        STATS_LEVEL1);
+  StatsCounterItem *counter = dyn_metrics_store_retrieve_counter(diskq_global_metrics.cache, &available_bytes_sc_key,
+                              STATS_LEVEL1);
   stats_counter_set(counter, available_space_mib);
 }
 

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -612,32 +612,32 @@ _update_status_code_metrics(HTTPDestinationWorker *self, const gchar *url, glong
 {
   gint level = log_pipe_is_internal(&self->super.owner->super.super.super) ? STATS_LEVEL3 : STATS_LEVEL1;
 
-  metrics_cache_reset_labels(self->metrics.cache);
+  dyn_metrics_store_reset_labels(self->metrics.cache);
 
-  StatsClusterLabel *url_label = metrics_cache_alloc_label(self->metrics.cache);
+  StatsClusterLabel *url_label = dyn_metrics_store_alloc_label(self->metrics.cache);
   url_label->name = "url";
   url_label->value = url;
 
-  StatsClusterLabel *response_code_label = metrics_cache_alloc_label(self->metrics.cache);
+  StatsClusterLabel *response_code_label = dyn_metrics_store_alloc_label(self->metrics.cache);
   g_snprintf(self->metrics.requests_response_code_str_buffer, sizeof(self->metrics.requests_response_code_str_buffer),
              "%ld", http_code);
   response_code_label->name = "response_code";
   response_code_label->value = self->metrics.requests_response_code_str_buffer;
 
-  StatsClusterLabel *driver_label = metrics_cache_alloc_label(self->metrics.cache);
+  StatsClusterLabel *driver_label = dyn_metrics_store_alloc_label(self->metrics.cache);
   driver_label->name = "driver";
   driver_label->value = "http";
 
-  StatsClusterLabel *id_label = metrics_cache_alloc_label(self->metrics.cache);
+  StatsClusterLabel *id_label = dyn_metrics_store_alloc_label(self->metrics.cache);
   id_label->name = "id";
   id_label->value = self->super.owner->super.super.id;
 
   StatsClusterKey key;
   stats_cluster_single_key_set(&key, "output_http_requests_total",
-                               metrics_cache_get_labels(self->metrics.cache),
-                               metrics_cache_get_labels_len(self->metrics.cache));
+                               dyn_metrics_store_get_labels(self->metrics.cache),
+                               dyn_metrics_store_get_labels_len(self->metrics.cache));
 
-  StatsCounterItem *counter = metrics_cache_get_counter(self->metrics.cache, &key, level);
+  StatsCounterItem *counter = dyn_metrics_store_get_counter(self->metrics.cache, &key, level);
   stats_counter_inc(counter);
 }
 
@@ -902,7 +902,7 @@ http_dw_free(LogThreadedDestWorker *s)
 {
   HTTPDestinationWorker *self = (HTTPDestinationWorker *) s;
 
-  metrics_cache_free(self->metrics.cache);
+  dyn_metrics_store_free(self->metrics.cache);
   http_lb_client_deinit(&self->lbc);
   log_threaded_dest_worker_free_method(s);
 }
@@ -924,7 +924,7 @@ http_dw_new(LogThreadedDestDriver *o, gint worker_index)
   else
     self->super.insert = _insert_single;
 
-  self->metrics.cache = metrics_cache_new();
+  self->metrics.cache = dyn_metrics_store_new();
 
   http_lb_client_init(&self->lbc, owner->load_balancer);
   return &self->super;

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -612,30 +612,30 @@ _update_status_code_metrics(HTTPDestinationWorker *self, const gchar *url, glong
 {
   gint level = log_pipe_is_internal(&self->super.owner->super.super.super) ? STATS_LEVEL3 : STATS_LEVEL1;
 
-  dyn_metrics_store_reset_labels(self->metrics.cache);
+  dyn_metrics_store_reset_labels_cache(self->metrics.cache);
 
-  StatsClusterLabel *url_label = dyn_metrics_store_alloc_label(self->metrics.cache);
+  StatsClusterLabel *url_label = dyn_metrics_store_cache_label(self->metrics.cache);
   url_label->name = "url";
   url_label->value = url;
 
-  StatsClusterLabel *response_code_label = dyn_metrics_store_alloc_label(self->metrics.cache);
+  StatsClusterLabel *response_code_label = dyn_metrics_store_cache_label(self->metrics.cache);
   g_snprintf(self->metrics.requests_response_code_str_buffer, sizeof(self->metrics.requests_response_code_str_buffer),
              "%ld", http_code);
   response_code_label->name = "response_code";
   response_code_label->value = self->metrics.requests_response_code_str_buffer;
 
-  StatsClusterLabel *driver_label = dyn_metrics_store_alloc_label(self->metrics.cache);
+  StatsClusterLabel *driver_label = dyn_metrics_store_cache_label(self->metrics.cache);
   driver_label->name = "driver";
   driver_label->value = "http";
 
-  StatsClusterLabel *id_label = dyn_metrics_store_alloc_label(self->metrics.cache);
+  StatsClusterLabel *id_label = dyn_metrics_store_cache_label(self->metrics.cache);
   id_label->name = "id";
   id_label->value = self->super.owner->super.super.id;
 
   StatsClusterKey key;
   stats_cluster_single_key_set(&key, "output_http_requests_total",
-                               dyn_metrics_store_get_labels(self->metrics.cache),
-                               dyn_metrics_store_get_labels_len(self->metrics.cache));
+                               dyn_metrics_store_get_cached_labels(self->metrics.cache),
+                               dyn_metrics_store_get_cached_labels_len(self->metrics.cache));
 
   StatsCounterItem *counter = dyn_metrics_store_retrieve_counter(self->metrics.cache, &key, level);
   stats_counter_inc(counter);

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -637,7 +637,7 @@ _update_status_code_metrics(HTTPDestinationWorker *self, const gchar *url, glong
                                dyn_metrics_store_get_labels(self->metrics.cache),
                                dyn_metrics_store_get_labels_len(self->metrics.cache));
 
-  StatsCounterItem *counter = dyn_metrics_store_get_counter(self->metrics.cache, &key, level);
+  StatsCounterItem *counter = dyn_metrics_store_retrieve_counter(self->metrics.cache, &key, level);
   stats_counter_inc(counter);
 }
 

--- a/modules/http/http-worker.h
+++ b/modules/http/http-worker.h
@@ -29,7 +29,7 @@
 #include "http-loadbalancer.h"
 #include "http-curl-header-list.h"
 #include "compression.h"
-#include "metrics/metrics-cache.h"
+#include "metrics/dyn-metrics-store.h"
 
 typedef struct _HTTPDestinationWorker
 {
@@ -45,7 +45,7 @@ typedef struct _HTTPDestinationWorker
 
   struct
   {
-    MetricsCache *cache;
+    DynMetricsStore *cache;
     gchar requests_response_code_str_buffer[4];
   } metrics;
 } HTTPDestinationWorker;

--- a/modules/metrics-probe/metrics-probe-grammar.ym
+++ b/modules/metrics-probe/metrics-probe-grammar.ym
@@ -78,7 +78,7 @@ metrics_probe_opt
         : KW_INCREMENT '(' template_content ')' { metrics_probe_set_increment_template(last_parser, $3); log_template_unref($3); }
         | { last_template_options = metrics_probe_get_template_options(last_parser); } template_option
         | parser_opt
-	| { last_metrics_template = metrics_probe_get_metrics_template(last_parser); } metrics_template_opt
+	| { last_dyn_metrics_template = metrics_probe_get_metrics_template(last_parser); } dyn_metrics_template_opt
         ;
 
 /* INCLUDE_RULES */

--- a/modules/metrics-probe/metrics-probe.h
+++ b/modules/metrics-probe/metrics-probe.h
@@ -23,7 +23,7 @@
 #ifndef METRICS_PROBE_H_INCLUDED
 #define METRICS_PROBE_H_INCLUDED
 
-#include "metrics/metrics-template.h"
+#include "metrics/dyn-metrics-template.h"
 #include "parser/parser-expr.h"
 #include "template/templates.h"
 
@@ -31,6 +31,6 @@ LogParser *metrics_probe_new(GlobalConfig *cfg);
 void metrics_probe_set_increment_template(LogParser *s, LogTemplate *increment_template);
 
 LogTemplateOptions *metrics_probe_get_template_options(LogParser *s);
-MetricsTemplate *metrics_probe_get_metrics_template(LogParser *s);
+DynMetricsTemplate *metrics_probe_get_metrics_template(LogParser *s);
 
 #endif

--- a/modules/metrics-probe/tests/test_metrics_probe.c
+++ b/modules/metrics-probe/tests/test_metrics_probe.c
@@ -32,7 +32,7 @@ _add_label(LogParser *s, const gchar *label, const gchar *value_template_str)
 {
   LogTemplate *value_template = log_template_new(s->super.cfg, NULL);
   log_template_compile(value_template, value_template_str, NULL);
-  metrics_template_add_label_template(metrics_probe_get_metrics_template(s), label, value_template);
+  dyn_metrics_template_add_label_template(metrics_probe_get_metrics_template(s), label, value_template);
   log_template_unref(value_template);
 }
 
@@ -111,7 +111,7 @@ Test(metrics_probe, test_metrics_probe_custom_labels_only)
 Test(metrics_probe, test_metrics_probe_custom_key_only)
 {
   LogParser *tmp_metrics_probe = metrics_probe_new(configuration);
-  metrics_template_set_key(metrics_probe_get_metrics_template(tmp_metrics_probe), "custom_key");
+  dyn_metrics_template_set_key(metrics_probe_get_metrics_template(tmp_metrics_probe), "custom_key");
 
   LogParser *metrics_probe = (LogParser *) log_pipe_clone(&tmp_metrics_probe->super);
   log_pipe_unref(&tmp_metrics_probe->super);
@@ -140,7 +140,7 @@ Test(metrics_probe, test_metrics_probe_custom_key_only)
 Test(metrics_probe, test_metrics_probe_custom_full)
 {
   LogParser *tmp_metrics_probe = metrics_probe_new(configuration);
-  metrics_template_set_key(metrics_probe_get_metrics_template(tmp_metrics_probe), "custom_key");
+  dyn_metrics_template_set_key(metrics_probe_get_metrics_template(tmp_metrics_probe), "custom_key");
 
   _add_label(tmp_metrics_probe, "test_label_3", "foo");
   _add_label(tmp_metrics_probe, "test_label_1", "${test_field_1}");
@@ -202,7 +202,7 @@ Test(metrics_probe, test_metrics_probe_stats_max_dynamics)
   stats_reinit(&configuration->stats_options);
 
   LogParser *tmp_metrics_probe = metrics_probe_new(configuration);
-  metrics_template_set_key(metrics_probe_get_metrics_template(tmp_metrics_probe), "custom_key");
+  dyn_metrics_template_set_key(metrics_probe_get_metrics_template(tmp_metrics_probe), "custom_key");
   _add_label(tmp_metrics_probe, "test_label", "${test_field}");
 
   LogParser *metrics_probe = (LogParser *) log_pipe_clone(&tmp_metrics_probe->super);
@@ -244,7 +244,7 @@ Test(metrics_probe, test_metrics_probe_stats_max_dynamics)
 Test(metrics_probe, test_metrics_probe_increment)
 {
   LogParser *tmp_metrics_probe = metrics_probe_new(configuration);
-  metrics_template_set_key(metrics_probe_get_metrics_template(tmp_metrics_probe), "custom_key");
+  dyn_metrics_template_set_key(metrics_probe_get_metrics_template(tmp_metrics_probe), "custom_key");
   LogTemplate *increment_template = log_template_new(tmp_metrics_probe->super.cfg, NULL);
   log_template_compile(increment_template, "${custom_increment}", NULL);
   metrics_probe_set_increment_template(tmp_metrics_probe, increment_template);
@@ -272,8 +272,8 @@ Test(metrics_probe, test_metrics_probe_increment)
 Test(metrics_probe, test_metrics_probe_level)
 {
   LogParser *tmp_metrics_probe = metrics_probe_new(configuration);
-  metrics_template_set_key(metrics_probe_get_metrics_template(tmp_metrics_probe), "custom_key");
-  metrics_template_set_level(metrics_probe_get_metrics_template(tmp_metrics_probe), STATS_LEVEL2);
+  dyn_metrics_template_set_key(metrics_probe_get_metrics_template(tmp_metrics_probe), "custom_key");
+  dyn_metrics_template_set_level(metrics_probe_get_metrics_template(tmp_metrics_probe), STATS_LEVEL2);
 
   LogParser *metrics_probe = (LogParser *) log_pipe_clone(&tmp_metrics_probe->super);
   log_pipe_unref(&tmp_metrics_probe->super);
@@ -311,9 +311,9 @@ Test(metrics_probe, test_metrics_probe_level)
 Test(metrics_probe, test_metrics_probe_dynamic_labels)
 {
   LogParser *tmp_metrics_probe = metrics_probe_new(configuration);
-  metrics_template_set_key(metrics_probe_get_metrics_template(tmp_metrics_probe), "custom_key");
+  dyn_metrics_template_set_key(metrics_probe_get_metrics_template(tmp_metrics_probe), "custom_key");
   _add_label(tmp_metrics_probe, "test_label", "${test_field}");
-  ValuePairs *vp = metrics_template_get_value_pairs(metrics_probe_get_metrics_template(tmp_metrics_probe));
+  ValuePairs *vp = dyn_metrics_template_get_value_pairs(metrics_probe_get_metrics_template(tmp_metrics_probe));
   value_pairs_add_glob_pattern(vp, "test_prefix.*", TRUE);
 
   LogParser *metrics_probe = (LogParser *) log_pipe_clone(&tmp_metrics_probe->super);

--- a/news/bugfix-243.md
+++ b/news/bugfix-243.md
@@ -1,0 +1,4 @@
+`metrics-probe()`: fix disappearing metrics from `stats prometheus` output
+
+`metrics-probe()` metrics became orphaned and disappeared from the `syslog-ng-ctl stats prometheus` output
+whenever an ivykis worker stopped (after 10 seconds of inactivity).

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -92,7 +92,7 @@ lib/metrics-pipe\.[ch]
 lib/metrics/label-template\.(c|h)$
 lib/metrics/metrics-template\.(c|h)$
 lib/metrics/dyn-metrics-store\.(c|h)$
-lib/metrics/metrics-tls-cache\.(c|h)$
+lib/metrics/dyn-metrics-cache\.(c|h)$
 lib/metrics/metrics\.(c|h)$
 lib/rewrite/rewrite-set-facility\.h
 lib/rewrite/rewrite-set-matches\.[ch]

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -91,7 +91,7 @@ lib/cfg-source\.[ch]
 lib/metrics-pipe\.[ch]
 lib/metrics/label-template\.(c|h)$
 lib/metrics/metrics-template\.(c|h)$
-lib/metrics/metrics-cache\.(c|h)$
+lib/metrics/dyn-metrics-store\.(c|h)$
 lib/metrics/metrics-tls-cache\.(c|h)$
 lib/metrics/metrics\.(c|h)$
 lib/rewrite/rewrite-set-facility\.h

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -90,7 +90,7 @@ lib/cfg-monitor\.[ch]
 lib/cfg-source\.[ch]
 lib/metrics-pipe\.[ch]
 lib/metrics/label-template\.(c|h)$
-lib/metrics/metrics-template\.(c|h)$
+lib/metrics/dyn-metrics-template\.(c|h)$
 lib/metrics/dyn-metrics-store\.(c|h)$
 lib/metrics/dyn-metrics-cache\.(c|h)$
 lib/metrics/metrics\.(c|h)$


### PR DESCRIPTION
The TLS cache of `metrics-probe()` has been extended with a global cache in order not to make metrics orphaned whenever an ivykis worker stops (after 10 seconds of inactivity).

The global cache requires a lock, but it is only updated on thread shutdown. It is purged during reload.

Refactor overview:
- metrics-cache --> dyn-metrics-store
- metrics-tls-cache --> dyn-metrics-cache

I've also tried to decouple metrics-template from the cache functionality, but it would have had performance implications, so I only added a comment about the coupled functionality.