### PR TITLE
ci: build arm64 image natively without QEMU

### DIFF
--- a/.github/workflows/axosyslog-docker.yml
+++ b/.github/workflows/axosyslog-docker.yml
@@ -49,7 +49,7 @@ jobs:
 
   image-build:
     if: github.repository_owner == 'axoflow' || github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'linux-arm64' || 'ubuntu-latest' }}
     needs: prepare
 
     strategy:
@@ -65,6 +65,19 @@ jobs:
         run: |
           [ "$TYPE" = "stable" ] || [ "$TYPE" = "snapshot" ]
           echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> $GITHUB_ENV
+
+          # TODO: remove this block once the arm64 runner is available for open-source and has docker pre-installed
+          if [ "${{ matrix.platform }}" = "linux/arm64" ]; then
+            sudo install -m 0755 -d /etc/apt/keyrings
+            sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+            echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+            sudo apt-get update && sudo apt-get install -y acl docker-ce docker-ce-cli containerd.io docker-buildx-plugin
+            USERID=$(id -u)
+            sudo setfacl --modify user:${USERID}:rw /var/run/docker.sock
+          fi
 
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION
https://github.blog/news-insights/product-news/arm64-on-github-actions-powering-faster-more-efficient-build-systems/

> We expect to begin offering Arm runners for open source projects by the end of the year. 

Unfortunately, I can't test this in my fork.