### PR TITLE
dbld: do not try to get pseudo terminal when TTY is not available

### DIFF
--- a/dbld/rules
+++ b/dbld/rules
@@ -54,7 +54,8 @@ GIT_RELEASE_TAG=axosyslog-$(VERSION)
 CONFIGURE_OPTS=--enable-debug --enable-manpages --with-python=3 --prefix=/install $(CONFIGURE_ADD)
 DBLD_RULES=$(MAKE) --no-print-directory -f $(DBLD_DIR)/rules
 
-DOCKER_SHELL=$(DOCKER) run $(DOCKER_RUN_ARGS) --rm -ti ${CONTAINER_REGISTRY}/axosyslog-dbld-$* /dbld/shell $(if $(SHELL_COMMAND),"$(SHELL_COMMAND)",bash)
+DOCKER_INTERACTIVE=$(shell if tty -s; then echo "-ti"; else echo "-i"; fi)
+DOCKER_SHELL=$(DOCKER) run $(DOCKER_RUN_ARGS) --rm $(DOCKER_INTERACTIVE) ${CONTAINER_REGISTRY}/axosyslog-dbld-$* /dbld/shell $(if $(SHELL_COMMAND),"$(SHELL_COMMAND)",bash)
 
 -include $(if $(RULES_CONF),$(RULES_CONF),$(DBLD_DIR)/rules.conf)
 
@@ -203,7 +204,7 @@ clean:
 run: run-$(DEFAULT_IMAGE)
 run: RUN_COMMAND=echo Specify RUN_COMMAND to do something sensible here
 run-%: setup
-	$(DOCKER) run $(DOCKER_RUN_ARGS) --rm -ti ${CONTAINER_REGISTRY}/axosyslog-dbld-$* bash -c "$(RUN_COMMAND)"
+	$(DOCKER) run $(DOCKER_RUN_ARGS) --rm $(DOCKER_INTERACTIVE) ${CONTAINER_REGISTRY}/axosyslog-dbld-$* bash -c "$(RUN_COMMAND)"
 
 shell: shell-$(DEFAULT_IMAGE)
 shell-%: setup
@@ -258,7 +259,7 @@ exec: exec-$(DEFAULT_IMAGE)
 exec: EXEC_COMMAND=echo Specify EXEC_COMMAND to do something sensible here
 exec-%: setup
 	@container=`$(DOCKER) ps | grep axosyslog-dbld-$* | head -1 | cut -d ' ' -f1`; \
-	$(DOCKER) exec -ti  $$container $(EXEC_COMMAND)
+	$(DOCKER) exec $(DOCKER_INTERACTIVE)  $$container $(EXEC_COMMAND)
 
 login: login-$(DEFAULT_IMAGE)
 login-%: EXEC_COMMAND=sudo -u $(shell whoami) /dbld/shell


### PR DESCRIPTION
For example in CI, like GitHub Actions.

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
