### PR TITLE
csvparser-filterx: do not traverse column list 3 times

### DIFF
--- a/modules/csvparser/filterx-func-parse-csv.c
+++ b/modules/csvparser/filterx-func-parse-csv.c
@@ -141,17 +141,11 @@ static inline gboolean
 _fill_object_col(FilterXObject *cols, gint64 index, CSVScanner *scanner, FilterXObject *result)
 {
   FilterXObject *col = filterx_list_get_subscript(cols, index);
-  const gchar *col_name;
-  gsize col_name_len;
-  filterx_object_extract_string(col, &col_name, &col_name_len);
-
-  FilterXObject *key = filterx_string_new(col_name, col_name_len);
   FilterXObject *val = filterx_string_new(csv_scanner_get_current_value(scanner),
                                           csv_scanner_get_current_value_len(scanner));
 
-  gboolean ok = filterx_object_set_subscript(result, key, &val);
+  gboolean ok = filterx_object_set_subscript(result, col, &val);
 
-  filterx_object_unref(key);
   filterx_object_unref(val);
   filterx_object_unref(col);
 

--- a/modules/csvparser/filterx-func-parse-csv.c
+++ b/modules/csvparser/filterx-func-parse-csv.c
@@ -152,6 +152,20 @@ _fill_object_col(FilterXObject *cols, gint64 index, CSVScanner *scanner, FilterX
   return ok;
 }
 
+static inline gboolean
+_fill_array_element(CSVScanner *scanner, FilterXObject *result)
+{
+  const gchar *current_value = csv_scanner_get_current_value(scanner);
+  gint current_value_len = csv_scanner_get_current_value_len(scanner);
+  FilterXObject *val = filterx_string_new(current_value, current_value_len);
+
+  gboolean ok = filterx_list_append(result, &val);
+
+  filterx_object_unref(val);
+
+  return ok;
+}
+
 static FilterXObject *
 _eval(FilterXExpr *s)
 {
@@ -206,13 +220,7 @@ _eval(FilterXExpr *s)
         }
       else
         {
-          const gchar *current_value = csv_scanner_get_current_value(&scanner);
-          gint current_value_len = csv_scanner_get_current_value_len(&scanner);
-          FilterXObject *val = filterx_string_new(current_value, current_value_len);
-
-          ok = filterx_list_append(result, &val);
-
-          filterx_object_unref(val);
+          ok = _fill_array_element(&scanner, result);
         }
     }
 

--- a/modules/csvparser/filterx-func-parse-csv.c
+++ b/modules/csvparser/filterx-func-parse-csv.c
@@ -89,12 +89,12 @@ exit:
 }
 
 static inline void
-_init_scanner(FilterXFunctionParseCSV *self, GList *string_delimiters, GList *cols, const gchar *input,
+_init_scanner(FilterXFunctionParseCSV *self, GList *string_delimiters, gint num_of_cols, const gchar *input,
               CSVScanner *scanner, CSVScannerOptions *local_opts)
 {
   CSVScannerOptions *opts = &self->options;
 
-  if (string_delimiters || cols)
+  if (string_delimiters || num_of_cols)
     {
       csv_scanner_options_copy(local_opts, &self->options);
       opts = local_opts;
@@ -103,8 +103,8 @@ _init_scanner(FilterXFunctionParseCSV *self, GList *string_delimiters, GList *co
   if (string_delimiters)
     csv_scanner_options_set_string_delimiters(local_opts, string_delimiters);
 
-  if (cols)
-    csv_scanner_options_set_expected_columns(local_opts, g_list_length(cols));
+  if (num_of_cols)
+    csv_scanner_options_set_expected_columns(local_opts, num_of_cols);
 
   csv_scanner_init(scanner, opts, input);
 }
@@ -144,7 +144,7 @@ _eval(FilterXExpr *s)
 
   CSVScanner scanner;
   CSVScannerOptions local_opts = {0};
-  _init_scanner(self, string_delimiters, cols, input, &scanner, &local_opts);
+  _init_scanner(self, string_delimiters, g_list_length(cols), input, &scanner, &local_opts);
 
   GList *col = cols;
   while (csv_scanner_scan_next(&scanner))


### PR DESCRIPTION
Depends on #249

csvparser-filterx: do not traverse column list 3 times

- constructing list
- g_list_length()
- traversing list

This also fixes a possible bug where a name-value pair passed to `filterx_string_new()` may not have been null-terminated.