### PR TITLE
afsocket: avoid using rfc3164 in $TRANSPORT

### DIFF
--- a/modules/afsocket/tests/test-transport-mapper-inet.c
+++ b/modules/afsocket/tests/test-transport-mapper-inet.c
@@ -149,7 +149,7 @@ Test(transport_mapper_inet, test_tcp_apply_transport_sets_defaults)
   assert_transport_mapper_logproto(transport_mapper, "text");
   assert_transport_mapper_stats_source(transport_mapper, SCS_TCP);
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
-  assert_transport_mapper_transport_name(transport_mapper, "rfc3164+tcp");
+  assert_transport_mapper_transport_name(transport_mapper, "bsdsyslog+tcp");
 }
 
 Test(transport_mapper_inet, test_tcp6_apply_transport_sets_defaults)
@@ -162,7 +162,7 @@ Test(transport_mapper_inet, test_tcp6_apply_transport_sets_defaults)
   assert_transport_mapper_logproto(transport_mapper, "text");
   assert_transport_mapper_stats_source(transport_mapper, SCS_TCP6);
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
-  assert_transport_mapper_transport_name(transport_mapper, "rfc3164+tcp");
+  assert_transport_mapper_transport_name(transport_mapper, "bsdsyslog+tcp");
 }
 
 Test(transport_mapper_inet, test_udp_apply_transport_sets_defaults)
@@ -175,7 +175,7 @@ Test(transport_mapper_inet, test_udp_apply_transport_sets_defaults)
   assert_transport_mapper_logproto(transport_mapper, "dgram");
   assert_transport_mapper_stats_source(transport_mapper, SCS_UDP);
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
-  assert_transport_mapper_transport_name(transport_mapper, "rfc3164+udp");
+  assert_transport_mapper_transport_name(transport_mapper, "bsdsyslog+udp");
 }
 
 Test(transport_mapper_inet, test_udp_apply_fails_when_tls_context_is_set)
@@ -183,7 +183,7 @@ Test(transport_mapper_inet, test_udp_apply_fails_when_tls_context_is_set)
   transport_mapper = transport_mapper_udp_new();
   transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context());
   assert_transport_mapper_apply_fails(transport_mapper, "udp");
-  assert_transport_mapper_transport_name(transport_mapper, "rfc3164+udp");
+  assert_transport_mapper_transport_name(transport_mapper, "bsdsyslog+udp");
 }
 
 Test(transport_mapper_inet, test_udp6_apply_transport_sets_defaults)
@@ -196,7 +196,7 @@ Test(transport_mapper_inet, test_udp6_apply_transport_sets_defaults)
   assert_transport_mapper_logproto(transport_mapper, "dgram");
   assert_transport_mapper_stats_source(transport_mapper, SCS_UDP6);
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
-  assert_transport_mapper_transport_name(transport_mapper, "rfc3164+udp");
+  assert_transport_mapper_transport_name(transport_mapper, "bsdsyslog+udp");
 }
 
 Test(transport_mapper_inet, test_network_transport_udp_apply_transport_sets_defaults)
@@ -209,7 +209,7 @@ Test(transport_mapper_inet, test_network_transport_udp_apply_transport_sets_defa
   assert_transport_mapper_logproto(transport_mapper, "dgram");
   assert_transport_mapper_stats_source(transport_mapper, SCS_NETWORK);
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
-  assert_transport_mapper_transport_name(transport_mapper, "rfc3164+udp");
+  assert_transport_mapper_transport_name(transport_mapper, "bsdsyslog+udp");
 }
 
 Test(transport_mapper_inet, test_network_transport_udp_apply_fails_when_tls_context_is_set)
@@ -229,7 +229,7 @@ Test(transport_mapper_inet, test_network_transport_tcp_apply_transport_sets_defa
   assert_transport_mapper_logproto(transport_mapper, "text");
   assert_transport_mapper_stats_source(transport_mapper, SCS_NETWORK);
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
-  assert_transport_mapper_transport_name(transport_mapper, "rfc3164+tcp");
+  assert_transport_mapper_transport_name(transport_mapper, "bsdsyslog+tcp");
 }
 
 Test(transport_mapper_inet, test_network_transport_tls_apply_fails_without_tls_context)
@@ -249,7 +249,7 @@ Test(transport_mapper_inet, test_network_transport_tls_apply_transport_sets_defa
   assert_transport_mapper_logproto(transport_mapper, "text");
   assert_transport_mapper_stats_source(transport_mapper, SCS_NETWORK);
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
-  assert_transport_mapper_transport_name(transport_mapper, "rfc3164+tls");
+  assert_transport_mapper_transport_name(transport_mapper, "bsdsyslog+tls");
 }
 
 Test(transport_mapper_inet, test_network_transport_foo_apply_transport_sets_defaults)
@@ -262,7 +262,7 @@ Test(transport_mapper_inet, test_network_transport_foo_apply_transport_sets_defa
   assert_transport_mapper_logproto(transport_mapper, "foo");
   assert_transport_mapper_stats_source(transport_mapper, SCS_NETWORK);
   assert_transport_mapper_inet_server_port(transport_mapper, 514);
-  assert_transport_mapper_transport_name(transport_mapper, "rfc3164+foo");
+  assert_transport_mapper_transport_name(transport_mapper, "bsdsyslog+foo");
 }
 
 Test(transport_mapper_inet, test_syslog_transport_udp_apply_transport_sets_defaults)

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -314,9 +314,9 @@ transport_mapper_tcp_apply_transport(TransportMapper *s, GlobalConfig *cfg)
     return FALSE;
 
   if (self->tls_context)
-    self->super.transport_name = g_strdup("rfc3164+tls");
+    self->super.transport_name = g_strdup("bsdsyslog+tls");
   else
-    self->super.transport_name = g_strdup("rfc3164+tcp");
+    self->super.transport_name = g_strdup("bsdsyslog+tcp");
 
   return TRUE;
 }
@@ -351,7 +351,7 @@ transport_mapper_udp_new(void)
 {
   TransportMapperInet *self = transport_mapper_inet_new_instance("udp");
 
-  self->super.transport_name = g_strdup("rfc3164+udp");
+  self->super.transport_name = g_strdup("bsdsyslog+udp");
   self->super.sock_type = SOCK_DGRAM;
   self->super.sock_proto = IPPROTO_UDP;
   self->super.logproto = "dgram";
@@ -388,14 +388,14 @@ transport_mapper_network_apply_transport(TransportMapper *s, GlobalConfig *cfg)
       self->super.sock_type = SOCK_DGRAM;
       self->super.sock_proto = IPPROTO_UDP;
       self->super.logproto = "dgram";
-      self->super.transport_name = g_strdup("rfc3164+udp");
+      self->super.transport_name = g_strdup("bsdsyslog+udp");
     }
   else if (strcasecmp(transport, "tcp") == 0)
     {
       self->super.logproto = "text";
       self->super.sock_type = SOCK_STREAM;
       self->super.sock_proto = IPPROTO_TCP;
-      self->super.transport_name = g_strdup("rfc3164+tcp");
+      self->super.transport_name = g_strdup("bsdsyslog+tcp");
     }
   else if (strcasecmp(transport, "tls") == 0)
     {
@@ -403,7 +403,7 @@ transport_mapper_network_apply_transport(TransportMapper *s, GlobalConfig *cfg)
       self->super.sock_type = SOCK_STREAM;
       self->super.sock_proto = IPPROTO_TCP;
       self->require_tls = TRUE;
-      self->super.transport_name = g_strdup("rfc3164+tls");
+      self->super.transport_name = g_strdup("bsdsyslog+tls");
     }
   else if (strcasecmp(transport, "proxied-tls") == 0)
     {
@@ -411,7 +411,7 @@ transport_mapper_network_apply_transport(TransportMapper *s, GlobalConfig *cfg)
       self->super.sock_type = SOCK_STREAM;
       self->super.sock_proto = IPPROTO_TCP;
       self->require_tls = TRUE;
-      self->super.transport_name = g_strdup("rfc3164+proxied-tls");
+      self->super.transport_name = g_strdup("bsdsyslog+proxied-tls");
     }
   else
     {
@@ -421,7 +421,7 @@ transport_mapper_network_apply_transport(TransportMapper *s, GlobalConfig *cfg)
       /* FIXME: look up port/protocol from the logproto */
       self->server_port = TCP_PORT;
       self->allow_tls = TRUE;
-      self->super.transport_name = g_strdup_printf("rfc3164+%s", self->super.transport);
+      self->super.transport_name = g_strdup_printf("bsdsyslog+%s", self->super.transport);
     }
 
   g_assert(self->server_port != 0);


### PR DESCRIPTION
RFC3164 is both a data format and a transport. Sometimes 5424 style messages are received on a 3164-like transport, and seeing both 3164 in TRANSPORT and 5424 in MSGFORMAT can be a source of confusion.


