### PR TITLE
light: use larger fonts when executing xterm

### DIFF
--- a/tests/light/src/syslog_ng/syslog_ng_executor.py
+++ b/tests/light/src/syslog_ng/syslog_ng_executor.py
@@ -80,7 +80,7 @@ class SyslogNgExecutor(object):
             syslog_ng_bin,
         ]
         return self.__process_executor.start(
-            command=["xterm", "-e", shlex.join(gdb_command_args)],
+            command=["xterm", "-fa", "Monospace", "-fs", "18", "-e", shlex.join(gdb_command_args)],
             stdout_path="/dev/null",
             stderr_path="/dev/null",
         )


### PR DESCRIPTION
This will cause gdb under light to use a larger font size so that's actually legible.
