### PR TITLE
otel/ipv6: respect ipv6 compile switch

### DIFF
--- a/modules/grpc/otel/otel-protobuf-parser.cpp
+++ b/modules/grpc/otel/otel-protobuf-parser.cpp
@@ -255,14 +255,16 @@ _extract_saddr(const grpc::string &peer)
       else
         host = peer.substr(first + 1, last - first - 1);
 
-      if (ip_version.compare("ipv6") == 0)
-        {
-          return g_sockaddr_inet6_new(host.c_str(), port);
-        }
-      else if (ip_version.compare("ipv4") == 0)
+      if (ip_version.compare("ipv4") == 0)
         {
           return g_sockaddr_inet_new(host.c_str(), port);
         }
+#if SYSLOG_NG_ENABLE_IPV6
+      else if (ip_version.compare("ipv6") == 0)
+        {
+          return g_sockaddr_inet6_new(host.c_str(), port);
+        }
+#endif
     }
 
   return NULL;
@@ -1311,6 +1313,7 @@ syslogng::grpc::otel::ProtobufParser::set_syslog_ng_address(LogMessage *msg, GSo
       sin.sin_port = htons(port);
       *sa = g_sockaddr_inet_new2(&sin);
     }
+#if SYSLOG_NG_ENABLE_IPV6
   else if (addr_bytes->length() == 16)
     {
       /* ipv6 */
@@ -1320,6 +1323,7 @@ syslogng::grpc::otel::ProtobufParser::set_syslog_ng_address(LogMessage *msg, GSo
       sin6.sin6_port = htons(port);
       *sa = g_sockaddr_inet6_new2(&sin6);
     }
+#endif
 }
 
 void

--- a/modules/grpc/otel/otel-protobuf-parser.hpp
+++ b/modules/grpc/otel/otel-protobuf-parser.hpp
@@ -23,6 +23,8 @@
 #ifndef OTEL_PROTOBUF_PARSER_HPP
 #define OTEL_PROTOBUF_PARSER_HPP
 
+#include "syslog-ng.h"
+
 #include "otel-protobuf-parser.h"
 
 #include "compat/cpp-start.h"


### PR DESCRIPTION
Cherry-picked from syslog-ng/syslog-ng#5084 (@HofiOne)