### PR TITLE
Filterx refactor eval metrics

### DIFF
--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -168,12 +168,6 @@ _init(FilterXExpr *s, GlobalConfig *cfg)
         }
     }
 
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_compound_evals_total", NULL, 0);
-  stats_register_counter(STATS_LEVEL3, &sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
-
   return filterx_expr_init_method(s, cfg);
 }
 
@@ -181,12 +175,6 @@ static void
 _deinit(FilterXExpr *s, GlobalConfig *cfg)
 {
   FilterXCompoundExpr *self = (FilterXCompoundExpr *) s;
-
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_compound_evals_total", NULL, 0);
-  stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
 
   for (gint i = 0; i < self->exprs->len; i++)
     {

--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -60,12 +60,6 @@ _init(FilterXExpr *s, GlobalConfig *cfg)
       return FALSE;
     }
 
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_condition_evals_total", NULL, 0);
-  stats_register_counter(STATS_LEVEL3, &sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
-
   return filterx_expr_init_method(s, cfg);
 }
 
@@ -73,12 +67,6 @@ static void
 _deinit(FilterXExpr *s, GlobalConfig *cfg)
 {
   FilterXConditional *self = (FilterXConditional *) s;
-
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_condition_evals_total", NULL, 0);
-  stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
 
   filterx_expr_deinit(self->condition, cfg);
   filterx_expr_deinit(self->true_branch, cfg);

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -242,26 +242,12 @@ filterx_function_optimize_method(FilterXFunction *s)
 gboolean
 filterx_function_init_method(FilterXFunction *s, GlobalConfig *cfg)
 {
-  stats_lock();
-  StatsClusterKey sc_key;
-  StatsClusterLabel labels[] = { stats_cluster_label("name", s->function_name) };
-  stats_cluster_single_key_set(&sc_key, "fx_func_evals_total", labels, G_N_ELEMENTS(labels));
-  stats_register_counter(STATS_LEVEL3, &sc_key, SC_TYPE_SINGLE_VALUE, &s->super.eval_count);
-  stats_unlock();
-
   return filterx_expr_init_method(&s->super, cfg);
 }
 
 void
 filterx_function_deinit_method(FilterXFunction *s, GlobalConfig *cfg)
 {
-  stats_lock();
-  StatsClusterKey sc_key;
-  StatsClusterLabel labels[] = { stats_cluster_label("name", s->function_name) };
-  stats_cluster_single_key_set(&sc_key, "fx_func_evals_total", labels, G_N_ELEMENTS(labels));
-  stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &s->super.eval_count);
-  stats_unlock();
-
   filterx_expr_deinit_method(&s->super, cfg);
 }
 
@@ -308,6 +294,7 @@ filterx_function_init_instance(FilterXFunction *s, const gchar *function_name)
   s->super.optimize = _function_optimize;
   s->super.init = _function_init;
   s->super.deinit = _function_deinit;
+  s->super.name = s->function_name;
   s->super.free_fn = _function_free;
 }
 

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -129,12 +129,6 @@ _init(FilterXExpr *s, GlobalConfig *cfg)
       return FALSE;
     }
 
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_get_subscript_evals_total", NULL, 0);
-  stats_register_counter(STATS_LEVEL3, &sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
-
   return filterx_expr_init_method(s, cfg);
 }
 
@@ -142,12 +136,6 @@ static void
 _deinit(FilterXExpr *s, GlobalConfig *cfg)
 {
   FilterXGetSubscript *self = (FilterXGetSubscript *) s;
-
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_get_subscript_evals_total", NULL, 0);
-  stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
 
   filterx_expr_deinit(self->operand, cfg);
   filterx_expr_deinit(self->key, cfg);

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -109,12 +109,6 @@ _init(FilterXExpr *s, GlobalConfig *cfg)
   if (!filterx_expr_init(self->operand, cfg))
     return FALSE;
 
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_getattr_evals_total", NULL, 0);
-  stats_register_counter(STATS_LEVEL3, &sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
-
   return filterx_expr_init_method(s, cfg);
 }
 
@@ -122,12 +116,6 @@ static void
 _deinit(FilterXExpr *s, GlobalConfig *cfg)
 {
   FilterXGetAttr *self = (FilterXGetAttr *) s;
-
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_getattr_evals_total", NULL, 0);
-  stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
 
   filterx_expr_deinit(self->operand, cfg);
   filterx_expr_deinit_method(s, cfg);

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -147,6 +147,7 @@ filterx_getattr_new(FilterXExpr *operand, FilterXString *attr_name)
   self->operand = operand;
 
   self->attr = (FilterXObject *) attr_name;
-
+  /* NOTE: name borrows the string value from the string object */
+  self->super.name = filterx_string_get_value_ref(self->attr, NULL);
   return &self->super;
 }

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -180,12 +180,6 @@ _init(FilterXExpr *s, GlobalConfig *cfg)
       return FALSE;
     }
 
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_set_subscript_evals_total", NULL, 0);
-  stats_register_counter(STATS_LEVEL3, &sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
-
   return filterx_expr_init_method(s, cfg);
 }
 
@@ -193,12 +187,6 @@ static void
 _deinit(FilterXExpr *s, GlobalConfig *cfg)
 {
   FilterXSetSubscript *self = (FilterXSetSubscript *) s;
-
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_set_subscript_evals_total", NULL, 0);
-  stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
 
   filterx_expr_deinit(self->object, cfg);
   filterx_expr_deinit(self->new_value, cfg);

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -155,12 +155,6 @@ _init(FilterXExpr *s, GlobalConfig *cfg)
       return FALSE;
     }
 
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_setattr_evals_total", NULL, 0);
-  stats_register_counter(STATS_LEVEL3, &sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
-
   return filterx_expr_init_method(s, cfg);
 }
 
@@ -168,12 +162,6 @@ static void
 _deinit(FilterXExpr *s, GlobalConfig *cfg)
 {
   FilterXSetAttr *self = (FilterXSetAttr *) s;
-
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_setattr_evals_total", NULL, 0);
-  stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
 
   filterx_expr_deinit(self->object, cfg);
   filterx_expr_deinit(self->new_value, cfg);

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -196,6 +196,8 @@ filterx_nullv_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterX
 
   self->new_value = new_value;
   self->super.ignore_falsy_result = TRUE;
+  /* NOTE: name borrows the string value from the string object */
+  self->super.name = filterx_string_get_value_ref(self->attr, NULL);
   return &self->super;
 }
 

--- a/lib/filterx/expr-template.c
+++ b/lib/filterx/expr-template.c
@@ -65,34 +65,6 @@ _free(FilterXExpr *s)
   filterx_expr_free_method(s);
 }
 
-static gboolean
-_template_init(FilterXExpr *s, GlobalConfig *cfg)
-{
-  FilterXTemplate *self = (FilterXTemplate *) s;
-
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_template_evals_total", NULL, 0);
-  stats_register_counter(STATS_LEVEL3, &sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
-
-  return filterx_expr_init_method(s, cfg);
-}
-
-static void
-_template_deinit(FilterXExpr *s, GlobalConfig *cfg)
-{
-  FilterXTemplate *self = (FilterXTemplate *) s;
-
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_template_evals_total", NULL, 0);
-  stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
-
-  filterx_expr_deinit_method(s, cfg);
-}
-
 /* NOTE: takes the object reference */
 FilterXExpr *
 filterx_template_new(LogTemplate *template)
@@ -100,8 +72,6 @@ filterx_template_new(LogTemplate *template)
   FilterXTemplate *self = g_new0(FilterXTemplate, 1);
 
   filterx_expr_init_instance(&self->super, "template");
-  self->super.init = _template_init;
-  self->super.deinit = _template_deinit;
   self->super.eval = _eval;
   self->super.free_fn = _free;
   self->template = template;

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -193,6 +193,9 @@ filterx_variable_expr_new(FilterXString *name, FilterXVariableType type)
   if (type == FX_VAR_MESSAGE)
     self->handle_is_macro = log_msg_is_handle_macro(filterx_variable_handle_to_nv_handle(self->handle));
 
+  /* NOTE: name borrows the string value from the string object */
+  self->super.name = filterx_string_get_value_ref(self->variable_name, NULL);
+
   return &self->super;
 }
 

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -175,34 +175,6 @@ _free(FilterXExpr *s)
   filterx_expr_free_method(s);
 }
 
-static gboolean
-_init(FilterXExpr *s, GlobalConfig *cfg)
-{
-  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
-
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_variable_evals_total", NULL, 0);
-  stats_register_counter(STATS_LEVEL3, &sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
-
-  return filterx_expr_init_method(s, cfg);
-}
-
-static void
-_deinit(FilterXExpr *s, GlobalConfig *cfg)
-{
-  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
-
-  stats_lock();
-  StatsClusterKey sc_key;
-  stats_cluster_single_key_set(&sc_key, "fx_variable_evals_total", NULL, 0);
-  stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
-  stats_unlock();
-
-  return filterx_expr_deinit_method(s, cfg);
-}
-
 static FilterXExpr *
 filterx_variable_expr_new(FilterXString *name, FilterXVariableType type)
 {
@@ -210,8 +182,6 @@ filterx_variable_expr_new(FilterXString *name, FilterXVariableType type)
 
   filterx_expr_init_instance(&self->super, "variable");
   self->super.free_fn = _free;
-  self->super.init = _init;
-  self->super.deinit = _deinit;
   self->super.eval = _eval;
   self->super._update_repr = _update_repr;
   self->super.assign = _assign;

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -56,8 +56,14 @@ struct _FilterXExpr
   FilterXExpr *(*optimize)(FilterXExpr *self);
   void (*free_fn)(FilterXExpr *self);
 
-  /* type of the expr */
+  /* type of the expr, is not freed, assumed to be managed by something else
+   * */
+
   const gchar *type;
+
+  /* name associated with the expr (e.g.  function name), is not freed by
+   * FilterXExpr, assumed to be managed by something else */
+  const gchar *name;
   CFG_LTYPE *lloc;
   gchar *expr_text;
 };


### PR DESCRIPTION
This simplifies the registration of filterx eval metrics and at the same time makes them more granular.  

Please merge #444 first as I've extracted the initial patch from this series into a separate PR to facilitate merging other bits.

