### PR TITLE
ci: add --enable-extra-warnings for autotools

### DIFF
--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -50,6 +50,7 @@ jobs:
             --disable-java-modules
             --enable-ebpf
             --with-python=3
+            --enable-extra-warnings
             `[ $CC = clang ] && echo '--enable-force-gnu99' || true`
           "
           CMAKE_FLAGS="


### PR DESCRIPTION
Signed-off-by: Szilard Parrag <szilard.parrag@axoflow.com>
