### PR TITLE
Syslog ng ctl attach debugger

### DIFF
--- a/lib/debugger/debugger-main.c
+++ b/lib/debugger/debugger-main.c
@@ -54,6 +54,28 @@ _attach_debugger(gpointer user_data)
   main_loop_worker_sync_call(_install_hook, NULL);
   return NULL;
 }
+
+static void
+_remove_hook_and_clean_up_the_debugger(gpointer user_data)
+{
+  /* NOTE: this is invoked via main_loop_worker_sync_call(), e.g. all workers are stopped */
+
+  pipe_single_step_hook = NULL;
+
+  Debugger *d = current_debugger;
+  current_debugger = NULL;
+
+  debugger_exit(d);
+  debugger_free(d);
+}
+
+static gpointer
+_detach_debugger(gpointer user_data)
+{
+  main_loop_worker_sync_call(_remove_hook_and_clean_up_the_debugger, NULL);
+  return NULL;
+}
+
 void
 debugger_start(MainLoop *main_loop, GlobalConfig *cfg)
 {
@@ -62,4 +84,10 @@ debugger_start(MainLoop *main_loop, GlobalConfig *cfg)
   current_debugger = debugger_new(main_loop, cfg);
   debugger_start_console(current_debugger);
   main_loop_call(_attach_debugger, NULL, FALSE);
+}
+
+void
+debugger_stop(void)
+{
+  main_loop_call(_detach_debugger, NULL, FALSE);
 }

--- a/lib/debugger/debugger-main.c
+++ b/lib/debugger/debugger-main.c
@@ -52,6 +52,8 @@ _attach_debugger(gpointer user_data)
 {
   /* NOTE: this function is always run in the main thread via main_loop_call. */
   main_loop_worker_sync_call(_install_hook, NULL);
+
+  debugger_start_console(current_debugger);
   return NULL;
 }
 
@@ -82,8 +84,7 @@ debugger_start(MainLoop *main_loop, GlobalConfig *cfg)
   /* we don't support threaded mode (yet), force it to non-threaded */
   cfg->threaded = FALSE;
   current_debugger = debugger_new(main_loop, cfg);
-  debugger_start_console(current_debugger);
-  main_loop_call(_attach_debugger, NULL, FALSE);
+  main_loop_call(_attach_debugger, current_debugger, FALSE);
 }
 
 void

--- a/lib/debugger/debugger-main.c
+++ b/lib/debugger/debugger-main.c
@@ -38,6 +38,11 @@ _pipe_hook(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
     return debugger_stop_at_breakpoint(current_debugger, s, msg);
 }
 
+gboolean
+debugger_is_running(void)
+{
+  return current_debugger != NULL;
+}
 
 static void
 _install_hook(gpointer user_data)

--- a/lib/debugger/debugger-main.c
+++ b/lib/debugger/debugger-main.c
@@ -81,8 +81,6 @@ _detach_debugger(gpointer user_data)
 void
 debugger_start(MainLoop *main_loop, GlobalConfig *cfg)
 {
-  /* we don't support threaded mode (yet), force it to non-threaded */
-  cfg->threaded = FALSE;
   current_debugger = debugger_new(main_loop, cfg);
   main_loop_call(_attach_debugger, current_debugger, FALSE);
 }

--- a/lib/debugger/debugger-main.c
+++ b/lib/debugger/debugger-main.c
@@ -24,6 +24,8 @@
 
 #include "debugger/debugger.h"
 #include "logpipe.h"
+#include "mainloop-worker.h"
+#include "mainloop-call.h"
 
 static Debugger *current_debugger;
 
@@ -36,12 +38,28 @@ _pipe_hook(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
     return debugger_stop_at_breakpoint(current_debugger, s, msg);
 }
 
+
+static void
+_install_hook(gpointer user_data)
+{
+  /* NOTE: this is invoked via main_loop_worker_sync_call(), e.g. all workers are stopped */
+
+  pipe_single_step_hook = _pipe_hook;
+}
+
+static gpointer
+_attach_debugger(gpointer user_data)
+{
+  /* NOTE: this function is always run in the main thread via main_loop_call. */
+  main_loop_worker_sync_call(_install_hook, NULL);
+  return NULL;
+}
 void
 debugger_start(MainLoop *main_loop, GlobalConfig *cfg)
 {
   /* we don't support threaded mode (yet), force it to non-threaded */
   cfg->threaded = FALSE;
   current_debugger = debugger_new(main_loop, cfg);
-  pipe_single_step_hook = _pipe_hook;
   debugger_start_console(current_debugger);
+  main_loop_call(_attach_debugger, NULL, FALSE);
 }

--- a/lib/debugger/debugger-main.h
+++ b/lib/debugger/debugger-main.h
@@ -28,6 +28,7 @@
 #include "debugger/debugger.h"
 #include "cfg.h"
 
+gboolean debugger_is_running(void);
 void debugger_start(MainLoop *main_loop, GlobalConfig *cfg);
 void debugger_stop(void);
 

--- a/lib/debugger/debugger-main.h
+++ b/lib/debugger/debugger-main.h
@@ -29,5 +29,6 @@
 #include "cfg.h"
 
 void debugger_start(MainLoop *main_loop, GlobalConfig *cfg);
+void debugger_stop(void);
 
 #endif

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -45,7 +45,7 @@ struct _Debugger
   LogPipe *current_pipe;
   gboolean drop_current_message;
   struct timespec last_trace_event;
-  GThread *interactive_thread;
+  GThread *debugger_thread;
 };
 
 static gboolean
@@ -369,7 +369,7 @@ _handle_interactive_prompt(Debugger *self)
 }
 
 static gpointer
-_interactive_console_thread_func(Debugger *self)
+_debugger_thread_func(Debugger *self)
 {
   app_thread_start();
   printf("Waiting for breakpoint...\n");
@@ -389,7 +389,7 @@ _interactive_console_thread_func(Debugger *self)
 void
 debugger_start_console(Debugger *self)
 {
-  self->interactive_thread = g_thread_new(NULL, (GThreadFunc) _interactive_console_thread_func, self);
+  self->debugger_thread = g_thread_new(NULL, (GThreadFunc) _debugger_thread_func, self);
 }
 
 gboolean
@@ -426,7 +426,7 @@ void
 debugger_exit(Debugger *self)
 {
   tracer_cancel(self->tracer);
-  g_thread_join(self->interactive_thread);
+  g_thread_join(self->debugger_thread);
 }
 
 Debugger *

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -389,6 +389,8 @@ _debugger_thread_func(Debugger *self)
 void
 debugger_start_console(Debugger *self)
 {
+  main_loop_assert_main_thread();
+
   self->debugger_thread = g_thread_new(NULL, (GThreadFunc) _debugger_thread_func, self);
 }
 
@@ -425,6 +427,8 @@ debugger_perform_tracing(Debugger *self, LogPipe *pipe_, LogMessage *msg)
 void
 debugger_exit(Debugger *self)
 {
+  main_loop_assert_main_thread();
+
   tracer_cancel(self->tracer);
   g_thread_join(self->debugger_thread);
 }

--- a/lib/debugger/debugger.h
+++ b/lib/debugger/debugger.h
@@ -32,13 +32,16 @@ typedef struct _Debugger Debugger;
 
 typedef gchar *(*FetchCommandFunc)(void);
 
-Debugger *debugger_new(MainLoop *main_loop, GlobalConfig *cfg);
-void debugger_free(Debugger *self);
 
 gchar *debugger_builtin_fetch_command(void);
 void debugger_register_command_fetcher(FetchCommandFunc fetcher);
+void debugger_exit(Debugger *self);
 void debugger_start_console(Debugger *self);
 gboolean debugger_perform_tracing(Debugger *self, LogPipe *pipe, LogMessage *msg);
 gboolean debugger_stop_at_breakpoint(Debugger *self, LogPipe *pipe, LogMessage *msg);
+
+Debugger *debugger_new(MainLoop *main_loop, GlobalConfig *cfg);
+void debugger_free(Debugger *self);
+
 
 #endif

--- a/lib/debugger/tracer.c
+++ b/lib/debugger/tracer.c
@@ -25,32 +25,38 @@
 
 struct _Tracer
 {
+  GQueue *waiting_breakpoints;
   GMutex breakpoint_mutex;
   GCond breakpoint_cond;
+
+  /* this condition variable is shared between all breakpoints, but each of
+   * them has its own "resume_requested" variable, this means that all
+   * resumes will wake up all waiting breakpoints, but only one of them will
+   * actually resume, it's not the most efficient implementation, but avoids
+   * us having to free the GCond instance as a thread is terminated. */
+
   GCond resume_cond;
-  gboolean breakpoint_hit;
-  gboolean resume_requested;
+  BreakpointSite *pending_breakpoint;
   gboolean cancel_requested;
 };
 
 /* NOTE: called by workers to stop on a breakpoint, wait for the debugger to
  * do its stuff and return to continue */
 void
-tracer_stop_on_breakpoint(Tracer *self)
+tracer_stop_on_breakpoint(Tracer *self, BreakpointSite *breakpoint_site)
 {
   g_mutex_lock(&self->breakpoint_mutex);
 
   if (self->cancel_requested)
     goto exit;
-
+  breakpoint_site->resume_requested = FALSE;
   /* send break point */
-  self->breakpoint_hit = TRUE;
+  g_queue_push_tail(self->waiting_breakpoints, breakpoint_site);
   g_cond_signal(&self->breakpoint_cond);
 
   /* wait for resume or cancel */
-  while (!(self->resume_requested || self->cancel_requested))
+  while (!(breakpoint_site->resume_requested || self->cancel_requested))
     g_cond_wait(&self->resume_cond, &self->breakpoint_mutex);
-  self->resume_requested = FALSE;
 
 exit:
   g_mutex_unlock(&self->breakpoint_mutex);
@@ -59,20 +65,26 @@ exit:
 /* NOTE: called by the interactive debugger to wait for a breakpoint to
  * trigger, a return of FALSE indicates that the tracing was cancelled */
 gboolean
-tracer_wait_for_breakpoint(Tracer *self)
+tracer_wait_for_breakpoint(Tracer *self, BreakpointSite **breakpoint_site)
 {
   gboolean cancelled = FALSE;
   g_mutex_lock(&self->breakpoint_mutex);
-  while (!(self->breakpoint_hit || self->cancel_requested))
+  while (g_queue_is_empty(self->waiting_breakpoints) && !self->cancel_requested)
     g_cond_wait(&self->breakpoint_cond, &self->breakpoint_mutex);
-  self->breakpoint_hit = FALSE;
-  if (self->cancel_requested)
+
+  g_assert(self->pending_breakpoint == NULL);
+  *breakpoint_site = NULL;
+  if (!self->cancel_requested)
+    {
+      *breakpoint_site = self->pending_breakpoint = g_queue_pop_head(self->waiting_breakpoints);
+    }
+  else
     {
       cancelled = TRUE;
 
       /* cancel out threads waiting on breakpoint, e.g.  in the cancelled
        * case no need to call tracer_resume_after_breakpoint() */
-      g_cond_signal(&self->resume_cond);
+      g_cond_broadcast(&self->resume_cond);
     }
   g_mutex_unlock(&self->breakpoint_mutex);
   return !cancelled;
@@ -80,11 +92,13 @@ tracer_wait_for_breakpoint(Tracer *self)
 
 /* NOTE: called by the interactive debugger to resume the worker after a breakpoint */
 void
-tracer_resume_after_breakpoint(Tracer *self)
+tracer_resume_after_breakpoint(Tracer *self, BreakpointSite *breakpoint_site)
 {
   g_mutex_lock(&self->breakpoint_mutex);
-  self->resume_requested = TRUE;
-  g_cond_signal(&self->resume_cond);
+  g_assert(self->pending_breakpoint == breakpoint_site);
+  self->pending_breakpoint->resume_requested = TRUE;
+  self->pending_breakpoint = NULL;
+  g_cond_broadcast(&self->resume_cond);
   g_mutex_unlock(&self->breakpoint_mutex);
 }
 
@@ -107,7 +121,7 @@ tracer_new(GlobalConfig *cfg)
   g_mutex_init(&self->breakpoint_mutex);
   g_cond_init(&self->breakpoint_cond);
   g_cond_init(&self->resume_cond);
-
+  self->waiting_breakpoints = g_queue_new();
   return self;
 }
 
@@ -117,5 +131,6 @@ tracer_free(Tracer *self)
   g_mutex_clear(&self->breakpoint_mutex);
   g_cond_clear(&self->breakpoint_cond);
   g_cond_clear(&self->resume_cond);
+  g_queue_free(self->waiting_breakpoints);
   g_free(self);
 }

--- a/lib/debugger/tracer.c
+++ b/lib/debugger/tracer.c
@@ -23,6 +23,16 @@
  */
 #include "debugger/tracer.h"
 
+struct _Tracer
+{
+  GMutex breakpoint_mutex;
+  GCond breakpoint_cond;
+  GCond resume_cond;
+  gboolean breakpoint_hit;
+  gboolean resume_requested;
+  gboolean cancel_requested;
+};
+
 /* NOTE: called by workers to stop on a breakpoint, wait for the debugger to
  * do its stuff and return to continue */
 void

--- a/lib/debugger/tracer.h
+++ b/lib/debugger/tracer.h
@@ -28,9 +28,19 @@
 
 typedef struct _Tracer Tracer;
 
-void tracer_stop_on_breakpoint(Tracer *self);
-gboolean tracer_wait_for_breakpoint(Tracer *self);
-void tracer_resume_after_breakpoint(Tracer *self);
+/* struct to track the invocation of a breakpoint, we have an instance for each thread */
+typedef struct _BreakpointSite
+{
+  gboolean resume_requested;
+  LogMessage *msg;
+  LogPipe *pipe;
+  gboolean drop;
+} BreakpointSite;
+
+
+void tracer_stop_on_breakpoint(Tracer *self, BreakpointSite *breakpoint_site);
+gboolean tracer_wait_for_breakpoint(Tracer *self, BreakpointSite **breakpoint_site);
+void tracer_resume_after_breakpoint(Tracer *self, BreakpointSite *breakpoint_site);
 void tracer_cancel(Tracer *self);
 
 Tracer *tracer_new(GlobalConfig *cfg);

--- a/lib/debugger/tracer.h
+++ b/lib/debugger/tracer.h
@@ -33,11 +33,13 @@ typedef struct _Tracer
   GCond resume_cond;
   gboolean breakpoint_hit;
   gboolean resume_requested;
+  gboolean cancel_requested;
 } Tracer;
 
 void tracer_stop_on_breakpoint(Tracer *self);
-void tracer_wait_for_breakpoint(Tracer *self);
+gboolean tracer_wait_for_breakpoint(Tracer *self);
 void tracer_resume_after_breakpoint(Tracer *self);
+void tracer_cancel(Tracer *self);
 
 Tracer *tracer_new(GlobalConfig *cfg);
 void tracer_free(Tracer *self);

--- a/lib/debugger/tracer.h
+++ b/lib/debugger/tracer.h
@@ -26,15 +26,7 @@
 
 #include "syslog-ng.h"
 
-typedef struct _Tracer
-{
-  GMutex breakpoint_mutex;
-  GCond breakpoint_cond;
-  GCond resume_cond;
-  gboolean breakpoint_hit;
-  gboolean resume_requested;
-  gboolean cancel_requested;
-} Tracer;
+typedef struct _Tracer Tracer;
 
 void tracer_stop_on_breakpoint(Tracer *self);
 gboolean tracer_wait_for_breakpoint(Tracer *self);

--- a/syslog-ng-ctl/commands/attach.c
+++ b/syslog-ng-ctl/commands/attach.c
@@ -47,7 +47,7 @@ GOptionEntry attach_options[] =
 {
   { "seconds", 0, 0, G_OPTION_ARG_INT, &attach_options_seconds, "amount of time to attach for", NULL },
   { "log-level", 0, 0, G_OPTION_ARG_CALLBACK, _store_log_level, "change syslog-ng log level", "<default|verbose|debug|trace>" },
-  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &attach_commands, "attach mode: logs, stdio", NULL },
+  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &attach_commands, "attach mode: logs, debugger, stdio", NULL },
   { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 };
 
@@ -73,6 +73,8 @@ slng_attach(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
     g_string_append(command, " STDIO");
   else if (g_str_equal(attach_mode, "logs"))
     g_string_append(command, " LOGS");
+  else if (g_str_equal(attach_mode, "debugger"))
+    g_string_append(command, " DEBUGGER");
   else
     {
       fprintf(stderr, "Unknown attach mode\n");


### PR DESCRIPTION
This is a continuation of #326 to add interactive debugger functionality over syslog-ng-ctl

