### PR TITLE
filterx: perf improvement and fix race condition in readonly FilterXJson::to_json_literal()

### DIFF
--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -86,6 +86,7 @@ struct _FilterXObject
    */
   guint modified_in_place:1, readonly:1, weak_referenced:1;
   FilterXType *type;
+  void (*make_readonly)(FilterXObject *self);
 };
 
 FilterXObject *filterx_object_getattr_string(FilterXObject *self, const gchar *attr_name);
@@ -116,6 +117,9 @@ filterx_object_is_type(FilterXObject *object, FilterXType *type)
 static inline void
 filterx_object_make_readonly(FilterXObject *self)
 {
+  if (self->make_readonly)
+    self->make_readonly(self);
+
   self->readonly = TRUE;
 }
 

--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -41,6 +41,9 @@ struct FilterXJsonArray_
   FilterXList super;
   FilterXWeakRef root_container;
   struct json_object *jso;
+
+  GMutex lock;
+  const gchar *cached_ro_literal;
 };
 
 static gboolean
@@ -49,12 +52,21 @@ _truthy(FilterXObject *s)
   return TRUE;
 }
 
+static inline const gchar *
+_json_string(FilterXJsonArray *self)
+{
+  if (self->super.super.readonly)
+    return g_atomic_pointer_get(&self->cached_ro_literal);
+
+  return json_object_to_json_string_ext(self->jso, JSON_C_TO_STRING_PLAIN);
+}
+
 static gboolean
 _marshal_to_json_literal_append(FilterXJsonArray *self, GString *repr, LogMessageValueType *t)
 {
   *t = LM_VT_JSON;
 
-  const gchar *json_repr = json_object_to_json_string_ext(self->jso, JSON_C_TO_STRING_PLAIN);
+  const gchar *json_repr = _json_string(self);
   g_string_append(repr, json_repr);
 
   return TRUE;
@@ -86,7 +98,7 @@ _repr(FilterXObject *s, GString *repr)
 {
   FilterXJsonArray *self = (FilterXJsonArray *) s;
 
-  const gchar *json_repr = json_object_to_json_string_ext(self->jso, JSON_C_TO_STRING_PLAIN);
+  const gchar *json_repr = _json_string(self);
   g_string_append(repr, json_repr);
 
   return TRUE;
@@ -231,6 +243,21 @@ _unset_index(FilterXList *s, guint64 index)
   return TRUE;
 }
 
+static void
+_make_readonly(FilterXObject *s)
+{
+  FilterXJsonArray *self = (FilterXJsonArray *) s;
+
+  if (g_atomic_pointer_get(&self->cached_ro_literal))
+    return;
+
+  /* json_object_to_json_string_ext() writes/caches into jso, so it's not thread safe  */
+  g_mutex_lock(&self->lock);
+  if (!g_atomic_pointer_get(&self->cached_ro_literal))
+    g_atomic_pointer_set(&self->cached_ro_literal, json_object_to_json_string_ext(self->jso, JSON_C_TO_STRING_PLAIN));
+  g_mutex_unlock(&self->lock);
+}
+
 /* NOTE: consumes root ref */
 FilterXObject *
 filterx_json_array_new_sub(struct json_object *jso, FilterXObject *root)
@@ -238,6 +265,7 @@ filterx_json_array_new_sub(struct json_object *jso, FilterXObject *root)
   FilterXJsonArray *self = g_new0(FilterXJsonArray, 1);
   filterx_list_init_instance(&self->super, &FILTERX_TYPE_NAME(json_array));
 
+  self->super.super.make_readonly = _make_readonly;
   self->super.get_subscript = _get_subscript;
   self->super.set_subscript = _set_subscript;
   self->super.append = _append;
@@ -247,6 +275,8 @@ filterx_json_array_new_sub(struct json_object *jso, FilterXObject *root)
   filterx_weakref_set(&self->root_container, root);
   filterx_object_unref(root);
   self->jso = jso;
+
+  g_mutex_init(&self->lock);
 
   return &self->super.super;
 }
@@ -258,6 +288,8 @@ _free(FilterXObject *s)
 
   json_object_put(self->jso);
   filterx_weakref_clear(&self->root_container);
+
+  g_mutex_clear(&self->lock);
 }
 
 FilterXObject *
@@ -330,7 +362,7 @@ filterx_json_array_to_json_literal(FilterXObject *s)
 
   if (!filterx_object_is_type(s, &FILTERX_TYPE_NAME(json_array)))
     return NULL;
-  return json_object_to_json_string_ext(self->jso, JSON_C_TO_STRING_PLAIN);
+  return _json_string(self);
 }
 
 /* NOTE: Consider using filterx_object_extract_json_array() to also support message_value. */

--- a/modules/grpc/otel/filterx/otel-field.cpp
+++ b/modules/grpc/otel/filterx/otel-field.cpp
@@ -301,7 +301,7 @@ public:
     if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(integer)))
       {
         int64_t value;
-        filterx_integer_unwrap(object, &value);
+        g_assert(filterx_integer_unwrap(object, &value));
         if (!SeverityNumber_IsValid((int) value))
           {
             msg_error("otel-field: Failed to set severity_number",

--- a/modules/json/filterx-format-json.c
+++ b/modules/json/filterx-format-json.c
@@ -55,14 +55,6 @@ _append_literal(const gchar *value, gsize len, GString *result)
 }
 
 static gboolean
-_format_and_append_json(struct json_object *value, GString *result)
-{
-  _append_comma_if_needed(result);
-  g_string_append(result, json_object_to_json_string_ext(value, JSON_C_TO_STRING_PLAIN));
-  return TRUE;
-}
-
-static gboolean
 _format_and_append_null(GString *result)
 {
   _append_comma_if_needed(result);
@@ -238,10 +230,13 @@ _format_and_append_value(FilterXObject *value, GString *result)
       return _append_literal(str, len, result);
     }
 
-  struct json_object *js;
-  if (filterx_object_extract_json_array(value, &js) ||
-      filterx_object_extract_json_object(value, &js))
-    return _format_and_append_json(js, result);
+  const gchar *json_literal = filterx_json_to_json_literal(value);
+  if (json_literal)
+    {
+      _append_comma_if_needed(result);
+      g_string_append(result, json_literal);
+      return TRUE;
+    }
 
   if (filterx_object_extract_null(value))
     return _format_and_append_null(result);


### PR DESCRIPTION
json_object_to_json_string_ext() writes/cached into the given JSON object, so it's not thread safe.

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
