### PR TITLE
filterx: rework of unset_empties

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -52,6 +52,7 @@ set(FILTERX_HEADERS
     filterx/expr-plus.h
     filterx/expr-null-coalesce.h
     filterx/expr-plus-generator.h
+    filterx/func-flags.h
     PARENT_SCOPE
     )
 

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -53,7 +53,8 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/func-sdata.h		\
 	lib/filterx/filterx-private.h			\
 	lib/filterx/expr-null-coalesce.h	\
-	lib/filterx/expr-plus-generator.h
+	lib/filterx/expr-plus-generator.h	\
+	lib/filterx/func-flags.h
 
 
 filterx_sources = 				\

--- a/lib/filterx/expr-literal-generator.c
+++ b/lib/filterx/expr-literal-generator.c
@@ -302,3 +302,10 @@ filterx_expr_is_literal_list_generator(FilterXExpr *s)
   FilterXExprGenerator *generator = (FilterXExprGenerator *) s;
   return filterx_expr_is_generator(s) && generator->create_container == filterx_generator_create_list_container;
 }
+
+guint
+filterx_expr_literal_generator_len(FilterXExpr *s)
+{
+  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
+  return g_list_length(self->elements);
+}

--- a/lib/filterx/expr-literal-generator.c
+++ b/lib/filterx/expr-literal-generator.c
@@ -290,17 +290,37 @@ filterx_literal_inner_list_generator_new(FilterXExpr *root_literal_generator, GL
 }
 
 gboolean
+_filterx_expr_is_inner_dict_generator(FilterXExpr *s)
+{
+  return s && (s->eval == _inner_dict_generator_eval);
+}
+
+gboolean
+_filterx_expr_is_inner_list_generator(FilterXExpr *s)
+{
+  return s && (s->eval == _inner_list_generator_eval);
+}
+
+gboolean
 filterx_expr_is_literal_dict_generator(FilterXExpr *s)
 {
   FilterXExprGenerator *generator = (FilterXExprGenerator *) s;
-  return filterx_expr_is_generator(s) && generator->create_container == filterx_generator_create_dict_container;
+  return (filterx_expr_is_generator(s) && generator->create_container == filterx_generator_create_dict_container)
+         || _filterx_expr_is_inner_dict_generator(s);
 }
 
 gboolean
 filterx_expr_is_literal_list_generator(FilterXExpr *s)
 {
   FilterXExprGenerator *generator = (FilterXExprGenerator *) s;
-  return filterx_expr_is_generator(s) && generator->create_container == filterx_generator_create_list_container;
+  return (filterx_expr_is_generator(s) && generator->create_container == filterx_generator_create_list_container)
+         || _filterx_expr_is_inner_list_generator(s);
+}
+
+gboolean
+filterx_expr_is_literal_generator(FilterXExpr *s)
+{
+  return filterx_expr_is_literal_list_generator(s) || filterx_expr_is_literal_dict_generator(s);
 }
 
 guint

--- a/lib/filterx/expr-literal-generator.h
+++ b/lib/filterx/expr-literal-generator.h
@@ -49,4 +49,6 @@ FilterXExpr *filterx_literal_inner_list_generator_new(FilterXExpr *root_literal_
 gboolean filterx_expr_is_literal_dict_generator(FilterXExpr *s);
 gboolean filterx_expr_is_literal_list_generator(FilterXExpr *s);
 
+guint filterx_expr_literal_generator_len(FilterXExpr *s);
+
 #endif

--- a/lib/filterx/expr-literal-generator.h
+++ b/lib/filterx/expr-literal-generator.h
@@ -50,5 +50,6 @@ gboolean filterx_expr_is_literal_dict_generator(FilterXExpr *s);
 gboolean filterx_expr_is_literal_list_generator(FilterXExpr *s);
 
 guint filterx_expr_literal_generator_len(FilterXExpr *s);
+gboolean filterx_expr_is_literal_generator(FilterXExpr *s);
 
 #endif

--- a/lib/filterx/func-flags.h
+++ b/lib/filterx/func-flags.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023 Axoflow
+ * Copyright (c) 2024 shifter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FUNC_FLAGS_H
+#define FUNC_FLAGS_H
+
+#include "syslog-ng.h"
+
+#define MAX_ENUMS 64
+
+#define STATIC_ASSERT(COND) G_STATIC_ASSERT(COND)
+
+#define DEFINE_FUNC_FLAGS(ENUM_NAME, ...) \
+    typedef enum { __VA_ARGS__, ENUM_NAME##_MAX} ENUM_NAME; \
+    STATIC_ASSERT(ENUM_NAME##_MAX <= MAX_ENUMS) \
+
+#define FUNC_FLAGS_ITER(ENUM_NAME, CODE) for (guint64 enum_elt = 0; enum_elt < ENUM_NAME##_MAX; enum_elt++) { CODE; };
+
+#define FLAG_VAL(ID) (1 << ID)
+
+#define ALL_FLAG_SET(ENUM_NAME) (FLAG_VAL(ENUM_NAME##_MAX) - 1)
+
+static inline void
+set_flag(guint64 *flags, guint64 flag, gboolean val)
+{
+  if (val)
+    {
+      *flags |= FLAG_VAL(flag);
+    }
+  else
+    {
+      *flags &= ~FLAG_VAL(flag);
+    }
+}
+
+static inline gboolean
+check_flag(guint64 flags, guint64 flag)
+{
+  return (flags & FLAG_VAL(flag)) != 0;
+}
+
+static inline void
+reset_flags(guint64 *flags, guint64 val)
+{
+  *flags = val;
+}
+
+static inline gboolean
+toggle_flag(guint64 *flags, guint64 flag)
+{
+  *flags ^= FLAG_VAL(flag);
+  return (*flags & FLAG_VAL(flag)) != 0;
+}
+
+#endif

--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -1,5 +1,7 @@
 /*
+ * Copyright (c) 2023 Axoflow
  * Copyright (c) 2024 Attila Szakacs
+ * Copyright (c) 2024 shifter
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -30,45 +32,90 @@
 #include "filterx/object-list-interface.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/filterx-globals.h"
+#include "filterx/func-flags.h"
+#include "filterx/expr-literal-generator.h"
+#include "filterx/expr-literal.h"
 
-#define FILTERX_FUNC_UNSET_EMPTIES_USAGE "Usage: unset_empties(object, recursive=true)"
+#define FILTERX_FUNC_UNSET_EMPTIES_USAGE "Usage: unset_empties(object, " \
+FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_RECURSIVE"=bool, " \
+FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_IGNORECASE"=bool, " \
+FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS"=[objects...], " \
+FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_REPLACEMENT"=str);"
+
+DEFINE_FUNC_FLAGS(FilterXFunctionUnsetEmptiesFlags,
+                  FILTERX_FUNC_UNSET_EMPTIES_FLAG_RECURSIVE,
+                  FILTERX_FUNC_UNSET_EMPTIES_FLAG_IGNORECASE,
+                  FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_NULL,
+                  FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_STRING,
+                  FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_LIST,
+                  FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_DICT
+                 );
 
 typedef struct FilterXFunctionUnsetEmpties_
 {
   FilterXFunction super;
   FilterXExpr *object_expr;
-  gboolean recursive;
+  GPtrArray *targets;
+  FilterXObject *replacement;
+  guint64 flags;
 } FilterXFunctionUnsetEmpties;
 
 static gboolean _process_dict(FilterXFunctionUnsetEmpties *self, FilterXObject *obj);
 static gboolean _process_list(FilterXFunctionUnsetEmpties *self, FilterXObject *obj);
 
+typedef int (*str_cmp_fn)(const char *, const char *);
+
+static gboolean _string_compare(FilterXFunctionUnsetEmpties *self, const gchar *str, str_cmp_fn cmp_fn)
+{
+  guint num_targets = self->targets ? self->targets->len : 0;
+  for (guint i = 0; i < num_targets; i++)
+    {
+      const gchar *target = g_ptr_array_index(self->targets, i);
+      if (cmp_fn(str, target) == 0)
+        return TRUE;
+    }
+  return FALSE;
+}
+
+static gboolean _should_unset_string(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
+{
+  gsize str_len = 0;
+  const gchar *str = NULL;
+  gchar *casefold_str = NULL;
+  if (!filterx_object_extract_string(obj, &str, &str_len))
+    return FALSE;
+  g_assert(str);
+
+  if (check_flag(self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_STRING) && (str_len == 0))
+    return TRUE;
+
+  if (check_flag(self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_IGNORECASE))
+    {
+      casefold_str = g_utf8_casefold(str, str_len);
+      gboolean result = _string_compare(self, casefold_str, g_utf8_collate);
+      g_free(casefold_str);
+      return result;
+    }
+  return _string_compare(self, str, g_strcmp0);
+}
+
 static gboolean
 _should_unset(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
 {
-  gsize str_len;
-  const gchar *str;
-  if (filterx_object_extract_string(obj, &str, &str_len))
-    {
-      return str_len == 0 ||
-             strcasecmp(str, "n/a") == 0 ||
-             strcmp(str, "-") == 0;
-    }
+  if (check_flag(self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_NULL) &&
+      filterx_object_is_type(obj, &FILTERX_TYPE_NAME(null)))
+    return TRUE;
 
-  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(null)))
-    {
-      return TRUE;
-    }
-
-  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(dict)) ||
-      filterx_object_is_type(obj, &FILTERX_TYPE_NAME(list)))
+  if ((check_flag(self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_LIST) &&
+       filterx_object_is_type(obj, &FILTERX_TYPE_NAME(list))) ||
+      (check_flag(self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_DICT) &&
+       filterx_object_is_type(obj, &FILTERX_TYPE_NAME(dict))))
     {
       guint64 len;
       filterx_object_len(obj, &len);
       return len == 0;
     }
-
-  return FALSE;
+  return _should_unset_string(self, obj);
 }
 
 /* Also unsets inner dicts' and lists' values is recursive is set. */
@@ -78,7 +125,7 @@ _add_key_to_unset_list_if_needed(FilterXObject *key, FilterXObject *value, gpoin
   FilterXFunctionUnsetEmpties *self = ((gpointer *) user_data)[0];
   GList **keys_to_unset = ((gpointer *) user_data)[1];
 
-  if (self->recursive)
+  if (check_flag(self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_RECURSIVE))
     {
       if (filterx_object_is_type(value, &FILTERX_TYPE_NAME(dict)) && !_process_dict(self, value))
         return FALSE;
@@ -103,8 +150,16 @@ _process_dict(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
   for (GList *elem = keys_to_unset; elem && success; elem = elem->next)
     {
       FilterXObject *key = (FilterXObject *) elem->data;
-      if (!filterx_object_unset_key(obj, key))
-        success = FALSE;
+      if (self->replacement)
+        {
+          if (!filterx_object_set_subscript(obj, key, &self->replacement))
+            success = FALSE;
+        }
+      else
+        {
+          if (!filterx_object_unset_key(obj, key))
+            success = FALSE;
+        }
     }
 
   g_list_free_full(keys_to_unset, (GDestroyNotify) filterx_object_unref);
@@ -132,7 +187,7 @@ _process_list(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
     {
       FilterXObject *elem = filterx_list_get_subscript(obj, i);
 
-      if (self->recursive)
+      if (check_flag(self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_RECURSIVE))
         {
           if (filterx_object_is_type(elem, &FILTERX_TYPE_NAME(dict)) && !_process_dict(self, elem))
             {
@@ -148,7 +203,15 @@ _process_list(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
 
       if (_should_unset(self, elem))
         {
-          if (!filterx_list_unset_index(obj, i))
+          if (self->replacement)
+            {
+              if (!filterx_list_set_subscript(obj, i, &self->replacement))
+                {
+                  filterx_object_unref(elem);
+                  return FALSE;
+                }
+            }
+          else if (!filterx_list_unset_index(obj, i))
             {
               filterx_object_unref(elem);
               return FALSE;
@@ -197,7 +260,10 @@ static void
 _free(FilterXExpr *s)
 {
   FilterXFunctionUnsetEmpties *self = (FilterXFunctionUnsetEmpties *) s;
+  if (self->targets)
+    g_ptr_array_free(self->targets, TRUE);
   filterx_expr_unref(self->object_expr);
+  filterx_object_unref(self->replacement);
   filterx_function_free_method(&self->super);
 }
 
@@ -216,22 +282,171 @@ _extract_object_expr(FilterXFunctionArgs *args, GError **error)
 }
 
 static gboolean
-_extract_optional_args(FilterXFunctionUnsetEmpties *self, FilterXFunctionArgs *args, GError **error)
+_extract_optional_arg_recursive(FilterXFunctionUnsetEmpties *self, FilterXFunctionArgs *args, GError **error)
 {
   gboolean exists, eval_error;
-  gboolean value = filterx_function_args_get_named_literal_boolean(args, "recursive", &exists, &eval_error);
+  gboolean value = filterx_function_args_get_named_literal_boolean(args, FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_RECURSIVE,
+                   &exists, &eval_error);
   if (!exists)
     return TRUE;
 
   if (eval_error)
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
-                  "recursive argument must be boolean literal. " FILTERX_FUNC_UNSET_EMPTIES_USAGE);
+                  FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_RECURSIVE" argument must be boolean literal. " FILTERX_FUNC_UNSET_EMPTIES_USAGE);
       return FALSE;
     }
 
-  self->recursive = value;
+  set_flag(&self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_RECURSIVE, value);
+
   return TRUE;
+}
+
+static gboolean
+_extract_optional_arg_ignorecase(FilterXFunctionUnsetEmpties *self, FilterXFunctionArgs *args, GError **error)
+{
+  gboolean exists, eval_error;
+  gboolean value = filterx_function_args_get_named_literal_boolean(args, FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_IGNORECASE,
+                   &exists, &eval_error);
+  if (!exists)
+    return TRUE;
+
+  if (eval_error)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_IGNORECASE" argument must be boolean literal. " FILTERX_FUNC_UNSET_EMPTIES_USAGE);
+      return FALSE;
+    }
+
+  set_flag(&self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_IGNORECASE, value);
+
+  return TRUE;
+}
+
+
+static gboolean
+_extract_optional_arg_replacement(FilterXFunctionUnsetEmpties *self, FilterXFunctionArgs *args, GError **error)
+{
+  gboolean exists;
+  FilterXObject *value = filterx_function_args_get_named_literal_object(args,
+                         FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_REPLACEMENT, &exists);
+  if (!exists)
+    return TRUE;
+  if (!value)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_REPLACEMENT" argument must be literal. " FILTERX_FUNC_UNSET_EMPTIES_USAGE);
+      return FALSE;
+    }
+
+  self->replacement = value;
+  return TRUE;
+}
+
+static gboolean
+_handle_target_object(FilterXFunctionUnsetEmpties *self, FilterXObject *target, GError **error)
+{
+  g_assert(target);
+  guint64 len;
+  if (filterx_object_is_type(target, &FILTERX_TYPE_NAME(null)))
+    set_flag(&self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_NULL, TRUE);
+  else if (filterx_object_is_type(target, &FILTERX_TYPE_NAME(list)))
+    {
+      g_assert(filterx_object_len(target, &len));
+      if (len != 0)
+        {
+          g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                      FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS" argument list must be empty! " FILTERX_FUNC_UNSET_EMPTIES_USAGE);
+          return FALSE;
+        }
+      set_flag(&self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_LIST, TRUE);
+    }
+  else if (filterx_object_is_type(target, &FILTERX_TYPE_NAME(dict)))
+    {
+      g_assert(filterx_object_len(target, &len));
+      if (len != 0)
+        {
+          g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                      FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS" argument dict must be empty! " FILTERX_FUNC_UNSET_EMPTIES_USAGE);
+          return FALSE;
+        }
+      set_flag(&self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_DICT, TRUE);
+    }
+  else if (filterx_object_is_type(target, &FILTERX_TYPE_NAME(string)))
+    {
+      const gchar *str = filterx_string_get_value(target, &len);
+      if (len == 0)
+        {
+          set_flag(&self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_STRING, TRUE);
+          return TRUE;
+        }
+      if (check_flag(self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_IGNORECASE))
+        {
+          g_ptr_array_add(self->targets, g_utf8_casefold(str, len));
+          return TRUE;
+        }
+      g_ptr_array_add(self->targets, g_strdup(str));
+    }
+  else
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS" has unknown target type: %s", target->type->name);
+      return FALSE;
+    }
+  return TRUE;
+}
+
+static gboolean
+_target_iterator(FilterXExpr *key, FilterXExpr *value, gpointer user_data)
+{
+  FilterXFunctionUnsetEmpties *self = ((gpointer *) user_data)[0];
+  GError **error = ((gpointer *) user_data)[1];
+
+  if (!filterx_expr_is_literal(value) && !filterx_expr_is_literal_generator(value))
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS" list members must be literals!" FILTERX_FUNC_UNSET_EMPTIES_USAGE);
+      return FALSE;
+    }
+
+  FilterXObject *target = filterx_expr_eval(value);
+  g_assert(target);
+
+  gboolean res = _handle_target_object(self, target, error);
+  filterx_object_unref(target);
+  return res;
+}
+
+static gboolean
+_extract_target_objects(FilterXFunctionUnsetEmpties *self, FilterXFunctionArgs *args, GError **error)
+{
+  gboolean exists;
+  FilterXExpr *targets = filterx_function_args_get_named_expr(args,
+                                                              FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS);
+  exists = !!targets;
+
+  if (!exists)
+    return TRUE;
+
+  if (!filterx_expr_is_literal_list_generator(targets))
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS" argument must be literal list. " FILTERX_FUNC_UNSET_EMPTIES_USAGE);
+      return FALSE;
+    }
+
+  guint64 num_targets = filterx_expr_literal_generator_len(targets);
+  if (num_targets > 0)
+    reset_flags(&self->flags, self->flags & (FLAG_VAL(FILTERX_FUNC_UNSET_EMPTIES_FLAG_IGNORECASE) |
+                                             FLAG_VAL(FILTERX_FUNC_UNSET_EMPTIES_FLAG_RECURSIVE)));
+  self->targets = g_ptr_array_new_full(num_targets, (GDestroyNotify)g_free);
+
+  gpointer user_data[] = { self, error };
+  gboolean result = TRUE;
+  if (!filterx_literal_dict_generator_foreach(targets, _target_iterator, user_data))
+    result = FALSE;
+  filterx_expr_unref(targets);
+  return result;
 }
 
 static gboolean
@@ -248,8 +463,18 @@ _extract_args(FilterXFunctionUnsetEmpties *self, FilterXFunctionArgs *args, GErr
   if (!self->object_expr)
     return FALSE;
 
-  if (!_extract_optional_args(self, args, error))
+  if (!_extract_optional_arg_recursive(self, args, error))
     return FALSE;
+
+  if (!_extract_optional_arg_ignorecase(self, args, error))
+    return FALSE;
+
+  if (!_extract_optional_arg_replacement(self, args, error))
+    return FALSE;
+
+  if (!_extract_target_objects(self, args, error))
+    return FALSE;
+
 
   return TRUE;
 }
@@ -262,7 +487,7 @@ filterx_function_unset_empties_new(FilterXFunctionArgs *args, GError **error)
   self->super.super.eval = _eval;
   self->super.super.free_fn = _free;
 
-  self->recursive = TRUE;
+  reset_flags(&self->flags, ALL_FLAG_SET(FilterXFunctionUnsetEmptiesFlags));
 
   if (!_extract_args(self, args, error))
     goto error;

--- a/lib/filterx/func-unset-empties.h
+++ b/lib/filterx/func-unset-empties.h
@@ -1,5 +1,7 @@
 /*
+ * Copyright (c) 2023 Axoflow
  * Copyright (c) 2024 Attila Szakacs
+ * Copyright (c) 2024 shifter
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -25,6 +27,11 @@
 #define FILTERX_FUNC_UNSET_EMPTIES_H_INCLUDED
 
 #include "filterx/expr-function.h"
+
+#define FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_RECURSIVE "recursive"
+#define FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS "targets"
+#define FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_REPLACEMENT "replacement"
+#define FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_IGNORECASE "ignorecase"
 
 FilterXExpr *filterx_function_unset_empties_new(FilterXFunctionArgs *args, GError **error);
 

--- a/lib/filterx/tests/test_func_unset_empties.c
+++ b/lib/filterx/tests/test_func_unset_empties.c
@@ -29,6 +29,8 @@
 #include "filterx/object-primitive.h"
 #include "filterx/object-json.h"
 #include "filterx/expr-literal.h"
+#include "filterx/expr-literal-generator.h"
+#include "filterx/object-null.h"
 
 #include "apphook.h"
 #include "scratch-buffers.h"
@@ -75,6 +77,27 @@ _assert_unset_empties(GList *args, const gchar *expected_repr)
   filterx_expr_unref(modifiable_object_expr);
 }
 
+FilterXExpr *
+_list_generator_helper(FilterXObject *first, ...)
+{
+  FilterXExpr *result = filterx_literal_list_generator_new();
+  GList *target_vals = NULL;
+  va_list va;
+
+  va_start(va, first);
+  FilterXObject *arg = first;
+  while (arg)
+    {
+      target_vals = g_list_append(target_vals, filterx_literal_generator_elem_new(NULL, filterx_literal_new(arg), FALSE));
+      arg = va_arg(va, FilterXObject *);
+    }
+  va_end(va);
+
+
+  filterx_literal_generator_set_elements(result, target_vals);
+  return result;
+}
+
 Test(filterx_func_unset_empties, invalid_args)
 {
   GList *args = NULL;
@@ -84,28 +107,22 @@ Test(filterx_func_unset_empties, invalid_args)
 
   /* non-literal recursive */
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
-  args = g_list_append(args, filterx_function_arg_new("recursive",
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_RECURSIVE,
                                                       filterx_non_literal_new(filterx_boolean_new(TRUE))));
   _assert_unset_empties_init_fail(args);
   args = NULL;
 
   /* non-boolean recursive */
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
-  args = g_list_append(args, filterx_function_arg_new("recursive",
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_RECURSIVE,
                                                       filterx_literal_new(filterx_string_new("", -1))));
-  _assert_unset_empties_init_fail(args);
-  args = NULL;
-
-  /* too many args */
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("", -1))));
   _assert_unset_empties_init_fail(args);
   args = NULL;
 }
 
-Test(filterx_func_unset_empties, all_known_empties)
+Test(filterx_func_unset_empties, default_empties)
 {
-  const gchar *input = "[\"\", \"n/a\", \"N/A\", \"-\", null, [], {}]";
+  const gchar *input = "[\"\", null, [], {}]";
   GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
                                                              filterx_literal_new(filterx_json_new_from_repr(input, -1))));
   _assert_unset_empties(args, "[]");
@@ -119,13 +136,14 @@ Test(filterx_func_unset_empties, recursive)
 
   /* default is true */
   args = g_list_append(args, filterx_function_arg_new(NULL,
-                                                      filterx_literal_new(filterx_json_new_from_repr("[{\"foo\": \"\"}]", -1))));
+                                                      filterx_literal_new(filterx_json_new_from_repr("[{\"foo\":\"\"}]", -1))));
   _assert_unset_empties(args, "[]");
   args = NULL;
 
   args = g_list_append(args, filterx_function_arg_new(NULL,
-                                                      filterx_literal_new(filterx_json_new_from_repr("[{\"foo\": \"\"}]", -1))));
-  args = g_list_append(args, filterx_function_arg_new("recursive", filterx_literal_new(filterx_boolean_new(FALSE))));
+                                                      filterx_literal_new(filterx_json_new_from_repr("[{\"foo\":\"\"}]", -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_RECURSIVE,
+                                                      filterx_literal_new(filterx_boolean_new(FALSE))));
   _assert_unset_empties(args, "[{\"foo\":\"\"}]");
   args = NULL;
 
@@ -139,9 +157,246 @@ Test(filterx_func_unset_empties, recursive)
 
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_json_new_from_repr("[[\"\"]]",
                                                       -1))));
-  args = g_list_append(args, filterx_function_arg_new("recursive", filterx_literal_new(filterx_boolean_new(FALSE))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_RECURSIVE,
+                                                      filterx_literal_new(filterx_boolean_new(FALSE))));
   _assert_unset_empties(args, "[[\"\"]]");
   args = NULL;
+}
+
+Test(filterx_func_unset_empties, target_resets_defaults)
+{
+  const gchar *input = "[\"\",null,[],{}]";
+  GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
+                                                             filterx_literal_new(filterx_json_new_from_repr(input, -1))));
+  FilterXExpr *targets = _list_generator_helper(filterx_string_new("anything", -1), NULL);
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  _assert_unset_empties(args, input);
+}
+
+Test(filterx_func_unset_empties, target_null_only)
+{
+  const gchar *input = "[\"\",null,[],{}]";
+  GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
+                                                             filterx_literal_new(filterx_json_new_from_repr(input, -1))));
+  FilterXExpr *targets = _list_generator_helper(filterx_null_new(), NULL);
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  _assert_unset_empties(args, "[\"\",[],{}]");
+}
+
+Test(filterx_func_unset_empties, target_empty_string_only)
+{
+  const gchar *input = "[\"\",null,[],{}]";
+  GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
+                                                             filterx_literal_new(filterx_json_new_from_repr(input, -1))));
+  FilterXExpr *targets = _list_generator_helper(filterx_string_new("", -1), NULL);
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  _assert_unset_empties(args, "[null,[],{}]");
+}
+
+Test(filterx_func_unset_empties, target_empty_list_only)
+{
+  const gchar *input = "[\"\",null,[],{}]";
+  GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
+                                                             filterx_literal_new(filterx_json_new_from_repr(input, -1))));
+  FilterXExpr *targets = _list_generator_helper(filterx_json_array_new_empty(), NULL);
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  _assert_unset_empties(args, "[\"\",null,{}]");
+}
+
+Test(filterx_func_unset_empties, target_empty_dict_only)
+{
+  const gchar *input = "[\"\",null,[],{}]";
+  GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
+                                                             filterx_literal_new(filterx_json_new_from_repr(input, -1))));
+  FilterXExpr *targets = _list_generator_helper(filterx_json_object_new_empty(), NULL);
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  _assert_unset_empties(args, "[\"\",null,[]]");
+}
+
+Test(filterx_func_unset_empties, target_empties_manual)
+{
+  const gchar *input = "[\"\",null,[],{}]";
+  GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
+                                                             filterx_literal_new(filterx_json_new_from_repr(input, -1))));
+  FilterXExpr *targets = _list_generator_helper(filterx_json_object_new_empty(),
+                                                filterx_json_array_new_empty(),
+                                                filterx_string_new("", -1),
+                                                filterx_null_new(), NULL);
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  _assert_unset_empties(args, "[]");
+}
+
+Test(filterx_func_unset_empties, target_empties_manual_and_strings)
+{
+  const gchar *input = "[\"bar\",\"\",null,[],{},\"foo\",\"bar\",\"baz\"]";
+  GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
+                                                             filterx_literal_new(filterx_json_new_from_repr(input, -1))));
+  FilterXExpr *targets = _list_generator_helper(filterx_json_object_new_empty(),
+                                                filterx_json_array_new_empty(),
+                                                filterx_string_new("", -1),
+                                                filterx_null_new(),
+                                                filterx_string_new("foo", -1),
+                                                filterx_string_new("bar", -1),
+                                                NULL);
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  _assert_unset_empties(args, "[\"baz\"]");
+}
+
+Test(filterx_func_unset_empties, string_targets)
+{
+  GList *args = NULL;
+  FilterXExpr *targets = NULL;
+
+  /* dict */
+  targets = _list_generator_helper(filterx_string_new("baz", -1),
+                                   NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_json_new_from_repr("{\"foo\":{\"bar\":\"baz\",\"tik\":\"tak\"}}", -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  _assert_unset_empties(args, "{\"foo\":{\"tik\":\"tak\"}}");
+  args = NULL;
+
+
+  targets = _list_generator_helper(filterx_string_new("baz", -1),
+                                   filterx_string_new("tak", -1),
+                                   filterx_json_object_new_empty(), //also remove empty dict
+                                   NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_json_new_from_repr("{\"foo\":{\"bar\":\"baz\",\"tik\":\"tak\"}}", -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  _assert_unset_empties(args, "{}");
+  args = NULL;
+
+  // /* list */
+
+  targets = _list_generator_helper(filterx_string_new("baz", -1),
+                                   filterx_null_new(), // also remove null values
+                                   NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_json_new_from_repr("[\"foo\",\"bar\",null,\"baz\"]",
+                                                          -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  _assert_unset_empties(args, "[\"foo\",\"bar\"]");
+  args = NULL;
+
+
+  targets = _list_generator_helper(filterx_string_new("baz", -1),
+                                   filterx_string_new("foo", -1),
+                                   filterx_null_new(), // also remove null values
+                                   NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_json_new_from_repr("[\"foo\",\"bar\",null,\"baz\"]",
+                                                          -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  _assert_unset_empties(args, "[\"bar\"]");
+  args = NULL;
+}
+
+Test(filterx_func_unset_empties, replacement)
+{
+  GList *args = NULL;
+  FilterXExpr *targets = NULL;
+
+  /* dict */
+
+  targets = _list_generator_helper(filterx_string_new("baz", -1),
+                                   filterx_string_new("tak", -1),
+                                   NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_json_new_from_repr("{\"foo\":{\"bar\":\"baz\",\"tik\":\"tak\"}}", -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_REPLACEMENT,
+                                                      filterx_literal_new(filterx_string_new("replaced", -1))));
+  _assert_unset_empties(args, "{\"foo\":{\"bar\":\"replaced\",\"tik\":\"replaced\"}}");
+  args = NULL;
+
+  /* list */
+
+  targets = _list_generator_helper(filterx_string_new("baz", -1),
+                                   filterx_string_new("foo", -1),
+                                   filterx_null_new(), //also replace null
+                                   NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_json_new_from_repr("[\"foo\",\"bar\",null,\"baz\"]",
+                                                          -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_REPLACEMENT,
+                                                      filterx_literal_new(filterx_string_new("replaced", -1))));
+  _assert_unset_empties(args, "[\"replaced\",\"bar\",\"replaced\",\"replaced\"]");
+  args = NULL;
+}
+
+Test(filterx_func_unset_empties, ignorecase)
+{
+  GList *args = NULL;
+  FilterXExpr *targets = NULL;
+
+  /* dict */
+
+  targets = _list_generator_helper(filterx_string_new("BAZ", -1),
+                                   NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_json_new_from_repr("{\"foo\":{\"bar\":\"baz\",\"tik\":\"tak\"}}", -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_IGNORECASE,
+                                                      filterx_literal_new(filterx_boolean_new(FALSE))));
+  _assert_unset_empties(args, "{\"foo\":{\"bar\":\"baz\",\"tik\":\"tak\"}}");
+  args = NULL;
+
+
+  targets = _list_generator_helper(filterx_string_new("BAZ", -1),
+                                   NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_json_new_from_repr("{\"foo\":{\"bar\":\"baz\",\"tik\":\"tak\"}}", -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_IGNORECASE,
+                                                      filterx_literal_new(filterx_boolean_new(TRUE))));
+  _assert_unset_empties(args, "{\"foo\":{\"tik\":\"tak\"}}");
+  args = NULL;
+
+  /* list */
+
+  targets = _list_generator_helper(filterx_string_new("BAR", -1),
+                                   filterx_null_new(), // also remove null
+                                   NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_json_new_from_repr("[\"foo\",\"bar\",null,\"baz\"]",
+                                                          -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_IGNORECASE,
+                                                      filterx_literal_new(filterx_boolean_new(FALSE))));
+  _assert_unset_empties(args, "[\"foo\",\"bar\",\"baz\"]");
+  args = NULL;
+
+  targets = _list_generator_helper(filterx_string_new("BAR", -1),
+                                   filterx_null_new(), // also remove null
+                                   NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_json_new_from_repr("[\"foo\",\"bar\",null,\"baz\"]",
+                                                          -1))));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
+                                                      targets));
+  args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_IGNORECASE,
+                                                      filterx_literal_new(filterx_boolean_new(TRUE))));
+  _assert_unset_empties(args, "[\"foo\",\"baz\"]");
+  args = NULL;
+
 }
 
 static void

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -1522,23 +1522,71 @@ def test_unset_empties(config, syslog_ng):
             dict = {"foo": "", "bar": "-", "baz": "N/A", "almafa": null, "kortefa": {"a":{"s":{"d":{}}}}, "szilvafa": [[[]]]};
             defaults_dict = dict;
             explicit_dict = dict;
-            unset_empties(defaults_dict);
+            no_defaults_dict = dict;
+            target_dict = dict;
+            ignorecase_dict = dict;
+            replacement_dict = dict;
+            unset_empties(defaults_dict, recursive=false);
             unset_empties(explicit_dict, recursive=true);
+            unset_empties(no_defaults_dict, targets=["n/a", "-"], recursive=true, ignorecase=true);
+            unset_empties(target_dict, targets=["n/a", "-", null, "", {}, []], recursive=true, ignorecase=false);
+            unset_empties(ignorecase_dict, targets=["n/a", "-", null, "", {}, []], recursive=true, ignorecase=true);
+            unset_empties(replacement_dict, targets=["n/a", "-", null, "", {}, []], recursive=true, ignorecase=true, replacement="do");
 
             list = ["", "-", "N/A", null, {"a":{"s":{"d":{}}}}, [[[]]]];
             defaults_list = list;
             explicit_list = list;
-            unset_empties(defaults_list);
+            no_defaults_list = list;
+            target_list = list;
+            ignorecase_list = list;
+            replacement_list = list;
+            unset_empties(defaults_list, recursive=false);
             unset_empties(explicit_list, recursive=true);
+            unset_empties(no_defaults_list, targets=["n/a", "-"], recursive=true, ignorecase=true);
+            unset_empties(target_list, targets=["n/a", "-", null, "", {}, []], recursive=true, ignorecase=false);
+            unset_empties(ignorecase_list, targets=["n/a", "-", null, "", {}, []], recursive=true, ignorecase=true);
+            unset_empties(replacement_list, targets=["n/a", "-", null, "", {}, []], recursive=true, ignorecase=true, replacement="do");
 
-            $MSG = [defaults_dict, explicit_dict, defaults_list, explicit_list];
+            $MSG = [
+                    defaults_dict,
+                    explicit_dict,
+                    no_defaults_dict,
+                    target_dict,
+                    ignorecase_dict,
+                    replacement_dict,
+                    defaults_list,
+                    explicit_list,
+                    no_defaults_list,
+                    target_list,
+                    ignorecase_list,
+                    replacement_list
+                    ];
     """,
     )
     syslog_ng.start(config)
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "[{},{},[],[]]\n"
+
+    exp = (
+        r"""["""
+        r"""{"bar":"-","baz":"N\/A","kortefa":{"a":{"s":{"d":{}}}},"szilvafa":[[[]]]}"""
+        r""",{"bar":"-","baz":"N\/A"}"""
+        r""",{"foo":"","almafa":null,"kortefa":{"a":{"s":{"d":{}}}},"szilvafa":[[[]]]}"""
+        r""",{"baz":"N\/A"}"""
+        r""",{}"""
+        r""",{"foo":"do","bar":"do","baz":"do","almafa":"do","kortefa":{"a":{"s":{"d":"do"}}},"szilvafa":[["do"]]}"""
+        r""",["-","N\/A",{"a":{"s":{"d":{}}}},[[[]]]]"""
+        r""",["-","N\/A"]"""
+        r""",["",null,{"a":{"s":{"d":{}}}},[[[]]]]"""
+        r""",["N\/A"]"""
+        r""",[]"""
+        r""",["do","do","do","do",{"a":{"s":{"d":"do"}}},[["do"]]]"""
+        r"""]"""
+        """\n"""
+    )
+
+    assert file_true.read_log() == exp
 
 
 def test_null_coalesce_use_default_on_null(config, syslog_ng):


### PR DESCRIPTION
   - Default empty set: "", null, [], {}.
    - Optional named arguments:
      - recursive: Enables recursive processing of nested dictionaries.
      - ignorecase: Enables case-insensitive matching.
      - replacement: Specifies a filterxobject to replace target elements instead of removing them.
      - targets: A list of elements to identify for removal or replacement, clearing the default empty set.
    - UTF-8 support.
    - ignorecase and recursive args are defaults to TRUE
    
    This change removes elements from the given dictionary or list that match
    the empty set. If the recursive argument is provided, the function will
    process nested dictionaries as well. The replacement argument allows
    replacing target elements with a specified object, and the targets
    argument customizes which elements are removed or replaced, overriding
    the default empty set.

```
Usage: unset_empties(object, recursive=bool, ignorecase=bool, targets=[objects...], replacement=str);
```

example:
```
unset_empties(js1, targets=["foo", "bar", null, "", [], {}], ignorecase=false, replacement="N/A", recursive=false);
```