### PR TITLE
dbld: change devshell to use ubuntu-noble as base

### DIFF
--- a/dbld/images/devshell.dockerfile
+++ b/dbld/images/devshell.dockerfile
@@ -1,5 +1,5 @@
 ARG CONTAINER_REGISTRY
-FROM $CONTAINER_REGISTRY/axosyslog-dbld-tarball:latest
+FROM $CONTAINER_REGISTRY/axosyslog-dbld-ubuntu-noble:latest
 
 ARG ARG_IMAGE_PLATFORM
 ARG COMMIT

--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -42,16 +42,19 @@ which				[fedora]
 #############################################################################
 # eBPF related tools
 #############################################################################
-clang				[tarball]
-libbpf-dev			[tarball]
+clang				[tarball, devshell]
+libbpf-dev			[tarball, devshell]
 bpftool				[tarball]
+# as long as devshell is based on ubuntu and not tarball
+linux-tools-common		[devshell]
+linux-tools-generic		[devshell]
 
 #############################################################################
 # Tarball related tools
 #############################################################################
 
 # docbook to generate man pages
-docbook-xsl                     [tarball]
+docbook-xsl                     [tarball, devshell]
 docbook-style-xsl               [fedora]
 
 #############################################################################
@@ -128,7 +131,8 @@ libglib2.0-0t64-dbgsym          [devshell]
 libjemalloc-dev                 [devshell]
 libjemalloc2-dbgsym             [devshell]
 libssl3t64-dbgsym               [devshell]
-linux-perf                      [devshell]
+libjson-c5-dbgsym		[devshell]
+libpcre2-8-0-dbgsym		[devshell]
 locales                         [devshell]
 lsof                            [devshell]
 netcat-openbsd                  [devshell]

--- a/dbld/rules
+++ b/dbld/rules
@@ -213,7 +213,7 @@ shell-%: setup
 
 images: $(foreach image,$(IMAGES), image-$(image))
 image: image-$(DEFAULT_IMAGE)
-image-devshell: image-tarball
+image-devshell: image-ubuntu-noble
 image-tarball: image-debian-testing
 image-%:
 	$(DBLD_DIR)/prepare-image-build $* && \


### PR DESCRIPTION
Ubuntu has -fno-omit-frame-pointer in CFLAGS which Debian testing does not have, making profiling a lot more difficult on Debian.

At least as long as https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=767756 is not resolved, we are better off on Ubuntu as a devshell.

Note that this patch separates the tarball image (which continues to remain Debian testing) and devshell.

