### PR TITLE
filterx: make ref_cnt atomic

### DIFF
--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -65,7 +65,7 @@ filterx_expr_free_method(FilterXExpr *self)
 void
 filterx_expr_init_instance(FilterXExpr *self)
 {
-  self->ref_cnt = 1;
+  g_atomic_counter_set(&self->ref_cnt, 1);
   self->free_fn = filterx_expr_free_method;
 }
 
@@ -83,7 +83,7 @@ filterx_expr_ref(FilterXExpr *self)
   if (!self)
     return NULL;
 
-  self->ref_cnt++;
+  g_atomic_counter_inc(&self->ref_cnt);
   return self;
 }
 
@@ -93,7 +93,7 @@ filterx_expr_unref(FilterXExpr *self)
   if (!self)
     return;
 
-  if (--self->ref_cnt == 0)
+  if (g_atomic_counter_dec_and_test(&self->ref_cnt))
     {
       self->free_fn(self);
       g_free(self);

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -26,10 +26,11 @@
 
 #include "filterx-object.h"
 #include "cfg-lexer.h"
+#include "atomic.h"
 
 struct _FilterXExpr
 {
-  guint32 ref_cnt;
+  GAtomicCounter ref_cnt;
   const gchar *type;
   guint32 ignore_falsy_result:1, suppress_from_trace:1;
 

--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -96,9 +96,8 @@ filterx_object_free_method(FilterXObject *self)
 void
 filterx_object_init_instance(FilterXObject *self, FilterXType *type)
 {
-  self->ref_cnt = 1;
+  g_atomic_counter_set(&self->ref_cnt, 1);
   self->type = type;
-  self->thread_index = (guint16) main_loop_worker_get_thread_index();
   self->readonly = !type->is_mutable;
 }
 
@@ -115,22 +114,22 @@ filterx_object_freeze(FilterXObject *self)
 {
   if (filterx_object_is_frozen(self))
     return FALSE;
-  g_assert(self->ref_cnt == 1);
-  self->ref_cnt = FILTERX_OBJECT_MAGIC_BIAS;
+  g_assert(g_atomic_counter_get(&self->ref_cnt) == 1);
+  g_atomic_counter_set(&self->ref_cnt, FILTERX_OBJECT_MAGIC_BIAS);
   return TRUE;
 }
 
 gboolean
 filterx_object_is_frozen(FilterXObject *self)
 {
-  return self->ref_cnt == FILTERX_OBJECT_MAGIC_BIAS;
+  return g_atomic_counter_get(&self->ref_cnt) == FILTERX_OBJECT_MAGIC_BIAS;
 }
 
 void
 filterx_object_unfreeze_and_free(FilterXObject *self)
 {
   g_assert(filterx_object_is_frozen(self));
-  self->ref_cnt = 1;
+  g_atomic_counter_set(&self->ref_cnt, 1);
   filterx_object_unref(self);
 }
 
@@ -142,7 +141,9 @@ filterx_object_ref(FilterXObject *self)
 
   if (filterx_object_is_frozen(self))
     return self;
-  self->ref_cnt++;
+
+  g_atomic_counter_inc(&self->ref_cnt);
+
   return self;
 }
 
@@ -155,35 +156,9 @@ filterx_object_unref(FilterXObject *self)
   if (filterx_object_is_frozen(self))
     return;
 
-  /* this asserts that the 16 bit wide thread_index suffices to hold a
-   * thread identifier.
-   *
-   * NOTE the definition of FilterXObject where the * thread_index is a 16 bit bitfield.
-   *
-   * NOTE/2: thread_index might be -1 to indicate unset state.  So the valid
-   * range of values is 0..65534, as 65535 would be -1.
-   *
-   */
-  G_STATIC_ASSERT(MAIN_LOOP_MAX_WORKER_THREADS < ((1 << 16) - 1));
-
-  g_assert(self->ref_cnt > 0);
-  if (--self->ref_cnt == 0)
+  g_assert(g_atomic_counter_get(&self->ref_cnt) > 0);
+  if (g_atomic_counter_dec_and_test(&self->ref_cnt))
     {
-      /* FilterXObjects may not cross a thread boundary as their refcount is
-       * not atomic, let's validate that. */
-
-      /* NOTE: we are only validating the thread_id when we actually reach
-       * ref_cnt 0 for performance reasons.  This means we are not
-       * validating all unref calls.  But it's quite likely that the final
-       * unref call would come from the thread that we passed our reference
-       * to.
-       *
-       * We could be stricter at the cost of some performance but there's a
-       * very good chance that if we ever do hand over FilterXObject
-       * instances across a thread boundary, we will trip on the assert
-       * below, during testing.  */
-
-      g_assert(self->thread_index == (guint16) main_loop_worker_get_thread_index());
       self->type->free_fn(self);
       g_free(self);
     }

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -25,6 +25,7 @@
 
 #include "logmsg/logmsg.h"
 #include "compat/json.h"
+#include "atomic.h"
 
 typedef struct _FilterXType FilterXType;
 typedef struct _FilterXObject FilterXObject;
@@ -73,13 +74,7 @@ FILTERX_DECLARE_TYPE(object);
 
 struct _FilterXObject
 {
-  /* NOTE: this packs into 16 bytes in total (64 bit), let's try to keep
-   * this small, potentially using bitfields.  A simple boolean is 32 bytes
-   * in total at the moment (factoring in GenericNumber which is used to
-   * represent it).  Maybe we could get rid off the GenericNumber wrapper
-   * which would potentially decrease the struct to 16-24 bytes. */
-
-  gint ref_cnt;
+  GAtomicCounter ref_cnt;
 
   /* NOTE:
    *
@@ -89,7 +84,7 @@ struct _FilterXObject
    *                          propagates to the inner elements lazily
    *
    */
-  guint thread_index:16, modified_in_place:1, readonly:1, weak_referenced:1;
+  guint modified_in_place:1, readonly:1, weak_referenced:1;
   FilterXType *type;
 };
 


### PR DESCRIPTION
Thread boundaries were already crossed, for example:
FilterXGetAttr::attr and filterx_eval_push_error().

Even this can be considered as a bug, I saw other paths where we crossed
these boundaries.

We can always restore the non-atomic refcount if we see this as a
performance bottleneck in profiler results.