### PR TITLE
add date heuristics of wallclocktime to strptime in filterx

### DIFF
--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -282,6 +282,8 @@ _strptime_eval(FilterXExpr *s)
         break;
     }
 
+  wall_clock_time_guess_missing_fields(&wct);
+
   if (end)
     {
       convert_wall_clock_time_to_unix_time(&wct, &ut);


### PR DESCRIPTION

closes #2460

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
