### PR TITLE
filterx/filterx-scope: don't move the variables array multiple times

### DIFF
--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -284,7 +284,7 @@ filterx_scope_new(void)
 
   g_atomic_counter_set(&self->ref_cnt, 1);
   self->variables = g_array_sized_new(FALSE, TRUE, sizeof(FilterXVariable), 16);
-  g_array_set_clear_func(self->variables, (GDestroyNotify) filterx_variable_free_method);
+  g_array_set_clear_func(self->variables, (GDestroyNotify) filterx_variable_free);
   return self;
 }
 

--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -377,16 +377,31 @@ filterx_scope_invalidate_log_msg_cache(FilterXScope *self)
 {
   g_assert(filterx_scope_has_log_msg_changes(self));
 
-  gint i = 0;
-  while (i < self->variables->len)
+  /* this is a bit hacky and the solution would be to get rid of the GArray
+   * wrapper.  GArray does not allow us to remove multiple elements in a
+   * single loop, without moving the array multiple times.  So we basically
+   * open code this instead of multiple calls to g_array_remove_index()
+   */
+
+  gint src_index, dst_index;
+  for (src_index = 0, dst_index = 0; src_index < self->variables->len; src_index++)
     {
-      FilterXVariable *v = &g_array_index(self->variables, FilterXVariable, i);
+      FilterXVariable *v = &g_array_index(self->variables, FilterXVariable, src_index);
 
       if (!filterx_variable_is_floating(v) && self->syncable)
-        g_array_remove_index(self->variables, i);
+        {
+          /* skip this variable */
+          filterx_variable_free(v);
+        }
       else
-        i++;
+        {
+          if (src_index != dst_index)
+            g_array_index(self->variables, FilterXVariable, dst_index) = g_array_index(self->variables, FilterXVariable, src_index);
+          dst_index++;
+        }
     }
+  /* and this is the HACK: we reset the "len" member by poking that inside the GArray data structure */
+  self->variables->len = dst_index;
 
   filterx_scope_clear_log_msg_has_changes(self);
 }

--- a/lib/filterx/filterx-variable.c
+++ b/lib/filterx/filterx-variable.c
@@ -39,7 +39,7 @@ filterx_map_varname_to_handle(const gchar *name, FilterXVariableType type)
 }
 
 void
-filterx_variable_free_method(FilterXVariable *v)
+filterx_variable_free(FilterXVariable *v)
 {
   filterx_object_unref(v->value);
 }

--- a/lib/filterx/filterx-variable.h
+++ b/lib/filterx/filterx-variable.h
@@ -58,7 +58,7 @@ typedef enum
 
 void filterx_variable_init_instance(FilterXVariable *v, FilterXVariableHandle handle,
                                     FilterXObject *initial_value, guint32 generation);
-void filterx_variable_free_method(FilterXVariable *v);
+void filterx_variable_free(FilterXVariable *v);
 
 #define FILTERX_HANDLE_FLOATING_BIT (1UL << 31)
 


### PR DESCRIPTION
Optimize the removal of multiple elements.

