### PR TITLE
filterx: use "type" as a description to FilterXExpr type

### DIFF
--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -231,7 +231,7 @@ filterx_compound_expr_new(gboolean return_value_of_last_expr)
 {
   FilterXCompoundExpr *self = g_new0(FilterXCompoundExpr, 1);
 
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "compound");
   self->super.eval = _eval;
   self->super.optimize = _optimize;
   self->super.init = _init;

--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -212,7 +212,7 @@ FilterXExpr *
 filterx_conditional_new(FilterXExpr *condition)
 {
   FilterXConditional *self = g_new0(FilterXConditional, 1);
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "conditional");
   self->super.eval = _eval;
   self->super.optimize = _optimize;
   self->super.init = _init;

--- a/lib/filterx/expr-done.c
+++ b/lib/filterx/expr-done.c
@@ -40,7 +40,7 @@ FilterXExpr *
 filterx_expr_done(void)
 {
   FilterXExpr *self = g_new0(FilterXExpr, 1);
-  filterx_expr_init_instance(self);
+  filterx_expr_init_instance(self, "done");
   self->eval = _eval;
 
   return self;

--- a/lib/filterx/expr-drop.c
+++ b/lib/filterx/expr-drop.c
@@ -39,7 +39,7 @@ FilterXExpr *
 filterx_expr_drop_msg(void)
 {
   FilterXExpr *self = g_new0(FilterXExpr, 1);
-  filterx_expr_init_instance(self);
+  filterx_expr_init_instance(self, "drop");
   self->eval = _eval;
 
   return self;

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -303,7 +303,7 @@ _function_free(FilterXExpr *s)
 void
 filterx_function_init_instance(FilterXFunction *s, const gchar *function_name)
 {
-  filterx_expr_init_instance(&s->super);
+  filterx_expr_init_instance(&s->super, "function");
   s->function_name = g_strdup_printf("%s()", function_name);
   s->super.optimize = _function_optimize;
   s->super.init = _function_init;

--- a/lib/filterx/expr-generator.c
+++ b/lib/filterx/expr-generator.c
@@ -67,7 +67,7 @@ filterx_generator_optimize_method(FilterXExpr *s)
 void
 filterx_generator_init_instance(FilterXExpr *s)
 {
-  filterx_expr_init_instance(s);
+  filterx_expr_init_instance(s, "generator");
   s->optimize = filterx_generator_optimize_method;
   s->init = filterx_generator_init_method;
   s->deinit = filterx_generator_deinit_method;
@@ -188,7 +188,7 @@ filterx_generator_create_container_new(FilterXExpr *g, FilterXExpr *fillable_par
 {
   FilterXExprGeneratorCreateContainer *self = g_new0(FilterXExprGeneratorCreateContainer, 1);
 
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "create_container");
   self->generator = (FilterXExprGenerator *) g;
   self->fillable_parent = fillable_parent;
   self->super.optimize = _create_container_optimize;

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -169,7 +169,7 @@ filterx_get_subscript_new(FilterXExpr *operand, FilterXExpr *key)
 {
   FilterXGetSubscript *self = g_new0(FilterXGetSubscript, 1);
 
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "get_subscript");
   self->super.eval = _eval;
   self->super.is_set = _isset;
   self->super.unset = _unset;

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -148,7 +148,7 @@ filterx_getattr_new(FilterXExpr *operand, FilterXString *attr_name)
 {
   FilterXGetAttr *self = g_new0(FilterXGetAttr, 1);
 
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "getattr");
   self->super.eval = _eval;
   self->super.unset = _unset;
   self->super.is_set = _isset;

--- a/lib/filterx/expr-literal-generator.c
+++ b/lib/filterx/expr-literal-generator.c
@@ -263,7 +263,7 @@ static void
 _literal_inner_generator_init_instance(FilterXLiteralInnerGenerator *self, FilterXExpr *root_literal_generator,
                                        GList *elements)
 {
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "literal_inner_generator");
   self->super.free_fn = _literal_inner_generator_free;
 
   /*

--- a/lib/filterx/expr-literal.c
+++ b/lib/filterx/expr-literal.c
@@ -49,7 +49,7 @@ filterx_literal_new(FilterXObject *object)
 {
   FilterXLiteral *self = g_new0(FilterXLiteral, 1);
 
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "literal");
   self->super.eval = _eval;
   self->super.free_fn = _free;
   self->object = object;

--- a/lib/filterx/expr-regexp.c
+++ b/lib/filterx/expr-regexp.c
@@ -111,7 +111,7 @@ filterx_expr_regexp_match_new(FilterXExpr *lhs, const gchar *pattern)
 {
   FilterXExprRegexpMatch *self = g_new0(FilterXExprRegexpMatch, 1);
 
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "regexp_match");
   self->super.eval = _regexp_match_eval;
   self->super.optimize = _regexp_match_optimize;
   self->super.init = _regexp_match_init;

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -222,7 +222,7 @@ filterx_nullv_set_subscript_new(FilterXExpr *object, FilterXExpr *key, FilterXEx
 {
   FilterXSetSubscript *self = g_new0(FilterXSetSubscript, 1);
 
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "nullv_set_subscript");
   self->super.eval = _nullv_set_subscript_eval;
   self->super.optimize = _optimize;
   self->super.init = _init;
@@ -240,7 +240,7 @@ filterx_set_subscript_new(FilterXExpr *object, FilterXExpr *key, FilterXExpr *ne
 {
   FilterXSetSubscript *self = g_new0(FilterXSetSubscript, 1);
 
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "set_subscript");
   self->super.eval = _set_subscript_eval;
   self->super.optimize = _optimize;
   self->super.init = _init;

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -196,7 +196,7 @@ filterx_nullv_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterX
 {
   FilterXSetAttr *self = g_new0(FilterXSetAttr, 1);
 
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "nullv_setattr");
   self->super.eval = _nullv_setattr_eval;
   self->super.optimize = _optimize;
   self->super.init = _init;
@@ -217,7 +217,7 @@ filterx_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterXExpr *
 {
   FilterXSetAttr *self = g_new0(FilterXSetAttr, 1);
 
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "setattr");
   self->super.eval = _setattr_eval;
   self->super.optimize = _optimize;
   self->super.init = _init;

--- a/lib/filterx/expr-template.c
+++ b/lib/filterx/expr-template.c
@@ -99,7 +99,7 @@ filterx_template_new(LogTemplate *template)
 {
   FilterXTemplate *self = g_new0(FilterXTemplate, 1);
 
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "template");
   self->super.init = _template_init;
   self->super.deinit = _template_deinit;
   self->super.eval = _eval;

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -208,7 +208,7 @@ filterx_variable_expr_new(FilterXString *name, FilterXVariableType type)
 {
   FilterXVariableExpr *self = g_new0(FilterXVariableExpr, 1);
 
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "variable");
   self->super.free_fn = _free;
   self->super.init = _init;
   self->super.deinit = _deinit;

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -118,19 +118,20 @@ filterx_expr_free_method(FilterXExpr *self)
 }
 
 void
-filterx_expr_init_instance(FilterXExpr *self)
+filterx_expr_init_instance(FilterXExpr *self, const gchar *type)
 {
   self->ref_cnt = 1;
   self->init = filterx_expr_init_method;
   self->deinit = filterx_expr_deinit_method;
   self->free_fn = filterx_expr_free_method;
+  self->type = type;
 }
 
 FilterXExpr *
 filterx_expr_new(void)
 {
   FilterXExpr *self = g_new0(FilterXExpr, 1);
-  filterx_expr_init_instance(self);
+  filterx_expr_init_instance(self, "expr");
   return self;
 }
 
@@ -180,7 +181,7 @@ filterx_unary_op_init_method(FilterXExpr *s, GlobalConfig *cfg)
 
   stats_lock();
   StatsClusterKey sc_key;
-  StatsClusterLabel labels[] = { stats_cluster_label("name", self->name) };
+  StatsClusterLabel labels[] = { stats_cluster_label("name", self->super.type) };
   stats_cluster_single_key_set(&sc_key, "fx_op_evals_total", labels, G_N_ELEMENTS(labels));
   stats_register_counter(STATS_LEVEL3, &sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
   stats_unlock();
@@ -195,7 +196,7 @@ filterx_unary_op_deinit_method(FilterXExpr *s, GlobalConfig *cfg)
 
   stats_lock();
   StatsClusterKey sc_key;
-  StatsClusterLabel labels[] = { stats_cluster_label("name", self->name) };
+  StatsClusterLabel labels[] = { stats_cluster_label("name", self->super.type) };
   stats_cluster_single_key_set(&sc_key, "fx_op_evals_total", labels, G_N_ELEMENTS(labels));
   stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
   stats_unlock();
@@ -216,14 +217,12 @@ filterx_unary_op_free_method(FilterXExpr *s)
 void
 filterx_unary_op_init_instance(FilterXUnaryOp *self, const gchar *name, FilterXExpr *operand)
 {
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, name);
   self->super.optimize = filterx_unary_op_optimize_method;
   self->super.init = filterx_unary_op_init_method;
   self->super.deinit = filterx_unary_op_deinit_method;
   self->super.free_fn = filterx_unary_op_free_method;
   self->operand = operand;
-
-  self->name = name;
 }
 
 void
@@ -259,7 +258,7 @@ filterx_binary_op_init_method(FilterXExpr *s, GlobalConfig *cfg)
 
   stats_lock();
   StatsClusterKey sc_key;
-  StatsClusterLabel labels[] = { stats_cluster_label("name", self->name) };
+  StatsClusterLabel labels[] = { stats_cluster_label("name", self->super.type) };
   stats_cluster_single_key_set(&sc_key, "fx_op_evals_total", labels, G_N_ELEMENTS(labels));
   stats_register_counter(STATS_LEVEL3, &sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
   stats_unlock();
@@ -274,7 +273,7 @@ filterx_binary_op_deinit_method(FilterXExpr *s, GlobalConfig *cfg)
 
   stats_lock();
   StatsClusterKey sc_key;
-  StatsClusterLabel labels[] = { stats_cluster_label("name", self->name) };
+  StatsClusterLabel labels[] = { stats_cluster_label("name", self->super.type) };
   stats_cluster_single_key_set(&sc_key, "fx_op_evals_total", labels, G_N_ELEMENTS(labels));
   stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &self->super.eval_count);
   stats_unlock();
@@ -287,7 +286,7 @@ filterx_binary_op_deinit_method(FilterXExpr *s, GlobalConfig *cfg)
 void
 filterx_binary_op_init_instance(FilterXBinaryOp *self, const gchar *name, FilterXExpr *lhs, FilterXExpr *rhs)
 {
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, name);
   self->super.optimize = filterx_binary_op_optimize_method;
   self->super.init = filterx_binary_op_init_method;
   self->super.deinit = filterx_binary_op_deinit_method;
@@ -296,6 +295,4 @@ filterx_binary_op_init_instance(FilterXBinaryOp *self, const gchar *name, Filter
   g_assert(rhs);
   self->lhs = lhs;
   self->rhs = rhs;
-
-  self->name = name;
 }

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -56,6 +56,7 @@ struct _FilterXExpr
   FilterXExpr *(*optimize)(FilterXExpr *self);
   void (*free_fn)(FilterXExpr *self);
 
+  /* type of the expr */
   const gchar *type;
   CFG_LTYPE *lloc;
   gchar *expr_text;
@@ -151,7 +152,7 @@ void filterx_expr_set_location(FilterXExpr *self, CfgLexer *lexer, CFG_LTYPE *ll
 void filterx_expr_set_location_with_text(FilterXExpr *self, CFG_LTYPE *lloc, const gchar *text);
 EVTTAG *filterx_expr_format_location_tag(FilterXExpr *self);
 FilterXExpr *filterx_expr_optimize(FilterXExpr *self);
-void filterx_expr_init_instance(FilterXExpr *self);
+void filterx_expr_init_instance(FilterXExpr *self, const gchar *type);
 FilterXExpr *filterx_expr_new(void);
 FilterXExpr *filterx_expr_ref(FilterXExpr *self);
 void filterx_expr_unref(FilterXExpr *self);
@@ -190,7 +191,6 @@ typedef struct _FilterXUnaryOp
 {
   FilterXExpr super;
   FilterXExpr *operand;
-  const gchar *name;
 } FilterXUnaryOp;
 
 FilterXExpr *filterx_unary_op_optimize_method(FilterXExpr *s);
@@ -203,7 +203,6 @@ typedef struct _FilterXBinaryOp
 {
   FilterXExpr super;
   FilterXExpr *lhs, *rhs;
-  const gchar *name;
 } FilterXBinaryOp;
 
 FilterXExpr *filterx_binary_op_optimize_method(FilterXExpr *s);

--- a/libtest/filterx-lib.c
+++ b/libtest/filterx-lib.c
@@ -168,7 +168,7 @@ filterx_dummy_error_new(const gchar *msg)
 {
   FilterXDummyError *self = g_new0(FilterXDummyError, 1);
   self->msg = g_strdup(msg);
-  filterx_expr_init_instance(&self->super);
+  filterx_expr_init_instance(&self->super, "dummy");
   self->super.eval = _eval;
   self->super.free_fn = _free;
   return &self->super;


### PR DESCRIPTION
I extracted this patch from #423 so that we can build changes that build on this specific patch and can be merged independently of #423.

The point of this patch is to add a new "type" member into FilterXExpr, a string that can be used in various log messages.
I used this to initialize metrics in #423 but I might need it for identifying expr types instead of the "eval" function pointer in #433. Other than that I have a few other patches that change the expr constructors and simply started depending on this change as a part of their diff context.
