### PR TITLE
filterx: support casting datetime to integer or double

### DIFF
--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -30,6 +30,7 @@
 #include "cfg.h"
 #include "filterx-globals.h"
 #include "str-utils.h"
+#include "timeutils/misc.h"
 
 #include "compat/json.h"
 
@@ -307,6 +308,10 @@ filterx_typecast_integer(FilterXExpr *s, GPtrArray *args)
         return filterx_integer_new(val);
     }
 
+  UnixTime ut;
+  if (filterx_object_extract_datetime(object, &ut))
+    return filterx_integer_new(ut.ut_sec * USEC_PER_SEC + ut.ut_usec);
+
   msg_error("filterx: invalid typecast",
             evt_tag_str("from", object->type->name),
             evt_tag_str("to", "integer"));
@@ -338,6 +343,10 @@ filterx_typecast_double(FilterXExpr *s, GPtrArray *args)
       if (str != endptr && *endptr == '\0')
         return filterx_double_new(val);
     }
+
+  UnixTime ut;
+  if (filterx_object_extract_datetime(object, &ut))
+    return filterx_double_new(ut.ut_sec + (gdouble) ut.ut_usec / USEC_PER_SEC);
 
   msg_error("filterx: invalid typecast",
             evt_tag_str("from", object->type->name),

--- a/lib/filterx/tests/test_object_double.c
+++ b/lib/filterx/tests/test_object_double.c
@@ -26,6 +26,7 @@
 #include "filterx/object-string.h"
 #include "filterx/object-null.h"
 #include "filterx/object-primitive.h"
+#include "filterx/object-datetime.h"
 #include "apphook.h"
 #include "scratch-buffers.h"
 
@@ -143,6 +144,24 @@ Test(filterx_double, test_filterx_double_typecast_from_string)
 
   GenericNumber gn = filterx_primitive_get_value(obj);
   cr_assert_float_eq(443.117, gn_as_double(&gn), 0.00001);
+
+  g_ptr_array_free(args, TRUE);
+  filterx_object_unref(obj);
+}
+
+Test(filterx_double, test_filterx_double_typecast_from_datetime)
+{
+  GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
+  UnixTime ut = { .ut_sec = 171, .ut_usec = 443221 };
+  FilterXObject *in = filterx_datetime_new(&ut);
+  g_ptr_array_add(args, in);
+
+  FilterXObject *obj = filterx_typecast_double(NULL, args);
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(double)));
+
+  GenericNumber gn = filterx_primitive_get_value(obj);
+  cr_assert_float_eq(171.443221, gn_as_double(&gn), 0.00001);
 
   g_ptr_array_free(args, TRUE);
   filterx_object_unref(obj);

--- a/lib/filterx/tests/test_object_integer.c
+++ b/lib/filterx/tests/test_object_integer.c
@@ -26,6 +26,7 @@
 #include "filterx/object-string.h"
 #include "filterx/object-null.h"
 #include "filterx/object-primitive.h"
+#include "filterx/object-datetime.h"
 
 #include "apphook.h"
 #include "scratch-buffers.h"
@@ -197,6 +198,25 @@ Test(filterx_integer, test_filterx_integer_typecast_from_double_string)
 
   FilterXObject *obj = filterx_typecast_integer(NULL, args);
   cr_assert_null(obj);
+
+  g_ptr_array_free(args, TRUE);
+  filterx_object_unref(obj);
+}
+
+Test(filterx_integer, test_filterx_integer_typecast_from_datetime)
+{
+  GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
+  UnixTime ut = { .ut_sec = 171, .ut_usec = 443221 };
+  FilterXObject *in = filterx_datetime_new(&ut);
+  g_ptr_array_add(args, in);
+
+  FilterXObject *obj = filterx_typecast_integer(NULL, args);
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(integer)));
+
+  GenericNumber gn = filterx_primitive_get_value(obj);
+
+  cr_assert(gn_as_int64(&gn) == 171443221);
 
   g_ptr_array_free(args, TRUE);
   filterx_object_unref(obj);


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
