### PR TITLE
msg-format: include "syslog:" prefix for $MSGFORMAT values

### DIFF
--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -179,7 +179,7 @@ msg_format_parse_into(MsgFormatOptions *options, LogMessage *msg,
       msg_format_postprocess_message(options, msg, data, length);
 
       gchar buf[256];
-      gsize len = g_snprintf(buf, sizeof(buf), "%s-error", options->format);
+      gsize len = g_snprintf(buf, sizeof(buf), "%s:error", options->format);
       log_msg_set_value(msg, LM_V_MSGFORMAT, buf, len);
     }
 }

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -1028,7 +1028,7 @@ _syslog_format_parse_legacy(const MsgFormatOptions *parse_options,
 
   _syslog_format_parse_legacy_message(msg, &src, &left, parse_options);
 
-  log_msg_set_value_to_string(msg, LM_V_MSGFORMAT, "rfc3164");
+  log_msg_set_value_to_string(msg, LM_V_MSGFORMAT, "syslog:rfc3164");
   return TRUE;
 error:
   *position = src - data;
@@ -1124,7 +1124,7 @@ _syslog_format_parse_syslog_proto(const MsgFormatOptions *parse_options, const g
   if (!_syslog_format_parse_message_column(msg, &src, &left, parse_options))
     goto error;
 
-  log_msg_set_value_to_string(msg, LM_V_MSGFORMAT, "rfc5424");
+  log_msg_set_value_to_string(msg, LM_V_MSGFORMAT, "syslog:rfc5424");
 
   return TRUE;
 error:

--- a/modules/syslogformat/tests/test_syslog_format.c
+++ b/modules/syslogformat/tests/test_syslog_format.c
@@ -100,7 +100,7 @@ Test(syslog_format, rfc3164_style_message_when_parsed_as_rfc5424_is_marked_as_su
   assert_log_message_value_by_name(msg, "PROGRAM", "program");
   assert_log_message_value_by_name(msg, "PID", "pid");
   assert_log_message_value_by_name(msg, "MSG", "message");
-  assert_log_message_value_by_name(msg, "MSGFORMAT", "rfc3164");
+  assert_log_message_value_by_name(msg, "MSGFORMAT", "syslog:rfc3164");
 
   log_msg_unref(msg);
 }
@@ -120,7 +120,7 @@ Test(syslog_format, rfc5424_style_message_when_parsed_as_rfc5424_is_marked_as_su
   assert_log_message_value_by_name(msg, "PID", "pid");
   assert_log_message_value_by_name(msg, "MSGID", "msgid");
   assert_log_message_value_by_name(msg, "MSG", "message");
-  assert_log_message_value_by_name(msg, "MSGFORMAT", "rfc5424");
+  assert_log_message_value_by_name(msg, "MSGFORMAT", "syslog:rfc5424");
 
   log_msg_unref(msg);
 }


### PR DESCRIPTION
This helps the "error" case match the successfully parsed ones. Also, this will improve consistency with linux:kmsg and linux:audit which are also possible values for $MSGFORMAT.


