### PR TITLE
filterx: support passing generator to functions' not first param

### DIFF
--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -128,7 +128,8 @@ construct_template_expr(LogTemplate *template)
 %type <node> generator_function_call
 %type <node> function_call
 %type <ptr> arguments
-%type <ptr> argument
+%type <ptr> first_argument
+%type <ptr> rest_argument
 %type <ptr> list_argument
 %type <ptr> dict_argument
 %type <node> literal
@@ -443,16 +444,22 @@ function_call
 	;
 
 arguments
-	: arguments ',' argument		{ $$ = g_list_append($1, $3); }
-	| argument				{ $$ = g_list_append(NULL, $1); }
+	: arguments ',' rest_argument		{ $$ = g_list_append($1, $3); }
+	| first_argument			{ $$ = g_list_append(NULL, $1); }
 	|					{ $$ = NULL; }
 	;
 
-argument
+first_argument
 	: expr					{ $$ = filterx_function_arg_new(NULL, $1); }
 	| string KW_ASSIGN expr			{ $$ = filterx_function_arg_new($1, $3); free($1); }
 	| string KW_ASSIGN list_argument	{ $$ = filterx_function_arg_new($1, $3); free($1); }
 	| string KW_ASSIGN dict_argument	{ $$ = filterx_function_arg_new($1, $3); free($1); }
+	;
+
+rest_argument
+	: first_argument
+	| dict_argument				{ $$ = filterx_function_arg_new(NULL, $1); }
+	| list_argument				{ $$ = filterx_function_arg_new(NULL, $1); }
 	;
 
 list_argument


### PR DESCRIPTION
Unfortunately, the syntax of function call with a generator as its first param is reserved for the generator casted assignment. Sometime in the future we should fix this conflict fully, but for now supporting generators starting from the second param is a bit better than not supporting them at all.

(Will be useful for startswith(), endswith())

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
