### PR TITLE
ci: fix macOS dep conflict

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update --preinstall
-          brew bundle --file=contrib/Brewfile
+          brew bundle --force --file=contrib/Brewfile
 
       - name: Set ENV variables
         run: |

--- a/contrib/Brewfile
+++ b/contrib/Brewfile
@@ -4,14 +4,13 @@ brew "automake"
 brew "binutils"
 brew "bison"
 brew "flex"
-brew "gcc@11"
 brew "glib"
 brew "ivykis"
 brew "json-c"
 brew "libtool"
 brew "openssl@3"
 brew "pcre2"
-brew "pkg-config"
+brew "pkgconf"
 
 brew "curl"
 brew "gradle"
@@ -26,7 +25,6 @@ brew "python@3", link: true, force: true
 brew "rabbitmq-c"
 brew "riemann-client"
 brew "libpaho-mqtt"
-
 brew "grpc"
 
 brew "criterion"


### PR DESCRIPTION
pkgconf is a newer, actively maintained implementation of pkg-config.

This is to fix CI on certain macOS runner instances (not all of them are affected). pkg-config is now migrated to pkgconf in brew, but a few runners have old pkg-config installed in a way they can't be overwritten by just a simple upgrade.