### PR TITLE
Filterx regexp_subst supports match groups

### DIFF
--- a/lib/filterx/expr-regexp.h
+++ b/lib/filterx/expr-regexp.h
@@ -33,6 +33,7 @@
 #define FILTERX_FUNC_REGEXP_SUBST_FLAG_UTF8_NAME "utf8"
 #define FILTERX_FUNC_REGEXP_SUBST_FLAG_IGNORECASE_NAME "ignorecase"
 #define FILTERX_FUNC_REGEXP_SUBST_FLAG_NEWLINE_NAME "newline"
+#define FILTERX_FUNC_REGEXP_SUBST_FLAG_GROUPS_NAME "groups"
 
 typedef struct FilterXFuncRegexpSubstOpts_
 {
@@ -41,6 +42,7 @@ typedef struct FilterXFuncRegexpSubstOpts_
   gboolean utf8;
   gboolean ignorecase;
   gboolean newline;
+  gboolean groups;
 } FilterXFuncRegexpSubstOpts;
 
 FilterXExpr *filterx_expr_regexp_match_new(FilterXExpr *lhs, const gchar *pattern);

--- a/lib/filterx/tests/test_expr_regexp.c
+++ b/lib/filterx/tests/test_expr_regexp.c
@@ -547,6 +547,16 @@ Test(filterx_expr_regexp, regexp_subst_group_subst)
   filterx_object_unref(result_alt);
 }
 
+Test(filterx_expr_regexp, regexp_subst_group_subst_without_ref)
+{
+  FilterXFuncRegexpSubstOpts opts = {.groups = TRUE};
+  FilterXObject *result = _sub("(\\d{2})-(\\d{2})-(\\d{4})", "group without ref", "25-02-2022", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
+  cr_assert_str_eq(res, "group without ref");
+  filterx_object_unref(result);
+}
+
 static void
 setup(void)
 {

--- a/lib/filterx/tests/test_expr_regexp.c
+++ b/lib/filterx/tests/test_expr_regexp.c
@@ -276,6 +276,9 @@ _build_subst_func(const gchar *pattern, const gchar *repr, const gchar *str, Fil
   if (opts.utf8)
     args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_REGEXP_SUBST_FLAG_UTF8_NAME,
                                                         filterx_literal_new(filterx_boolean_new(TRUE))));
+  if (opts.groups)
+    args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_REGEXP_SUBST_FLAG_GROUPS_NAME,
+                                                        filterx_literal_new(filterx_boolean_new(TRUE))));
 
   GError *err = NULL;
   FilterXExpr *func = filterx_function_regexp_subst_new(filterx_function_args_new(args, NULL), &err);
@@ -524,6 +527,23 @@ Test(filterx_expr_regexp, regexp_subst_match_opt_ignorecase_nojit)
   cr_assert(filterx_object_is_type(result_alt, &FILTERX_TYPE_NAME(string)));
   const gchar *res_alt = filterx_string_get_value_ref(result_alt, NULL);
   cr_assert_str_eq(res_alt, "fXXbXrbXz");
+  filterx_object_unref(result_alt);
+}
+
+Test(filterx_expr_regexp, regexp_subst_group_subst)
+{
+  FilterXFuncRegexpSubstOpts opts = {};
+  FilterXObject *result = _sub("(\\d{2})-(\\d{2})-(\\d{4})", "\\3-\\2-\\1", "25-02-2022", opts);
+  cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(string)));
+  const gchar *res = filterx_string_get_value_ref(result, NULL);
+  cr_assert_str_eq(res, "\\3-\\2-\\1");
+  filterx_object_unref(result);
+
+  FilterXFuncRegexpSubstOpts opts_alt = {.groups = TRUE};
+  FilterXObject *result_alt = _sub("(\\d{2})-(\\d{2})-(\\d{4})", "\\3-\\2-\\1", "25-02-2022", opts_alt);
+  cr_assert(filterx_object_is_type(result_alt, &FILTERX_TYPE_NAME(string)));
+  const gchar *res_alt = filterx_string_get_value_ref(result_alt, NULL);
+  cr_assert_str_eq(res_alt, "2022-02-25");
   filterx_object_unref(result_alt);
 }
 

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -1938,6 +1938,9 @@ def test_regexp_subst(config, syslog_ng):
         $MSG.orgrp_global = regexp_subst("foobarbaz", "(fo|az)", "!", global=true);
         $MSG.ignore_case_control = regexp_subst("FoObArBaz", "(o|a)", "!", global=true);
         $MSG.ignore_case = regexp_subst("FoObArBaz", "(o|a)", "!", ignorecase=true, global=true);
+        $MSG.groups_off = regexp_subst("25-02-2022", /(\d{2})-(\d{2})-(\d{4})/, "\\3-\\2-\\1");;
+        $MSG.groups_on = regexp_subst("25-02-2022", /(\d{2})-(\d{2})-(\d{4})/, "\\3-\\2-\\1", groups=true);
+        $MSG.mixed_grps = regexp_subst("25-02-2022", /(\d{2})-(\d{2})-(\d{4})/, "foo:\\3-\\2-\\1:bar:baz", groups=true);
     """,
     )
     syslog_ng.start(config)
@@ -1956,7 +1959,10 @@ def test_regexp_subst(config, syslog_ng):
         r""""zero_length_match_global":"!f!o!o!b!a!r!b!a!z!","""
         r""""orgrp_global":"!obarb!","""
         r""""ignore_case_control":"F!ObArB!z","""
-        r""""ignore_case":"F!!b!rB!z"}""" + "\n"
+        r""""ignore_case":"F!!b!rB!z","""
+        r""""groups_off":"\\3-\\2-\\1","""
+        r""""groups_on":"2022-02-25","""
+        r""""mixed_grps":"foo:2022-02-25:bar:baz"}""" + "\n"
     )
     assert file_true.read_log() == exp
 


### PR DESCRIPTION
Enhanced regexp_subst to support match group identifiers in patterns.

Since this feature could have a significant impact on performance, it is
controlled by a flag called 'groups', which is set to false by default.
To enable this feature, add the optional groups=true argument to your regexp_subst call.

example:
```
filterx{
  $MSG.on = regexp_subst("25-02-2022", /(\d{2})-(\d{2})-(\d{4})/, "\\3/\\2/\\1", groups=true);
  # returns "2022\/02\/25"
}
```
This feature could have been implemented using the pcre2_substitute() function provided by the PCRE2 library. However, this approach was not viable because pcre2_substitute() does not support zero-length matches, which are a critical aspect of syslog-ng's legacy regex matcher.

As a result, the implementation introduced unwanted/unnecessary code and increased complexity. Given this, I would recommend discontinuing support for zero-length matches in filterx regexps. This change would improve both performance and code maintainability. While zero-length matches may seem like a useful feature in regular expressions, their practical use cases are likely to be rare and non-critical.

