### PR TITLE
filterx: support message_value on the left hand side of +

### DIFF
--- a/lib/filterx/expr-plus.c
+++ b/lib/filterx/expr-plus.c
@@ -35,7 +35,7 @@ _eval(FilterXExpr *s)
 {
   FilterXOperatorPlus *self = (FilterXOperatorPlus *) s;
 
-  FilterXObject *lhs_object = filterx_expr_eval(self->super.lhs);
+  FilterXObject *lhs_object = filterx_expr_eval_typed(self->super.lhs);
   if (!lhs_object)
     return NULL;
 

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -1799,7 +1799,7 @@ def test_add_operator_for_base_types(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, r"""
             $MSG = {};
-            $MSG.string = "foo" + "bar" + "baz";
+            $MSG.string = ${values.str} + "bar" + "baz";
             $MSG.bytes = string(bytes("\xCA") + bytes("\xFE"));
             $MSG.datetime_integer = string(strptime("2000-01-01T00:00:00Z", "%Y-%m-%dT%H:%M:%S%z") + 3600000000);
             $MSG.datetime_double = string(strptime("2000-01-01T00:00:00Z", "%Y-%m-%dT%H:%M:%S%z") + 3600.0);
@@ -1820,7 +1820,7 @@ def test_add_operator_for_base_types(config, syslog_ng):
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
     exp = (
-        r"""{"string":"foobarbaz","""
+        r"""{"string":"stringbarbaz","""
         r""""bytes":"cafe","""
         r""""datetime_integer":"2000-01-01T01:00:00.000+00:00","""
         r""""datetime_double":"2000-01-01T01:00:00.000+00:00","""


### PR DESCRIPTION
The right hand side can be a `message_value`, as we only extract value from it in the add operator implementations, but the left hand side is special in a way that it is also used to find the correct add implementation based on its type, so we need a properly typed object there.

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
