### PR TITLE
filterx: add missing check for unexpected arguments in unset_empties

### DIFF
--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -489,7 +489,8 @@ filterx_function_unset_empties_new(FilterXFunctionArgs *args, GError **error)
 
   reset_flags(&self->flags, ALL_FLAG_SET(FilterXFunctionUnsetEmptiesFlags));
 
-  if (!_extract_args(self, args, error))
+  if (!_extract_args(self, args, error) ||
+      !filterx_function_args_check(args, error))
     goto error;
 
   filterx_function_args_free(args);


### PR DESCRIPTION
```
Error parsing filterx expression: unset(): unexpected argument "invalid_key"

In /axosyslog/build/install/etc/syslog-ng.conf:19:13-19:46:
19---->             unset(dict, invalid_key="foobar");
```