### PR TITLE
debian-sid: remove tzdata-legacy build dep (temporarily)

### DIFF
--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -31,7 +31,7 @@
 debian-bullseye		python3,nojava,notzdatalegacy,nobpf
 debian-bookworm		python3,nojava,notzdatalegacy
 debian-testing		python3,nojava
-debian-sid		python3,nojava
+debian-sid		python3,nojava,notzdatalegacy
 
 # on ubuntu, we start using Python3 at focal onwards.
 # libcriterion-dev is available starting with 21.04


### PR DESCRIPTION
It seems tzdata 2024b-1 has introduced some regressions

> Unpacking tzdata-legacy (2024b-1) ...
> dpkg: error processing archive /tmp/apt-dpkg-install-Mvcn0a/003-tzdata-legacy_2024b-1_all.deb (--unpack):
> trying to overwrite '/usr/share/zoneinfo/Asia/Choibalsan', which is also in package tzdata 2024a-4

https://tracker.debian.org/pkg/tzdata
https://tracker.debian.org/news/1571180/accepted-tzdata-2024b-1-source-into-unstable/

Signed-off-by: Szilard Parrag <szilard.parrag@axoflow.com>
