### PR TITLE
stats: do not allow resetting Prometheus metrics

### DIFF
--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -369,6 +369,9 @@ stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **
 static inline void
 _reset_counter_if_needed(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
 {
+  if (!stats_cluster_key_is_legacy(&sc->key))
+    return;
+
   if (strcmp(stats_cluster_get_type_name(sc, type), "memory_usage") == 0)
     return;
 

--- a/news/bugfix-370.md
+++ b/news/bugfix-370.md
@@ -1,0 +1,1 @@
+metrics: `syslog-ng-ctl --reset` will no longer reset Prometheus metrics


### PR DESCRIPTION
AxoSyslog now has a lot of gauge metrics, which should not be reset. Instead of implementing metric typing support and filtering based on that, this patch disallows the reset mechanism for all new metrics, since resetting anything sent to Prometheus does not make sense.

(The patch keeps the original behavior for legacy stats counters.)
