### PR TITLE
 dbld: Update docker container before installing packages

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -10,6 +10,21 @@ APT_INSTALL="apt-get install -y --no-install-recommends"
 set -e
 set -x
 
+function update_packages() {
+    case "${OS_DISTRIBUTION}" in
+        centos|almalinux)
+            yum update -y
+            ;;
+        debian|ubuntu)
+            apt-get update
+            apt-get upgrade -y
+            ;;
+        fedora)
+            dnf upgrade -y
+            ;;
+    esac
+}
+
 function workaround_rpm_repos() {
     MIRROR_URL='https://ftp.halifax.rwth-aachen.de/fedora/linux'
     case "${OS_DISTRIBUTION}" in

--- a/dbld/images/almalinux-8.dockerfile
+++ b/dbld/images/almalinux-8.dockerfile
@@ -11,6 +11,7 @@ LABEL COMMIT=${COMMIT}
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps add_epel_repo
 RUN /dbld/builddeps add_copr_repo

--- a/dbld/images/almalinux-9.dockerfile
+++ b/dbld/images/almalinux-9.dockerfile
@@ -11,6 +11,7 @@ LABEL COMMIT=${COMMIT}
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps add_epel_repo
 RUN /dbld/builddeps add_copr_repo

--- a/dbld/images/centos-7.dockerfile
+++ b/dbld/images/centos-7.dockerfile
@@ -11,6 +11,7 @@ LABEL COMMIT=${COMMIT}
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps add_epel_repo
 RUN /dbld/builddeps add_copr_repo

--- a/dbld/images/debian-bookworm.dockerfile
+++ b/dbld/images/debian-bookworm.dockerfile
@@ -15,6 +15,7 @@ ENV LANG C.UTF-8
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps

--- a/dbld/images/debian-bullseye.dockerfile
+++ b/dbld/images/debian-bullseye.dockerfile
@@ -15,6 +15,7 @@ ENV LANG C.UTF-8
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps

--- a/dbld/images/debian-sid.dockerfile
+++ b/dbld/images/debian-sid.dockerfile
@@ -15,6 +15,7 @@ ENV LANG C.UTF-8
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps

--- a/dbld/images/debian-testing.dockerfile
+++ b/dbld/images/debian-testing.dockerfile
@@ -15,6 +15,7 @@ ENV LANG C.UTF-8
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps

--- a/dbld/images/fedora-39.dockerfile
+++ b/dbld/images/fedora-39.dockerfile
@@ -11,6 +11,7 @@ LABEL COMMIT=${COMMIT}
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps workaround_rpm_repos
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps add_copr_repo

--- a/dbld/images/fedora-40.dockerfile
+++ b/dbld/images/fedora-40.dockerfile
@@ -11,6 +11,7 @@ LABEL COMMIT=${COMMIT}
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps workaround_rpm_repos
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps add_copr_repo

--- a/dbld/images/ubuntu-focal.dockerfile
+++ b/dbld/images/ubuntu-focal.dockerfile
@@ -15,6 +15,7 @@ ENV LANG C.UTF-8
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps

--- a/dbld/images/ubuntu-jammy.dockerfile
+++ b/dbld/images/ubuntu-jammy.dockerfile
@@ -15,6 +15,7 @@ ENV LANG C.UTF-8
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps

--- a/dbld/images/ubuntu-lunar.dockerfile
+++ b/dbld/images/ubuntu-lunar.dockerfile
@@ -15,6 +15,7 @@ ENV LANG C.UTF-8
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps

--- a/dbld/images/ubuntu-mantic.dockerfile
+++ b/dbld/images/ubuntu-mantic.dockerfile
@@ -15,6 +15,7 @@ ENV LANG C.UTF-8
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps

--- a/dbld/images/ubuntu-noble.dockerfile
+++ b/dbld/images/ubuntu-noble.dockerfile
@@ -15,6 +15,7 @@ ENV LANG C.UTF-8
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps update_packages
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps


### PR DESCRIPTION
To avoid out of date packages to break the image build
Cherry-picked from https://github.com/syslog-ng/syslog-ng/pull/5152 by @kovgeri01