### PR TITLE
wildcard-file: fix crash when flow-controlled driver gets destroyed

### DIFF
--- a/modules/affile/wildcard-source.c
+++ b/modules/affile/wildcard-source.c
@@ -366,6 +366,7 @@ _deinit(LogPipe *s)
 
   g_pattern_spec_free(self->compiled_pattern);
   g_hash_table_foreach(self->file_readers, _deinit_reader, NULL);
+  g_hash_table_remove_all(self->directory_monitors);
   return TRUE;
 }
 

--- a/news/bugfix-293.md
+++ b/news/bugfix-293.md
@@ -1,0 +1,1 @@
+`wildcard-file()`: fix a crash that occurs after config reload when the source is flow-controlled


### PR DESCRIPTION
Previously, `directory_monitors` were stopped and destroyed in the `free()` method of `WildcardSourceDriver`.

This can cause a crash because flow-controlled sources may retain references to their driver (through their ack tracker), and the last `unref()` call may be executed from a source thread (non-main thread).

Stopping directory monitors in the `deinit()` method fixes this issue, and it also fixes another issue where the driver would register a new superfluous monitor for the same directory each config revert.

Fixes syslog-ng/syslog-ng#5085 and the mentioned monitor reregistration issue