### PR TITLE
`file()`, `stdout()`: fix log sources getting stuck

### DIFF
--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -122,6 +122,8 @@ _process_partial_write(LogProtoFileWriter *self, gsize written)
 
   self->partial_pos = 0;
   self->partial_messages = self->buf_count - first_non_written_chunk_index;
+
+  log_proto_client_msg_ack(&self->super, self->buf_count - self->partial_messages);
 }
 
 /*

--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -83,6 +83,7 @@ _flush_partial(LogProtoFileWriter *self, LogProtoStatus *status)
   log_proto_client_msg_ack(&self->super, self->partial_messages);
   g_free(self->partial);
   self->partial = NULL;
+  self->partial_messages = 0;
   return TRUE;
 }
 

--- a/news/bugfix-303.md
+++ b/news/bugfix-303.md
@@ -1,0 +1,8 @@
+`file()`, `stdout()`: fix log sources getting stuck
+
+Due to an acknowledgment bug in the `file()` and `stdout()` destinations,
+sources routed to those destinations may have gotten stuck as they were
+flow-controlled incorrectly.
+
+This issue occured only in extremely rare cases with regular files, but it
+occured frequently with `/dev/stderr` and other slow pseudo-devices.


### PR DESCRIPTION
If a partial write occurs, the written messages must be acknowledged.

It is important to note that a message may be written partially.
In that case, the message will be acknowledged once the complete write is successful. If write errors occur during this process, the partially written message may be duplicated.