### PR TITLE
filterx/unset-empties: call the virtual init function of object_expr

### DIFF
--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -253,7 +253,7 @@ _init(FilterXExpr *s, GlobalConfig *cfg)
 {
   FilterXFunctionUnsetEmpties *self = (FilterXFunctionUnsetEmpties *) s;
 
-  if (!filterx_expr_init_method(self->object_expr, cfg))
+  if (!filterx_expr_init(self->object_expr, cfg))
     return FALSE;
 
   return filterx_function_init_method(&self->super, cfg);


### PR DESCRIPTION
We incorrectly called filterx_expr_init_method() directly instead of going through the virtual function pointer.


