### PR TITLE
filterx: support `declare` with generators and fix UB in `parse_csv()`

### DIFF
--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -335,8 +335,23 @@ generator_casted_assignment
 	;
 
 declaration
-	: KW_DECLARE filterx_variable KW_ASSIGN expr	{ filterx_variable_expr_declare($2); $$ = filterx_assign_new($2, $4); }
-	;
+    : KW_DECLARE filterx_variable KW_ASSIGN expr	{ filterx_variable_expr_declare($2); $$ = filterx_assign_new($2, $4); }
+    | KW_DECLARE filterx_variable KW_ASSIGN expr_generator
+        {
+          GError *error = NULL;
+          FilterXExpr *json_func = filterx_function_lookup(configuration, "json", NULL, &error);
+          CHECK_FUNCTION_ERROR(json_func, @1, "json", error);
+
+          filterx_variable_expr_declare($2);
+
+          filterx_generator_set_fillable($4, filterx_expr_ref($2));
+          $$ = filterx_compound_expr_new_va(TRUE,
+            filterx_assign_new($2, filterx_generator_create_container_new($4, json_func)),
+            $4,
+            NULL
+          );
+        }
+    ;
 
 expr
 	: expr_value				{ $$ = $1; }

--- a/modules/csvparser/filterx-func-parse-csv.c
+++ b/modules/csvparser/filterx-func-parse-csv.c
@@ -180,6 +180,7 @@ _eval(FilterXExpr *s)
   GList *string_delimiters = NULL;
   guint64 num_of_columns = 0;
   FilterXObject *cols = NULL;
+  CSVScannerOptions local_opts = {0};
 
   gsize len;
   const gchar *input;
@@ -201,7 +202,6 @@ _eval(FilterXExpr *s)
     result = filterx_json_array_new_empty();
 
   CSVScanner scanner;
-  CSVScannerOptions local_opts = {0};
   _init_scanner(self, string_delimiters, num_of_columns, input, &scanner, &local_opts);
 
   guint64 i = 0;


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
