### PR TITLE
Fix std::transform and std::tolower usage in GRPCDest

### DIFF
--- a/modules/grpc/common/grpc-dest.hpp
+++ b/modules/grpc/common/grpc-dest.hpp
@@ -110,7 +110,11 @@ public:
 
   void add_header(std::string name, std::string value)
   {
-    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+    std::transform(name.begin(), name.end(), name.begin(),
+                   [](auto c)
+    {
+      return ::tolower(c);
+    });
     this->headers.push_back(std::make_pair(name, value));
   }
 


### PR DESCRIPTION
`std::tolower` is not an addressible function, the intended way to use it is within a lambda.

See the following for more information:
https://devblogs.microsoft.com/oldnewthing/20241007-00/?p=110345
https://en.cppreference.com/w/cpp/string/byte/tolower