### PR TITLE
fix(lib): do not insert "nulls" as values for __VARARGS__ config arguments

### DIFF
--- a/lib/cfg-block-generator.c
+++ b/lib/cfg-block-generator.c
@@ -39,6 +39,7 @@ _report_generator_args(gpointer key, gpointer value, gpointer user_data)
 {
   GString *result = (GString *) user_data;
   g_string_append_printf(result, "## %s=", (gchar *) key);
+  value = value ? : "";
   for (const gchar *c = (const gchar *) value; *c; c++)
     {
       if (*c == '\n' && *(c + 1))


### PR DESCRIPTION
```
@version: current

block destination second(...) {
      `__VARARGS__`
};

block destination first(...) {
      second(`__VARARGS__`);
};

log {
   destination{ first(some-param("")) };
};
```

After the fix:

```
[2024-10-15T09:49:23.089776] Unknown argument, adding it to __VARARGS__; argument='some_param', value='', reference='../install_dir/etc/empty.conf:12:17'
[2024-10-15T09:49:23.089776] Unknown argument, adding it to __VARARGS__; argument='some_param', value='', reference='../install_dir/etc/empty.conf:8:7'

Error parsing log statement: syntax error, unexpected LL_IDENTIFIER, expecting '}'

In ../install_dir/etc/empty.conf:4:7-4:17:
-1      
0       #Start Block block destination second() at ../install_dir/etc/empty.conf:3
1       ## some_param=
2       @line "../install_dir/etc/empty.conf" 3 31
3       
4----->       some_param("") 
4----->       ^^^^^^^^^^
5       
6       #End Block block destination second() at ../install_dir/etc/empty.conf:3
7       

Included from ../install_dir/etc/empty.conf:8:7-8:30:
3       
4       #Start Block block destination first() at ../install_dir/etc/empty.conf:7
5       ## some_param=
6       @line "../install_dir/etc/empty.conf" 7 30
7       
8----->       second(some_param("") );
8----->       ^^^^^^^^^^^^^^^^^^^^^^^
9       
10      #End Block block destination first() at ../install_dir/etc/empty.conf:7
11      

Included from ../install_dir/etc/empty.conf:12:17-12:38:
7       block destination first(...) {
8             second(`__VARARGS__`);
9       };
10      
11      log {
12---->    destination{ first(some-param("")) };
12---->                 ^^^^^^^^^^^^^^^^^^^^^
13      };
```

Fixes #244.