### PR TITLE
filterx: fix use after free in `strptime()` and macro caching

### DIFF
--- a/lib/filterx/expr-comparison.c
+++ b/lib/filterx/expr-comparison.c
@@ -49,7 +49,7 @@ _convert_filterx_object_to_generic_number(FilterXObject *obj, GenericNumber *gn)
     return;
 
   const gchar *str;
-  if (filterx_object_extract_string(obj, &str, NULL))
+  if (filterx_object_extract_string_ref(obj, &str, NULL))
     {
       if (!parse_generic_number(str, gn))
         gn_set_nan(gn);
@@ -77,9 +77,9 @@ static const gchar *
 _convert_filterx_object_to_string(FilterXObject *obj, gsize *len)
 {
   const gchar *str;
-  if (filterx_object_extract_string(obj, &str, len) ||
-      filterx_object_extract_bytes(obj, &str, len) ||
-      filterx_object_extract_protobuf(obj, &str, len))
+  if (filterx_object_extract_string_ref(obj, &str, len) ||
+      filterx_object_extract_bytes_ref(obj, &str, len) ||
+      filterx_object_extract_protobuf_ref(obj, &str, len))
     {
       return str;
     }

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -318,7 +318,7 @@ _get_literal_string_from_expr(FilterXExpr *expr, gsize *len)
     goto error;
 
   /* Literal message values don't exist, so we don't need to use the extractor. */
-  str = filterx_string_get_value(obj, len);
+  str = filterx_string_get_value_ref(obj, len);
 
   /*
    * We can unref both obj and expr, the underlying string will be kept alive as long as the literal expr is alive,

--- a/lib/filterx/expr-regexp.c
+++ b/lib/filterx/expr-regexp.c
@@ -145,7 +145,7 @@ _match(FilterXExpr *lhs_expr, pcre2_code_8 *pattern, FilterXReMatchState *state)
   if (!state->lhs_obj)
     goto error;
 
-  if (!filterx_object_extract_string(state->lhs_obj, &state->lhs_str, &state->lhs_str_len))
+  if (!filterx_object_extract_string_ref(state->lhs_obj, &state->lhs_str, &state->lhs_str_len))
     {
       msg_error("FilterX: Regexp matching left hand side must be string type",
                 evt_tag_str("type", state->lhs_obj->type->name));

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -48,7 +48,12 @@ _pull_variable_from_message(FilterXVariableExpr *self, FilterXEvalContext *conte
       return NULL;
     }
 
-  FilterXObject *msg_ref = filterx_message_value_new_borrowed(value, value_len, t);
+  FilterXObject *msg_ref;
+  if (log_msg_is_value_from_macro(value))
+    msg_ref = filterx_message_value_new(value, value_len, t);
+  else
+    msg_ref = filterx_message_value_new_borrowed(value, value_len, t);
+
   filterx_scope_register_variable(context->scope, self->handle, msg_ref);
   return msg_ref;
 }

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -183,7 +183,7 @@ filterx_variable_expr_new(FilterXString *name, FilterXVariableType type)
   self->super.unset = _unset;
 
   self->variable_name = (FilterXObject *) name;
-  self->handle = filterx_scope_map_variable_to_handle(filterx_string_get_value(self->variable_name, NULL), type);
+  self->handle = filterx_scope_map_variable_to_handle(filterx_string_get_value_ref(self->variable_name, NULL), type);
 
   return &self->super;
 }

--- a/lib/filterx/filterx-metrics-labels.c
+++ b/lib/filterx/filterx-metrics-labels.c
@@ -117,7 +117,7 @@ _init_label_name(FilterXExpr *name)
     }
 
   FilterXObject *obj = filterx_expr_eval_typed(name);
-  gchar *str = g_strdup(filterx_string_get_value(obj, NULL));
+  gchar *str = g_strdup(filterx_string_get_value_ref(obj, NULL));
   if (!str)
     filterx_eval_push_error_info("failed to initialize metrics label name, name must be a string literal", name,
                                  g_strdup_printf("got %s instead", obj->type->name), TRUE);

--- a/lib/filterx/filterx-metrics.c
+++ b/lib/filterx/filterx-metrics.c
@@ -67,7 +67,7 @@ _format_sck_name(FilterXMetrics *self)
 
   gsize len;
   const gchar *name;
-  if (!filterx_object_extract_string(key_obj, &name, &len) || len == 0)
+  if (!filterx_object_extract_string_ref(key_obj, &name, &len) || len == 0)
     {
       filterx_eval_push_error("failed to format metrics key: key must be a non-empty string", self->key.expr, key_obj);
       goto exit;

--- a/lib/filterx/filterx-metrics.c
+++ b/lib/filterx/filterx-metrics.c
@@ -216,7 +216,7 @@ _init_key(FilterXMetrics *self, FilterXExpr *key)
     }
 
   /* There are no literal message values, so we don't need to call extract_string() here. */
-  self->key.str = g_strdup(filterx_string_get_value(key_obj, NULL));
+  self->key.str = g_strdup(filterx_string_get_value_ref(key_obj, NULL));
   return TRUE;
 }
 

--- a/lib/filterx/func-str-transform.c
+++ b/lib/filterx/func-str-transform.c
@@ -40,7 +40,7 @@ _extract_str_arg(FilterXExpr *s, GPtrArray *args, gssize *len)
   gsize inner_len;
   FilterXObject *object = g_ptr_array_index(args, 0);
 
-  if (!filterx_object_extract_string(object, &str, &inner_len))
+  if (!filterx_object_extract_string_ref(object, &str, &inner_len))
     {
       filterx_simple_function_argument_error(s, "Object must be string", FALSE);
       return NULL;

--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -376,7 +376,7 @@ _handle_target_object(FilterXFunctionUnsetEmpties *self, FilterXObject *target, 
     }
   else if (filterx_object_is_type(target, &FILTERX_TYPE_NAME(string)))
     {
-      const gchar *str = filterx_string_get_value(target, &len);
+      const gchar *str = filterx_string_get_value_ref(target, &len);
       if (len == 0)
         {
           set_flag(&self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_STRING, TRUE);

--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -82,7 +82,7 @@ static gboolean _should_unset_string(FilterXFunctionUnsetEmpties *self, FilterXO
   gsize str_len = 0;
   const gchar *str = NULL;
   gchar *casefold_str = NULL;
-  if (!filterx_object_extract_string(obj, &str, &str_len))
+  if (!filterx_object_extract_string_ref(obj, &str, &str_len))
     return FALSE;
   g_assert(str);
 

--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -255,10 +255,10 @@ _strptime_eval(FilterXExpr *s)
   const gchar *time_str;
   gsize time_str_len;
   gboolean extract_success = filterx_object_extract_string(time_str_obj, &time_str, &time_str_len);
-  filterx_object_unref(time_str_obj);
 
   if (!extract_success)
     {
+      filterx_object_unref(time_str_obj);
       filterx_eval_push_error("First argument must be string typed. " FILTERX_FUNC_STRPTIME_USAGE, s, NULL);
       return NULL;
     }
@@ -289,6 +289,7 @@ _strptime_eval(FilterXExpr *s)
   else
     result = filterx_null_new();
 
+  filterx_object_unref(time_str_obj);
   return result;
 }
 

--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -155,7 +155,7 @@ filterx_typecast_datetime_isodate(FilterXExpr *s, GPtrArray *args)
 
   const gchar *str;
   gsize len;
-  if (!filterx_object_extract_string(object, &str, &len))
+  if (!filterx_object_extract_string_ref(object, &str, &len))
     return NULL;
 
   UnixTime ut = UNIX_TIME_INIT;
@@ -254,7 +254,7 @@ _strptime_eval(FilterXExpr *s)
 
   const gchar *time_str;
   gsize time_str_len;
-  gboolean extract_success = filterx_object_extract_string(time_str_obj, &time_str, &time_str_len);
+  gboolean extract_success = filterx_object_extract_string_ref(time_str_obj, &time_str, &time_str_len);
 
   if (!extract_success)
     {

--- a/lib/filterx/object-dict-interface.c
+++ b/lib/filterx/object-dict-interface.c
@@ -157,7 +157,7 @@ _add_elem_to_json_object(FilterXObject *key_obj, FilterXObject *value_obj, gpoin
 
   const gchar *key;
   gsize len;
-  if (!filterx_object_extract_string(key_obj, &key, &len))
+  if (!filterx_object_extract_string_ref(key_obj, &key, &len))
     return FALSE;
 
   APPEND_ZERO(key, key, len);

--- a/lib/filterx/object-extractor.c
+++ b/lib/filterx/object-extractor.c
@@ -33,7 +33,7 @@ gboolean
 filterx_object_extract_string_ref(FilterXObject *obj, const gchar **value, gsize *len)
 {
   if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
-    return filterx_message_value_get_string(obj, value, len);
+    return filterx_message_value_get_string_ref(obj, value, len);
 
   *value = filterx_string_get_value(obj, len);
   return !!(*value);
@@ -43,7 +43,7 @@ gboolean
 filterx_object_extract_bytes_ref(FilterXObject *obj, const gchar **value, gsize *len)
 {
   if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
-    return filterx_message_value_get_bytes(obj, value, len);
+    return filterx_message_value_get_bytes_ref(obj, value, len);
 
   *value = filterx_bytes_get_value(obj, len);
   return !!(*value);
@@ -53,7 +53,7 @@ gboolean
 filterx_object_extract_protobuf_ref(FilterXObject *obj, const gchar **value, gsize *len)
 {
   if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
-    return filterx_message_value_get_protobuf(obj, value, len);
+    return filterx_message_value_get_protobuf_ref(obj, value, len);
 
   *value = filterx_protobuf_get_value(obj, len);
   return !!(*value);

--- a/lib/filterx/object-extractor.c
+++ b/lib/filterx/object-extractor.c
@@ -35,7 +35,7 @@ filterx_object_extract_string_ref(FilterXObject *obj, const gchar **value, gsize
   if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
     return filterx_message_value_get_string_ref(obj, value, len);
 
-  *value = filterx_string_get_value(obj, len);
+  *value = filterx_string_get_value_ref(obj, len);
   return !!(*value);
 }
 
@@ -45,7 +45,7 @@ filterx_object_extract_bytes_ref(FilterXObject *obj, const gchar **value, gsize 
   if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
     return filterx_message_value_get_bytes_ref(obj, value, len);
 
-  *value = filterx_bytes_get_value(obj, len);
+  *value = filterx_bytes_get_value_ref(obj, len);
   return !!(*value);
 }
 
@@ -55,7 +55,7 @@ filterx_object_extract_protobuf_ref(FilterXObject *obj, const gchar **value, gsi
   if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
     return filterx_message_value_get_protobuf_ref(obj, value, len);
 
-  *value = filterx_protobuf_get_value(obj, len);
+  *value = filterx_protobuf_get_value_ref(obj, len);
   return !!(*value);
 }
 

--- a/lib/filterx/object-extractor.c
+++ b/lib/filterx/object-extractor.c
@@ -30,7 +30,7 @@
 #include "filterx/object-json.h"
 
 gboolean
-filterx_object_extract_string(FilterXObject *obj, const gchar **value, gsize *len)
+filterx_object_extract_string_ref(FilterXObject *obj, const gchar **value, gsize *len)
 {
   if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
     return filterx_message_value_get_string(obj, value, len);
@@ -40,7 +40,7 @@ filterx_object_extract_string(FilterXObject *obj, const gchar **value, gsize *le
 }
 
 gboolean
-filterx_object_extract_bytes(FilterXObject *obj, const gchar **value, gsize *len)
+filterx_object_extract_bytes_ref(FilterXObject *obj, const gchar **value, gsize *len)
 {
   if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
     return filterx_message_value_get_bytes(obj, value, len);
@@ -50,7 +50,7 @@ filterx_object_extract_bytes(FilterXObject *obj, const gchar **value, gsize *len
 }
 
 gboolean
-filterx_object_extract_protobuf(FilterXObject *obj, const gchar **value, gsize *len)
+filterx_object_extract_protobuf_ref(FilterXObject *obj, const gchar **value, gsize *len)
 {
   if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
     return filterx_message_value_get_protobuf(obj, value, len);

--- a/lib/filterx/object-extractor.h
+++ b/lib/filterx/object-extractor.h
@@ -28,9 +28,9 @@
 #include "generic-number.h"
 #include "compat/json.h"
 
-gboolean filterx_object_extract_string(FilterXObject *obj, const gchar **value, gsize *len);
-gboolean filterx_object_extract_bytes(FilterXObject *obj, const gchar **value, gsize *len);
-gboolean filterx_object_extract_protobuf(FilterXObject *obj, const gchar **value, gsize *len);
+gboolean filterx_object_extract_string_ref(FilterXObject *obj, const gchar **value, gsize *len);
+gboolean filterx_object_extract_bytes_ref(FilterXObject *obj, const gchar **value, gsize *len);
+gboolean filterx_object_extract_protobuf_ref(FilterXObject *obj, const gchar **value, gsize *len);
 gboolean filterx_object_extract_boolean(FilterXObject *obj, gboolean *value);
 gboolean filterx_object_extract_integer(FilterXObject *obj, gint64 *value);
 gboolean filterx_object_extract_double(FilterXObject *obj, gdouble *value);

--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -335,7 +335,7 @@ filterx_json_array_new_from_args(FilterXExpr *s, GPtrArray *args)
 
   const gchar *repr;
   gsize repr_len;
-  if (filterx_object_extract_string(arg, &repr, &repr_len))
+  if (filterx_object_extract_string_ref(arg, &repr, &repr_len))
     return filterx_json_array_new_from_repr(repr, repr_len);
 
   filterx_eval_push_error_info("Argument must be a json array, a string or a syslog-ng list", s,

--- a/lib/filterx/object-json-object.c
+++ b/lib/filterx/object-json-object.c
@@ -109,7 +109,7 @@ _get_subscript(FilterXDict *s, FilterXObject *key)
 
   const gchar *key_str;
   gsize len;
-  if (!filterx_object_extract_string(key, &key_str, &len))
+  if (!filterx_object_extract_string_ref(key, &key_str, &len))
     return NULL;
 
   APPEND_ZERO(key_str, key_str, len);
@@ -128,7 +128,7 @@ _set_subscript(FilterXDict *s, FilterXObject *key, FilterXObject **new_value)
 
   const gchar *key_str;
   gsize len;
-  if (!filterx_object_extract_string(key, &key_str, &len))
+  if (!filterx_object_extract_string_ref(key, &key_str, &len))
     return FALSE;
 
   APPEND_ZERO(key_str, key_str, len);
@@ -168,7 +168,7 @@ _unset_key(FilterXDict *s, FilterXObject *key)
 
   const gchar *key_str;
   gsize len;
-  if (!filterx_object_extract_string(key, &key_str, &len))
+  if (!filterx_object_extract_string_ref(key, &key_str, &len))
     return FALSE;
 
   APPEND_ZERO(key_str, key_str, len);

--- a/lib/filterx/object-json.c
+++ b/lib/filterx/object-json.c
@@ -229,7 +229,7 @@ filterx_json_new_from_args(FilterXExpr *s, GPtrArray *args)
 
   const gchar *repr;
   gsize repr_len;
-  if (filterx_object_extract_string(arg, &repr, &repr_len))
+  if (filterx_object_extract_string_ref(arg, &repr, &repr_len))
     return filterx_json_new_from_repr(repr, repr_len);
 
   filterx_eval_push_error_info("Argument must be a json, a string or a syslog-ng list", s,

--- a/lib/filterx/object-message-value.c
+++ b/lib/filterx/object-message-value.c
@@ -43,7 +43,7 @@ typedef struct _FilterXMessageValue
 } FilterXMessageValue;
 
 gboolean
-filterx_message_value_get_string(FilterXObject *s, const gchar **value, gsize *len)
+filterx_message_value_get_string_ref(FilterXObject *s, const gchar **value, gsize *len)
 {
   FilterXMessageValue *self = (FilterXMessageValue *) s;
 
@@ -56,7 +56,7 @@ filterx_message_value_get_string(FilterXObject *s, const gchar **value, gsize *l
 }
 
 gboolean
-filterx_message_value_get_bytes(FilterXObject *s, const gchar **value, gsize *len)
+filterx_message_value_get_bytes_ref(FilterXObject *s, const gchar **value, gsize *len)
 {
   FilterXMessageValue *self = (FilterXMessageValue *) s;
 
@@ -69,7 +69,7 @@ filterx_message_value_get_bytes(FilterXObject *s, const gchar **value, gsize *le
 }
 
 gboolean
-filterx_message_value_get_protobuf(FilterXObject *s, const gchar **value, gsize *len)
+filterx_message_value_get_protobuf_ref(FilterXObject *s, const gchar **value, gsize *len)
 {
   FilterXMessageValue *self = (FilterXMessageValue *) s;
 

--- a/lib/filterx/object-message-value.h
+++ b/lib/filterx/object-message-value.h
@@ -34,9 +34,9 @@ FilterXObject *filterx_message_value_new(const gchar *repr, gssize repr_len, Log
 LogMessageValueType filterx_message_value_get_type(FilterXObject *s);
 const gchar *filterx_message_value_get_value(FilterXObject *s, gsize *len);
 
-gboolean filterx_message_value_get_string(FilterXObject *s, const gchar **value, gsize *len);
-gboolean filterx_message_value_get_bytes(FilterXObject *s, const gchar **value, gsize *len);
-gboolean filterx_message_value_get_protobuf(FilterXObject *s, const gchar **value, gsize *len);
+gboolean filterx_message_value_get_string_ref(FilterXObject *s, const gchar **value, gsize *len);
+gboolean filterx_message_value_get_bytes_ref(FilterXObject *s, const gchar **value, gsize *len);
+gboolean filterx_message_value_get_protobuf_ref(FilterXObject *s, const gchar **value, gsize *len);
 gboolean filterx_message_value_get_boolean(FilterXObject *s, gboolean *value);
 gboolean filterx_message_value_get_integer(FilterXObject *s, gint64 *value);
 gboolean filterx_message_value_get_double(FilterXObject *s, gdouble *value);

--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -298,7 +298,7 @@ filterx_typecast_integer(FilterXExpr *s, GPtrArray *args)
 
   const gchar *str;
   gsize str_len;
-  if (filterx_object_extract_string(object, &str, &str_len))
+  if (filterx_object_extract_string_ref(object, &str, &str_len))
     {
       APPEND_ZERO(str, str, str_len);
 
@@ -334,7 +334,7 @@ filterx_typecast_double(FilterXExpr *s, GPtrArray *args)
 
   const gchar *str;
   gsize str_len;
-  if (filterx_object_extract_string(object, &str, &str_len))
+  if (filterx_object_extract_string_ref(object, &str, &str_len))
     {
       APPEND_ZERO(str, str, str_len);
 

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -38,7 +38,7 @@ struct _FilterXString
 
 /* NOTE: Consider using filterx_object_extract_string_ref() to also support message_value. */
 const gchar *
-filterx_string_get_value(FilterXObject *s, gsize *length)
+filterx_string_get_value_ref(FilterXObject *s, gsize *length)
 {
   FilterXString *self = (FilterXString *) s;
 
@@ -54,7 +54,7 @@ filterx_string_get_value(FilterXObject *s, gsize *length)
 
 /* NOTE: Consider using filterx_object_extract_bytes_ref() to also support message_value. */
 const gchar *
-filterx_bytes_get_value(FilterXObject *s, gsize *length)
+filterx_bytes_get_value_ref(FilterXObject *s, gsize *length)
 {
   FilterXString *self = (FilterXString *) s;
 
@@ -69,7 +69,7 @@ filterx_bytes_get_value(FilterXObject *s, gsize *length)
 
 /* NOTE: Consider using filterx_object_extract_protobuf_ref() to also support message_value. */
 const gchar *
-filterx_protobuf_get_value(FilterXObject *s, gsize *length)
+filterx_protobuf_get_value_ref(FilterXObject *s, gsize *length)
 {
   FilterXString *self = (FilterXString *) s;
 

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -36,7 +36,7 @@ struct _FilterXString
   gchar str[];
 };
 
-/* NOTE: Consider using filterx_object_extract_string() to also support message_value. */
+/* NOTE: Consider using filterx_object_extract_string_ref() to also support message_value. */
 const gchar *
 filterx_string_get_value(FilterXObject *s, gsize *length)
 {
@@ -52,7 +52,7 @@ filterx_string_get_value(FilterXObject *s, gsize *length)
   return self->str;
 }
 
-/* NOTE: Consider using filterx_object_extract_bytes() to also support message_value. */
+/* NOTE: Consider using filterx_object_extract_bytes_ref() to also support message_value. */
 const gchar *
 filterx_bytes_get_value(FilterXObject *s, gsize *length)
 {
@@ -67,7 +67,7 @@ filterx_bytes_get_value(FilterXObject *s, gsize *length)
   return self->str;
 }
 
-/* NOTE: Consider using filterx_object_extract_protobuf() to also support message_value. */
+/* NOTE: Consider using filterx_object_extract_protobuf_ref() to also support message_value. */
 const gchar *
 filterx_protobuf_get_value(FilterXObject *s, gsize *length)
 {
@@ -132,7 +132,7 @@ _string_add(FilterXObject *s, FilterXObject *object)
 
   const gchar *other_str;
   gsize other_str_len;
-  if (!filterx_object_extract_string(object, &other_str, &other_str_len))
+  if (!filterx_object_extract_string_ref(object, &other_str, &other_str_len))
     return NULL;
 
   GString *buffer = scratch_buffers_alloc();
@@ -234,7 +234,7 @@ _bytes_add(FilterXObject *s, FilterXObject *object)
 
   const gchar *other_str;
   gsize other_str_len;
-  if (!filterx_object_extract_bytes(object, &other_str, &other_str_len))
+  if (!filterx_object_extract_bytes_ref(object, &other_str, &other_str_len))
     return NULL;
 
   GString *buffer = scratch_buffers_alloc();
@@ -297,8 +297,8 @@ filterx_typecast_bytes(FilterXExpr *s, GPtrArray *args)
 
   const gchar *data;
   gsize size;
-  if (filterx_object_extract_string(object, &data, &size) ||
-      filterx_object_extract_protobuf(object, &data, &size))
+  if (filterx_object_extract_string_ref(object, &data, &size) ||
+      filterx_object_extract_protobuf_ref(object, &data, &size))
     {
       return filterx_bytes_new(data, size);
     }
@@ -324,8 +324,8 @@ filterx_typecast_protobuf(FilterXExpr *s, GPtrArray *args)
 
   const gchar *data;
   gsize size;
-  if (filterx_object_extract_protobuf(object, &data, &size) ||
-      filterx_object_extract_bytes(object, &data, &size))
+  if (filterx_object_extract_protobuf_ref(object, &data, &size) ||
+      filterx_object_extract_bytes_ref(object, &data, &size))
     return filterx_protobuf_new(data, size);
 
   msg_error("filterx: invalid typecast",

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -31,9 +31,9 @@ FILTERX_DECLARE_TYPE(string);
 FILTERX_DECLARE_TYPE(bytes);
 FILTERX_DECLARE_TYPE(protobuf);
 
-const gchar *filterx_string_get_value(FilterXObject *s, gsize *length);
-const gchar *filterx_bytes_get_value(FilterXObject *s, gsize *length);
-const gchar *filterx_protobuf_get_value(FilterXObject *s, gsize *length);
+const gchar *filterx_string_get_value_ref(FilterXObject *s, gsize *length);
+const gchar *filterx_bytes_get_value_ref(FilterXObject *s, gsize *length);
+const gchar *filterx_protobuf_get_value_ref(FilterXObject *s, gsize *length);
 FilterXObject *filterx_typecast_string(FilterXExpr *s, GPtrArray *args);
 FilterXObject *filterx_typecast_bytes(FilterXExpr *s, GPtrArray *args);
 FilterXObject *filterx_typecast_protobuf(FilterXExpr *s, GPtrArray *args);

--- a/lib/filterx/tests/test_builtin_functions.c
+++ b/lib/filterx/tests/test_builtin_functions.c
@@ -86,7 +86,7 @@ Test(builtin_functions, test_builtin_simple_functions_lookup)
   cr_assert(res != NULL);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
   gsize len;
-  const gchar *str = filterx_string_get_value(res, &len);
+  const gchar *str = filterx_string_get_value_ref(res, &len);
   cr_assert(len > 0);
 
   cr_assert(strcmp(str, "test-builtin-functions") == 0);
@@ -149,7 +149,7 @@ Test(builtin_functions, test_builtin_function_ctors_lookup)
   FilterXObject *res = filterx_expr_eval(func_expr);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
   gsize len;
-  const gchar *str = filterx_string_get_value(res, &len);
+  const gchar *str = filterx_string_get_value_ref(res, &len);
   cr_assert(len > 0);
 
   cr_assert(strcmp(str, "test-builtin-functions") == 0);

--- a/lib/filterx/tests/test_expr_compound.c
+++ b/lib/filterx/tests/test_expr_compound.c
@@ -55,7 +55,7 @@ _assert_cmp_string_to_filterx_object(const char *str, FilterXObject *obj)
 {
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)));
   gsize string_len;
-  const gchar *string = filterx_string_get_value(obj, &string_len);
+  const gchar *string = filterx_string_get_value_ref(obj, &string_len);
   return strcmp(string, str);
 }
 

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -55,7 +55,7 @@ _assert_cmp_string_to_filterx_object(const char *str, FilterXObject *obj)
 {
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)));
   gsize string_len;
-  const gchar *string = filterx_string_get_value(obj, &string_len);
+  const gchar *string = filterx_string_get_value_ref(obj, &string_len);
   return strcmp(string, str);
 }
 
@@ -360,7 +360,7 @@ Test(expr_condition, test_condition_return_expr_result_on_missing_stmts)
   FilterXObject *res = filterx_expr_eval(cond);
   cr_assert_not_null(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
-  const gchar *strval = filterx_string_get_value(res, NULL);
+  const gchar *strval = filterx_string_get_value_ref(res, NULL);
   cr_assert_str_eq(strval, "foobar");
 
   filterx_expr_unref(cond);
@@ -396,7 +396,7 @@ Test(expr_condition, test_condition_with_complex_expression_to_check_memory_leak
   FilterXObject *res = filterx_expr_eval(cond);
   cr_assert_not_null(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
-  const gchar *str = filterx_string_get_value(res, NULL);
+  const gchar *str = filterx_string_get_value_ref(res, NULL);
   cr_assert_str_eq(str, "foobar");
 
   filterx_expr_unref(cond);

--- a/lib/filterx/tests/test_expr_function.c
+++ b/lib/filterx/tests/test_expr_function.c
@@ -102,7 +102,7 @@ Test(expr_function, test_function_valid_arg)
   FilterXObject *res = filterx_expr_eval(func);
   cr_assert_not_null(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
-  const gchar *str = filterx_string_get_value(res, NULL);
+  const gchar *str = filterx_string_get_value_ref(res, NULL);
   cr_assert_str_eq(str, "bad format 1");
   filterx_expr_unref(func);
   filterx_object_unref(res);
@@ -125,7 +125,7 @@ Test(expr_function, test_function_multiple_args)
   FilterXObject *res = filterx_expr_eval(func);
   cr_assert_not_null(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
-  const gchar *str = filterx_string_get_value(res, NULL);
+  const gchar *str = filterx_string_get_value_ref(res, NULL);
   cr_assert_str_eq(str, "null443foobar");
   filterx_expr_unref(func);
   filterx_object_unref(res);

--- a/lib/filterx/tests/test_expr_plus.c
+++ b/lib/filterx/tests/test_expr_plus.c
@@ -63,7 +63,7 @@ Test(expr_plus, test_string_success)
 
 
   gsize size;
-  const gchar *res = filterx_string_get_value(obj, &size);
+  const gchar *res = filterx_string_get_value_ref(obj, &size);
 
   cr_assert_str_eq(res, "foobar");
 

--- a/lib/filterx/tests/test_expr_regexp.c
+++ b/lib/filterx/tests/test_expr_regexp.c
@@ -154,7 +154,7 @@ _assert_list_elem(FilterXObject *list, gint64 index, const gchar *expected_value
   FilterXObject *elem = filterx_list_get_subscript(list, index);
   cr_assert(elem);
 
-  const gchar *value = filterx_string_get_value(elem, NULL);
+  const gchar *value = filterx_string_get_value_ref(elem, NULL);
   cr_assert_str_eq(value, expected_value);
 
   filterx_object_unref(elem);
@@ -167,7 +167,7 @@ _assert_dict_elem(FilterXObject *list, const gchar *key, const gchar *expected_v
   FilterXObject *elem = filterx_object_get_subscript(list, key_obj);
   cr_assert(elem);
 
-  const gchar *value = filterx_string_get_value(elem, NULL);
+  const gchar *value = filterx_string_get_value_ref(elem, NULL);
   cr_assert_str_eq(value, expected_value);
 
   filterx_object_unref(key_obj);
@@ -303,7 +303,7 @@ Test(filterx_expr_regexp, regexp_subst_single_replace)
   FilterXFuncRegexpSubstOpts opts = {};
   FilterXObject *result = _sub("oo", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "fXbarbaz");
   filterx_object_unref(result);
 }
@@ -313,7 +313,7 @@ Test(filterx_expr_regexp, regexp_subst_single_replace_with_global)
   FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
   FilterXObject *result = _sub("oo", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "fXbarbaz");
   filterx_object_unref(result);
 }
@@ -323,7 +323,7 @@ Test(filterx_expr_regexp, regexp_subst_multi_replace)
   FilterXFuncRegexpSubstOpts opts = {};
   FilterXObject *result = _sub("a", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "foobXrbaz");
   filterx_object_unref(result);
 }
@@ -333,7 +333,7 @@ Test(filterx_expr_regexp, regexp_subst_multi_replace_with_global)
   FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
   FilterXObject *result = _sub("a", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "foobXrbXz");
   filterx_object_unref(result);
 }
@@ -343,7 +343,7 @@ Test(filterx_expr_regexp, regexp_subst_zero_length_matches)
   FilterXFuncRegexpSubstOpts opts = {};
   FilterXObject *result = _sub("u*", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "XfoobarbazX");
   filterx_object_unref(result);
 }
@@ -353,7 +353,7 @@ Test(filterx_expr_regexp, regexp_subst_zero_length_matches_with_global)
   FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
   FilterXObject *result = _sub("u*", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "XfXoXoXbXaXrXbXaXzX");
   filterx_object_unref(result);
 }
@@ -363,7 +363,7 @@ Test(filterx_expr_regexp, regexp_subst_zero_length_matches_with_char_matches)
   FilterXFuncRegexpSubstOpts opts = {};
   FilterXObject *result = _sub("a*", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "XfoobarbazX");
   filterx_object_unref(result);
 }
@@ -373,7 +373,7 @@ Test(filterx_expr_regexp, regexp_subst_zero_length_matches_with_char_matches_wit
   FilterXFuncRegexpSubstOpts opts = {.global = TRUE, .jit=FALSE};
   FilterXObject *result = _sub("a*", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "XfXoXoXbXXrXbXXzX");
   filterx_object_unref(result);
 }
@@ -383,7 +383,7 @@ Test(filterx_expr_regexp, regexp_subst_at_beginning)
   FilterXFuncRegexpSubstOpts opts = {};
   FilterXObject *result = _sub("fo", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "Xobarbaz");
   filterx_object_unref(result);
 }
@@ -393,7 +393,7 @@ Test(filterx_expr_regexp, regexp_subst_at_beginning_with_global)
   FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
   FilterXObject *result = _sub("fo", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "Xobarbaz");
   filterx_object_unref(result);
 }
@@ -403,7 +403,7 @@ Test(filterx_expr_regexp, regexp_subst_at_the_end)
   FilterXFuncRegexpSubstOpts opts = {};
   FilterXObject *result = _sub("az", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "foobarbX");
   filterx_object_unref(result);
 }
@@ -413,7 +413,7 @@ Test(filterx_expr_regexp, regexp_subst_at_the_end_with_global)
   FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
   FilterXObject *result = _sub("az", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "foobarbX");
   filterx_object_unref(result);
 }
@@ -423,7 +423,7 @@ Test(filterx_expr_regexp, regexp_subst_multi_replace_multi_pattern)
   FilterXFuncRegexpSubstOpts opts = {};
   FilterXObject *result = _sub("(a|o)", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "fXobarbaz");
   filterx_object_unref(result);
 }
@@ -433,7 +433,7 @@ Test(filterx_expr_regexp, regexp_subst_multi_replace_multi_pattern_with_global)
   FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
   FilterXObject *result = _sub("(a|o)", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "fXXbXrbXz");
   filterx_object_unref(result);
 }
@@ -443,7 +443,7 @@ Test(filterx_expr_regexp, regexp_subst_accept_end_literal)
   FilterXFuncRegexpSubstOpts opts = {};
   FilterXObject *result = _sub("ba.$", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "foobarX");
   filterx_object_unref(result);
 }
@@ -453,7 +453,7 @@ Test(filterx_expr_regexp, regexp_subst_accept_end_literal_with_global)
   FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
   FilterXObject *result = _sub("ba.$", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "foobarX");
   filterx_object_unref(result);
 }
@@ -463,7 +463,7 @@ Test(filterx_expr_regexp, regexp_subst_accept_groups)
   FilterXFuncRegexpSubstOpts opts = {};
   FilterXObject *result = _sub("(o)*(ba)", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "fXrbaz");
   filterx_object_unref(result);
 }
@@ -473,7 +473,7 @@ Test(filterx_expr_regexp, regexp_subst_accept_groups_with_global)
   FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
   FilterXObject *result = _sub("(o)*(ba)", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "fXrXz");
   filterx_object_unref(result);
 }
@@ -498,14 +498,14 @@ Test(filterx_expr_regexp, regexp_subst_match_opt_ignorecase)
   FilterXFuncRegexpSubstOpts opts = {.global = TRUE};
   FilterXObject *result = _sub("(O|A)", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "foobarbaz");
   filterx_object_unref(result);
 
   FilterXFuncRegexpSubstOpts opts_alt = {.ignorecase = TRUE, .global = TRUE};
   FilterXObject *result_alt = _sub("(O|A)", "X", "foobarbaz", opts_alt);
   cr_assert(filterx_object_is_type(result_alt, &FILTERX_TYPE_NAME(string)));
-  const gchar *res_alt = filterx_string_get_value(result_alt, NULL);
+  const gchar *res_alt = filterx_string_get_value_ref(result_alt, NULL);
   cr_assert_str_eq(res_alt, "fXXbXrbXz");
   filterx_object_unref(result_alt);
 }
@@ -516,14 +516,14 @@ Test(filterx_expr_regexp, regexp_subst_match_opt_ignorecase_nojit)
   FilterXFuncRegexpSubstOpts opts = {.global=TRUE};
   FilterXObject *result = _sub("(O|A)", "X", "foobarbaz", opts);
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
-  const gchar *res = filterx_string_get_value(result, NULL);
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
   cr_assert_str_eq(res, "foobarbaz");
   filterx_object_unref(result);
 
   FilterXFuncRegexpSubstOpts opts_alt = {.ignorecase = TRUE, .global = TRUE, .jit = TRUE};
   FilterXObject *result_alt = _sub("(O|A)", "X", "foobarbaz", opts_alt);
   cr_assert(filterx_object_is_type(result_alt, &FILTERX_TYPE_NAME(string)));
-  const gchar *res_alt = filterx_string_get_value(result_alt, NULL);
+  const gchar *res_alt = filterx_string_get_value_ref(result_alt, NULL);
   cr_assert_str_eq(res_alt, "fXXbXrbXz");
   filterx_object_unref(result_alt);
 }

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -312,7 +312,7 @@ Test(filterx_expr, test_filterx_assign)
   FilterXObject *res = filterx_expr_eval(assign);
   cr_assert_not_null(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
-  cr_assert_str_eq(filterx_string_get_value(res, NULL), "foobar");
+  cr_assert_str_eq(filterx_string_get_value_ref(res, NULL), "foobar");
   cr_assert(filterx_object_truthy(res));
   cr_assert(assign->ignore_falsy_result);
 
@@ -320,7 +320,7 @@ Test(filterx_expr, test_filterx_assign)
   FilterXObject *result_obj = filterx_expr_eval(result_var);
   cr_assert_not_null(result_obj);
   cr_assert(filterx_object_is_type(result_obj, &FILTERX_TYPE_NAME(string)));
-  const gchar *result_val = filterx_string_get_value(result_obj, NULL);
+  const gchar *result_val = filterx_string_get_value_ref(result_obj, NULL);
   cr_assert_str_eq("foobar", result_val);
 
   filterx_object_unref(res);
@@ -340,7 +340,7 @@ Test(filterx_expr, test_filterx_setattr)
   FilterXObject *res = filterx_expr_eval(setattr);
   cr_assert_not_null(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
-  cr_assert_str_eq(filterx_string_get_value(res, NULL), "bar");
+  cr_assert_str_eq(filterx_string_get_value_ref(res, NULL), "bar");
   cr_assert(filterx_object_truthy(res));
   cr_assert(setattr->ignore_falsy_result);
 
@@ -362,7 +362,7 @@ Test(filterx_expr, test_filterx_set_subscript)
   FilterXObject *res = filterx_expr_eval(setattr);
   cr_assert_not_null(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
-  cr_assert_str_eq(filterx_string_get_value(res, NULL), "bar");
+  cr_assert_str_eq(filterx_string_get_value_ref(res, NULL), "bar");
   cr_assert(filterx_object_truthy(res));
   cr_assert(setattr->ignore_falsy_result);
 

--- a/lib/filterx/tests/test_object_bytes.c
+++ b/lib/filterx/tests/test_object_bytes.c
@@ -95,7 +95,7 @@ Test(filterx_bytes, test_filterx_bytes_typecast_from_string)
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(bytes)));
 
   gsize size;
-  const gchar *bytes = filterx_bytes_get_value(obj, &size);
+  const gchar *bytes = filterx_bytes_get_value_ref(obj, &size);
 
   cr_assert(memcmp("string whatever", bytes, size) == 0);
 
@@ -114,7 +114,7 @@ Test(filterx_bytes, test_filterx_bytes_typecast_from_protobuf)
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(bytes)));
 
   gsize size;
-  const gchar *bytes = filterx_bytes_get_value(obj, &size);
+  const gchar *bytes = filterx_bytes_get_value_ref(obj, &size);
 
   cr_assert(memcmp("not a valid \0protobuf!", bytes, size) == 0);
 

--- a/lib/filterx/tests/test_object_protobuf.c
+++ b/lib/filterx/tests/test_object_protobuf.c
@@ -80,7 +80,7 @@ Test(filterx_protobuf, test_filterx_protobuf_typecast_from_bytes)
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(protobuf)));
 
   gsize size;
-  const gchar *bytes = filterx_protobuf_get_value(obj, &size);
+  const gchar *bytes = filterx_protobuf_get_value_ref(obj, &size);
 
   cr_assert(memcmp("not valid \0protobuf!", bytes, size) == 0);
 

--- a/lib/filterx/tests/test_object_string.c
+++ b/lib/filterx/tests/test_object_string.c
@@ -84,7 +84,7 @@ Test(filterx_string, test_filterx_string_typecast_null_object_arg)
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)));
 
   gsize size;
-  const gchar *str = filterx_string_get_value(obj, &size);
+  const gchar *str = filterx_string_get_value_ref(obj, &size);
 
   cr_assert(strcmp("null", str) == 0);
 
@@ -117,7 +117,7 @@ Test(filterx_string, test_filterx_string_typecast_from_bytes)
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)));
 
   gsize size;
-  const gchar *str = filterx_string_get_value(obj, &size);
+  const gchar *str = filterx_string_get_value_ref(obj, &size);
   cr_assert(memcmp("001f2062797465205c73657175656e6365207f20ff", str, size) == 0);
 
 
@@ -136,7 +136,7 @@ Test(filterx_string, test_filterx_string_typecast_from_protobuf)
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)));
 
   gsize size;
-  const gchar *str = filterx_string_get_value(obj, &size);
+  const gchar *str = filterx_string_get_value_ref(obj, &size);
   cr_assert(memcmp("ff6e6f7420612076616c69642070726f746f6275662120d9", str, size) == 0);
 
 

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -497,6 +497,13 @@ log_msg_get_macro_value(const LogMessage *self, gint id, gssize *value_len, LogM
   return value->str;
 }
 
+gboolean
+log_msg_is_value_from_macro(const gchar *value)
+{
+  GString *buffer = g_private_get(&priv_macro_value);
+  return buffer && buffer->str == value;
+}
+
 
 static void
 log_msg_init_queue_node(LogMessage *msg, LogMessageQueueNode *node, const LogPathOptions *path_options)

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -387,6 +387,8 @@ log_msg_get_value_if_set_with_type(const LogMessage *self, NVHandle handle,
     return nv_table_get_value(self->payload, handle, value_len, type);
 }
 
+gboolean log_msg_is_value_from_macro(const gchar *value);
+
 static inline gboolean
 log_msg_is_value_set(const LogMessage *self, NVHandle handle)
 {

--- a/modules/csvparser/filterx-func-parse-csv.c
+++ b/modules/csvparser/filterx-func-parse-csv.c
@@ -91,7 +91,7 @@ _parse_list_argument(FilterXFunctionParseCSV *self, FilterXExpr *list_expr, GLis
 
       const gchar *val;
       gsize len;
-      if (filterx_object_extract_string(elt, &val, &len))
+      if (filterx_object_extract_string_ref(elt, &val, &len))
         *list = g_list_append(*list, g_strndup(val, len));
       filterx_object_unref(elt);
     }
@@ -233,7 +233,7 @@ _generate(FilterXExprGenerator *s, FilterXObject *fillable)
 
   gsize len;
   const gchar *input;
-  if (!filterx_object_extract_string(obj, &input, &len))
+  if (!filterx_object_extract_string_ref(obj, &input, &len))
     goto exit;
 
   APPEND_ZERO(input, input, len);

--- a/modules/csvparser/tests/test_filterx_func_format_csv.c
+++ b/modules/csvparser/tests/test_filterx_func_format_csv.c
@@ -54,7 +54,7 @@ _assert_format_csv(GList *args, const gchar *expected_output)
   FilterXObject *obj = filterx_expr_eval(func);
   cr_assert(obj);
 
-  const gchar *output = filterx_string_get_value(obj, NULL);
+  const gchar *output = filterx_string_get_value_ref(obj, NULL);
   cr_assert(output);
 
   cr_assert_str_eq(output, expected_output);

--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -67,7 +67,7 @@ Array::Array(FilterXOtelArray *s, FilterXObject *protobuf_object) :
 {
   const gchar *value;
   gsize length;
-  if (!filterx_object_extract_protobuf(protobuf_object, &value, &length))
+  if (!filterx_object_extract_protobuf_ref(protobuf_object, &value, &length))
     {
       delete array;
       throw std::runtime_error("Argument is not a protobuf object");

--- a/modules/grpc/otel/filterx/object-otel-kvlist.cpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.cpp
@@ -63,7 +63,7 @@ KVList::KVList(FilterXOtelKVList *s, FilterXObject *protobuf_object) :
 {
   const gchar *value;
   gsize length;
-  if (!filterx_object_extract_protobuf(protobuf_object, &value, &length))
+  if (!filterx_object_extract_protobuf_ref(protobuf_object, &value, &length))
     {
       delete repeated_kv;
       throw std::runtime_error("Argument is not a protobuf object");
@@ -474,7 +474,7 @@ _add_elem_to_repeated_kv(FilterXObject *key_obj, FilterXObject *value_obj, gpoin
 
   const gchar *key;
   gsize key_len;
-  if (!filterx_object_extract_string(key_obj, &key, &key_len))
+  if (!filterx_object_extract_string_ref(key_obj, &key, &key_len))
     return false;
 
   KeyValue *kv = repeated_kv->Add();

--- a/modules/grpc/otel/filterx/object-otel-logrecord.cpp
+++ b/modules/grpc/otel/filterx/object-otel-logrecord.cpp
@@ -53,7 +53,7 @@ LogRecord::LogRecord(FilterXOtelLogRecord *super_, FilterXObject *protobuf_objec
 {
   const gchar *value;
   gsize length;
-  if (!filterx_object_extract_protobuf(protobuf_object, &value, &length))
+  if (!filterx_object_extract_protobuf_ref(protobuf_object, &value, &length))
     throw std::runtime_error("Argument is not a protobuf object");
 
   if (!logRecord.ParsePartialFromArray(value, length))

--- a/modules/grpc/otel/filterx/object-otel-resource.cpp
+++ b/modules/grpc/otel/filterx/object-otel-resource.cpp
@@ -42,7 +42,7 @@ Resource::Resource(FilterXOtelResource *s, FilterXObject *protobuf_object) : sup
 {
   const gchar *value;
   gsize length;
-  if (!filterx_object_extract_protobuf(protobuf_object, &value, &length))
+  if (!filterx_object_extract_protobuf_ref(protobuf_object, &value, &length))
     throw std::runtime_error("Argument is not a protobuf object");
 
   if (!resource.ParsePartialFromArray(value, length))

--- a/modules/grpc/otel/filterx/object-otel-scope.cpp
+++ b/modules/grpc/otel/filterx/object-otel-scope.cpp
@@ -42,7 +42,7 @@ Scope::Scope(FilterXOtelScope *s, FilterXObject *protobuf_object) : super(s)
 {
   const gchar *value;
   gsize length;
-  if (!filterx_object_extract_protobuf(protobuf_object, &value, &length))
+  if (!filterx_object_extract_protobuf_ref(protobuf_object, &value, &length))
     throw std::runtime_error("Argument is not a protobuf object");
 
   if (!scope.ParsePartialFromArray(value, length))

--- a/modules/grpc/otel/filterx/protobuf-field.cpp
+++ b/modules/grpc/otel/filterx/protobuf-field.cpp
@@ -213,7 +213,7 @@ public:
     const gchar *str;
     gsize len;
 
-    if (filterx_object_extract_string(object, &str, &len))
+    if (filterx_object_extract_string_ref(object, &str, &len))
       goto success;
 
     if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(message_value)) &&
@@ -320,8 +320,8 @@ public:
     const gchar *str;
     gsize len;
 
-    if (filterx_object_extract_bytes(object, &str, &len) ||
-        filterx_object_extract_protobuf(object, &str, &len))
+    if (filterx_object_extract_bytes_ref(object, &str, &len) ||
+        filterx_object_extract_protobuf_ref(object, &str, &len))
       {
         reflectors.reflection->SetString(message, reflectors.fieldDescriptor, std::string{str, len});
         return true;
@@ -374,7 +374,7 @@ syslogng::grpc::otel::extract_string_from_object(FilterXObject *object)
   const gchar *key_c_str;
   gsize len;
 
-  if (!filterx_object_extract_string(object, &key_c_str, &len))
+  if (!filterx_object_extract_string_ref(object, &key_c_str, &len))
     throw std::runtime_error("not a string instance");
 
   return std::string{key_c_str, len};

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -63,7 +63,7 @@ _assert_filterx_string_attribute(FilterXObject *obj, const std::string &attribut
   cr_assert(filterx_object_is_type(filterx_string, &FILTERX_TYPE_NAME(string)));
 
   gsize len;
-  const gchar *value = filterx_string_get_value(filterx_string, &len);
+  const gchar *value = filterx_string_get_value_ref(filterx_string, &len);
   cr_assert_eq(expected_value.compare(std::string(value, len)), 0);
 
   filterx_object_unref(filterx_string);
@@ -114,7 +114,7 @@ _assert_filterx_string_element(FilterXObject *obj, FilterXObject *key,
   cr_assert(filterx_object_is_type(filterx_string, &FILTERX_TYPE_NAME(string)));
 
   gsize len;
-  const gchar *value = filterx_string_get_value(filterx_string, &len);
+  const gchar *value = filterx_string_get_value_ref(filterx_string, &len);
   cr_assert_eq(expected_value.compare(std::string(value, len)), 0);
 
   filterx_object_unref(filterx_string);

--- a/modules/json/filterx-format-json.c
+++ b/modules/json/filterx-format-json.c
@@ -148,7 +148,7 @@ _format_and_append_dict_elem(FilterXObject *key, FilterXObject *value, gpointer 
 
   const gchar *key_str;
   gsize key_str_len;
-  if (!filterx_object_extract_string(key, &key_str, &key_str_len))
+  if (!filterx_object_extract_string_ref(key, &key_str, &key_str_len))
     return FALSE;
 
   _append_comma_if_needed(result);
@@ -256,13 +256,13 @@ _format_and_append_value(FilterXObject *value, GString *result)
   const gchar *str;
   gsize str_len;
 
-  if (filterx_object_extract_bytes(value, &str, &str_len))
+  if (filterx_object_extract_bytes_ref(value, &str, &str_len))
     return _format_and_append_bytes(str, str_len, result);
 
-  if (filterx_object_extract_protobuf(value, &str, &str_len))
+  if (filterx_object_extract_protobuf_ref(value, &str, &str_len))
     return _format_and_append_protobuf(str, str_len, result);
 
-  if (filterx_object_extract_string(value, &str, &str_len))
+  if (filterx_object_extract_string_ref(value, &str, &str_len))
     return _format_and_append_string(str, str_len, result);
 
   if (filterx_object_is_type(value, &FILTERX_TYPE_NAME(dict)))

--- a/modules/json/tests/test_filterx_format_json.c
+++ b/modules/json/tests/test_filterx_format_json.c
@@ -55,7 +55,8 @@ static void
 _assert_filterx_format_json_and_unref(FilterXObject *arg, const gchar *expected_json)
 {
   FilterXObject *result = _exec_format_json_and_unref(arg);
-  cr_assert_str_eq(filterx_string_get_value(result, NULL), expected_json, "%s", filterx_string_get_value(result, NULL));
+  cr_assert_str_eq(filterx_string_get_value_ref(result, NULL), expected_json, "%s", filterx_string_get_value_ref(result,
+                   NULL));
   filterx_object_unref(result);
 }
 
@@ -63,7 +64,7 @@ static void
 _assert_filterx_format_json_double_and_unref(FilterXObject *arg, gdouble expected_double)
 {
   FilterXObject *result = _exec_format_json_and_unref(arg);
-  cr_assert_float_eq(g_strtod(filterx_string_get_value(result, NULL), NULL), expected_double, DBL_EPSILON);
+  cr_assert_float_eq(g_strtod(filterx_string_get_value_ref(result, NULL), NULL), expected_double, DBL_EPSILON);
   filterx_object_unref(result);
 }
 

--- a/modules/kvformat/filterx-func-parse-kv.c
+++ b/modules/kvformat/filterx-func-parse-kv.c
@@ -133,7 +133,7 @@ _generate(FilterXExprGenerator *s, FilterXObject *fillable)
   const gchar *input;
 
   gboolean result = FALSE;
-  if (!filterx_object_extract_string(obj, &input, &len))
+  if (!filterx_object_extract_string_ref(obj, &input, &len))
     goto exit;
 
   APPEND_ZERO(input, input, len);

--- a/modules/kvformat/tests/test_filterx_func_format_kv.c
+++ b/modules/kvformat/tests/test_filterx_func_format_kv.c
@@ -54,7 +54,7 @@ _assert_format_kv(GList *args, const gchar *expected_output)
   FilterXObject *obj = filterx_expr_eval(func);
   cr_assert(obj);
 
-  const gchar *output = filterx_string_get_value(obj, NULL);
+  const gchar *output = filterx_string_get_value_ref(obj, NULL);
   cr_assert(output);
 
   cr_assert_str_eq(output, expected_output);

--- a/modules/xml/filterx-parse-xml.c
+++ b/modules/xml/filterx-parse-xml.c
@@ -514,7 +514,7 @@ _add_text_to_dict(XmlElemContext *elem_context, const gchar *text, gsize text_le
 
   if (!filterx_object_set_subscript(elem_context->current_obj, key, &text_obj))
     {
-      const gchar *new_text = filterx_string_get_value(text_obj, NULL);
+      const gchar *new_text = filterx_string_get_value_ref(text_obj, NULL);
       _set_error(error, "failed to add text to dict: \"#text\"=\"%s\"", new_text);
       goto fail;
     }

--- a/modules/xml/filterx-parse-xml.c
+++ b/modules/xml/filterx-parse-xml.c
@@ -339,7 +339,7 @@ _convert_to_dict(GMarkupParseContext *context, XmlElemContext *elem_context, GEr
   /* current_obj is either a dict or a string, ensured by _prepare_elem() and _text_cb(). */
   gsize existing_value_len;
   const gchar *existing_value;
-  g_assert(filterx_object_extract_string(elem_context->current_obj, &existing_value, &existing_value_len));
+  g_assert(filterx_object_extract_string_ref(elem_context->current_obj, &existing_value, &existing_value_len));
 
   if (existing_value_len > 0)
     {
@@ -483,7 +483,7 @@ _create_text_obj(FilterXObject *dict, FilterXObject *existing_text_key, const gc
     {
       gsize existing_value_len;
       const gchar *existing_value;
-      if (!filterx_object_extract_string(existing_obj, &existing_value, &existing_value_len))
+      if (!filterx_object_extract_string_ref(existing_obj, &existing_value, &existing_value_len))
         {
           msg_debug("FilterX: parse_xml(): Unexpected node type, overwriting",
                     evt_tag_str("type", existing_obj->type->name));
@@ -580,7 +580,7 @@ static const gchar *
 _extract_raw_xml(FilterXGeneratorFunctionParseXml *self, FilterXObject *xml_obj, gsize *len)
 {
   const gchar *raw_xml;
-  if (!filterx_object_extract_string(xml_obj, &raw_xml, len))
+  if (!filterx_object_extract_string_ref(xml_obj, &raw_xml, len))
     {
       filterx_eval_push_error_info("input must be string", &self->super.super.super,
                                    g_strdup_printf("got %s instead", xml_obj->type->name), TRUE);


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
