### PR TITLE
Filterx regexp_search rework

### DIFF
--- a/lib/filterx/expr-regexp.h
+++ b/lib/filterx/expr-regexp.h
@@ -27,6 +27,7 @@
 #include "filterx/filterx-expr.h"
 #include "filterx/expr-generator.h"
 #include "filterx/expr-function.h"
+#include "filterx/func-flags.h"
 
 #define FILTERX_FUNC_REGEXP_SUBST_FLAG_JIT_NAME "jit"
 #define FILTERX_FUNC_REGEXP_SUBST_FLAG_GLOBAL_NAME "global"
@@ -34,6 +35,16 @@
 #define FILTERX_FUNC_REGEXP_SUBST_FLAG_IGNORECASE_NAME "ignorecase"
 #define FILTERX_FUNC_REGEXP_SUBST_FLAG_NEWLINE_NAME "newline"
 #define FILTERX_FUNC_REGEXP_SUBST_FLAG_GROUPS_NAME "groups"
+
+DEFINE_FUNC_FLAGS(FilterXRegexpSearchFlags,
+                  FILTERX_REGEXP_SEARCH_KEEP_GRP_ZERO,
+                  FILTERX_REGEXP_SEARCH_LIST_MODE
+                 );
+
+#define FILTERX_REGEXP_SEARCH_KEEP_GRP_ZERO_NAME "keep_zero"
+#define FILTERX_REGEXP_SEARCH_LIST_MODE_NAME "list_mode"
+
+extern const char *FilterXRegexpSearchFlags_NAMES[];
 
 typedef struct FilterXFuncRegexpSubstOpts_
 {

--- a/lib/filterx/func-flags.h
+++ b/lib/filterx/func-flags.h
@@ -27,6 +27,8 @@
 
 #include "syslog-ng.h"
 
+#define FLAGSET guint64
+
 #define MAX_ENUMS 64
 
 #define STATIC_ASSERT(COND) G_STATIC_ASSERT(COND)
@@ -35,14 +37,19 @@
     typedef enum { __VA_ARGS__, ENUM_NAME##_MAX} ENUM_NAME; \
     STATIC_ASSERT(ENUM_NAME##_MAX <= MAX_ENUMS) \
 
-#define FUNC_FLAGS_ITER(ENUM_NAME, CODE) for (guint64 enum_elt = 0; enum_elt < ENUM_NAME##_MAX; enum_elt++) { CODE; };
+#define DEFINE_FUNC_FLAG_NAMES(ENUM_NAME, ...)  \
+    const char *ENUM_NAME##_NAMES[] = {  \
+      __VA_ARGS__                               \
+    };
+
+#define FUNC_FLAGS_ITER(ENUM_NAME, CODE) for (FLAGSET enum_elt = 0; enum_elt < ENUM_NAME##_MAX; enum_elt++) { CODE; };
 
 #define FLAG_VAL(ID) (1 << ID)
 
 #define ALL_FLAG_SET(ENUM_NAME) (FLAG_VAL(ENUM_NAME##_MAX) - 1)
 
 static inline void
-set_flag(guint64 *flags, guint64 flag, gboolean val)
+set_flag(FLAGSET *flags, FLAGSET flag, gboolean val)
 {
   if (val)
     {
@@ -55,19 +62,19 @@ set_flag(guint64 *flags, guint64 flag, gboolean val)
 }
 
 static inline gboolean
-check_flag(guint64 flags, guint64 flag)
+check_flag(FLAGSET flags, FLAGSET flag)
 {
   return (flags & FLAG_VAL(flag)) != 0;
 }
 
 static inline void
-reset_flags(guint64 *flags, guint64 val)
+reset_flags(FLAGSET *flags, FLAGSET val)
 {
   *flags = val;
 }
 
 static inline gboolean
-toggle_flag(guint64 *flags, guint64 flag)
+toggle_flag(FLAGSET *flags, FLAGSET flag)
 {
   *flags ^= FLAG_VAL(flag);
   return (*flags & FLAG_VAL(flag)) != 0;


### PR DESCRIPTION
continuation of #394 
based on https://github.com/axoflow/axosyslog/issues/392

Introduced two new optional flags: keep_zero and list_mode.
The result type no longer switches between dict and list based on the presence of named groups.
The default result type is now dict.
list_mode can force a list result, either via the flag or the type of the fillable (the fillable's type takes precedence).
Match group zero is now excluded by default unless no other groups are present. This behavior can be overridden using the keep_zero flag.

Additionally, the FilterXRematchState structure, shared across other regexp functions, has been updated with a generic flags field. This allows functions to pass custom options to the state without incurring additional overhead.