### PR TITLE
Fix handshake regression

### DIFF
--- a/lib/logproto/logproto-buffered-server.h
+++ b/lib/logproto/logproto-buffered-server.h
@@ -118,6 +118,8 @@ LogProtoPrepareAction log_proto_buffered_server_prepare(LogProtoServer *s, GIOCo
                                                         gint *timeout G_GNUC_UNUSED);
 LogProtoBufferedServerState *log_proto_buffered_server_get_state(LogProtoBufferedServer *self);
 void log_proto_buffered_server_put_state(LogProtoBufferedServer *self);
+gboolean log_proto_buffered_server_restart_with_state(LogProtoServer *s,
+                                                      PersistState *persist_state, const gchar *persist_name);
 
 /* LogProtoBufferedServer */
 gboolean log_proto_buffered_server_validate_options_method(LogProtoServer *s);

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -56,14 +56,6 @@ log_reader_set_local_addr(LogReader *s, GSockAddr *local_addr)
 }
 
 void
-log_reader_set_immediate_check(LogReader *s)
-{
-  LogReader *self = (LogReader *) s;
-
-  self->immediate_check = TRUE;
-}
-
-void
 log_reader_set_options(LogReader *s, LogPipe *control, LogReaderOptions *options,
                        const gchar *stats_id, StatsClusterKeyBuilder *kb)
 {
@@ -160,7 +152,6 @@ log_reader_disable_watches(LogReader *self)
 static void
 log_reader_suspend_until_awoken(LogReader *self)
 {
-  self->immediate_check = FALSE;
   log_reader_disable_watches(self);
   self->suspended = TRUE;
 }
@@ -168,7 +159,6 @@ log_reader_suspend_until_awoken(LogReader *self)
 static void
 log_reader_force_check_in_next_poll(LogReader *self)
 {
-  self->immediate_check = FALSE;
   log_reader_disable_watches(self);
   self->suspended = FALSE;
 
@@ -324,12 +314,6 @@ log_reader_update_watches(LogReader *self)
       self->idle_timer.expires.tv_sec += idle_timeout;
 
       iv_timer_register(&self->idle_timer);
-    }
-
-  if (self->immediate_check)
-    {
-      log_reader_force_check_in_next_poll(self);
-      return;
     }
 
   switch (prepare_action)
@@ -574,8 +558,6 @@ log_reader_fetch_log(LogReader *self)
     }
   log_transport_aux_data_destroy(aux);
 
-  if (msg_count == self->options->fetch_limit)
-    self->immediate_check = TRUE;
   return 0;
 }
 
@@ -785,7 +767,6 @@ log_reader_new(GlobalConfig *cfg)
   self->super.wakeup = log_reader_wakeup;
   self->super.schedule_dynamic_window_realloc = _schedule_dynamic_window_realloc;
   self->super.metrics.raw_bytes_enabled = TRUE;
-  self->immediate_check = FALSE;
   self->handshake_in_progress = TRUE;
   log_reader_init_watches(self);
   g_mutex_init(&self->pending_close_lock);

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -62,7 +62,7 @@ struct _LogReader
 {
   LogSource super;
   LogProtoServer *proto;
-  gboolean immediate_check, handshake_in_progress;
+  gboolean handshake_in_progress;
   LogPipe *control;
   LogReaderOptions *options;
   PollEvents *poll_events;
@@ -99,7 +99,6 @@ void log_reader_set_follow_filename(LogReader *self, const gchar *follow_filenam
 void log_reader_set_name(LogReader *s, const gchar *name);
 void log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr);
 void log_reader_set_local_addr(LogReader *s, GSockAddr *local_addr);
-void log_reader_set_immediate_check(LogReader *s);
 void log_reader_disable_bookmark_saving(LogReader *s);
 void log_reader_open(LogReader *s, LogProtoServer *proto, PollEvents *poll_events);
 void log_reader_close_proto(LogReader *s);

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -155,7 +155,7 @@ _deinit_sd_logreader(FileReader *self)
 }
 
 static void
-_setup_logreader(LogPipe *s, PollEvents *poll_events, LogProtoServer *proto, gboolean check_immediately)
+_setup_logreader(LogPipe *s, PollEvents *poll_events, LogProtoServer *proto)
 {
   FileReader *self = (FileReader *) s;
 
@@ -172,23 +172,10 @@ _setup_logreader(LogPipe *s, PollEvents *poll_events, LogProtoServer *proto, gbo
                          self->owner->super.id,
                          kb);
 
-  if (check_immediately)
-    log_reader_set_immediate_check(self->reader);
-
   /* NOTE: if the file could not be opened, we ignore the last
    * remembered file position, if the file is created in the future
    * we're going to read from the start. */
   log_pipe_append((LogPipe *) self->reader, s);
-}
-
-static gboolean
-_is_immediate_check_needed(gboolean file_opened, gboolean open_deferred)
-{
-  if (file_opened)
-    return TRUE;
-  else if (open_deferred)
-    return FALSE;
-  return FALSE;
 }
 
 static gboolean
@@ -214,7 +201,6 @@ _reader_open_file(LogPipe *s, gboolean recover_state)
     {
       LogProtoServer *proto;
       PollEvents *poll_events;
-      gboolean check_immediately;
 
       poll_events = _construct_poll_events(self, fd);
       if (!poll_events)
@@ -224,8 +210,9 @@ _reader_open_file(LogPipe *s, gboolean recover_state)
         }
       proto = _construct_proto(self, fd);
 
-      check_immediately = _is_immediate_check_needed(file_opened, open_deferred);
-      _setup_logreader(s, poll_events, proto, check_immediately);
+      _setup_logreader(s, poll_events, proto);
+      if (recover_state)
+        _recover_state(s, cfg, proto);
       if (!log_pipe_init((LogPipe *) self->reader))
         {
           msg_error("Error initializing log_reader, closing fd",
@@ -235,8 +222,6 @@ _reader_open_file(LogPipe *s, gboolean recover_state)
           close(fd);
           return FALSE;
         }
-      if (recover_state)
-        _recover_state(s, cfg, proto);
     }
   else
     {


### PR DESCRIPTION
This is an alternative solution to #388 

* this fixes a regression caused by #155 , reported by @HofiOne  
* This simplifies the I/O tracking for files, LogProto/LogTransport should get full authority on whether data is already available before poll and also how we need to poll it
* Instead of the ugly "immediate_check" mechanism, we wake up LogReader if there's any event available

The regression happens in the LogReader: #155 causes us to skip a poll iteration because of the handshake (even if it does not exist). This causes a problem as at the very first iteration it is only "immediate_check" that causes us to start fetching messages. And that only fires once. By skipping that first iteration, we stall and stop fetching messages.

Instead of reverting the handshake related change  (which should be correct in any async environment), I dropped the immediate_check mechanism (instead of a single internal user that could probably be eliminated) and implemented checking for I/O state in the usual polling paths. Which means: we want to know if there are unprocessed bytes in the file (e.g. poll-file-events), and if there are no bytes there, we want to know if our buffer contains an entire line.

I tried to limit the scope of this change as much as possible.