### PR TITLE
filterx/object-message-value: ensure that an extra NUL character is present

### DIFF
--- a/lib/filterx/object-message-value.c
+++ b/lib/filterx/object-message-value.c
@@ -339,8 +339,11 @@ FilterXObject *
 filterx_message_value_new(const gchar *repr, gssize repr_len, LogMessageValueType type)
 {
   gssize len = repr_len < 0 ? strlen(repr) : repr_len;
-  gssize alloc_len = repr_len < 0 ? len + 1 : repr_len;
-  gchar *buf = g_memdup2(repr, alloc_len);
+
+  /* NOTE: always add a zero byte to the end, even if length was specified */
+  gchar *buf = g_malloc(len + 1);
+  memcpy(buf, repr, len);
+  buf[len] = 0;
   FilterXMessageValue *self = (FilterXMessageValue *) filterx_message_value_new_borrowed(buf, len, type);
   self->buf = buf;
   return &self->super;


### PR DESCRIPTION
Macro based values are captured into an allocated buffer in FilterXMessageValue, but there was no extra NUL character added in case repr_len was specified (which is for any log_msg_get_value() resolutions).

This causes valgrind to throw errors when the APPEND_ZERO() macro is used.
