### PR TITLE
Debugger filterx

### DIFF
--- a/lib/cfg-grammar-internal.h
+++ b/lib/cfg-grammar-internal.h
@@ -43,6 +43,7 @@
 #include "filter/filter-pipe.h"
 #include "filterx/filterx-parser.h"
 #include "filterx/filterx-expr.h"
+#include "filterx/expr-compound.h"
 #include "filterx/filterx-pipe.h"
 #include "parser/parser-expr-parser.h"
 #include "rewrite/rewrite-expr-parser.h"

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -719,16 +719,20 @@ filter_content
 	;
 
 filterx_content
-        : _filterx_context_push <ptr>{
-            FilterXExpr *filterx_block = NULL;
+        : '{' _filterx_context_push <ptr>{
+            GList *filterx_expr_list = NULL;
             FilterXEvalContext compile_context;
 
             filterx_eval_begin_compile(&compile_context, configuration);
-	    CHECK_ERROR_WITHOUT_MESSAGE(cfg_parser_parse(&filterx_parser, lexer, (gpointer *) &filterx_block, NULL), @$);
+	    CHECK_ERROR_WITHOUT_MESSAGE(cfg_parser_parse(&filterx_parser, lexer, (gpointer *) &filterx_expr_list, NULL), @$);
             filterx_eval_end_compile(&compile_context);
 
+            FilterXExpr *filterx_block = filterx_compound_expr_new(FALSE);
+            filterx_compound_expr_add_list(filterx_block, filterx_expr_list);
+	    filterx_expr_set_location_with_text(filterx_block, &@$, "{ ... }");
+
             $$ = log_expr_node_new_pipe(log_filterx_pipe_new(filterx_block, configuration), &@$);
-	  } _filterx_context_pop			{ $$ = $2; }
+	  } _filterx_context_pop '}'			{ $$ = $3; }
 	;
 
 parser_content

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -543,6 +543,12 @@ cfg_run_parser(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer 
 }
 
 gboolean
+cfg_parsing_in_progress(void)
+{
+  return configuration != NULL;
+}
+
+gboolean
 cfg_run_parser_with_main_context(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer *result, gpointer arg,
                                  const gchar *desc)
 {

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -161,6 +161,7 @@ GlobalConfig *cfg_new_subordinate(GlobalConfig *master);
 gboolean cfg_run_parser(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer *result, gpointer arg);
 gboolean cfg_run_parser_with_main_context(GlobalConfig *self, CfgLexer *lexer, CfgParser *parser, gpointer *result,
                                           gpointer arg, const gchar *desc);
+gboolean cfg_parsing_in_progress(void);
 gboolean cfg_read_config(GlobalConfig *cfg, const gchar *fname, gchar *preprocess_into);
 void cfg_shutdown(GlobalConfig *self);
 gboolean cfg_is_shutting_down(GlobalConfig *cfg);

--- a/lib/debugger/Makefile.am
+++ b/lib/debugger/Makefile.am
@@ -9,6 +9,7 @@ EXTRA_DIST += lib/debugger/CMakeLists.txt \
 	cmd-info.c     \
 	cmd-list.c     \
 	cmd-print.c    \
+	cmd-printx.c    \
 	cmd-quit.c     \
 	cmd-step.c     \
 	cmd-trace.c

--- a/lib/debugger/Makefile.am
+++ b/lib/debugger/Makefile.am
@@ -1,6 +1,17 @@
 debuggerincludedir			= ${pkgincludedir}/debugger
 
-EXTRA_DIST += lib/debugger/CMakeLists.txt
+EXTRA_DIST += lib/debugger/CMakeLists.txt \
+	cmd-continue.c \
+	cmd-display.c  \
+	cmd-drop.c     \
+	cmd-follow.c   \
+	cmd-help.c     \
+	cmd-info.c     \
+	cmd-list.c     \
+	cmd-print.c    \
+	cmd-quit.c     \
+	cmd-step.c     \
+	cmd-trace.c
 
 debuggerinclude_HEADERS = \
 	lib/debugger/debugger.h		\

--- a/lib/debugger/cmd-continue.c
+++ b/lib/debugger/cmd-continue.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+static gboolean
+_cmd_continue(Debugger *self, gint argc, gchar *argv[])
+{
+  _set_mode(self, DBG_WAITING_FOR_BREAKPOINT, FALSE);
+  return FALSE;
+}

--- a/lib/debugger/cmd-display.c
+++ b/lib/debugger/cmd-display.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+static gboolean
+_cmd_display(Debugger *self, gint argc, gchar *argv[])
+{
+  if (argc == 2)
+    {
+      GError *error = NULL;
+      if (!log_template_compile(self->display_template, argv[1], &error))
+        {
+          printf("display: Error compiling template: %s\n", error->message);
+          g_clear_error(&error);
+          return TRUE;
+        }
+    }
+  printf("display: The template is set to: \"%s\"\n", self->display_template->template_str);
+  return TRUE;
+}

--- a/lib/debugger/cmd-drop.c
+++ b/lib/debugger/cmd-drop.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+static gboolean
+_cmd_drop(Debugger *self, gint argc, gchar *argv[])
+{
+  self->breakpoint_site->drop = TRUE;
+  return FALSE;
+}

--- a/lib/debugger/cmd-follow.c
+++ b/lib/debugger/cmd-follow.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+static gboolean
+_cmd_follow(Debugger *self, gint argc, gchar *argv[])
+{
+  _set_mode(self, DBG_FOLLOW_AND_BREAK, TRUE);
+  return FALSE;
+}

--- a/lib/debugger/cmd-help.c
+++ b/lib/debugger/cmd-help.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+static gboolean
+_cmd_help(Debugger *self, gint argc, gchar *argv[])
+{
+  if (self->breakpoint_site)
+    {
+      printf("syslog-ng interactive console\n"
+             "Stopped on a breakpoint.\n"
+             "The following commands are available:\n\n"
+             "  help, h, ?               Display this help\n"
+             "  info, i                  Display information about the current execution state\n"
+             "  list, l                  Display source code at the current location\n"
+             "  continue, c              Continue until the next breakpoint\n"
+             "  step, s                  Single step\n"
+             "  follow, f                Follow this message, ignoring any other breakpoints\n"
+             "  display                  Set the displayed message template\n"
+             "  trace, t                 Trace this message along the configuration\n"
+             "  print, p                 Print the current log message\n"
+             "  drop, d                  Drop the current message\n"
+             "  quit, q                  Tell syslog-ng to exit\n"
+            );
+    }
+  else
+    {
+      printf("syslog-ng interactive console\n"
+             "Stopped on an interrupt.\n"
+             "The following commands are available:\n\n"
+             "  help, h, ?               Display this help\n"
+             "  list, l                  Display source code at the current location\n"
+             "  continue, c              Continue until the next breakpoint\n"
+             "  quit, q                  Tell syslog-ng to exit\n"
+            );
+    }
+  return TRUE;
+}

--- a/lib/debugger/cmd-help.c
+++ b/lib/debugger/cmd-help.c
@@ -41,6 +41,7 @@ _cmd_help(Debugger *self, gint argc, gchar *argv[])
              "  display                  Set the displayed message template\n"
              "  trace, t                 Trace this message along the configuration\n"
              "  print, p                 Print the current log message\n"
+             "  printx, px               Print the value of a filterx expression\n"
              "  drop, d                  Drop the current message\n"
              "  quit, q                  Tell syslog-ng to exit\n"
             );

--- a/lib/debugger/cmd-info.c
+++ b/lib/debugger/cmd-info.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+static gboolean
+_cmd_info_pipe(Debugger *self, LogPipe *pipe)
+{
+  gchar buf[1024];
+
+  printf("LogPipe %p at %s\n", pipe, log_expr_node_format_location(pipe->expr_node, buf, sizeof(buf)));
+  _display_source_line(self);
+
+  return TRUE;
+}
+
+static gboolean
+_cmd_info(Debugger *self, gint argc, gchar *argv[])
+{
+  if (argc >= 2)
+    {
+      if (strcmp(argv[1], "pipe") == 0)
+        return _cmd_info_pipe(self, self->breakpoint_site->pipe);
+    }
+
+  printf("info: List of info subcommands\n"
+         "info pipe -- display information about the current pipe\n");
+  return TRUE;
+}

--- a/lib/debugger/cmd-list.c
+++ b/lib/debugger/cmd-list.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+static gboolean
+_cmd_list(Debugger *self, gint argc, gchar *argv[])
+{
+  gint shift = 11;
+  if (argc >= 2)
+    {
+      if (strcmp(argv[1], "+") == 0)
+        shift = 11;
+      else if (strcmp(argv[1], "-") == 0)
+        shift = -11;
+      else if (strcmp(argv[1], ".") == 0)
+        {
+          shift = 0;
+          if (self->breakpoint_site)
+            _set_current_location(self, self->breakpoint_site->pipe->expr_node);
+        }
+      else if (isdigit(argv[1][0]))
+        {
+          gint target_lineno = atoi(argv[1]);
+          if (target_lineno <= 0)
+            target_lineno = 1;
+          self->current_location.list_start = target_lineno;
+        }
+      /* drop any arguments for repeated execution */
+      _set_command(self, "l");
+    }
+  _display_source_line(self);
+  if (shift)
+    self->current_location.list_start += shift;
+  return TRUE;
+}

--- a/lib/debugger/cmd-print.c
+++ b/lib/debugger/cmd-print.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+
+static void
+_display_msg_details(Debugger *self, LogMessage *msg)
+{
+  GString *output = g_string_sized_new(128);
+
+  log_msg_values_foreach(msg, _format_nvpair, NULL);
+  g_string_truncate(output, 0);
+  log_msg_format_tags(msg, output, TRUE);
+  printf("TAGS=%s\n", output->str);
+  printf("\n");
+  g_string_free(output, TRUE);
+}
+
+static gboolean
+_display_msg_with_template_string(Debugger *self, LogMessage *msg, const gchar *template_string, GError **error)
+{
+  LogTemplate *template;
+
+  template = log_template_new(self->cfg, NULL);
+  if (!log_template_compile(template, template_string, error))
+    {
+      return FALSE;
+    }
+  _display_msg_with_template(self, msg, template);
+  log_template_unref(template);
+  return TRUE;
+}
+
+static gboolean
+_cmd_print(Debugger *self, gint argc, gchar *argv[])
+{
+  if (argc == 1)
+    _display_msg_details(self, self->breakpoint_site->msg);
+  else if (argc == 2)
+    {
+      GError *error = NULL;
+      if (!_display_msg_with_template_string(self, self->breakpoint_site->msg, argv[1], &error))
+        {
+          printf("print: %s\n", error->message);
+          g_clear_error(&error);
+        }
+    }
+  else
+    printf("print: expected no arguments or exactly one\n");
+  return TRUE;
+}

--- a/lib/debugger/cmd-printx.c
+++ b/lib/debugger/cmd-printx.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/filterx-parser.h"
+
+static void
+_eval_filterx_expr(Debugger *self, GList *list_of_exprs, LogMessage *msg)
+{
+  NVTable *payload = nv_table_ref(msg->payload);
+
+  gint expr_index = 1;
+  for (GList *l = list_of_exprs; l; l = l->next)
+    {
+      FilterXExpr *expr = (FilterXExpr *) l->data;
+      FilterXObject *res = filterx_expr_eval(expr);
+
+      if (!res)
+        {
+          printf("$%d = error(%s)\n", expr_index, filterx_eval_get_last_error());
+          filterx_eval_clear_errors();
+          goto fail;
+        }
+
+      GString *buf = scratch_buffers_alloc();
+      if (!filterx_object_repr(res, buf))
+        {
+          LogMessageValueType t;
+          if (!filterx_object_marshal(res, buf, &t))
+            g_assert_not_reached();
+        }
+      printf("$%d = %s\n", expr_index, buf->str);
+
+      filterx_object_unref(res);
+      expr_index++;
+    }
+
+fail:
+  nv_table_unref(payload);
+}
+
+static void
+_display_filterx_expr(Debugger *self, gint argc, gchar *argv[])
+{
+  GList *list_of_exprs = NULL;
+  for (gint i = 0; i < argc; i++)
+    {
+      gchar *expr_text = g_strdup_printf("%s;", argv[i]);
+      CfgLexer *lexer = cfg_lexer_new_buffer(self->cfg, expr_text, strlen(expr_text));
+
+      GList *partial = NULL;
+      if (!cfg_run_parser(self->cfg, lexer, &filterx_parser, (gpointer *) &partial, NULL) ||
+          !partial)
+        {
+          printf("Error parsing filterx expression: %s\n", expr_text);
+          g_free(expr_text);
+          goto exit;
+        }
+      g_free(expr_text);
+      list_of_exprs = g_list_concat(list_of_exprs, partial);
+    }
+  _eval_filterx_expr(self,
+                     list_of_exprs,
+                     self->breakpoint_site->msg);
+
+exit:
+  g_list_free_full(list_of_exprs, (GDestroyNotify) filterx_expr_unref);
+}
+
+static gboolean
+_cmd_printx(Debugger *self, gint argc, gchar *argv[])
+{
+  if (argc == 1)
+    {
+      gchar *vars[] = { "vars();", NULL };
+      _display_filterx_expr(self, 1, vars);
+    }
+  else
+    {
+      _display_filterx_expr(self, argc - 1, &argv[1]);
+    }
+  return TRUE;
+}

--- a/lib/debugger/cmd-quit.c
+++ b/lib/debugger/cmd-quit.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+static gboolean
+_cmd_quit(Debugger *self, gint argc, gchar *argv[])
+{
+  _set_mode(self, DBG_QUIT, FALSE);
+  if (self->breakpoint_site)
+    self->breakpoint_site->drop = TRUE;
+  main_loop_exit(self->main_loop);
+  return FALSE;
+}

--- a/lib/debugger/cmd-step.c
+++ b/lib/debugger/cmd-step.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+static gboolean
+_cmd_step(Debugger *self, gint argc, gchar *argv[])
+{
+  _set_mode(self, DBG_WAITING_FOR_STEP, FALSE);
+  return FALSE;
+}

--- a/lib/debugger/cmd-trace.c
+++ b/lib/debugger/cmd-trace.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015 Balabit
+ * Copyright (c) 2015 Balázs Scheidler
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+static gboolean
+_cmd_trace(Debugger *self, gint argc, gchar *argv[])
+{
+  clock_gettime(CLOCK_MONOTONIC, &self->last_trace_event);
+  _set_mode(self, DBG_FOLLOW_AND_TRACE, TRUE);
+  return FALSE;
+}

--- a/lib/debugger/debugger-main.c
+++ b/lib/debugger/debugger-main.c
@@ -32,9 +32,9 @@ static gboolean
 _pipe_hook(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   if (debugger_is_to_stop(current_debugger, s, msg))
-    return debugger_stop_at_breakpoint(current_debugger, s, msg);
+    return debugger_stop_at_breakpoint(current_debugger, s, msg, path_options);
   else if (debugger_is_to_trace(current_debugger, s, msg))
-    return debugger_perform_tracing(current_debugger, s, msg);
+    return debugger_perform_tracing(current_debugger, s, msg, path_options);
   return TRUE;
 }
 

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -578,7 +578,10 @@ debugger_start_console(Debugger *self)
 }
 
 gboolean
-debugger_stop_at_breakpoint(Debugger *self, LogPipe *pipe_, LogMessage *msg)
+debugger_stop_at_breakpoint(Debugger *self,
+                            LogPipe *pipe_,
+                            LogMessage *msg,
+                            const LogPathOptions *path_options)
 {
   BreakpointSite breakpoint_site = {0};
   msg_trace("Debugger: stopping at breakpoint",
@@ -586,6 +589,7 @@ debugger_stop_at_breakpoint(Debugger *self, LogPipe *pipe_, LogMessage *msg)
 
   breakpoint_site.msg = log_msg_ref(msg);
   breakpoint_site.pipe = log_pipe_ref(pipe_);
+  breakpoint_site.path_options = path_options;
   tracer_stop_on_breakpoint(self->tracer, &breakpoint_site);
   log_msg_unref(breakpoint_site.msg);
   log_pipe_unref(breakpoint_site.pipe);
@@ -593,7 +597,10 @@ debugger_stop_at_breakpoint(Debugger *self, LogPipe *pipe_, LogMessage *msg)
 }
 
 gboolean
-debugger_perform_tracing(Debugger *self, LogPipe *pipe_, LogMessage *msg)
+debugger_perform_tracing(Debugger *self,
+                         LogPipe *pipe_,
+                         LogMessage *msg,
+                         const LogPathOptions *path_options)
 {
   struct timespec ts, *prev_ts = &self->last_trace_event;
   gchar buf[1024];

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2015 Balabit
  * Copyright (c) 2015 Balázs Scheidler
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -92,19 +94,6 @@ _format_nvpair(NVHandle handle,
 }
 
 static void
-_display_msg_details(Debugger *self, LogMessage *msg)
-{
-  GString *output = g_string_sized_new(128);
-
-  log_msg_values_foreach(msg, _format_nvpair, NULL);
-  g_string_truncate(output, 0);
-  log_msg_format_tags(msg, output, TRUE);
-  printf("TAGS=%s\n", output->str);
-  printf("\n");
-  g_string_free(output, TRUE);
-}
-
-static void
 _display_msg_with_template(Debugger *self, LogMessage *msg, LogTemplate *template)
 {
   GString *output = g_string_sized_new(128);
@@ -112,21 +101,6 @@ _display_msg_with_template(Debugger *self, LogMessage *msg, LogTemplate *templat
   log_template_format(template, msg, &DEFAULT_TEMPLATE_EVAL_OPTIONS, output);
   printf("%s\n", output->str);
   g_string_free(output, TRUE);
-}
-
-static gboolean
-_display_msg_with_template_string(Debugger *self, LogMessage *msg, const gchar *template_string, GError **error)
-{
-  LogTemplate *template;
-
-  template = log_template_new(self->cfg, NULL);
-  if (!log_template_compile(template, template_string, error))
-    {
-      return FALSE;
-    }
-  _display_msg_with_template(self, msg, template);
-  log_template_unref(template);
-  return TRUE;
 }
 
 static void
@@ -156,143 +130,6 @@ _display_source_line(Debugger *self)
     puts("Unable to list source, no current location set");
 }
 
-static gboolean
-_cmd_help(Debugger *self, gint argc, gchar *argv[])
-{
-  if (self->breakpoint_site)
-    {
-      printf("syslog-ng interactive console\n"
-             "Stopped on a breakpoint.\n"
-             "The following commands are available:\n\n"
-             "  help, h, ?               Display this help\n"
-             "  info, i                  Display information about the current execution state\n"
-             "  list, l                  Display source code at the current location\n"
-             "  continue, c              Continue until the next breakpoint\n"
-             "  step, s                  Single step\n"
-             "  follow, f                Follow this message, ignoring any other breakpoints\n"
-             "  display                  Set the displayed message template\n"
-             "  trace, t                 Trace this message along the configuration\n"
-             "  print, p                 Print the current log message\n"
-             "  drop, d                  Drop the current message\n"
-             "  quit, q                  Tell syslog-ng to exit\n"
-            );
-    }
-  else
-    {
-      printf("syslog-ng interactive console\n"
-             "Stopped on an interrupt.\n"
-             "The following commands are available:\n\n"
-             "  help, h, ?               Display this help\n"
-             "  list, l                  Display source code at the current location\n"
-             "  continue, c              Continue until the next breakpoint\n"
-             "  quit, q                  Tell syslog-ng to exit\n"
-            );
-    }
-  return TRUE;
-}
-
-
-static gboolean
-_cmd_print(Debugger *self, gint argc, gchar *argv[])
-{
-  if (argc == 1)
-    _display_msg_details(self, self->breakpoint_site->msg);
-  else if (argc == 2)
-    {
-      GError *error = NULL;
-      if (!_display_msg_with_template_string(self, self->breakpoint_site->msg, argv[1], &error))
-        {
-          printf("print: %s\n", error->message);
-          g_clear_error(&error);
-        }
-    }
-  else
-    printf("print: expected no arguments or exactly one\n");
-  return TRUE;
-}
-
-static gboolean
-_cmd_display(Debugger *self, gint argc, gchar *argv[])
-{
-  if (argc == 2)
-    {
-      GError *error = NULL;
-      if (!log_template_compile(self->display_template, argv[1], &error))
-        {
-          printf("display: Error compiling template: %s\n", error->message);
-          g_clear_error(&error);
-          return TRUE;
-        }
-    }
-  printf("display: The template is set to: \"%s\"\n", self->display_template->template_str);
-  return TRUE;
-}
-
-static gboolean
-_cmd_drop(Debugger *self, gint argc, gchar *argv[])
-{
-  self->breakpoint_site->drop = TRUE;
-  return FALSE;
-}
-
-
-static gboolean
-_cmd_info_pipe(Debugger *self, LogPipe *pipe)
-{
-  gchar buf[1024];
-
-  printf("LogPipe %p at %s\n", pipe, log_expr_node_format_location(pipe->expr_node, buf, sizeof(buf)));
-  _display_source_line(self);
-
-  return TRUE;
-}
-
-static gboolean
-_cmd_info(Debugger *self, gint argc, gchar *argv[])
-{
-  if (argc >= 2)
-    {
-      if (strcmp(argv[1], "pipe") == 0)
-        return _cmd_info_pipe(self, self->breakpoint_site->pipe);
-    }
-
-  printf("info: List of info subcommands\n"
-         "info pipe -- display information about the current pipe\n");
-  return TRUE;
-}
-
-static gboolean
-_cmd_list(Debugger *self, gint argc, gchar *argv[])
-{
-  gint shift = 11;
-  if (argc >= 2)
-    {
-      if (strcmp(argv[1], "+") == 0)
-        shift = 11;
-      else if (strcmp(argv[1], "-") == 0)
-        shift = -11;
-      else if (strcmp(argv[1], ".") == 0)
-        {
-          shift = 0;
-          if (self->breakpoint_site)
-            _set_current_location(self, self->breakpoint_site->pipe->expr_node);
-        }
-      else if (ch_isdigit(argv[1][0]))
-        {
-          gint target_lineno = atoi(argv[1]);
-          if (target_lineno <= 0)
-            target_lineno = 1;
-          self->current_location.list_start = target_lineno;
-        }
-      /* drop any arguments for repeated execution */
-      _set_command(self, "l");
-    }
-  _display_source_line(self);
-  if (shift)
-    self->current_location.list_start += shift;
-  return TRUE;
-}
-
 static inline void
 _set_mode(Debugger *self, DebuggerMode new_mode, gboolean trace_message)
 {
@@ -306,44 +143,17 @@ _set_mode(Debugger *self, DebuggerMode new_mode, gboolean trace_message)
     }
 }
 
-static gboolean
-_cmd_continue(Debugger *self, gint argc, gchar *argv[])
-{
-  _set_mode(self, DBG_WAITING_FOR_BREAKPOINT, FALSE);
-  return FALSE;
-}
-
-static gboolean
-_cmd_step(Debugger *self, gint argc, gchar *argv[])
-{
-  _set_mode(self, DBG_WAITING_FOR_STEP, FALSE);
-  return FALSE;
-}
-
-static gboolean
-_cmd_trace(Debugger *self, gint argc, gchar *argv[])
-{
-  clock_gettime(CLOCK_MONOTONIC, &self->last_trace_event);
-  _set_mode(self, DBG_FOLLOW_AND_TRACE, TRUE);
-  return FALSE;
-}
-
-static gboolean
-_cmd_follow(Debugger *self, gint argc, gchar *argv[])
-{
-  _set_mode(self, DBG_FOLLOW_AND_BREAK, TRUE);
-  return FALSE;
-}
-
-static gboolean
-_cmd_quit(Debugger *self, gint argc, gchar *argv[])
-{
-  _set_mode(self, DBG_QUIT, FALSE);
-  if (self->breakpoint_site)
-    self->breakpoint_site->drop = TRUE;
-  main_loop_exit(self->main_loop);
-  return FALSE;
-}
+#include "cmd-help.c"
+#include "cmd-print.c"
+#include "cmd-display.c"
+#include "cmd-drop.c"
+#include "cmd-info.c"
+#include "cmd-list.c"
+#include "cmd-continue.c"
+#include "cmd-step.c"
+#include "cmd-trace.c"
+#include "cmd-follow.c"
+#include "cmd-quit.c"
 
 typedef gboolean (*DebuggerCommandFunc)(Debugger *self, gint argc, gchar *argv[]);
 

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -145,6 +145,7 @@ _set_mode(Debugger *self, DebuggerMode new_mode, gboolean trace_message)
 
 #include "cmd-help.c"
 #include "cmd-print.c"
+#include "cmd-printx.c"
 #include "cmd-display.c"
 #include "cmd-drop.c"
 #include "cmd-info.c"
@@ -175,6 +176,8 @@ struct
   { "f",        _cmd_follow, .requires_breakpoint_site = TRUE },
   { "print",    _cmd_print, .requires_breakpoint_site = TRUE },
   { "p",        _cmd_print, .requires_breakpoint_site = TRUE },
+  { "printx",   _cmd_printx, .requires_breakpoint_site = TRUE },
+  { "px",       _cmd_printx, .requires_breakpoint_site = TRUE },
   { "list",     _cmd_list, },
   { "l",        _cmd_list, },
   { "display",  _cmd_display },
@@ -229,6 +232,30 @@ _fetch_command(Debugger *self)
   if (command && strlen(command) > 0)
     _set_command(self, command);
   g_free(command);
+}
+
+static void
+_setup_filterx_context(Debugger *self, FilterXEvalContext *context, FilterXScope **_scope)
+{
+  const LogPathOptions *path_options = self->breakpoint_site->path_options;
+  FilterXEvalContext *previous_context = path_options->filterx_context;
+  FilterXScope *scope = NULL;
+
+  if (previous_context)
+    scope = filterx_scope_reuse(previous_context->scope);
+
+  if (!scope)
+    *_scope = scope = filterx_scope_new(previous_context ? previous_context->scope : NULL);
+
+  filterx_eval_begin_context(context, previous_context, scope, self->breakpoint_site->msg);
+}
+
+static void
+_clear_filterx_context(Debugger *self, FilterXEvalContext *context, FilterXScope **_scope)
+{
+  if (*_scope)
+    filterx_scope_free(*_scope);
+  filterx_eval_end_context(context);
 }
 
 static gboolean
@@ -290,6 +317,12 @@ _handle_interactive_prompt(Debugger *self)
       _set_current_location(self, NULL);
       printf("  Stopping on Interrupt...\n");
     }
+
+  FilterXEvalContext temporary_context;
+  FilterXScope *scope = NULL;
+  if (self->breakpoint_site)
+    _setup_filterx_context(self, &temporary_context, &scope);
+
   while (1)
     {
       _fetch_command(self);
@@ -298,6 +331,8 @@ _handle_interactive_prompt(Debugger *self)
         break;
 
     }
+  if (self->breakpoint_site)
+    _clear_filterx_context(self, &temporary_context, &scope);
   printf("(continuing)\n");
 }
 

--- a/lib/debugger/debugger.h
+++ b/lib/debugger/debugger.h
@@ -52,8 +52,10 @@ gchar *debugger_builtin_fetch_command(void);
 void debugger_register_command_fetcher(FetchCommandFunc fetcher);
 void debugger_exit(Debugger *self);
 void debugger_start_console(Debugger *self);
-gboolean debugger_perform_tracing(Debugger *self, LogPipe *pipe, LogMessage *msg);
-gboolean debugger_stop_at_breakpoint(Debugger *self, LogPipe *pipe, LogMessage *msg);
+gboolean debugger_perform_tracing(Debugger *self, LogPipe *pipe, LogMessage *msg,
+                                  const LogPathOptions *path_options);
+gboolean debugger_stop_at_breakpoint(Debugger *self, LogPipe *pipe, LogMessage *msg,
+                                     const LogPathOptions *path_options);
 
 Debugger *debugger_new(MainLoop *main_loop, GlobalConfig *cfg);
 void debugger_free(Debugger *self);

--- a/lib/debugger/tracer.h
+++ b/lib/debugger/tracer.h
@@ -24,6 +24,7 @@
 #define DEBUGGER_TRACER_H_INCLUDED 1
 
 #include "syslog-ng.h"
+#include "logpipe.h"
 
 typedef struct _Tracer Tracer;
 
@@ -33,6 +34,7 @@ typedef struct _BreakpointSite
   gboolean resume_requested;
   LogMessage *msg;
   LogPipe *pipe;
+  const LogPathOptions *path_options;
   gboolean drop;
 } BreakpointSite;
 

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -66,7 +66,7 @@ static inline FilterXExpr *
 _args_get_expr(FilterXFunctionArgs *self, guint64 index)
 {
   /* 'retrieved' is not thread-safe */
-  main_loop_assert_main_thread();
+  g_assert(cfg_parsing_in_progress());
 
   if (self->positional_args->len <= index)
     return NULL;
@@ -411,7 +411,7 @@ FilterXExpr *
 _args_get_named_expr(FilterXFunctionArgs *self, const gchar *name)
 {
   /* 'retrieved' is not thread-safe */
-  main_loop_assert_main_thread();
+  g_assert(cfg_parsing_in_progress());
 
   FilterXFunctionArg *arg = g_hash_table_lookup(self->named_args, name);
   if (!arg)

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -276,7 +276,7 @@ filterx_expr_free_method(FilterXExpr *self)
 void
 filterx_expr_init_instance(FilterXExpr *self, const gchar *type, FilterXEffect effects)
 {
-  self->ref_cnt = 1;
+  g_atomic_counter_set(&self->ref_cnt, 1);
   self->init = filterx_expr_init_method;
   self->deinit = filterx_expr_deinit_method;
   self->move = filterx_expr_move_method;
@@ -296,24 +296,21 @@ filterx_expr_new(void)
 FilterXExpr *
 filterx_expr_ref(FilterXExpr *self)
 {
-  main_loop_assert_main_thread();
-
   if (!self)
     return NULL;
 
-  self->ref_cnt++;
+  g_atomic_counter_inc(&self->ref_cnt);
   return self;
 }
 
 void
 filterx_expr_unref(FilterXExpr *self)
 {
-  main_loop_assert_main_thread();
-
   if (!self)
     return;
 
-  if (--self->ref_cnt == 0)
+  g_assert(g_atomic_counter_get(&self->ref_cnt) > 0);
+  if (g_atomic_counter_dec_and_test(&self->ref_cnt))
     {
       g_assert(!self->inited);
       self->free_fn(self);

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -27,6 +27,7 @@
 #include "filterx-object.h"
 #include "cfg-lexer.h"
 #include "stats/stats-counter.h"
+#include "atomic.h"
 
 #define FXE_EFFECT_BITFIELD_SIZE 3
 typedef enum
@@ -49,11 +50,12 @@ typedef gboolean (*FilterXExprWalkFunc)(FilterXExpr *parent, FilterXExpr **child
 struct _FilterXExpr
 {
   StatsCounterItem *eval_count;
+  GAtomicCounter ref_cnt;
+
   /* evaluate expression */
   FilterXObject *(*eval)(FilterXExpr *self);
 
   /* not thread-safe */
-  guint32 ref_cnt;
   guint32 ignore_falsy_result:1, suppress_from_trace:1, inited:1, optimized:1, effects:FXE_EFFECT_BITFIELD_SIZE;
 
   /* not to be used except for FilterXMessageRef, replace any cached values

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -183,7 +183,7 @@ _assign_location(FilterXExpr *expr, CfgLexer *lexer, CFG_LTYPE *lloc)
 %%
 
 start
-        : block					{ *result = $1; if (yychar != FILTERX_EMPTY) { cfg_lexer_unput_token(lexer, &yylval); } YYACCEPT; }
+        : stmts					{ *result = $1; if (yychar != FILTERX_EMPTY) { cfg_lexer_unput_token(lexer, &yylval); } YYACCEPT; }
 	;
 
 block

--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -48,8 +48,6 @@ static void
 log_pipe_queue_slow_path(LogPipe *self, LogMessage *msg, const LogPathOptions *path_options)
 {
   LogPathOptions local_path_options;
-  if ((self->flags & PIF_SYNC_FILTERX_TO_MSG))
-    filterx_eval_sync_message(path_options->filterx_context, &msg, path_options);
 
   if (G_UNLIKELY(self->flags &
                  (PIF_HARD_FLOW_CONTROL | PIF_NO_HARD_FLOW_CONTROL | PIF_JUNCTION_END | PIF_CONDITIONAL_MIDPOINT)))
@@ -80,9 +78,6 @@ log_pipe_queue_slow_path(LogPipe *self, LogMessage *msg, const LogPathOptions *p
 static inline gboolean
 _is_fastpath(LogPipe *self)
 {
-  if (self->flags & PIF_SYNC_FILTERX_TO_MSG)
-    return FALSE;
-
   if (self->flags & (PIF_HARD_FLOW_CONTROL | PIF_NO_HARD_FLOW_CONTROL | PIF_JUNCTION_END | PIF_CONDITIONAL_MIDPOINT))
     return FALSE;
 
@@ -93,6 +88,9 @@ void
 log_pipe_queue(LogPipe *self, LogMessage *msg, const LogPathOptions *path_options)
 {
   g_assert((self->flags & PIF_INITIALIZED) != 0);
+
+  if ((self->flags & PIF_SYNC_FILTERX_TO_MSG))
+    filterx_eval_sync_message(path_options->filterx_context, &msg, path_options);
 
   if (G_UNLIKELY((self->flags & PIF_CONFIG_RELATED) != 0 && pipe_single_step_hook))
     {


### PR DESCRIPTION
This PR adds support for the printx/px commands to the debugger which evaluates a filterx expression.

This should go in after #546, #547 and #340

