### PR TITLE
filterx: make 0 sec 0 usec datetime falsy

### DIFF
--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -50,7 +50,8 @@ typedef struct _FilterXDateTime
 static gboolean
 _truthy(FilterXObject *s)
 {
-  return TRUE;
+  FilterXDateTime *self = (FilterXDateTime *) s;
+  return self->ut.ut_sec != 0 || self->ut.ut_usec != 0;
 }
 
 /* FIXME: delegate formatting and parsing to UnixTime */


### PR DESCRIPTION
It is particularly useful when the otel log record does not have a timestamp set.

With this we can write expressions, like:

```
  date_str = log.time_unix_nano ?
             string(log.time_unix_nano) :
             string(log.observed_time_unix_nano);
```
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
