### PR TITLE
filterx: `set_fields()`

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -42,6 +42,7 @@ set(FILTERX_HEADERS
     filterx/func-istype.h
     filterx/func-len.h
     filterx/func-sdata.h
+    filterx/func-set-fields.h
     filterx/func-str-transform.h
     filterx/func-str.h
     filterx/func-unset-empties.h
@@ -104,6 +105,7 @@ set(FILTERX_SOURCES
     filterx/func-istype.c
     filterx/func-len.c
     filterx/func-sdata.c
+    filterx/func-set-fields.c
     filterx/func-str-transform.c
     filterx/func-str.c
     filterx/func-unset-empties.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -45,6 +45,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/func-istype.h \
 	lib/filterx/func-len.h \
 	lib/filterx/func-sdata.h \
+	lib/filterx/func-set-fields.h \
 	lib/filterx/func-str-transform.h \
 	lib/filterx/func-str.h \
 	lib/filterx/func-unset-empties.h \
@@ -106,6 +107,7 @@ filterx_sources = 				\
 	lib/filterx/func-istype.c \
 	lib/filterx/func-len.c \
 	lib/filterx/func-sdata.c \
+	lib/filterx/func-set-fields.c \
 	lib/filterx/func-str-transform.c \
 	lib/filterx/func-str.c \
 	lib/filterx/func-unset-empties.c \

--- a/lib/filterx/expr-literal-generator.c
+++ b/lib/filterx/expr-literal-generator.c
@@ -354,16 +354,25 @@ filterx_expr_is_literal_generator(FilterXExpr *s)
 guint
 filterx_expr_literal_generator_len(FilterXExpr *s)
 {
-  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
-  return g_list_length(self->elements);
+  GList *elements = NULL;
+  if (_filterx_expr_is_inner_dict_generator(s))
+    elements = ((FilterXLiteralInnerGenerator *) s)->elements;
+  else
+    elements = ((FilterXExprLiteralGenerator *) s)->elements;
+
+  return g_list_length(elements);
 }
 
 gboolean
 filterx_literal_dict_generator_foreach(FilterXExpr *s, FilterXLiteralDictGeneratorForeachFunc func, gpointer user_data)
 {
-  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
+  GList *elements = NULL;
+  if (_filterx_expr_is_inner_dict_generator(s))
+    elements = ((FilterXLiteralInnerGenerator *) s)->elements;
+  else
+    elements = ((FilterXExprLiteralGenerator *) s)->elements;
 
-  for (GList *link = self->elements; link; link = link->next)
+  for (GList *link = elements; link; link = link->next)
     {
       FilterXLiteralGeneratorElem *elem = (FilterXLiteralGeneratorElem *) link->data;
 
@@ -377,10 +386,14 @@ filterx_literal_dict_generator_foreach(FilterXExpr *s, FilterXLiteralDictGenerat
 gboolean
 filterx_literal_list_generator_foreach(FilterXExpr *s, FilterXLiteralListGeneratorForeachFunc func, gpointer user_data)
 {
-  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
+  GList *elements = NULL;
+  if (_filterx_expr_is_inner_list_generator(s))
+    elements = ((FilterXLiteralInnerGenerator *) s)->elements;
+  else
+    elements = ((FilterXExprLiteralGenerator *) s)->elements;
 
   gsize i = 0;
-  for (GList *link = self->elements; link; link = link->next)
+  for (GList *link = elements; link; link = link->next)
     {
       FilterXLiteralGeneratorElem *elem = (FilterXLiteralGeneratorElem *) link->data;
 

--- a/lib/filterx/expr-literal-generator.c
+++ b/lib/filterx/expr-literal-generator.c
@@ -196,40 +196,6 @@ _literal_generator_init_instance(FilterXExprLiteralGenerator *self)
   self->super.super.free_fn = _literal_generator_free;
 }
 
-gboolean
-filterx_literal_dict_generator_foreach(FilterXExpr *s, FilterXLiteralDictGeneratorForeachFunc func, gpointer user_data)
-{
-  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
-
-  for (GList *link = self->elements; link; link = link->next)
-    {
-      FilterXLiteralGeneratorElem *elem = (FilterXLiteralGeneratorElem *) link->data;
-
-      if (!func(elem->key, elem->value, user_data))
-        return FALSE;
-    }
-
-  return TRUE;
-}
-
-gboolean
-filterx_literal_list_generator_foreach(FilterXExpr *s, FilterXLiteralListGeneratorForeachFunc func, gpointer user_data)
-{
-  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
-
-  gsize i = 0;
-  for (GList *link = self->elements; link; link = link->next)
-    {
-      FilterXLiteralGeneratorElem *elem = (FilterXLiteralGeneratorElem *) link->data;
-
-      if (!func(i, elem->value, user_data))
-        return FALSE;
-
-      i++;
-    }
-
-  return TRUE;
-}
 
 FilterXExpr *
 filterx_literal_dict_generator_new(void)
@@ -390,4 +356,39 @@ filterx_expr_literal_generator_len(FilterXExpr *s)
 {
   FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
   return g_list_length(self->elements);
+}
+
+gboolean
+filterx_literal_dict_generator_foreach(FilterXExpr *s, FilterXLiteralDictGeneratorForeachFunc func, gpointer user_data)
+{
+  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
+
+  for (GList *link = self->elements; link; link = link->next)
+    {
+      FilterXLiteralGeneratorElem *elem = (FilterXLiteralGeneratorElem *) link->data;
+
+      if (!func(elem->key, elem->value, user_data))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+gboolean
+filterx_literal_list_generator_foreach(FilterXExpr *s, FilterXLiteralListGeneratorForeachFunc func, gpointer user_data)
+{
+  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
+
+  gsize i = 0;
+  for (GList *link = self->elements; link; link = link->next)
+    {
+      FilterXLiteralGeneratorElem *elem = (FilterXLiteralGeneratorElem *) link->data;
+
+      if (!func(i, elem->value, user_data))
+        return FALSE;
+
+      i++;
+    }
+
+  return TRUE;
 }

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -35,6 +35,7 @@
 #include "filterx/func-len.h"
 #include "filterx/func-vars.h"
 #include "filterx/func-unset-empties.h"
+#include "filterx/func-set-fields.h"
 #include "filterx/func-str.h"
 #include "filterx/func-str-transform.h"
 #include "filterx/func-flatten.h"
@@ -135,6 +136,7 @@ _ctors_init(void)
   g_assert(filterx_builtin_function_ctor_register("strptime", filterx_function_strptime_new));
   g_assert(filterx_builtin_function_ctor_register("istype", filterx_function_istype_new));
   g_assert(filterx_builtin_function_ctor_register("unset_empties", filterx_function_unset_empties_new));
+  g_assert(filterx_builtin_function_ctor_register("set_fields", filterx_function_set_fields_new));
   g_assert(filterx_builtin_function_ctor_register("regexp_subst", filterx_function_regexp_subst_new));
   g_assert(filterx_builtin_function_ctor_register("unset", filterx_function_unset_new));
   g_assert(filterx_builtin_function_ctor_register("flatten", filterx_function_flatten_new));

--- a/lib/filterx/func-set-fields.c
+++ b/lib/filterx/func-set-fields.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/func-set-fields.h"
+
+typedef struct FilterXFunctionSetFields_
+{
+  FilterXFunction super;
+} FilterXFunctionSetFields;
+
+static FilterXObject *
+_eval(FilterXExpr *s)
+{
+  // TODO: implement
+  return NULL;
+}
+
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionSetFields *self = (FilterXFunctionSetFields *) s;
+
+  return filterx_function_init_method(&self->super, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionSetFields *self = (FilterXFunctionSetFields *) s;
+
+  filterx_function_deinit_method(&self->super, cfg);
+}
+
+static void
+_free(FilterXExpr *s)
+{
+  FilterXFunctionSetFields *self = (FilterXFunctionSetFields *) s;
+
+  filterx_function_free_method(&self->super);
+}
+
+static gboolean
+_extract_args(FilterXFunctionSetFields *self, FilterXFunctionArgs *args, GError **error)
+{
+  // TODO: implement
+  return TRUE;
+}
+
+FilterXExpr *
+filterx_function_set_fields_new(FilterXFunctionArgs *args, GError **error)
+{
+  FilterXFunctionSetFields *self = g_new0(FilterXFunctionSetFields, 1);
+  filterx_function_init_instance(&self->super, "set_fields");
+
+  self->super.super.eval = _eval;
+  self->super.super.init = _init;
+  self->super.super.deinit = _deinit;
+  self->super.super.free_fn = _free;
+
+  if (!_extract_args(self, args, error) ||
+      !filterx_function_args_check(args, error))
+    goto error;
+
+  filterx_function_args_free(args);
+  return &self->super.super;
+
+error:
+  filterx_function_args_free(args);
+  filterx_expr_unref(&self->super.super);
+  return NULL;
+}

--- a/lib/filterx/func-set-fields.h
+++ b/lib/filterx/func-set-fields.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 Attila Szakacs <attila.szakacs@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_FUNC_SET_FIELDS_H
+#define FILTERX_FUNC_SET_FIELDS_H
+
+#include "filterx/expr-function.h"
+
+FilterXExpr *filterx_function_set_fields_new(FilterXFunctionArgs *args, GError **error);
+
+#endif

--- a/news/fx-feature-397.md
+++ b/news/fx-feature-397.md
@@ -1,0 +1,36 @@
+`set_fields()`: Added new function to set a dict's fields with overrides and defaults.
+
+A recurring pattern in FilterX is to take a dict and set multiple
+fields in it with overrides or defaults.
+
+`set_fields()` takes a dict as the first argument and `overrides`
+and `defaults` as optional parameters.
+
+`overrides` and `defaults` are also dicts, where the key is
+the field's name, and the value is either an expression, or
+a list of expressions. If a list is provided, each expression
+will be evaluated, and the first successful, non-`null` one will
+be used to set the respective field's value. This is similar to
+chaining null-coalescing (`??`) operators, but is more performant.
+
+`overrides` are always processed for each field. The `defaults`
+for a field are only processed, if the field does not already
+have a value set.
+
+Example usage:
+```
+set_fields(
+  my_dict,
+  overrides={
+    "foo": [invalid_expr, "foo_override"],
+    "baz": "baz_override",
+    "almafa": [invalid_expr_1, null],  # No effect
+  },
+  defaults={
+    "foo": [invalid_expr, "foo_default"],
+    "bar": "bar_default",
+    "almafa": "almafa_default",
+    "kortefa": [invalid_expr_1, null],  # No effect
+    }
+);
+```

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -2520,3 +2520,33 @@ log {{
     assert "processed" in file_true.get_stats()
     assert file_true.get_stats()["processed"] == 1
     assert file_true.read_log() == '{"from_nvtable":"almafa","from_a_macro":"2000-01-01T00:00:00+01:00","unset_then_set":"kortefa"}\n'
+
+
+def test_set_fields(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, r"""
+    $MSG = {
+        "foo": "foo_exists",
+        "bar": "bar_exists",
+    };
+    set_fields(
+        $MSG,
+        overrides={
+            "foo": [invalid_expr, "foo_override"],
+            "baz": "baz_override",
+            "almafa": [invalid_expr_1, null],  # Should not have any effect, as there is no valid expr or non-null here.
+        },
+        defaults={
+            "foo": [invalid_expr, "foo_default"],  # Should not have any effect, "foo" is handled by overrides.
+            "bar": "bar_default",  # Should not have any effect, "bar" already has value in the dict.
+            "almafa": "almafa_default",
+            "kortefa": [invalid_expr_1, null],  # Should not have any effect, as there is no valid expr or non-null here.
+        }
+    );
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == '{"foo":"foo_override","bar":"bar_exists","baz":"baz_override","almafa":"almafa_default"}\n'


### PR DESCRIPTION
A recurring pattern in FilterX is to take a dict and set multiple fields in it with overrides or defaults.

`set_fields()` takes a dict as the first argument and `overrides` and `defaults` as optional parameters.

`overrides` and `defaults` are also dicts, where the key is the field's name, and the value is either an expression, or
a list of expressions. If a list is provided, each expression will be evaluated, and the first successful, non-`null` one will
be used to set the respective field's value. This is similar to chaining null-coalescing (`??`) operators, but is more performant.

`overrides` are always processed for each field. The `defaults` for a field are only processed, if the field does not already have a value set.

Example usage:
```
set_fields(
  my_dict,
  overrides={
    "foo": [invalid_expr, "foo_override"],
    "baz": "baz_override",
    "almafa": [invalid_expr_1, null],  # No effect
  },
  defaults={
    "foo": [invalid_expr, "foo_default"],
    "bar": "bar_default",
    "almafa": "almafa_default",
    "kortefa": [invalid_expr_1, null],  # No effect
    }
);
```
