### PR TITLE
logsource: fix free_window counters

### DIFF
--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -538,8 +538,6 @@ _unregister_counters(LogSource *self)
                                        instance_name);
   stats_unregister_counter(&sc_key, SC_TYPE_STAMP, &self->metrics.last_message_seen);
 
-  _unregister_window_stats(self);
-
   stats_unlock();
 }
 
@@ -799,6 +797,10 @@ log_source_free(LogPipe *s)
 
   g_free(self->name);
   g_free(self->stats_id);
+
+  stats_lock();
+  _unregister_window_stats(self);
+  stats_unlock();
 
   if (self->metrics.stats_kb)
     stats_cluster_key_builder_free(self->metrics.stats_kb);


### PR DESCRIPTION
The value of `free_window` was not updated properly as the counter was deregistered in `deinit()`, but `AckTracker`s propagate acknowledgments even after the source is deinitialized.