### PR TITLE
filterx-eval: fix leak in filterx_format_eval_result()

### DIFF
--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -218,17 +218,17 @@ filterx_format_eval_result(FilterXEvalResult result)
   switch (result)
     {
     case FXE_SUCCESS:
-      eval_result = g_strdup("matched");
+      eval_result = "matched";
       break;
     case FXE_DROP:
-      eval_result = g_strdup("explicitly dropped");
+      eval_result = "explicitly dropped";
       break;
     case FXE_FAILURE:
-      eval_result = g_strdup("unmatched");
+      eval_result = "unmatched";
       break;
     default:
       g_assert_not_reached();
       break;
     }
-  return evt_tag_printf("result", "%s", eval_result);
+  return evt_tag_str("result", eval_result);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
