### PR TITLE
transport-stack: fix shutdown

### DIFF
--- a/lib/transport/transport-stack.c
+++ b/lib/transport/transport-stack.c
@@ -124,17 +124,18 @@ log_transport_stack_init(LogTransportStack *self, LogTransport *initial_transpor
 void
 log_transport_stack_deinit(LogTransportStack *self)
 {
-  if (self->fd != -1)
-    {
-      msg_trace("Closing log transport fd",
-                evt_tag_int("fd", self->fd));
-      close(self->fd);
-    }
   for (gint i = 0; i < LOG_TRANSPORT__MAX; i++)
     {
       if (self->transports[i])
         log_transport_free(self->transports[i]);
       if (self->transport_factories[i])
         log_transport_factory_free(self->transport_factories[i]);
+    }
+
+  if (self->fd != -1)
+    {
+      msg_trace("Closing log transport fd",
+                evt_tag_int("fd", self->fd));
+      close(self->fd);
     }
 }

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2002-2013 Balabit
+ * Copyright (c) 2024 Axoflow
  * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2020-2024 László Várady
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -261,6 +263,10 @@ static void
 log_transport_tls_free_method(LogTransport *s)
 {
   LogTransportTLS *self = (LogTransportTLS *) s;
+
+  /* TODO: should handle SSL_ERROR_WANT_* and retry */
+  if (!SSL_in_init(self->tls_session->ssl))
+    log_transport_tls_send_shutdown(self);
 
   tls_session_free(self->tls_session);
   log_transport_stream_socket_free_method(s);

--- a/news/bugfix-420.md
+++ b/news/bugfix-420.md
@@ -1,0 +1,1 @@
+`network()`, `syslog()` sources and destinations: fix TCP/TLS shutdown


### PR DESCRIPTION
`log_transport_free()` is responsible for shutdown, which requires an open fd.