### PR TITLE
logproto: fixed state handling of the new internal handshake_in_progress flag

### DIFF
--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -112,13 +112,18 @@ log_proto_client_validate_options(LogProtoClient *self)
   return self->validate_options(self);
 }
 
+static inline gboolean
+log_proto_client_needs_handshake(LogProtoClient *s)
+{
+  return s->handshake != NULL;
+}
+
 static inline LogProtoStatus
 log_proto_client_handshake(LogProtoClient *s, gboolean *handshake_finished)
 {
-  if (s->handshake)
-    {
-      return s->handshake(s, handshake_finished);
-    }
+  if (log_proto_client_needs_handshake(s))
+    return s->handshake(s, handshake_finished);
+
   *handshake_finished = TRUE;
   return LPS_SUCCESS;
 }

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -99,13 +99,18 @@ log_proto_server_validate_options(LogProtoServer *self)
   return self->validate_options(self);
 }
 
+static inline gboolean
+log_proto_server_needs_handshake(LogProtoServer *s)
+{
+  return s->handshake != NULL;
+}
+
 static inline LogProtoStatus
 log_proto_server_handshake(LogProtoServer *s, gboolean *handshake_finished)
 {
-  if (s->handshake)
-    {
-      return s->handshake(s, handshake_finished);
-    }
+  if (log_proto_server_needs_handshake(s))
+    return s->handshake(s, handshake_finished);
+
   *handshake_finished = TRUE;
   return LPS_SUCCESS;
 }


### PR DESCRIPTION
There were multiple issues here
- proto change did not force re-handshake if needed
- initial state handling led to a drop of the first flush event both on the client and server-side that e.g. led to incorrect persist state processing at restart

Signed-off-by: Hofi <hofione@gmail.com>
