### PR TITLE
Filterx: add drop/done

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -12,6 +12,7 @@ set(FILTERX_HEADERS
     filterx/expr-template.h
     filterx/filterx-config.h
     filterx/filterx-eval.h
+    filterx/filterx-error.h
     filterx/filterx-expr.h
     filterx/filterx-globals.h
     filterx/filterx-object.h
@@ -66,6 +67,7 @@ set(FILTERX_SOURCES
     filterx/expr-template.c
     filterx/filterx-config.c
     filterx/filterx-eval.c
+    filterx/filterx-error.c
     filterx/filterx-expr.c
     filterx/filterx-globals.c
     filterx/filterx-object.c

--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -11,6 +11,7 @@ set(FILTERX_HEADERS
     filterx/expr-set-subscript.h
     filterx/expr-template.h
     filterx/expr-drop.h
+    filterx/expr-done.h
     filterx/filterx-config.h
     filterx/filterx-eval.h
     filterx/filterx-error.h
@@ -67,6 +68,7 @@ set(FILTERX_SOURCES
     filterx/expr-set-subscript.c
     filterx/expr-template.c
     filterx/expr-drop.c
+    filterx/expr-done.c
     filterx/filterx-config.c
     filterx/filterx-eval.c
     filterx/filterx-error.c

--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -10,6 +10,7 @@ set(FILTERX_HEADERS
     filterx/expr-setattr.h
     filterx/expr-set-subscript.h
     filterx/expr-template.h
+    filterx/expr-drop.h
     filterx/filterx-config.h
     filterx/filterx-eval.h
     filterx/filterx-error.h
@@ -65,6 +66,7 @@ set(FILTERX_SOURCES
     filterx/expr-setattr.c
     filterx/expr-set-subscript.c
     filterx/expr-template.c
+    filterx/expr-drop.c
     filterx/filterx-config.c
     filterx/filterx-eval.c
     filterx/filterx-error.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -20,6 +20,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/object-primitive.h		\
 	lib/filterx/filterx-scope.h		\
 	lib/filterx/filterx-eval.h		\
+	lib/filterx/filterx-error.h		\
 	lib/filterx/object-extractor.h		\
 	lib/filterx/object-json.h		\
 	lib/filterx/object-json-internal.h		\
@@ -73,6 +74,7 @@ filterx_sources = 				\
 	lib/filterx/object-primitive.c		\
 	lib/filterx/filterx-scope.c		\
 	lib/filterx/filterx-eval.c		\
+	lib/filterx/filterx-error.c		\
 	lib/filterx/object-extractor.c		\
 	lib/filterx/object-json.c		\
 	lib/filterx/object-json-object.c		\

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -16,6 +16,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/expr-variable.h		\
 	lib/filterx/expr-comparison.h		\
 	lib/filterx/expr-drop.h		\
+	lib/filterx/expr-done.h		\
 	lib/filterx/filterx-object.h		\
 	lib/filterx/filterx-weakrefs.h		\
 	lib/filterx/object-primitive.h		\
@@ -71,6 +72,7 @@ filterx_sources = 				\
 	lib/filterx/expr-variable.c		\
 	lib/filterx/expr-comparison.c		\
 	lib/filterx/expr-drop.c		\
+	lib/filterx/expr-done.c		\
 	lib/filterx/filterx-object.c		\
 	lib/filterx/filterx-weakrefs.c		\
 	lib/filterx/object-primitive.c		\

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -15,6 +15,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/expr-plus.h	\
 	lib/filterx/expr-variable.h		\
 	lib/filterx/expr-comparison.h		\
+	lib/filterx/expr-drop.h		\
 	lib/filterx/filterx-object.h		\
 	lib/filterx/filterx-weakrefs.h		\
 	lib/filterx/object-primitive.h		\
@@ -69,6 +70,7 @@ filterx_sources = 				\
 	lib/filterx/expr-plus.c	\
 	lib/filterx/expr-variable.c		\
 	lib/filterx/expr-comparison.c		\
+	lib/filterx/expr-drop.c		\
 	lib/filterx/filterx-object.c		\
 	lib/filterx/filterx-weakrefs.c		\
 	lib/filterx/object-primitive.c		\

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -86,7 +86,7 @@ _eval_exprs(FilterXCompoundExpr *self, FilterXObject **result)
       filterx_object_unref(*result);
       FilterXEvalContext *context = filterx_eval_get_context();
 
-      if (context->eval_control_modifier == FXC_DROP || context->eval_control_modifier == FXC_DONE)
+      if (G_UNLIKELY(context->eval_control_modifier == FXC_DROP || context->eval_control_modifier == FXC_DONE))
         /* code flow modifier detected, short circuiting */
         return TRUE;
 

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -86,7 +86,7 @@ _eval_exprs(FilterXCompoundExpr *self, FilterXObject **result)
       filterx_object_unref(*result);
       FilterXEvalContext *context = filterx_eval_get_context();
 
-      if (context->eval_control_modifier == FXC_DROP)
+      if (context->eval_control_modifier == FXC_DROP || context->eval_control_modifier == FXC_DONE)
         /* code flow modifier detected, short circuiting */
         return TRUE;
 

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -84,6 +84,11 @@ _eval_exprs(FilterXCompoundExpr *self, FilterXObject **result)
   for (gint i = 0; i < self->exprs->len; i++)
     {
       filterx_object_unref(*result);
+      FilterXEvalContext *context = filterx_eval_get_context();
+
+      if (context->eval_control_modifier == FXC_DROP)
+        /* code flow modifier detected, short circuiting */
+        return TRUE;
 
       FilterXExpr *expr = g_ptr_array_index(self->exprs, i);
       if (!_eval_expr(expr, result))

--- a/lib/filterx/expr-done.c
+++ b/lib/filterx/expr-done.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Szilard Parrag <szilard.parrag@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+
+#include "filterx/expr-done.h"
+#include "filterx/filterx-eval.h"
+#include "filterx/object-primitive.h"
+
+static FilterXObject *
+_eval(FilterXExpr *s)
+{
+  FilterXEvalContext *context = filterx_eval_get_context();
+  context->eval_control_modifier = FXC_DONE;
+
+  return filterx_boolean_new(TRUE);
+}
+
+FilterXExpr *
+filterx_expr_done(void)
+{
+  FilterXExpr *self = g_new0(FilterXExpr, 1);
+  filterx_expr_init_instance(self);
+  self->eval = _eval;
+
+  return self;
+}

--- a/lib/filterx/expr-done.h
+++ b/lib/filterx/expr-done.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Szilard Parrag <szilard.parrag@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_FUNC_DONE_H_INCLUDED
+#define FILTERX_FUNC_DONE_H_INCLUDED
+
+#include "filterx/expr-function.h"
+
+FilterXExpr *filterx_expr_done(void);
+
+#endif

--- a/lib/filterx/expr-drop.c
+++ b/lib/filterx/expr-drop.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Szilard Parrag <szilard.parrag@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/expr-drop.h"
+#include "filterx/filterx-eval.h"
+#include "filterx/object-primitive.h"
+
+static FilterXObject *
+_eval(FilterXExpr *s)
+{
+  FilterXEvalContext *context = filterx_eval_get_context();
+  context->eval_control_modifier = FXC_DROP;
+
+  return filterx_boolean_new(TRUE);
+}
+
+FilterXExpr *
+filterx_expr_drop_msg(void)
+{
+  FilterXExpr *self = g_new0(FilterXExpr, 1);
+  filterx_expr_init_instance(self);
+  self->eval = _eval;
+
+  return self;
+}

--- a/lib/filterx/expr-drop.h
+++ b/lib/filterx/expr-drop.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Szilard Parrag <szilard.parrag@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_EXPR_DROP_H_INCLUDED
+#define FILTERX_EXPR_DROP_H_INCLUDED
+#include "filterx/expr-function.h"
+
+FilterXExpr *filterx_expr_drop_msg(void);
+
+#endif

--- a/lib/filterx/filterx-error.c
+++ b/lib/filterx/filterx-error.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/filterx-error.h"
+
+void
+filterx_eval_clear_error(FilterXError *error)
+{
+  filterx_object_unref(error->object);
+  if (error->free_info)
+    g_free(error->info);
+  memset(error, 0, sizeof(*error));
+}

--- a/lib/filterx/filterx-error.c
+++ b/lib/filterx/filterx-error.c
@@ -64,3 +64,9 @@ filterx_error_format(FilterXError *error)
                         extra_info ? ": " : "",
                         extra_info ? : "");
 }
+
+EVTTAG *
+filterx_error_format_location(FilterXError *error)
+{
+  return filterx_expr_format_location_tag(error->expr);
+}

--- a/lib/filterx/filterx-error.c
+++ b/lib/filterx/filterx-error.c
@@ -70,3 +70,18 @@ filterx_error_format_location(FilterXError *error)
 {
   return filterx_expr_format_location_tag(error->expr);
 }
+
+void
+filterx_error_set_values(FilterXError *error, const gchar *message, FilterXExpr *expr, FilterXObject *object)
+{
+  error->message = message;
+  error->expr = expr;
+  error->object = filterx_object_ref(object);
+}
+
+void
+filterx_error_set_info(FilterXError *error, gchar *info, gboolean free_info)
+{
+  error->info = info;
+  error->free_info = free_info;
+}

--- a/lib/filterx/filterx-error.c
+++ b/lib/filterx/filterx-error.c
@@ -24,7 +24,7 @@
 #include "filterx/filterx-error.h"
 
 void
-filterx_eval_clear_error(FilterXError *error)
+filterx_error_clear(FilterXError *error)
 {
   filterx_object_unref(error->object);
   if (error->free_info)

--- a/lib/filterx/filterx-error.h
+++ b/lib/filterx/filterx-error.h
@@ -41,6 +41,8 @@ typedef struct _FilterXError
 void filterx_error_clear(FilterXError *error);
 EVTTAG *filterx_error_format(FilterXError *error);
 EVTTAG *filterx_error_format_location(FilterXError *error);
+void filterx_error_set_info(FilterXError *error, gchar *info, gboolean free_info);
+void filterx_error_set_values(FilterXError *error, const gchar *message, FilterXExpr *expr, FilterXObject *object);
 
 
 #endif

--- a/lib/filterx/filterx-error.h
+++ b/lib/filterx/filterx-error.h
@@ -38,4 +38,7 @@ typedef struct _FilterXError
   gboolean free_info;
 } FilterXError;
 
+void filterx_error_clear(FilterXError *error);
+
+
 #endif

--- a/lib/filterx/filterx-error.h
+++ b/lib/filterx/filterx-error.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+
+#ifndef FILTERX_ERROR_H_INCLUDED
+#define FILTERX_ERROR_H_INCLUDED
+
+#include "filterx/filterx-scope.h"
+#include "filterx/filterx-expr.h"
+#include "template/eval.h"
+
+typedef struct _FilterXError
+{
+  const gchar *message;
+  FilterXExpr *expr;
+  FilterXObject *object;
+  gchar *info;
+  gboolean free_info;
+} FilterXError;
+
+#endif

--- a/lib/filterx/filterx-error.h
+++ b/lib/filterx/filterx-error.h
@@ -39,6 +39,7 @@ typedef struct _FilterXError
 } FilterXError;
 
 void filterx_error_clear(FilterXError *error);
+EVTTAG *filterx_error_format(FilterXError *error);
 
 
 #endif

--- a/lib/filterx/filterx-error.h
+++ b/lib/filterx/filterx-error.h
@@ -40,6 +40,7 @@ typedef struct _FilterXError
 
 void filterx_error_clear(FilterXError *error);
 EVTTAG *filterx_error_format(FilterXError *error);
+EVTTAG *filterx_error_format_location(FilterXError *error);
 
 
 #endif

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -113,32 +113,7 @@ filterx_format_last_error(void)
 {
   FilterXEvalContext *context = filterx_eval_get_context();
 
-  if (!context->error.message)
-    return evt_tag_str("error", "Error information unset");
-
-  const gchar *extra_info = NULL;
-
-  if (context->error.info)
-    {
-      extra_info = context->error.info;
-    }
-  else if (context->error.object)
-    {
-      GString *buf = scratch_buffers_alloc();
-
-      if (!filterx_object_repr(context->error.object, buf))
-        {
-          LogMessageValueType t;
-          if (!filterx_object_marshal(context->error.object, buf, &t))
-            g_assert_not_reached();
-        }
-      extra_info = buf->str;
-    }
-
-  return evt_tag_printf("error", "%s%s%s",
-                        context->error.message,
-                        extra_info ? ": " : "",
-                        extra_info ? : "");
+  return filterx_error_format(&context->error);
 }
 
 EVTTAG *

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -165,7 +165,8 @@ filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *ms
       filterx_eval_clear_errors();
       goto fail;
     }
-  if (context->eval_control_modifier == FXC_DROP)
+
+  if (G_UNLIKELY(context->eval_control_modifier == FXC_DROP))
     result = FXE_DROP;
   else if (filterx_object_truthy(res))
     result = FXE_SUCCESS;

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -121,7 +121,7 @@ filterx_format_last_error_location(void)
 {
   FilterXEvalContext *context = filterx_eval_get_context();
 
-  return filterx_expr_format_location_tag(context->error.expr);
+  return filterx_error_format_location(&context->error);
 }
 
 

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -165,8 +165,9 @@ filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *ms
       filterx_eval_clear_errors();
       goto fail;
     }
-
-  if (filterx_object_truthy(res))
+  if (context->eval_control_modifier == FXC_DROP)
+    result = FXE_DROP;
+  else if (filterx_object_truthy(res))
     result = FXE_SUCCESS;
   filterx_object_unref(res);
   /* NOTE: we only store the results into the message if the entire evaluation was successful */
@@ -196,6 +197,7 @@ filterx_eval_init_context(FilterXEvalContext *context, FilterXEvalContext *previ
     context->weak_refs = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
   context->previous_context = previous_context;
 
+  context->eval_control_modifier = FXC_NOTSET;
   filterx_eval_set_context(context);
 }
 

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -21,6 +21,7 @@
  *
  */
 #include "filterx/filterx-eval.h"
+#include "filterx/filterx-error.h"
 #include "filterx/filterx-expr.h"
 #include "logpipe.h"
 #include "scratch-buffers.h"
@@ -61,7 +62,7 @@ filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObject *
 
   if (context)
     {
-      filterx_eval_clear_error(&context->error);
+      filterx_error_clear(&context->error);
       context->error.message = message;
       context->error.expr = expr;
       context->error.object = filterx_object_ref(object);
@@ -77,7 +78,7 @@ filterx_eval_push_error_info(const gchar *message, FilterXExpr *expr, gchar *inf
 
   if (context)
     {
-      filterx_eval_clear_error(&context->error);
+      filterx_error_clear(&context->error);
       context->error.message = message;
       context->error.expr = expr;
       context->error.object = NULL;
@@ -96,7 +97,7 @@ filterx_eval_clear_errors(void)
 {
   FilterXEvalContext *context = filterx_eval_get_context();
 
-  filterx_eval_clear_error(&context->error);
+  filterx_error_clear(&context->error);
 }
 
 const gchar *

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -54,15 +54,6 @@ filterx_eval_set_context(FilterXEvalContext *context)
   eval_context = context;
 }
 
-static void
-filterx_eval_clear_error(FilterXError *error)
-{
-  filterx_object_unref(error->object);
-  if (error->free_info)
-    g_free(error->info);
-  memset(error, 0, sizeof(*error));
-}
-
 void
 filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObject *object)
 {

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -63,10 +63,7 @@ filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObject *
   if (context)
     {
       filterx_error_clear(&context->error);
-      context->error.message = message;
-      context->error.expr = expr;
-      context->error.object = filterx_object_ref(object);
-      context->error.info = NULL;
+      filterx_error_set_values(&context->error, message, expr, object);
     }
 }
 
@@ -79,11 +76,8 @@ filterx_eval_push_error_info(const gchar *message, FilterXExpr *expr, gchar *inf
   if (context)
     {
       filterx_error_clear(&context->error);
-      context->error.message = message;
-      context->error.expr = expr;
-      context->error.object = NULL;
-      context->error.info = info;
-      context->error.free_info = free_info;
+      filterx_error_set_values(&context->error, message, expr, NULL);
+      filterx_error_set_info(&context->error, info, free_info);
     }
   else
     {

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -149,12 +149,12 @@ filterx_eval_store_weak_ref(FilterXObject *object)
     }
 }
 
-gboolean
+FilterXEvalResult
 filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *msg)
 {
   context->msgs = &msg;
   context->num_msg = 1;
-  gboolean success = FALSE;
+  FilterXEvalResult success = FXE_FAILURE;
 
   FilterXObject *res = filterx_expr_eval(expr);
   if (!res)
@@ -165,7 +165,10 @@ filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *ms
       filterx_eval_clear_errors();
       goto fail;
     }
-  success = filterx_object_truthy(res);
+  if (filterx_object_truthy(res))
+    success = FXE_SUCCESS;
+  else
+    success = FXE_FAILURE;
   filterx_object_unref(res);
   /* NOTE: we only store the results into the message if the entire evaluation was successful */
 fail:

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -36,6 +36,13 @@ typedef enum _FilterXEvalResult
   FXE_DROP,
 } FilterXEvalResult;
 
+
+typedef enum _FilterXEvalControl
+{
+  FXC_NOTSET,
+  FXC_DROP
+} FilterXEvalControl;
+
 typedef struct _FilterXEvalContext FilterXEvalContext;
 struct _FilterXEvalContext
 {
@@ -45,6 +52,7 @@ struct _FilterXEvalContext
   FilterXError error;
   LogTemplateEvalOptions template_eval_options;
   GPtrArray *weak_refs;
+  FilterXEvalControl eval_control_modifier;
   FilterXEvalContext *previous_context;
 };
 

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -40,7 +40,8 @@ typedef enum _FilterXEvalResult
 typedef enum _FilterXEvalControl
 {
   FXC_NOTSET,
-  FXC_DROP
+  FXC_DROP,
+  FXC_DONE
 } FilterXEvalControl;
 
 typedef struct _FilterXEvalContext FilterXEvalContext;

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -33,6 +33,7 @@ typedef enum _FilterXEvalResult
 {
   FXE_SUCCESS,
   FXE_FAILURE,
+  FXE_DROP,
 } FilterXEvalResult;
 
 typedef struct _FilterXEvalContext FilterXEvalContext;
@@ -58,6 +59,7 @@ const gchar *filterx_eval_get_last_error(void);
 EVTTAG *filterx_format_last_error(void);
 EVTTAG *filterx_format_last_error_location(void);
 void filterx_eval_clear_errors(void);
+EVTTAG *filterx_format_eval_result(FilterXEvalResult result);
 
 void filterx_eval_store_weak_ref(FilterXObject *object);
 

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -29,6 +29,12 @@
 #include "template/eval.h"
 
 
+typedef enum _FilterXEvalResult
+{
+  FXE_SUCCESS,
+  FXE_FAILURE,
+} FilterXEvalResult;
+
 typedef struct _FilterXEvalContext FilterXEvalContext;
 struct _FilterXEvalContext
 {
@@ -46,7 +52,7 @@ FilterXScope *filterx_eval_get_scope(void);
 void filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObject *object);
 void filterx_eval_push_error_info(const gchar *message, FilterXExpr *expr, gchar *info, gboolean free_info);
 void filterx_eval_set_context(FilterXEvalContext *context);
-gboolean filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *msg);
+FilterXEvalResult filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *msg);
 void filterx_eval_sync_scope_and_message(FilterXScope *scope, LogMessage *msg);
 const gchar *filterx_eval_get_last_error(void);
 EVTTAG *filterx_format_last_error(void);

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -25,16 +25,9 @@
 
 #include "filterx/filterx-scope.h"
 #include "filterx/filterx-expr.h"
+#include "filterx/filterx-error.h"
 #include "template/eval.h"
 
-typedef struct _FilterXError
-{
-  const gchar *message;
-  FilterXExpr *expr;
-  FilterXObject *object;
-  gchar *info;
-  gboolean free_info;
-} FilterXError;
 
 typedef struct _FilterXEvalContext FilterXEvalContext;
 struct _FilterXEvalContext

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -55,6 +55,7 @@
 #include "filterx/expr-plus.h"
 #include "filterx/expr-null-coalesce.h"
 #include "filterx/expr-plus-generator.h"
+#include "filterx/expr-drop.h"
 
 #include "template/templates.h"
 
@@ -103,6 +104,7 @@ construct_template_expr(LogTemplate *template)
 %token KW_ENUM
 %token KW_ISSET
 %token KW_DECLARE
+%token KW_DROP
 
 %type <ptr> block
 %type <ptr> stmts
@@ -362,6 +364,7 @@ expr
 	| ternary				{ $$ = $1; }
 	| default				{ $$ = $1; }
 	| KW_ISSET '(' expr ')'			{ $$ = filterx_isset_new($3); }
+	| KW_DROP                   { $$ = filterx_expr_drop_msg(); }
 	| regexp_match				{ $$ = $1; }
 	;
 

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -56,6 +56,7 @@
 #include "filterx/expr-null-coalesce.h"
 #include "filterx/expr-plus-generator.h"
 #include "filterx/expr-drop.h"
+#include "filterx/expr-done.h"
 
 #include "template/templates.h"
 
@@ -105,6 +106,7 @@ construct_template_expr(LogTemplate *template)
 %token KW_ISSET
 %token KW_DECLARE
 %token KW_DROP
+%token KW_DONE
 
 %type <ptr> block
 %type <ptr> stmts
@@ -365,6 +367,7 @@ expr
 	| default				{ $$ = $1; }
 	| KW_ISSET '(' expr ')'			{ $$ = filterx_isset_new($3); }
 	| KW_DROP                   { $$ = filterx_expr_drop_msg(); }
+	| KW_DONE                   { $$ = filterx_expr_done(); }
 	| regexp_match				{ $$ = $1; }
 	;
 

--- a/lib/filterx/filterx-parser.c
+++ b/lib/filterx/filterx-parser.c
@@ -51,6 +51,7 @@ static CfgLexerKeyword filterx_keywords[] =
   { "isset",              KW_ISSET },
   { "declare",            KW_DECLARE },
   { "drop",               KW_DROP },
+  { "done",               KW_DONE },
 
   { CFG_KEYWORD_STOP },
 };

--- a/lib/filterx/filterx-parser.c
+++ b/lib/filterx/filterx-parser.c
@@ -50,6 +50,7 @@ static CfgLexerKeyword filterx_keywords[] =
 
   { "isset",              KW_ISSET },
   { "declare",            KW_DECLARE },
+  { "drop",               KW_DROP },
 
   { CFG_KEYWORD_STOP },
 };

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -51,7 +51,7 @@ log_filterx_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_o
   LogFilterXPipe *self = (LogFilterXPipe *) s;
   FilterXEvalContext eval_context;
   LogPathOptions local_path_options;
-  gboolean res;
+  FilterXEvalResult eval_res;
 
   path_options = log_path_options_chain(&local_path_options, path_options);
   filterx_eval_init_context(&eval_context, path_options->filterx_context);
@@ -62,17 +62,17 @@ log_filterx_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_o
             evt_tag_msg_reference(msg));
 
   NVTable *payload = nv_table_ref(msg->payload);
-  res = filterx_eval_exec(&eval_context, self->block, msg);
+  eval_res = filterx_eval_exec(&eval_context, self->block, msg);
 
   msg_trace("<<<<<< filterx rule evaluation result",
-            evt_tag_str("result", res ? "matched" : "unmatched"),
+            evt_tag_str("result", eval_res == FXE_SUCCESS ? "matched" : "unmatched"),
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
             evt_tag_int("dirty", filterx_scope_is_dirty(eval_context.scope)),
             evt_tag_msg_reference(msg));
 
   local_path_options.filterx_context = &eval_context;
-  if (res)
+  if (eval_res == FXE_SUCCESS)
     {
       log_pipe_forward_msg(s, msg, path_options);
     }

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -2039,3 +2039,45 @@ def test_list_range_check_out_of_range(config, syslog_ng):
     syslog_ng.start(config)
     assert file_false.get_stats()["processed"] == 1
     assert file_false.read_log() == "foobar\n"
+
+
+def test_drop(config, syslog_ng):
+    file_true = config.create_file_destination(file_name="dest-true.log", template="'$MSG\n'")
+    file_false = config.create_file_destination(file_name="dest-false.log", template="'$MSG\n'")
+
+    raw_conf = f"""
+@version: {config.get_version()}
+
+options {{ stats(level(1)); }};
+
+source genmsg {{
+    example-msg-generator(num(1) template("foo"));
+    example-msg-generator(num(1) template("bar"));
+}};
+
+destination dest_true {{
+    {render_statement(file_true)};
+}};
+
+destination dest_false {{
+    {render_statement(file_false)};
+}};
+
+log {{
+    source(genmsg);
+    if {{
+        filterx {{ {"if ($MSG =~ 'foo') {drop;};"} \n}};
+        destination(dest_true);
+    }} else {{
+        destination(dest_false);
+    }};
+}};
+"""
+    config.set_raw_config(raw_conf)
+
+    syslog_ng.start(config)
+
+    assert "processed" in file_true.get_stats()
+    assert file_true.get_stats()["processed"] == 1
+    assert file_true.read_log() == 'bar\n'
+    assert syslog_ng.wait_for_message_in_console_log("filterx rule evaluation result; result='explicitly dropped'") != []


### PR DESCRIPTION
Example config
```
log {

  source { example-msg-generator(num(1) template("bar")); };
  source { example-msg-generator(num(1) template("foo")); };
  filterx {
    if ($MSG =~ '.*foo.*' ){
      drop;
    }
    else {
      done;
      declare var_should_not_exist = json(); # This will be skipped
    };

  };
  filterx {
    vars();
  };
  destination { file("/dev/stdout"); };
};
```

Result
```
Setting value; name='MESSAGE', value='-- Generated message. --', type='string', msg='0x6500309ffa40', rcptid='28'
Setting value; name='MESSAGE', value='bar', type='string', msg='0x6500309ffa40', rcptid='28'
Incoming generated message; msg='bar'
>>>>>> Source side message processing begin; location='./etc/drop_msg.conf:5:12', msg='0x6500309ffa40', rcptid='28'
Setting value; name='HOST_FROM', value='orion-T14G3', type='string', msg='0x6500309ffa40', rcptid='28'
Setting value; name='HOST', value='orion-T14G3', type='string', msg='0x6500309ffa40', rcptid='28'
Setting tag; name='.source.#anon-source0', value='1', msg='0x6500309ffa40'
Setting value; name='SOURCE', value='#anon-source0', type='string', msg='0x6500309ffa40', rcptid='28'
>>>>>> filterx rule evaluation begin; rule='#anon-filter0', location='./etc/drop_msg.conf:7:10', msg='0x6500309ffa40', rcptid='28'
FILTERX CONDF; expr='./etc/drop_msg.conf:8:9|      $MSG =~ \'.*foo.*\'', value='false', truthy='0', type='boolean'
FILTERX ESTEP; expr='./etc/drop_msg.conf:12:7|     done', value='true', truthy='1', type='boolean'
<<<<<< filterx rule evaluation result; result='matched', rule='#anon-filter0', location='./etc/drop_msg.conf:7:10', dirty='1', msg='0x6500309ffa40', rcptid='28'
>>>>>> filterx rule evaluation begin; rule='#anon-filter1', location='./etc/drop_msg.conf:17:10', msg='0x6500309ffa40', rcptid='28'
FILTERX ESTEP; expr='./etc/drop_msg.conf:18:5|     vars()', value='{"MESSAGE":"bar"}', truthy='1', type='json_object'
<<<<<< filterx rule evaluation result; result='matched', rule='#anon-filter1', location='./etc/drop_msg.conf:17:10', dirty='1', msg='0x6500309ffa40', rcptid='28'
Filterx sync: variable in scope and message in sync, not doing anything; variable='MESSAGE'
Initializing destination file writer; template='/dev/stdout', filename='/dev/stdout', symlink_as='(null)'
affile_open_file; path='/dev/stdout', fd='13'
<<<<<< Source side message processing finish; location='./etc/drop_msg.conf:5:12', msg='0x6500309ffa40', rcptid='28'
Setting value; name='MESSAGE', value='-- Generated message. --', type='string', msg='0x650030a02fd0', rcptid='29'
Setting value; name='MESSAGE', value='foo', type='string', msg='0x650030a02fd0', rcptid='29'
Incoming generated message; msg='foo'
>>>>>> Source side message processing begin; location='./etc/drop_msg.conf:6:12', msg='0x650030a02fd0', rcptid='29'
Setting value; name='HOST_FROM', value='orion-T14G3', type='string', msg='0x650030a02fd0', rcptid='29'
Setting value; name='HOST', value='orion-T14G3', type='string', msg='0x650030a02fd0', rcptid='29'
Setting tag; name='.source.#anon-source1', value='1', msg='0x650030a02fd0'
Setting value; name='SOURCE', value='#anon-source1', type='string', msg='0x650030a02fd0', rcptid='29'
>>>>>> filterx rule evaluation begin; rule='#anon-filter0', location='./etc/drop_msg.conf:7:10', msg='0x650030a02fd0', rcptid='29'
FILTERX CONDT; expr='./etc/drop_msg.conf:8:9|      $MSG =~ \'.*foo.*\'', value='true', truthy='1', type='boolean'
FILTERX ESTEP; expr='./etc/drop_msg.conf:9:7|      drop', value='true', truthy='1', type='boolean'
<<<<<< filterx rule evaluation result; result='explicitly dropped', rule='#anon-filter0', location='./etc/drop_msg.conf:7:10', dirty='1', msg='0x650030a02fd0', rcptid='29'
Window size adjustment; old_window_size='99', window_size_increment='1', suspended_before_increment='FALSE', last_ack_type_is_suspended='FALSE'
<<<<<< Source side message processing finish; location='./etc/drop_msg.conf:6:12', msg='0x650030a02fd0', rcptid='29'
Outgoing message; message='Sep  2 18:40:03 orion-T14G3 bar\x0a'
Sep  2 18:40:03 orion-T14G3 bar

``