### PR TITLE
Fix race condition in FilterX simple funcs and perf improvements

### DIFF
--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -257,6 +257,8 @@ filterx_function_args_empty(FilterXFunctionArgs *self)
 static inline FilterXExpr *
 _args_get_expr(FilterXFunctionArgs *self, guint64 index)
 {
+  /* 'retrieved' is not thread-safe */
+  main_loop_assert_main_thread();
 
   if (self->positional_args->len <= index)
     return NULL;

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -253,15 +253,21 @@ filterx_function_args_empty(FilterXFunctionArgs *self)
   return self->positional_args->len == 0 && g_hash_table_size(self->named_args) == 0;
 }
 
-FilterXExpr *
-filterx_function_args_get_expr(FilterXFunctionArgs *self, guint64 index)
+static inline FilterXExpr *
+_args_get_expr(FilterXFunctionArgs *self, guint64 index)
 {
   if (self->positional_args->len <= index)
     return NULL;
 
   FilterXFunctionArg *arg = g_ptr_array_index(self->positional_args, index);
   arg->retrieved = TRUE;
-  return filterx_expr_ref((FilterXExpr *) arg->value);
+  return (FilterXExpr *) arg->value;
+}
+
+FilterXExpr *
+filterx_function_args_get_expr(FilterXFunctionArgs *self, guint64 index)
+{
+  return filterx_expr_ref(_args_get_expr(self, index));
 }
 
 FilterXObject *

--- a/lib/filterx/expr-function.h
+++ b/lib/filterx/expr-function.h
@@ -78,11 +78,9 @@ FilterXFunctionArgs *filterx_function_args_new(GList *args, GError **error);
 guint64 filterx_function_args_len(FilterXFunctionArgs *self);
 gboolean filterx_function_args_empty(FilterXFunctionArgs *self);
 FilterXExpr *filterx_function_args_get_expr(FilterXFunctionArgs *self, guint64 index);
-FilterXObject *filterx_function_args_get_object(FilterXFunctionArgs *self, guint64 index);
 const gchar *filterx_function_args_get_literal_string(FilterXFunctionArgs *self, guint64 index, gsize *len);
 gboolean filterx_function_args_is_literal_null(FilterXFunctionArgs *self, guint64 index);
 FilterXExpr *filterx_function_args_get_named_expr(FilterXFunctionArgs *self, const gchar *name);
-FilterXObject *filterx_function_args_get_named_object(FilterXFunctionArgs *self, const gchar *name, gboolean *exists);
 FilterXObject *filterx_function_args_get_named_literal_object(FilterXFunctionArgs *self, const gchar *name,
     gboolean *exists);
 const gchar *filterx_function_args_get_named_literal_string(FilterXFunctionArgs *self, const gchar *name,

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Axoflow
  * Copyright (c) 2023 Balazs Scheidler <balazs.scheidler@axoflow.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -24,6 +25,7 @@
 #include "filterx/filterx-expr.h"
 #include "cfg-source.h"
 #include "messages.h"
+#include "mainloop.h"
 
 void
 filterx_expr_set_location_with_text(FilterXExpr *self, CfgLexer *lexer, CFG_LTYPE *lloc, const gchar *text)
@@ -80,6 +82,8 @@ filterx_expr_new(void)
 FilterXExpr *
 filterx_expr_ref(FilterXExpr *self)
 {
+  main_loop_assert_main_thread();
+
   if (!self)
     return NULL;
 
@@ -90,6 +94,8 @@ filterx_expr_ref(FilterXExpr *self)
 void
 filterx_expr_unref(FilterXExpr *self)
 {
+  main_loop_assert_main_thread();
+
   if (!self)
     return;
 

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -65,7 +65,7 @@ filterx_expr_free_method(FilterXExpr *self)
 void
 filterx_expr_init_instance(FilterXExpr *self)
 {
-  g_atomic_counter_set(&self->ref_cnt, 1);
+  self->ref_cnt = 1;
   self->free_fn = filterx_expr_free_method;
 }
 
@@ -83,7 +83,7 @@ filterx_expr_ref(FilterXExpr *self)
   if (!self)
     return NULL;
 
-  g_atomic_counter_inc(&self->ref_cnt);
+  self->ref_cnt++;
   return self;
 }
 
@@ -93,7 +93,7 @@ filterx_expr_unref(FilterXExpr *self)
   if (!self)
     return;
 
-  if (g_atomic_counter_dec_and_test(&self->ref_cnt))
+  if (--self->ref_cnt == 0)
     {
       self->free_fn(self);
       g_free(self);

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Axoflow
  * Copyright (c) 2023 Balazs Scheidler <balazs.scheidler@axoflow.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -29,6 +30,7 @@
 
 struct _FilterXExpr
 {
+  /* not thread-safe*/
   guint32 ref_cnt;
   const gchar *type;
   guint32 ignore_falsy_result:1, suppress_from_trace:1;

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -26,11 +26,10 @@
 
 #include "filterx-object.h"
 #include "cfg-lexer.h"
-#include "atomic.h"
 
 struct _FilterXExpr
 {
-  GAtomicCounter ref_cnt;
+  guint32 ref_cnt;
   const gchar *type;
   guint32 ignore_falsy_result:1, suppress_from_trace:1;
 

--- a/lib/filterx/filterx-metrics.c
+++ b/lib/filterx/filterx-metrics.c
@@ -101,7 +101,7 @@ _format_sck(FilterXMetrics *self, StatsClusterKey *sck)
 static gboolean
 _is_const(FilterXMetrics *self)
 {
-  return !self->key.expr && (!self->labels || filterx_metrics_labels_is_const(self->labels));
+  return !self->key.expr && (self->const_cluster || filterx_metrics_labels_is_const(self->labels));
 }
 
 static void
@@ -133,9 +133,6 @@ _optimize(FilterXMetrics *self)
 
   g_free(self->key.str);
   self->key.str = NULL;
-
-  filterx_metrics_labels_free(self->labels);
-  self->labels = NULL;
 
 exit:
   g_atomic_counter_set(&self->is_optimized, TRUE);

--- a/lib/filterx/filterx-private.h
+++ b/lib/filterx/filterx-private.h
@@ -28,7 +28,7 @@
 
 // Builtin functions
 FilterXExpr *filterx_simple_function_new(const gchar *function_name, FilterXFunctionArgs *args,
-                                         FilterXSimpleFunctionProto function_proto);
+                                         FilterXSimpleFunctionProto function_proto, GError **error);
 
 gboolean filterx_builtin_simple_function_register_private(GHashTable *ht, const gchar *fn_name,
                                                           FilterXSimpleFunctionProto func);

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -352,7 +352,9 @@ _dummy_func(FilterXExpr *s, GPtrArray *args)
 
 Test(expr_condition, test_condition_return_expr_result_on_missing_stmts)
 {
-  FilterXExpr *func = filterx_simple_function_new("test_fn", filterx_function_args_new(NULL, NULL), _dummy_func);
+  GError *error = NULL;
+  FilterXExpr *func = filterx_simple_function_new("test_fn", filterx_function_args_new(NULL, NULL), _dummy_func, &error);
+  g_clear_error(&error);
 
   FilterXExpr *cond = filterx_conditional_new(func);
   FilterXObject *res = filterx_expr_eval(cond);

--- a/lib/filterx/tests/test_expr_function.c
+++ b/lib/filterx/tests/test_expr_function.c
@@ -60,8 +60,12 @@ FilterXObject *test_dummy_function(FilterXExpr *s, GPtrArray *args)
 
 Test(expr_function, test_function_null_args)
 {
+  GError *error = NULL;
   FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(NULL, NULL),
-                                                  test_dummy_function);
+                                                  test_dummy_function, &error);
+  cr_assert_null(error);
+  g_clear_error(&error);
+
   cr_assert_not_null(func);
   filterx_expr_unref(func);
 }
@@ -70,9 +74,15 @@ Test(expr_function, test_function_null_arg)
 {
   GList *args = NULL;
   args = g_list_append(args, filterx_function_arg_new(NULL, NULL));
+
+  GError *error = NULL;
   FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(args, NULL),
-                                                  test_dummy_function);
-  cr_assert_not_null(func);
+                                                  test_dummy_function, &error);
+
+  cr_assert_not_null(error);
+  g_clear_error(&error);
+
+  cr_assert_null(func);
   filterx_expr_unref(func);
 }
 
@@ -81,9 +91,13 @@ Test(expr_function, test_function_valid_arg)
   GList *args = NULL;
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("bad format 1", -1))));
 
+  GError *error = NULL;
   FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(args, NULL),
-                                                  test_dummy_function);
+                                                  test_dummy_function, &error);
   cr_assert_not_null(func);
+
+  cr_assert_null(error);
+  g_clear_error(&error);
 
   FilterXObject *res = filterx_expr_eval(func);
   cr_assert_not_null(res);
@@ -100,8 +114,13 @@ Test(expr_function, test_function_multiple_args)
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new())));
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_integer_new(443))));
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("foobar", -1))));
+
+  GError *error = NULL;
   FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(args, NULL),
-                                                  test_dummy_function);
+                                                  test_dummy_function, &error);
+
+  cr_assert_null(error);
+  g_clear_error(&error);
   cr_assert_not_null(func);
   FilterXObject *res = filterx_expr_eval(func);
   cr_assert_not_null(res);


### PR DESCRIPTION
2 race conditions have been fixed around `FilterXFunctionArgs`:
- `retrieved` field should not be changed during eval
- expression `ref()/unref()` calls should not be called during eval

Depends on #252