### PR TITLE
filterx: add `Expr::init()` and `Expr::deinit()` and optimize `update_metric()` in `init()`

### DIFF
--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -35,6 +35,42 @@ struct _FilterXConditional
   FilterXExpr *false_branch;
 };
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXConditional *self = (FilterXConditional *) s;
+
+  if (!filterx_expr_init(self->condition, cfg))
+    return FALSE;
+
+  if (!filterx_expr_init(self->true_branch, cfg))
+    {
+      filterx_expr_deinit(self->condition, cfg);
+      return FALSE;
+    }
+
+  if (!filterx_expr_init(self->false_branch, cfg))
+    {
+      filterx_expr_deinit(self->condition, cfg);
+      filterx_expr_deinit(self->true_branch, cfg);
+      return FALSE;
+    }
+
+  return filterx_expr_init_method(s, cfg);
+}
+
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXConditional *self = (FilterXConditional *) s;
+
+  filterx_expr_deinit(self->condition, cfg);
+  filterx_expr_deinit(self->true_branch, cfg);
+  filterx_expr_deinit(self->false_branch, cfg);
+  filterx_expr_deinit_method(s, cfg);
+}
+
 static void
 _free(FilterXExpr *s)
 {
@@ -119,6 +155,8 @@ filterx_conditional_new(FilterXExpr *condition)
   FilterXConditional *self = g_new0(FilterXConditional, 1);
   filterx_expr_init_instance(&self->super);
   self->super.eval = _eval;
+  self->super.init = _init;
+  self->super.deinit = _deinit;
   self->super.free_fn = _free;
   self->super.suppress_from_trace = TRUE;
   self->condition = condition;

--- a/lib/filterx/expr-function.h
+++ b/lib/filterx/expr-function.h
@@ -69,7 +69,11 @@ enum FilterXFunctionError
 };
 
 void filterx_function_init_instance(FilterXFunction *s, const gchar *function_name);
+gboolean filterx_function_init_method(FilterXFunction *s, GlobalConfig *cfg);
+void filterx_function_deinit_method(FilterXFunction *s, GlobalConfig *cfg);
 void filterx_function_free_method(FilterXFunction *s);
+gboolean filterx_generator_function_init_method(FilterXGeneratorFunction *s, GlobalConfig *cfg);
+void filterx_generator_function_deinit_method(FilterXGeneratorFunction *s, GlobalConfig *cfg);
 void filterx_generator_function_init_instance(FilterXGeneratorFunction *s, const gchar *function_name);
 void filterx_generator_function_free_method(FilterXGeneratorFunction *s);
 

--- a/lib/filterx/expr-generator.h
+++ b/lib/filterx/expr-generator.h
@@ -37,6 +37,8 @@ struct FilterXExprGenerator_
 
 void filterx_generator_set_fillable(FilterXExpr *s, FilterXExpr *fillable);
 void filterx_generator_init_instance(FilterXExpr *s);
+gboolean filterx_generator_init_method(FilterXExpr *s, GlobalConfig *cfg);
+void filterx_generator_deinit_method(FilterXExpr *s, GlobalConfig *cfg);
 void filterx_generator_free_method(FilterXExpr *s);
 gboolean filterx_expr_is_generator(FilterXExpr *s);
 

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -103,6 +103,33 @@ exit:
   return result;
 }
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXGetSubscript *self = (FilterXGetSubscript *) s;
+
+  if (!filterx_expr_init(self->operand, cfg))
+    return FALSE;
+
+  if (!filterx_expr_init(self->key, cfg))
+    {
+      filterx_expr_deinit(self->operand, cfg);
+      return FALSE;
+    }
+
+  return filterx_expr_init_method(s, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXGetSubscript *self = (FilterXGetSubscript *) s;
+
+  filterx_expr_deinit(self->operand, cfg);
+  filterx_expr_deinit(self->key, cfg);
+  filterx_expr_deinit_method(s, cfg);
+}
+
 static void
 _free(FilterXExpr *s)
 {
@@ -122,6 +149,8 @@ filterx_get_subscript_new(FilterXExpr *operand, FilterXExpr *key)
   self->super.eval = _eval;
   self->super.is_set = _isset;
   self->super.unset = _unset;
+  self->super.init = _init;
+  self->super.deinit = _deinit;
   self->super.free_fn = _free;
   self->operand = operand;
   self->key = key;

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -90,6 +90,25 @@ _isset(FilterXExpr *s)
   return result;
 }
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXGetAttr *self = (FilterXGetAttr *) s;
+
+  if (!filterx_expr_init(self->operand, cfg))
+    return FALSE;
+
+  return filterx_expr_init_method(s, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXGetAttr *self = (FilterXGetAttr *) s;
+
+  filterx_expr_deinit(self->operand, cfg);
+  filterx_expr_deinit_method(s, cfg);
+}
 
 static void
 _free(FilterXExpr *s)
@@ -110,6 +129,8 @@ filterx_getattr_new(FilterXExpr *operand, FilterXString *attr_name)
   self->super.eval = _eval;
   self->super.unset = _unset;
   self->super.is_set = _isset;
+  self->super.init = _init;
+  self->super.deinit = _deinit;
   self->super.free_fn = _free;
   self->operand = operand;
 

--- a/lib/filterx/expr-plus-generator.c
+++ b/lib/filterx/expr-plus-generator.c
@@ -100,6 +100,31 @@ _expr_plus_generator_create_container(FilterXExprGenerator *s, FilterXExpr *fill
   return generator->create_container(generator, fillable_parent);
 }
 
+static gboolean
+_expr_plus_generator_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXOperatorPlusGenerator *self = (FilterXOperatorPlusGenerator *) s;
+
+  if (!filterx_expr_init(self->lhs, cfg))
+    return FALSE;
+
+  if (!filterx_expr_init(self->rhs, cfg))
+    {
+      filterx_expr_deinit(self->lhs, cfg);
+      return FALSE;
+    }
+  return filterx_generator_init_method(s, cfg);
+}
+
+static void
+_expr_plus_generator_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXOperatorPlusGenerator *self = (FilterXOperatorPlusGenerator *) s;
+  filterx_expr_deinit(self->lhs, cfg);
+  filterx_expr_deinit(self->rhs, cfg);
+  filterx_generator_deinit_method(s, cfg);
+}
+
 static void
 _expr_plus_generator_free(FilterXExpr *s)
 {
@@ -117,6 +142,8 @@ filterx_operator_plus_generator_new(FilterXExpr *lhs, FilterXExpr *rhs)
   self->lhs = lhs;
   self->rhs = rhs;
   self->super.generate = _expr_plus_generator_generate;
+  self->super.super.init = _expr_plus_generator_init;
+  self->super.super.deinit = _expr_plus_generator_deinit;
   self->super.super.free_fn = _expr_plus_generator_free;
   self->super.create_container = _expr_plus_generator_create_container;
 

--- a/lib/filterx/expr-regexp.c
+++ b/lib/filterx/expr-regexp.c
@@ -315,6 +315,26 @@ exit:
   return result;
 }
 
+static gboolean
+_regexp_match_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXExprRegexpMatch *self = (FilterXExprRegexpMatch *) s;
+
+  if (!filterx_expr_init(self->lhs, cfg))
+    return FALSE;
+
+  return filterx_expr_init_method(s, cfg);
+}
+
+static void
+_regexp_match_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXExprRegexpMatch *self = (FilterXExprRegexpMatch *) s;
+
+  filterx_expr_deinit(self->lhs, cfg);
+  filterx_expr_deinit_method(s, cfg);
+}
+
 static void
 _regexp_match_free(FilterXExpr *s)
 {
@@ -334,6 +354,8 @@ filterx_expr_regexp_match_new(FilterXExpr *lhs, const gchar *pattern)
 
   filterx_expr_init_instance(&self->super);
   self->super.eval = _regexp_match_eval;
+  self->super.init = _regexp_match_init;
+  self->super.deinit = _regexp_match_deinit;
   self->super.free_fn = _regexp_match_free;
 
   self->lhs = lhs;
@@ -403,6 +425,26 @@ _regexp_search_generator_create_container(FilterXExprGenerator *s, FilterXExpr *
   return filterx_generator_create_list_container(s, fillable_parent);
 }
 
+static gboolean
+_regexp_search_generator_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXExprRegexpSearchGenerator *self = (FilterXExprRegexpSearchGenerator *) s;
+
+  if (!filterx_expr_init(self->lhs, cfg))
+    return FALSE;
+
+  return filterx_generator_init_method(s, cfg);
+}
+
+static void
+_regexp_search_generator_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXExprRegexpSearchGenerator *self = (FilterXExprRegexpSearchGenerator *) s;
+
+  filterx_expr_deinit(self->lhs, cfg);
+  filterx_generator_deinit_method(s, cfg);
+}
+
 static void
 _regexp_search_generator_free(FilterXExpr *s)
 {
@@ -454,6 +496,8 @@ filterx_generator_function_regexp_search_new(FilterXFunctionArgs *args, GError *
 
   filterx_generator_function_init_instance(&self->super, "regexp_search");
   self->super.super.generate = _regexp_search_generator_generate;
+  self->super.super.super.init = _regexp_search_generator_init;
+  self->super.super.super.deinit = _regexp_search_generator_deinit;
   self->super.super.super.free_fn = _regexp_search_generator_free;
   self->super.super.create_container = _regexp_search_generator_create_container;
 
@@ -677,6 +721,25 @@ _extract_subst_args(FilterXFuncRegexpSubst *self, FilterXFunctionArgs *args, GEr
   return TRUE;
 }
 
+static gboolean
+_subst_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFuncRegexpSubst *self = (FilterXFuncRegexpSubst *) s;
+
+  if (!filterx_expr_init(self->string_expr, cfg))
+    return FALSE;
+
+  return filterx_function_init_method(&self->super, cfg);
+}
+
+static void
+_subst_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFuncRegexpSubst *self = (FilterXFuncRegexpSubst *) s;
+  filterx_expr_deinit(self->string_expr, cfg);
+  filterx_function_deinit_method(&self->super, cfg);
+}
+
 static void
 _subst_free(FilterXExpr *s)
 {
@@ -701,6 +764,8 @@ filterx_function_regexp_subst_new(FilterXFunctionArgs *args, GError **error)
   FilterXFuncRegexpSubst *self = g_new0(FilterXFuncRegexpSubst, 1);
   filterx_function_init_instance(&self->super, "regexp_subst");
   self->super.super.eval = _subst_eval;
+  self->super.super.init = _subst_init;
+  self->super.super.deinit = _subst_deinit;
   self->super.super.free_fn = _subst_free;
 
   _opts_init(&self->opts);

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -93,6 +93,41 @@ exit:
   return result;
 }
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXSetSubscript *self = (FilterXSetSubscript *) s;
+
+  if (!filterx_expr_init(self->object, cfg))
+    return FALSE;
+
+  if (!filterx_expr_init(self->new_value, cfg))
+    {
+      filterx_expr_deinit(self->object, cfg);
+      return FALSE;
+    }
+
+  if (!filterx_expr_init(self->key, cfg))
+    {
+      filterx_expr_deinit(self->object, cfg);
+      filterx_expr_deinit(self->new_value, cfg);
+      return FALSE;
+    }
+
+  return filterx_expr_init_method(s, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXSetSubscript *self = (FilterXSetSubscript *) s;
+
+  filterx_expr_deinit(self->object, cfg);
+  filterx_expr_deinit(self->new_value, cfg);
+  filterx_expr_deinit(self->key, cfg);
+  filterx_expr_deinit_method(s, cfg);
+}
+
 static void
 _free(FilterXExpr *s)
 {
@@ -111,6 +146,8 @@ filterx_set_subscript_new(FilterXExpr *object, FilterXExpr *key, FilterXExpr *ne
 
   filterx_expr_init_instance(&self->super);
   self->super.eval = _eval;
+  self->super.init = _init;
+  self->super.deinit = _deinit;
   self->super.free_fn = _free;
   self->object = object;
   self->key = key;

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -80,6 +80,33 @@ exit:
   return result;
 }
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXSetAttr *self = (FilterXSetAttr *) s;
+
+  if (!filterx_expr_init(self->object, cfg))
+    return FALSE;
+
+  if (!filterx_expr_init(self->new_value, cfg))
+    {
+      filterx_expr_deinit(self->object, cfg);
+      return FALSE;
+    }
+
+  return filterx_expr_init_method(s, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXSetAttr *self = (FilterXSetAttr *) s;
+
+  filterx_expr_deinit(self->object, cfg);
+  filterx_expr_deinit(self->new_value, cfg);
+  filterx_expr_deinit_method(s, cfg);
+}
+
 static void
 _free(FilterXExpr *s)
 {
@@ -99,6 +126,8 @@ filterx_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterXExpr *
 
   filterx_expr_init_instance(&self->super);
   self->super.eval = _eval;
+  self->super.init = _init;
+  self->super.deinit = _deinit;
   self->super.free_fn = _free;
   self->object = object;
 

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -119,6 +119,26 @@ filterx_expr_unref(FilterXExpr *self)
     }
 }
 
+gboolean
+filterx_unary_op_init_method(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXUnaryOp *self = (FilterXUnaryOp *) s;
+
+  if (!filterx_expr_init(self->operand, cfg))
+    return FALSE;
+
+  return filterx_expr_init_method(s, cfg);
+}
+
+void
+filterx_unary_op_deinit_method(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXUnaryOp *self = (FilterXUnaryOp *) s;
+
+  filterx_expr_deinit(self->operand, cfg);
+  filterx_expr_deinit_method(s, cfg);
+}
+
 void
 filterx_unary_op_free_method(FilterXExpr *s)
 {
@@ -132,6 +152,8 @@ void
 filterx_unary_op_init_instance(FilterXUnaryOp *self, FilterXExpr *operand)
 {
   filterx_expr_init_instance(&self->super);
+  self->super.init = filterx_unary_op_init_method;
+  self->super.deinit = filterx_unary_op_deinit_method;
   self->super.free_fn = filterx_unary_op_free_method;
   self->operand = operand;
 }
@@ -146,10 +168,36 @@ filterx_binary_op_free_method(FilterXExpr *s)
   filterx_expr_free_method(s);
 }
 
+gboolean
+filterx_binary_op_init_method(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXBinaryOp *self = (FilterXBinaryOp *) s;
+
+  if (!filterx_expr_init(self->lhs, cfg))
+    return FALSE;
+
+  if (!filterx_expr_init(self->rhs, cfg))
+    return FALSE;
+
+  return filterx_expr_init_method(s, cfg);
+}
+
+void
+filterx_binary_op_deinit_method(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXBinaryOp *self = (FilterXBinaryOp *) s;
+
+  filterx_expr_deinit(self->lhs, cfg);
+  filterx_expr_deinit(self->rhs, cfg);
+  filterx_expr_deinit_method(s, cfg);
+}
+
 void
 filterx_binary_op_init_instance(FilterXBinaryOp *self, FilterXExpr *lhs, FilterXExpr *rhs)
 {
   filterx_expr_init_instance(&self->super);
+  self->super.init = filterx_binary_op_init_method;
+  self->super.deinit = filterx_binary_op_deinit_method;
   self->super.free_fn = filterx_binary_op_free_method;
   g_assert(lhs);
   g_assert(rhs);

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -58,6 +58,17 @@ filterx_expr_format_location_tag(FilterXExpr *self)
     return evt_tag_str("expr", "n/a");
 }
 
+gboolean
+filterx_expr_init_method(FilterXExpr *self, GlobalConfig *cfg)
+{
+  return TRUE;
+}
+
+void
+filterx_expr_deinit_method(FilterXExpr *self, GlobalConfig *cfg)
+{
+}
+
 void
 filterx_expr_free_method(FilterXExpr *self)
 {
@@ -68,6 +79,8 @@ void
 filterx_expr_init_instance(FilterXExpr *self)
 {
   self->ref_cnt = 1;
+  self->init = filterx_expr_init_method;
+  self->deinit = filterx_expr_deinit_method;
   self->free_fn = filterx_expr_free_method;
 }
 

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -187,6 +187,8 @@ typedef struct _FilterXUnaryOp
   FilterXExpr *operand;
 } FilterXUnaryOp;
 
+gboolean filterx_unary_op_init_method(FilterXExpr *s, GlobalConfig *cfg);
+void filterx_unary_op_deinit_method(FilterXExpr *s, GlobalConfig *cfg);
 void filterx_unary_op_free_method(FilterXExpr *s);
 void filterx_unary_op_init_instance(FilterXUnaryOp *self, FilterXExpr *operand);
 
@@ -196,6 +198,8 @@ typedef struct _FilterXBinaryOp
   FilterXExpr *lhs, *rhs;
 } FilterXBinaryOp;
 
+gboolean filterx_binary_op_init_method(FilterXExpr *s, GlobalConfig *cfg);
+void filterx_binary_op_deinit_method(FilterXExpr *s, GlobalConfig *cfg);
 void filterx_binary_op_free_method(FilterXExpr *s);
 void filterx_binary_op_init_instance(FilterXBinaryOp *self, FilterXExpr *lhs, FilterXExpr *rhs);
 

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -49,7 +49,12 @@ struct _FilterXExpr
   /* unset the expression */
   gboolean (*unset)(FilterXExpr *self);
 
+  gboolean (*init)(FilterXExpr *self, GlobalConfig *cfg);
+  void (*deinit)(FilterXExpr *self, GlobalConfig *cfg);
   void (*free_fn)(FilterXExpr *self);
+
+  gboolean inited;
+
   CFG_LTYPE lloc;
   gchar *expr_text;
 };
@@ -145,7 +150,36 @@ void filterx_expr_init_instance(FilterXExpr *self);
 FilterXExpr *filterx_expr_new(void);
 FilterXExpr *filterx_expr_ref(FilterXExpr *self);
 void filterx_expr_unref(FilterXExpr *self);
+gboolean filterx_expr_init_method(FilterXExpr *self, GlobalConfig *cfg);
+void filterx_expr_deinit_method(FilterXExpr *self, GlobalConfig *cfg);
 void filterx_expr_free_method(FilterXExpr *self);
+
+static inline gboolean
+filterx_expr_init(FilterXExpr *self, GlobalConfig *cfg)
+{
+  if (!self || self->inited)
+    return TRUE;
+
+  if (!self->init || self->init(self, cfg))
+    {
+      self->inited = TRUE;
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
+static inline void
+filterx_expr_deinit(FilterXExpr *self, GlobalConfig *cfg)
+{
+  if (!self || !self->inited)
+    return;
+
+  if (self->deinit)
+    self->deinit(self, cfg);
+
+  self->inited = FALSE;
+}
 
 typedef struct _FilterXUnaryOp
 {

--- a/lib/filterx/filterx-metrics-labels.h
+++ b/lib/filterx/filterx-metrics-labels.h
@@ -30,6 +30,8 @@
 typedef struct _FilterXMetricsLabels FilterXMetricsLabels;
 
 FilterXMetricsLabels *filterx_metrics_labels_new(FilterXExpr *labels);
+gboolean filterx_metrics_labels_init(FilterXMetricsLabels *self, GlobalConfig *cfg);
+void filterx_metrics_labels_deinit(FilterXMetricsLabels *self, GlobalConfig *cfg);
 void filterx_metrics_labels_free(FilterXMetricsLabels *self);
 
 gboolean filterx_metrics_labels_format(FilterXMetricsLabels *self, StatsClusterLabel **labels, gsize *len);

--- a/lib/filterx/filterx-metrics.c
+++ b/lib/filterx/filterx-metrics.c
@@ -179,6 +179,28 @@ exit:
   return success;
 }
 
+gboolean
+filterx_metrics_init(FilterXMetrics *self, GlobalConfig *cfg)
+{
+  if (!filterx_expr_init(self->key.expr, cfg))
+    return FALSE;
+
+  if (!filterx_metrics_labels_init(self->labels, cfg))
+    {
+      filterx_expr_deinit(self->key.expr, cfg);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+void
+filterx_metrics_deinit(FilterXMetrics *self, GlobalConfig *cfg)
+{
+  filterx_expr_deinit(self->key.expr, cfg);
+  filterx_metrics_labels_deinit(self->labels, cfg);
+}
+
 void
 filterx_metrics_free(FilterXMetrics *self)
 {

--- a/lib/filterx/filterx-metrics.h
+++ b/lib/filterx/filterx-metrics.h
@@ -34,6 +34,8 @@ gboolean filterx_metrics_is_enabled(FilterXMetrics *self);
 gboolean filterx_metrics_get_stats_counter(FilterXMetrics *self, StatsCounterItem **counter);
 
 FilterXMetrics *filterx_metrics_new(gint level, FilterXExpr *key, FilterXExpr *labels);
+gboolean filterx_metrics_init(FilterXMetrics *self, GlobalConfig *cfg);
+void filterx_metrics_deinit(FilterXMetrics *self, GlobalConfig *cfg);
 void filterx_metrics_free(FilterXMetrics *self);
 
 #endif

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -41,9 +41,21 @@ log_filterx_pipe_init(LogPipe *s)
   if (!self->name)
     self->name = cfg_tree_get_rule_name(&cfg->tree, ENC_FILTER, s->expr_node);
 
+  if (!filterx_expr_init(self->block, cfg))
+    return FALSE;
+
   return TRUE;
 }
 
+static gboolean
+log_filterx_pipe_deinit(LogPipe *s)
+{
+  LogFilterXPipe *self = (LogFilterXPipe *) s;
+  GlobalConfig *cfg = log_pipe_get_config(s);
+
+  filterx_expr_deinit(self->block, cfg);
+  return TRUE;
+}
 
 static void
 log_filterx_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
@@ -127,6 +139,7 @@ log_filterx_pipe_new(FilterXExpr *block, GlobalConfig *cfg)
   log_pipe_init_instance(&self->super, cfg);
   self->super.flags = (self->super.flags | PIF_CONFIG_RELATED);
   self->super.init = log_filterx_pipe_init;
+  self->super.deinit = log_filterx_pipe_deinit;
   self->super.queue = log_filterx_pipe_queue;
   self->super.free_fn = log_filterx_pipe_free;
   self->super.clone = log_filterx_pipe_clone;

--- a/lib/filterx/func-flatten.c
+++ b/lib/filterx/func-flatten.c
@@ -208,6 +208,26 @@ exit:
   return result ? filterx_boolean_new(TRUE) : NULL;
 }
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionFlatten *self = (FilterXFunctionFlatten *) s;
+
+  if (!filterx_expr_init(self->dict_expr, cfg))
+    return FALSE;
+
+  return filterx_function_init_method(&self->super, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionFlatten *self = (FilterXFunctionFlatten *) s;
+
+  filterx_expr_deinit(self->dict_expr, cfg);
+  filterx_function_deinit_method(&self->super, cfg);
+}
+
 static void
 _free(FilterXExpr *s)
 {
@@ -262,6 +282,8 @@ filterx_function_flatten_new(FilterXFunctionArgs *args, GError **error)
   FilterXFunctionFlatten *self = g_new0(FilterXFunctionFlatten, 1);
   filterx_function_init_instance(&self->super, "flatten");
   self->super.super.eval = _eval;
+  self->super.super.init = _init;
+  self->super.super.deinit = _deinit;
   self->super.super.free_fn = _free;
 
   if (!_extract_args(self, args, error))

--- a/lib/filterx/func-istype.c
+++ b/lib/filterx/func-istype.c
@@ -59,6 +59,25 @@ _eval(FilterXExpr *s)
   return filterx_boolean_new(result);
 }
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionIsType *self = (FilterXFunctionIsType *) s;
+
+  if (!filterx_expr_init(self->object_expr, cfg))
+    return FALSE;
+
+  return filterx_function_init_method(&self->super, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionIsType *self = (FilterXFunctionIsType *) s;
+  filterx_expr_deinit(self->object_expr, cfg);
+  filterx_function_deinit_method(&self->super, cfg);
+}
+
 static void
 _free(FilterXExpr *s)
 {
@@ -130,6 +149,8 @@ filterx_function_istype_new(FilterXFunctionArgs *args, GError **error)
   FilterXFunctionIsType *self = g_new0(FilterXFunctionIsType, 1);
   filterx_function_init_instance(&self->super, "istype");
   self->super.super.eval = _eval;
+  self->super.super.init = _init;
+  self->super.super.deinit = _deinit;
   self->super.super.free_fn = _free;
 
   if (!_extract_args(self, args, error) ||

--- a/lib/filterx/func-str.c
+++ b/lib/filterx/func-str.c
@@ -217,6 +217,33 @@ _expr_affix_init_needle(FilterXExprAffix *self)
   return TRUE;
 }
 
+static gboolean
+_expr_affix_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXExprAffix *self = (FilterXExprAffix *) s;
+
+  if (!filterx_expr_init(self->haystack, cfg))
+    return FALSE;
+
+  if (!filterx_expr_init(self->needle.expr, cfg))
+    {
+      filterx_expr_deinit(self->haystack, cfg);
+      return FALSE;
+    }
+
+  return filterx_function_init_method(&self->super, cfg);
+}
+
+static void
+_expr_affix_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXExprAffix *self = (FilterXExprAffix *) s;
+
+  filterx_expr_deinit(self->haystack, cfg);
+  filterx_expr_deinit(self->needle.expr, cfg);
+  filterx_function_deinit_method(&self->super, cfg);
+}
+
 static void
 _expr_affix_free(FilterXExpr *s)
 {
@@ -376,6 +403,8 @@ _function_affix_new(FilterXFunctionArgs *args,
 
   filterx_function_init_instance(&self->super, affix_name);
   self->super.super.eval = _expr_affix_eval;
+  self->super.super.init = _expr_affix_init;
+  self->super.super.deinit = _expr_affix_deinit;
   self->super.super.free_fn = _expr_affix_free;
 
   self->needle.cached_strings = g_ptr_array_new_with_free_func((GDestroyNotify) _string_with_cache_free);

--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -248,6 +248,26 @@ _eval(FilterXExpr *s)
   return success ? filterx_boolean_new(TRUE) : NULL;
 }
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionUnsetEmpties *self = (FilterXFunctionUnsetEmpties *) s;
+
+  if (!filterx_expr_init_method(self->object_expr, cfg))
+    return FALSE;
+
+  return filterx_function_init_method(&self->super, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionUnsetEmpties *self = (FilterXFunctionUnsetEmpties *) s;
+
+  filterx_expr_deinit(self->object_expr, cfg);
+  filterx_function_deinit_method(&self->super, cfg);
+}
+
 static void
 _free(FilterXExpr *s)
 {
@@ -486,6 +506,8 @@ filterx_function_unset_empties_new(FilterXFunctionArgs *args, GError **error)
   FilterXFunctionUnsetEmpties *self = g_new0(FilterXFunctionUnsetEmpties, 1);
   filterx_function_init_instance(&self->super, "unset_empties");
   self->super.super.eval = _eval;
+  self->super.super.init = _init;
+  self->super.super.deinit = _deinit;
   self->super.super.free_fn = _free;
 
   reset_flags(&self->flags, ALL_FLAG_SET(FilterXFunctionUnsetEmptiesFlags));

--- a/modules/cef/event-format-parser.c
+++ b/modules/cef/event-format-parser.c
@@ -279,6 +279,25 @@ exit:
   return ok;
 }
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionEventFormatParser *self = (FilterXFunctionEventFormatParser *) s;
+
+  if (!filterx_expr_init(self->msg, cfg))
+    return FALSE;
+
+  return filterx_generator_init_method(s, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionEventFormatParser *self = (FilterXFunctionEventFormatParser *) s;
+  filterx_expr_deinit(self->msg, cfg);
+  filterx_generator_deinit_method(s, cfg);
+}
+
 static void
 _free(FilterXExpr *s)
 {
@@ -383,6 +402,8 @@ filterx_function_parser_init_instance(FilterXFunctionEventFormatParser *self, co
   filterx_generator_function_init_instance(&self->super, fn_name);
   self->super.super.generate = _generate;
   self->super.super.create_container = filterx_generator_create_dict_container;
+  self->super.super.super.init = _init;
+  self->super.super.super.deinit = _deinit;
   self->super.super.super.free_fn = _free;
 
   _set_config(self, cfg);

--- a/modules/csvparser/filterx-func-format-csv.c
+++ b/modules/csvparser/filterx-func-format-csv.c
@@ -164,6 +164,33 @@ _eval(FilterXExpr *s)
   return success ? filterx_string_new(formatted->str, formatted->len) : NULL;
 }
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionFormatCSV *self = (FilterXFunctionFormatCSV *) s;
+
+  if (!filterx_expr_init(self->input, cfg))
+    return FALSE;
+
+  if (!filterx_expr_init(self->columns, cfg))
+    {
+      filterx_expr_deinit(self->input, cfg);
+      return FALSE;
+    }
+
+  return filterx_function_init_method(&self->super, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionFormatCSV *self = (FilterXFunctionFormatCSV *) s;
+
+  filterx_expr_deinit(self->input, cfg);
+  filterx_expr_deinit(self->columns, cfg);
+  filterx_function_deinit_method(&self->super, cfg);
+}
+
 static void
 _free(FilterXExpr *s)
 {
@@ -271,6 +298,8 @@ filterx_function_format_csv_new(FilterXFunctionArgs *args, GError **error)
   filterx_function_init_instance(&self->super, "format_csv");
 
   self->super.super.eval = _eval;
+  self->super.super.init = _init;
+  self->super.super.deinit = _deinit;
   self->super.super.free_fn = _free;
   self->delimiter = ',';
   self->default_value = filterx_string_new("", -1);

--- a/modules/csvparser/filterx-func-parse-csv.c
+++ b/modules/csvparser/filterx-func-parse-csv.c
@@ -282,6 +282,40 @@ exit:
   return ok;
 }
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionParseCSV *self = (FilterXFunctionParseCSV *) s;
+
+  if (!filterx_expr_init(self->msg, cfg))
+    return FALSE;
+
+  if (!filterx_expr_init(self->columns.expr, cfg))
+    {
+      filterx_expr_deinit(self->msg, cfg);
+      return FALSE;
+    }
+
+  if (!filterx_expr_init(self->string_delimiters, cfg))
+    {
+      filterx_expr_deinit(self->msg, cfg);
+      filterx_expr_deinit(self->columns.expr, cfg);
+      return FALSE;
+    }
+
+  return filterx_generator_function_init_method(&self->super, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionParseCSV *self = (FilterXFunctionParseCSV *) s;
+  filterx_expr_deinit(self->msg, cfg);
+  filterx_expr_deinit(self->columns.expr, cfg);
+  filterx_expr_deinit(self->string_delimiters, cfg);
+  filterx_generator_function_deinit_method(&self->super, cfg);
+}
+
 static void
 _free(FilterXExpr *s)
 {
@@ -505,6 +539,8 @@ filterx_function_parse_csv_new(FilterXFunctionArgs *args, GError **error)
   filterx_generator_function_init_instance(&self->super, "parse_csv");
   self->super.super.generate = _generate;
   self->super.super.create_container = _create_container;
+  self->super.super.super.init = _init;
+  self->super.super.super.deinit = _deinit;
   self->super.super.super.free_fn = _free;
   csv_scanner_options_set_delimiters(&self->options, ",");
   csv_scanner_options_set_quote_pairs(&self->options, "\"\"''");

--- a/modules/kvformat/filterx-func-format-kv.c
+++ b/modules/kvformat/filterx-func-format-kv.c
@@ -116,6 +116,26 @@ _eval(FilterXExpr *s)
   return success ? filterx_string_new(formatted->str, formatted->len) : NULL;
 }
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionFormatKV *self = (FilterXFunctionFormatKV *) s;
+
+  if (!filterx_expr_init(self->kvs, cfg))
+    return FALSE;
+
+  return filterx_function_init_method(&self->super, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionFormatKV *self = (FilterXFunctionFormatKV *) s;
+
+  filterx_expr_deinit(self->kvs, cfg);
+  filterx_function_deinit_method(&self->super, cfg);
+}
+
 static void
 _free(FilterXExpr *s)
 {
@@ -218,6 +238,8 @@ filterx_function_format_kv_new(FilterXFunctionArgs *args, GError **error)
   filterx_function_init_instance(&self->super, "format_kv");
 
   self->super.super.eval = _eval;
+  self->super.super.init = _init;
+  self->super.super.deinit = _deinit;
   self->super.super.free_fn = _free;
   self->value_separator = '=';
   self->pair_separator = g_strdup(", ");

--- a/modules/kvformat/filterx-func-parse-kv.c
+++ b/modules/kvformat/filterx-func-parse-kv.c
@@ -145,6 +145,25 @@ exit:
   return result;
 }
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionParseKV *self = (FilterXFunctionParseKV *) s;
+
+  if (!filterx_expr_init(self->msg, cfg))
+    return FALSE;
+
+  return filterx_generator_function_init_method(&self->super, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionParseKV *self = (FilterXFunctionParseKV *) s;
+  filterx_expr_deinit(self->msg, cfg);
+  filterx_generator_function_deinit_method(&self->super, cfg);
+}
+
 static void
 _free(FilterXExpr *s)
 {
@@ -255,6 +274,8 @@ filterx_function_parse_kv_new(FilterXFunctionArgs *args, GError **error)
   filterx_generator_function_init_instance(&self->super, "parse_kv");
   self->super.super.generate = _generate;
   self->super.super.create_container = filterx_generator_create_dict_container;
+  self->super.super.super.init = _init;
+  self->super.super.super.deinit = _deinit;
   self->super.super.super.free_fn = _free;
   self->value_separator = '=';
   self->pair_separator = g_strdup(", ");

--- a/modules/metrics-probe/tests/test_filterx_func_update_metric.c
+++ b/modules/metrics-probe/tests/test_filterx_func_update_metric.c
@@ -95,6 +95,7 @@ Test(filterx_func_update_metric, key_and_labels)
   _add_label(labels, "test_label_1", "foo");
   _add_label(labels, "test_label_2", "bar");
   FilterXExpr *func = _create_func(key, labels, NULL, NULL);
+  cr_assert(filterx_expr_init(func, configuration));
 
   StatsClusterLabel expected_labels[] =
   {
@@ -115,6 +116,7 @@ Test(filterx_func_update_metric, key_and_labels)
                                           G_N_ELEMENTS(expected_labels),
                                           2);
 
+  filterx_expr_deinit(func, configuration);
   filterx_expr_unref(func);
 }
 
@@ -122,6 +124,7 @@ Test(filterx_func_update_metric, increment)
 {
   FilterXExpr *key = filterx_literal_new(filterx_string_new("test_key", -1));
   FilterXExpr *func = _create_func(key, NULL, filterx_non_literal_new(filterx_integer_new(42)), NULL);
+  cr_assert(filterx_expr_init(func, configuration));
 
   StatsClusterLabel expected_labels[] = {};
 
@@ -137,6 +140,7 @@ Test(filterx_func_update_metric, increment)
                                           G_N_ELEMENTS(expected_labels),
                                           84);
 
+  filterx_expr_deinit(func, configuration);
   filterx_expr_unref(func);
 }
 
@@ -149,7 +153,9 @@ Test(filterx_func_update_metric, level)
   cr_assert(cfg_init(configuration));
   func = _create_func(filterx_literal_new(filterx_string_new("test_key", -1)), NULL, NULL,
                       filterx_literal_new(filterx_integer_new(2)));
+  cr_assert(filterx_expr_init(func, configuration));
   cr_assert(_eval(func));
+  filterx_expr_deinit(func, configuration);
   filterx_expr_unref(func);
   cr_assert_not(metrics_probe_test_stats_cluster_exists("test_key", expected_labels, G_N_ELEMENTS(expected_labels)));
   cr_assert(cfg_deinit(configuration));
@@ -158,7 +164,9 @@ Test(filterx_func_update_metric, level)
   cr_assert(cfg_init(configuration));
   func = _create_func(filterx_literal_new(filterx_string_new("test_key", -1)), NULL, NULL,
                       filterx_literal_new(filterx_integer_new(2)));
+  cr_assert(filterx_expr_init(func, configuration));
   cr_assert(_eval(func));
+  filterx_expr_deinit(func, configuration);
   filterx_expr_unref(func);
   cr_assert_not(metrics_probe_test_stats_cluster_exists("test_key", expected_labels, G_N_ELEMENTS(expected_labels)));
   cr_assert(cfg_deinit(configuration));
@@ -167,7 +175,9 @@ Test(filterx_func_update_metric, level)
   cr_assert(cfg_init(configuration));
   func = _create_func(filterx_literal_new(filterx_string_new("test_key", -1)), NULL, NULL,
                       filterx_literal_new(filterx_integer_new(2)));
+  cr_assert(filterx_expr_init(func, configuration));
   cr_assert(_eval(func));
+  filterx_expr_deinit(func, configuration);
   filterx_expr_unref(func);
   metrics_probe_test_assert_counter_value("test_key",
                                           expected_labels,

--- a/modules/xml/filterx-parse-xml.c
+++ b/modules/xml/filterx-parse-xml.c
@@ -710,6 +710,26 @@ _extract_args(FilterXGeneratorFunctionParseXml *self, FilterXFunctionArgs *args,
   return TRUE;
 }
 
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXGeneratorFunctionParseXml *self = (FilterXGeneratorFunctionParseXml *) s;
+
+  if (!filterx_expr_init(self->xml_expr, cfg))
+    return FALSE;
+
+  return filterx_generator_function_init_method(&self->super, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXGeneratorFunctionParseXml *self = (FilterXGeneratorFunctionParseXml *) s;
+
+  filterx_expr_deinit(self->xml_expr, cfg);
+  filterx_generator_function_deinit_method(&self->super, cfg);
+}
+
 static void
 _free(FilterXExpr *s)
 {
@@ -727,6 +747,8 @@ filterx_generator_function_parse_xml_new(FilterXFunctionArgs *args, GError **err
   filterx_generator_function_init_instance(&self->super, "parse_xml");
   self->super.super.generate = _generate;
   self->super.super.create_container = filterx_generator_create_dict_container;
+  self->super.super.super.init = _init;
+  self->super.super.super.deinit = _deinit;
   self->super.super.super.free_fn = _free;
 
   self->create_state = _state_new;


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
