### PR TITLE
grpc/otel: add missing client context creation to axosyslog-otlp()

### DIFF
--- a/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
+++ b/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
@@ -57,6 +57,12 @@ SyslogNgDestWorker::insert(LogMessage *msg)
   logs_current_batch_bytes += log_record_bytes;
   log_threaded_dest_driver_insert_msg_length_stats(super->super.owner, log_record_bytes);
 
+  if (!client_context.get())
+    {
+      client_context = std::make_unique<::grpc::ClientContext>();
+      prepare_context_dynamic(*client_context, msg);
+    }
+
   if (should_initiate_flush())
     return log_threaded_dest_worker_flush(&super->super, LTF_FLUSH_NORMAL);
 

--- a/news/bugfix-384.md
+++ b/news/bugfix-384.md
@@ -1,0 +1,1 @@
+`axosyslog-otlp()` destination: Fixed a crash.


### PR DESCRIPTION
Missing from:
885051d331f9ce52a1ac90dfd8e4f28f0d741f73

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
