### PR TITLE
FilterX operator optimization for literals

### DIFF
--- a/lib/filterx/expr-comparison.c
+++ b/lib/filterx/expr-comparison.c
@@ -33,6 +33,7 @@
 #include "filterx/object-message-value.h"
 #include "filterx/filterx-object-istype.h"
 #include "filterx/filterx-ref.h"
+#include "filterx/expr-literal.h"
 #include "object-primitive.h"
 #include "generic-number.h"
 #include "parse-number.h"
@@ -42,6 +43,8 @@ typedef struct _FilterXComparison
 {
   FilterXBinaryOp super;
   gint operator;
+  FilterXObject *literal_lhs;
+  FilterXObject *literal_rhs;
 } FilterXComparison;
 
 static void
@@ -202,11 +205,13 @@ _eval(FilterXExpr *s)
   gint compare_mode = self->operator & FCMPX_MODE_MASK;
   gint operator = self->operator & FCMPX_OP_MASK;
 
-  FilterXObject *lhs_object = _eval_based_on_compare_mode(self->super.lhs, compare_mode);
+  FilterXObject *lhs_object = self->literal_lhs ? filterx_object_ref(self->literal_lhs)
+                              : _eval_based_on_compare_mode(self->super.lhs, compare_mode);
   if (!lhs_object)
     return NULL;
 
-  FilterXObject *rhs_object = _eval_based_on_compare_mode(self->super.rhs, compare_mode);
+  FilterXObject *rhs_object = self->literal_rhs ? filterx_object_ref(self->literal_rhs)
+                              : _eval_based_on_compare_mode(self->super.rhs, compare_mode);
   if (!rhs_object)
     {
       filterx_object_unref(lhs_object);
@@ -232,6 +237,16 @@ _eval(FilterXExpr *s)
   return filterx_boolean_new(result);
 }
 
+static void
+_filterx_comparison_free(FilterXExpr *s)
+{
+  FilterXComparison *self = (FilterXComparison *) s;
+  filterx_object_unref(self->literal_lhs);
+  filterx_object_unref(self->literal_rhs);
+
+  filterx_binary_op_free_method(s);
+}
+
 /* NOTE: takes the object reference */
 FilterXExpr *
 filterx_comparison_new(FilterXExpr *lhs, FilterXExpr *rhs, gint operator)
@@ -240,6 +255,22 @@ filterx_comparison_new(FilterXExpr *lhs, FilterXExpr *rhs, gint operator)
 
   filterx_binary_op_init_instance(&self->super, lhs, rhs);
   self->super.super.eval = _eval;
+  self->super.super.free_fn = _filterx_comparison_free;
   self->operator = operator;
+
+  gint compare_mode = self->operator & FCMPX_MODE_MASK;
+  if (filterx_expr_is_literal(lhs))
+    self->literal_lhs = _eval_based_on_compare_mode(lhs, compare_mode);
+
+  if (filterx_expr_is_literal(rhs))
+    self->literal_rhs = _eval_based_on_compare_mode(rhs, compare_mode);
+
+  if (filterx_expr_is_literal(lhs) && filterx_expr_is_literal(rhs))
+    {
+      FilterXExpr *optimized = filterx_literal_new(_eval(&self->super.super));
+      filterx_expr_unref(&self->super.super);
+      return optimized;
+    }
+
   return &self->super.super;
 }

--- a/lib/filterx/expr-condition.h
+++ b/lib/filterx/expr-condition.h
@@ -31,4 +31,6 @@ void filterx_conditional_set_false_branch(FilterXExpr *s, FilterXExpr *false_bra
 FilterXExpr *filterx_conditional_find_tail(FilterXExpr *s);
 FilterXExpr *filterx_conditional_new(FilterXExpr *condition);
 
+FilterXExpr *filterx_literal_conditional(FilterXExpr *condition, FilterXExpr *true_branch, FilterXExpr *false_branch);
+
 #endif

--- a/lib/filterx/expr-null-coalesce.c
+++ b/lib/filterx/expr-null-coalesce.c
@@ -23,6 +23,7 @@
  */
 
 #include "filterx/expr-null-coalesce.h"
+#include "filterx/expr-literal.h"
 #include "filterx/object-null.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/object-message-value.h"
@@ -61,6 +62,19 @@ _eval(FilterXExpr *s)
 FilterXExpr *
 filterx_null_coalesce_new(FilterXExpr *lhs, FilterXExpr *rhs)
 {
+  if (filterx_expr_is_literal(lhs))
+    {
+      FilterXObject *lhs_object = filterx_expr_eval(lhs);
+      if (!lhs_object || filterx_object_is_type(lhs_object, &FILTERX_TYPE_NAME(null)))
+        {
+          filterx_object_unref(lhs_object);
+          return rhs;
+        }
+
+      filterx_object_unref(lhs_object);
+      return lhs;
+    }
+
   FilterXNullCoalesce *self = g_new0(FilterXNullCoalesce, 1);
   filterx_binary_op_init_instance(&self->super, lhs, rhs);
   self->super.super.eval = _eval;

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -634,15 +634,29 @@ ternary
 	: expr '?' expr ':' expr
 	  {
             filterx_expr_set_location($1, lexer, &@1);
-	    $$ = filterx_conditional_new($1);
-            filterx_conditional_set_true_branch($$, $3);
-            filterx_conditional_set_false_branch($$, $5);
+            if (filterx_expr_is_literal($1))
+              {
+                $$ = filterx_literal_conditional($1, $3, $5);
+              }
+            else
+              {
+                $$ = filterx_conditional_new($1);
+                filterx_conditional_set_true_branch($$, $3);
+                filterx_conditional_set_false_branch($$, $5);
+              }
 	  }
 	| expr '?' ':' expr
 	  {
             filterx_expr_set_location($1, lexer, &@1);
-	    $$ = filterx_conditional_new($1);
-	    filterx_conditional_set_false_branch($$, $4);
+            if (filterx_expr_is_literal($1))
+              {
+                $$ = filterx_literal_conditional($1, NULL, $4);
+              }
+            else
+              {
+                $$ = filterx_conditional_new($1);
+                filterx_conditional_set_false_branch($$, $4);
+              }
 	  }
 	;
 

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -122,6 +122,10 @@ construct_template_expr(LogTemplate *template)
 %type <node> declaration
 %type <node> expr
 %type <node> expr_value
+%type <node> expr_operator
+%type <node> boolalg_operator
+%type <node> comparison_operator
+%type <node> arithmetic_operator
 %type <node> expr_generator
 %type <node> expr_generator_unchecked
 %type <node> expr_plus_generator
@@ -366,34 +370,50 @@ declaration
 expr
 	: expr_value
 	| function_call
-	| KW_NOT expr				{ $$ = filterx_unary_not_new($2); }
-	| expr KW_OR expr			{ $$ = filterx_binary_or_new($1, $3); }
-	| expr KW_AND expr                      { $$ = filterx_binary_and_new($1, $3); }
-	/* TODO extract lvalues */
-	| expr '.' identifier		{ $$ = filterx_getattr_new($1, filterx_config_frozen_string(configuration, $3)); free($3); }
-	| expr '[' expr ']'			{ $$ = filterx_get_subscript_new($1, $3); }
-        | expr KW_TA_LT expr		        { $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_LT); }
-        | expr KW_TA_LE expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_LT | FCMPX_EQ); }
-        | expr KW_TA_EQ expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_EQ); }
-        | expr KW_TA_NE expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_NE ); }
-        | expr KW_TA_GE expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_EQ | FCMPX_GT); }
-        | expr KW_TA_GT expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_GT); }
-        | expr KW_STR_LT expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_STRING_BASED | FCMPX_LT); }
-        | expr KW_STR_LE expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_STRING_BASED | FCMPX_LT | FCMPX_EQ); }
-        | expr KW_STR_EQ expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_STRING_BASED | FCMPX_EQ); }
-        | expr KW_STR_NE expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_STRING_BASED | FCMPX_NE ); }
-        | expr KW_STR_GE expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_STRING_BASED | FCMPX_EQ | FCMPX_GT); }
-        | expr KW_STR_GT expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_STRING_BASED | FCMPX_GT); }
-        | expr KW_TAV_EQ expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_EQ); }
-        | expr KW_TAV_NE expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_NE ); }
-	| expr '+' expr				{ $$ = filterx_operator_plus_new($1, $3); }
+	| expr_operator
 	| '(' expr ')'				{ $$ = $2; }
-	| ternary
-	| default
 	| KW_ISSET '(' expr ')'			{ $$ = filterx_isset_new($3); }
 	| KW_DROP                   { $$ = filterx_expr_drop_msg(); }
 	| KW_DONE                   { $$ = filterx_expr_done(); }
+	;
+
+expr_operator
+	: boolalg_operator
+	| comparison_operator
+	| arithmetic_operator
+	| ternary
+	| default
+	/* TODO extract lvalues */
+	| expr '.' identifier		{ $$ = filterx_getattr_new($1, filterx_config_frozen_string(configuration, $3)); free($3); }
+	| expr '[' expr ']'			{ $$ = filterx_get_subscript_new($1, $3); }
+	;
+
+boolalg_operator
+	: KW_NOT expr { $$ = filterx_unary_not_new($2); }
+	| expr KW_OR expr { $$ = filterx_binary_or_new($1, $3); }
+	| expr KW_AND expr { $$ = filterx_binary_and_new($1, $3); }
+	;
+
+comparison_operator
+	: expr KW_TA_LT expr { $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_LT); }
+	| expr KW_TA_LE expr { $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_LT | FCMPX_EQ); }
+	| expr KW_TA_EQ expr { $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_EQ); }
+	| expr KW_TA_NE expr { $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_NE ); }
+	| expr KW_TA_GE expr { $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_EQ | FCMPX_GT); }
+	| expr KW_TA_GT expr { $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_GT); }
+	| expr KW_STR_LT expr { $$ = filterx_comparison_new($1, $3, FCMPX_STRING_BASED | FCMPX_LT); }
+	| expr KW_STR_LE expr { $$ = filterx_comparison_new($1, $3, FCMPX_STRING_BASED | FCMPX_LT | FCMPX_EQ); }
+	| expr KW_STR_EQ expr { $$ = filterx_comparison_new($1, $3, FCMPX_STRING_BASED | FCMPX_EQ); }
+	| expr KW_STR_NE expr { $$ = filterx_comparison_new($1, $3, FCMPX_STRING_BASED | FCMPX_NE ); }
+	| expr KW_STR_GE expr { $$ = filterx_comparison_new($1, $3, FCMPX_STRING_BASED | FCMPX_EQ | FCMPX_GT); }
+	| expr KW_STR_GT expr { $$ = filterx_comparison_new($1, $3, FCMPX_STRING_BASED | FCMPX_GT); }
+	| expr KW_TAV_EQ expr { $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_EQ); }
+	| expr KW_TAV_NE expr { $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_NE ); }
 	| regexp_match
+	;
+
+arithmetic_operator
+	: expr '+' expr { $$ = filterx_operator_plus_new($1, $3); }
 	;
 
 expr_value

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -187,10 +187,10 @@ stmt
 	;
 
 stmt_expr
-	: expr 					{ $$ = $1; }
-	| conditional 				{ $$ = $1; }
-	| assignment 				{ $$ = $1; }
-	| declaration 				{ $$ = $1; }
+	: expr
+	| conditional
+	| assignment
+	| declaration
 	;
 
 plus_assignment
@@ -211,7 +211,7 @@ assignment
 	| expr '[' expr ']' KW_ASSIGN expr	{ $$ = filterx_set_subscript_new($1, $3, $6); }
 	| expr '[' ']' KW_ASSIGN expr  		{ $$ = filterx_set_subscript_new($1, NULL, $5); }
 	| generator_assignment
-	| plus_assignment			{ $$ = $1; }
+	| plus_assignment
 	;
 
 
@@ -364,8 +364,8 @@ declaration
     ;
 
 expr
-	: expr_value				{ $$ = $1; }
-	| function_call				{ $$ = $1; }
+	: expr_value
+	| function_call
 	| KW_NOT expr				{ $$ = filterx_unary_not_new($2); }
 	| expr KW_OR expr			{ $$ = filterx_binary_or_new($1, $3); }
 	| expr KW_AND expr                      { $$ = filterx_binary_and_new($1, $3); }
@@ -388,17 +388,17 @@ expr
         | expr KW_TAV_NE expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_NE ); }
 	| expr '+' expr				{ $$ = filterx_operator_plus_new($1, $3); }
 	| '(' expr ')'				{ $$ = $2; }
-	| ternary				{ $$ = $1; }
-	| default				{ $$ = $1; }
+	| ternary
+	| default
 	| KW_ISSET '(' expr ')'			{ $$ = filterx_isset_new($3); }
 	| KW_DROP                   { $$ = filterx_expr_drop_msg(); }
 	| KW_DONE                   { $$ = filterx_expr_done(); }
-	| regexp_match				{ $$ = $1; }
+	| regexp_match
 	;
 
 expr_value
 	: literal
-	| variable				{ $$ = $1; }
+	| variable
 	| template				{ $$ = construct_template_expr($1); }
 	;
 
@@ -577,7 +577,7 @@ regexp_match
 	;
 
 conditional
-	: if					{ $$ = $1; }
+	: if
 	| if KW_ELSE block
 	  {
             FilterXExpr *tailing_if = filterx_conditional_find_tail($1);

--- a/lib/filterx/object-primitive.h
+++ b/lib/filterx/object-primitive.h
@@ -82,6 +82,14 @@ filterx_double_unwrap(FilterXObject *s, gdouble *value)
   return TRUE;
 }
 
+static inline gboolean
+filterx_boolean_get_value(FilterXObject *s)
+{
+  FilterXPrimitive *self = (FilterXPrimitive *) s;
+
+  return !!gn_as_int64(&self->value);
+}
+
 /* NOTE: Consider using filterx_object_extract_boolean() to also support message_value. */
 static inline gboolean
 filterx_boolean_unwrap(FilterXObject *s, gboolean *value)


### PR DESCRIPTION
Can be useful when FilterX code is extracted into SCL blocks with parameters, or when the configuration is generated.

For example:

```
optimized_away_to_literal = `from_scl` && !`from_scl2` ? (`from_scl3`) ?? "ok" : "not " + "ok"
```

Depends on #387 (CI)