### PR TITLE
filterx: unset(): refuse exprs that have no unset() method

### DIFF
--- a/lib/filterx/expr-unset.c
+++ b/lib/filterx/expr-unset.c
@@ -66,7 +66,16 @@ filterx_function_unset_new(FilterXFunctionArgs *args, GError **error)
 
   self->exprs = g_ptr_array_new_full(filterx_function_args_len(args), (GDestroyNotify) filterx_expr_unref);
   for (guint64 i = 0; i < filterx_function_args_len(args); i++)
-    g_ptr_array_add(self->exprs, filterx_function_args_get_expr(args, i));
+    {
+      FilterXExpr *expr = filterx_function_args_get_expr(args, i);
+      if (!filterx_expr_unset_available(expr))
+        {
+          g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                      "expected argument %d to be unsettable", (gint) i);
+          goto error;
+        }
+      g_ptr_array_add(self->exprs, expr);
+    }
 
   if (!filterx_function_args_check(args, error))
     goto error;

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -132,6 +132,12 @@ filterx_expr_unset(FilterXExpr *self)
   return FALSE;
 }
 
+static inline gboolean
+filterx_expr_unset_available(FilterXExpr *self)
+{
+  return self->unset != NULL;
+}
+
 void filterx_expr_set_location(FilterXExpr *self, CfgLexer *lexer, CFG_LTYPE *lloc);
 void filterx_expr_set_location_with_text(FilterXExpr *self, CfgLexer *lexer, CFG_LTYPE *lloc, const gchar *text);
 EVTTAG *filterx_expr_format_location_tag(FilterXExpr *self);


### PR DESCRIPTION
as the summary says, refuse the non-unsettable arguments during compilation.
