### PR TITLE
Fiterx json array fix - unwanted NULL results in get_subscript

### DIFF
--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -119,12 +119,6 @@ _get_subscript(FilterXList *s, guint64 index)
   FilterXJsonArray *self = (FilterXJsonArray *) s;
 
   struct json_object *jso = json_object_array_get_idx(self->jso, index);
-  if (!jso)
-    {
-      /* NULL is returned if the stored value is null. */
-      if (json_object_array_length(self->jso) > index + 1)
-        return NULL;
-    }
 
   return filterx_json_convert_json_to_object_cached(&s->super, &self->root_container, jso);
 }


### PR DESCRIPTION
The `FilterXJsonArray`, which inherits from `FilterXList`, performed a redundant range check in the `get_subscript` method, leading to incorrect `NULL` results in certain cases due to a bug. Since this range check is already handled in the `FilterXList` abstraction, the unnecessary and faulty code block has been removed.

Additionally, some end-to-end tests for range checks have been added.
