### PR TITLE
syslog-format: get rid off RFC3164 error case in favour of setting error

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -2011,7 +2011,6 @@ void
 log_msg_tags_init(void)
 {
   log_tags_register_predefined_tag("message.utf8_sanitized", LM_T_MSG_UTF8_SANITIZED);
-  log_tags_register_predefined_tag("message.parse_error", LM_T_MSG_PARSE_ERROR);
 
   log_tags_register_predefined_tag("syslog.invalid_pri", LM_T_SYSLOG_INVALID_PRI);
   log_tags_register_predefined_tag("syslog.missing_pri", LM_T_SYSLOG_MISSING_PRI);

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -2013,6 +2013,7 @@ log_msg_tags_init(void)
   log_tags_register_predefined_tag("message.utf8_sanitized", LM_T_MSG_UTF8_SANITIZED);
   log_tags_register_predefined_tag("message.parse_error", LM_T_MSG_PARSE_ERROR);
 
+  log_tags_register_predefined_tag("syslog.invalid_pri", LM_T_SYSLOG_INVALID_PRI);
   log_tags_register_predefined_tag("syslog.missing_pri", LM_T_SYSLOG_MISSING_PRI);
   log_tags_register_predefined_tag("syslog.missing_timestamp", LM_T_SYSLOG_MISSING_TIMESTAMP);
   log_tags_register_predefined_tag("syslog.invalid_hostname", LM_T_SYSLOG_INVALID_HOSTNAME);

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -2018,7 +2018,6 @@ log_msg_tags_init(void)
   log_tags_register_predefined_tag("syslog.invalid_hostname", LM_T_SYSLOG_INVALID_HOSTNAME);
   log_tags_register_predefined_tag("syslog.unexpected_framing", LM_T_SYSLOG_UNEXPECTED_FRAMING);
   log_tags_register_predefined_tag("syslog.rfc3164_missing_header", LM_T_SYSLOG_RFC3164_MISSING_HEADER);
-  log_tags_register_predefined_tag("syslog.rfc5424_unquoted_sdata_value", LM_T_SYSLOG_RFC5424_UNQUOTED_SDATA_VALUE);
 
   log_tags_register_predefined_tag("syslog.rfc5424_missing_hostname", LM_T_SYSLOG_RFC5424_MISSING_HOSTNAME);
   log_tags_register_predefined_tag("syslog.rfc5424_missing_app_name", LM_T_SYSLOG_RFC5424_MISSING_APP_NAME);

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -106,8 +106,6 @@ enum
 {
   /* means that the message is not valid utf8 */
   LM_T_MSG_UTF8_SANITIZED,
-  /* msg-format parsing failed, "Error parsing ..." */
-  LM_T_MSG_PARSE_ERROR,
   /* missing <pri> value */
   LM_T_SYSLOG_MISSING_PRI,
   /* invalid <pri> value */

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -110,6 +110,8 @@ enum
   LM_T_MSG_PARSE_ERROR,
   /* missing <pri> value */
   LM_T_SYSLOG_MISSING_PRI,
+  /* invalid <pri> value */
+  LM_T_SYSLOG_INVALID_PRI,
   /* no timestamp present in the original message */
   LM_T_SYSLOG_MISSING_TIMESTAMP,
   /* hostname field does not seem valid, check-hostname(yes) failed */

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -118,8 +118,6 @@ enum
   LM_T_SYSLOG_UNEXPECTED_FRAMING,
   /* no date & host information in the syslog message */
   LM_T_SYSLOG_RFC3164_MISSING_HEADER,
-  /* incorrectly quoted RFC5424 SDATA */
-  LM_T_SYSLOG_RFC5424_UNQUOTED_SDATA_VALUE,
   /* hostname field missing */
   LM_T_SYSLOG_RFC5424_MISSING_HOSTNAME,
   /* program field missing */

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -183,6 +183,8 @@ msg_format_parse_into(MsgFormatOptions *options, LogMessage *msg,
     {
       if (options->flags & LP_PIGGYBACK_ERRORS)
         msg_format_inject_parse_error(options, msg, data, _rstripped_message_length(data, length), problem_position);
+      else
+        log_msg_set_value(msg, LM_V_MESSAGE, (gchar *) data, length);
 
       /* the injected error message needs to be postprocessed too */
       msg_format_postprocess_message(options, msg, data, length);

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -181,7 +181,6 @@ msg_format_parse_into(MsgFormatOptions *options, LogMessage *msg,
 
   if (!msg_format_try_parse_into(options, msg, data, length, &problem_position))
     {
-      log_msg_set_tag_by_id(msg, LM_T_MSG_PARSE_ERROR);
       if (options->flags & LP_PIGGYBACK_ERRORS)
         msg_format_inject_parse_error(options, msg, data, _rstripped_message_length(data, length), problem_position);
 

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -1005,6 +1005,9 @@ _syslog_format_parse_legacy_message(LogMessage *msg,
  *
  * Parse an RFC3164 formatted log message and store the parsed information
  * in @msg. Parsing is affected by the bits set @flags argument.
+ *
+ * This parser is _very_ forgiving, it basically accepts anything any device
+ * would barf on the line.
  **/
 static gboolean
 _syslog_format_parse_legacy(const MsgFormatOptions *parse_options,
@@ -1020,19 +1023,27 @@ _syslog_format_parse_legacy(const MsgFormatOptions *parse_options,
   _syslog_format_check_framing(msg, &src, &left);
   if (!_syslog_format_parse_pri(msg, &src, &left, parse_options->flags, parse_options->default_pri))
     {
-      goto error;
+      /* invalid <pri> value, that's really difficult to do, as it needs to
+       * start with an opening bracket and then no number OR no closing bracket
+       * follows. A missing <pri> value would be accepted.
+       *
+       * This is a very rare case, but it's best handled like all the other
+       * formatting errors, accept it and shove the entire line into $MSG.
+       * This basically disables error piggybacking for RFC3164 inputs.  */
+
+      log_msg_set_tag_by_id(msg, LM_T_SYSLOG_INVALID_PRI);
+      _syslog_format_parse_legacy_message(msg, &src, &left, parse_options);
     }
+  else
+    {
+      if ((parse_options->flags & LP_NO_HEADER) == 0)
+        _syslog_format_parse_legacy_header(msg, &src, &left, parse_options);
 
-  if ((parse_options->flags & LP_NO_HEADER) == 0)
-    _syslog_format_parse_legacy_header(msg, &src, &left, parse_options);
-
-  _syslog_format_parse_legacy_message(msg, &src, &left, parse_options);
+      _syslog_format_parse_legacy_message(msg, &src, &left, parse_options);
+    }
 
   log_msg_set_value_to_string(msg, LM_V_MSGFORMAT, "syslog:rfc3164");
   return TRUE;
-error:
-  *position = src - data;
-  return FALSE;
 }
 
 /**


### PR DESCRIPTION
The only case we had a hard error in RFC3164 when the incoming data had an opening angle bracket ("<") without a closing one. Actually this does not happen very often, but our piggy-backed error handling is a lot less user friendly than setting the right error tags. So let's do that.
