### PR TITLE
filterx/expr-compound: don't format result of expression unless debug is enabled

### DIFF
--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -51,7 +51,7 @@ _eval_expr(FilterXExpr *expr, FilterXObject **result)
 
   gboolean success = expr->ignore_falsy_result || filterx_object_truthy(res);
 
-  if ((!success || trace_flag) && !expr->suppress_from_trace)
+  if (((!success && debug_flag) || trace_flag) && !expr->suppress_from_trace)
     {
       ScratchBuffersMarker mark;
       GString *buf = scratch_buffers_alloc_and_mark(&mark);


### PR DESCRIPTION
This is a performance optimization that should eliminate filter_object_repr() calls from the profile.
