### PR TITLE
Minor FilterX cleanups

### DIFF
--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -63,7 +63,6 @@ void filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObj
 void filterx_eval_push_error_info(const gchar *message, FilterXExpr *expr, gchar *info, gboolean free_info);
 void filterx_eval_set_context(FilterXEvalContext *context);
 FilterXEvalResult filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr, LogMessage *msg);
-void filterx_eval_sync_scope_and_message(FilterXScope *scope, LogMessage *msg);
 const gchar *filterx_eval_get_last_error(void);
 EVTTAG *filterx_format_last_error(void);
 EVTTAG *filterx_format_last_error_location(void);


### PR DESCRIPTION
- **lib/filterx: refactor _pull_variable_from_message**
- **lib/filterx: remove obsolete filterx_eval_sync_scope_and_message() function declaration**
