### PR TITLE
cfg-source: avoid indexing over the end of the lines array

### DIFF
--- a/lib/cfg-source.c
+++ b/lib/cfg-source.c
@@ -237,7 +237,7 @@ _extract_source_from_buffer_location(GString *result, const gchar *buffer_conten
   if (yylloc->first_column < 1)
     goto exit;
 
-  for (gint lineno = yylloc->first_line; lineno <= yylloc->last_line; lineno++)
+  for (gint lineno = yylloc->first_line; lineno < num_lines && lineno <= yylloc->last_line; lineno++)
     {
       gchar *line = lines[lineno - 1];
       gint linelen = strlen(line);


### PR DESCRIPTION
This is not an exploitable problem, as the index that can overflow cannot be controlled externally. It will cause a segfault if there's a location tracking issue or if the source location we are extracting the source text from is incorrect.
