### PR TITLE
Filterx expr constructor improvements

### DIFF
--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -91,16 +91,6 @@ _assign_eval(FilterXExpr *s)
   return _assign(self, value);
 }
 
-FilterXExpr *
-filterx_nullv_assign_new(FilterXExpr *lhs, FilterXExpr *rhs)
-{
-  FilterXBinaryOp *self = g_new0(FilterXBinaryOp, 1);
-
-  filterx_binary_op_init_instance(self, "nullv_assign", lhs, rhs);
-  self->super.eval = _nullv_assign_eval;
-  self->super.ignore_falsy_result = TRUE;
-  return &self->super;
-}
 
 /* NOTE: takes the object reference */
 FilterXExpr *
@@ -112,4 +102,13 @@ filterx_assign_new(FilterXExpr *lhs, FilterXExpr *rhs)
   self->super.eval = _assign_eval;
   self->super.ignore_falsy_result = TRUE;
   return &self->super;
+}
+
+FilterXExpr *
+filterx_nullv_assign_new(FilterXExpr *lhs, FilterXExpr *rhs)
+{
+  FilterXExpr *self = filterx_assign_new(lhs, rhs);
+  self->type = "nullv_assign";
+  self->eval = _nullv_assign_eval;
+  return self;
 }

--- a/lib/filterx/expr-comparison.c
+++ b/lib/filterx/expr-comparison.c
@@ -198,7 +198,7 @@ _eval_based_on_compare_mode(FilterXExpr *expr, gint compare_mode)
 }
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_comparison(FilterXExpr *s)
 {
   FilterXComparison *self = (FilterXComparison *) s;
 
@@ -250,7 +250,7 @@ _optimize(FilterXExpr *s)
     self->literal_rhs = _eval_based_on_compare_mode(self->super.rhs, compare_mode);
 
   if (self->literal_lhs && self->literal_rhs)
-    return filterx_literal_new(_eval(&self->super.super));
+    return filterx_literal_new(_eval_comparison(&self->super.super));
 
   return NULL;
 }
@@ -273,7 +273,7 @@ filterx_comparison_new(FilterXExpr *lhs, FilterXExpr *rhs, gint operator)
 
   filterx_binary_op_init_instance(&self->super, "comparison", lhs, rhs);
   self->super.super.optimize = _optimize;
-  self->super.super.eval = _eval;
+  self->super.super.eval = _eval_comparison;
   self->super.super.free_fn = _filterx_comparison_free;
   self->operator = operator;
 

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -107,7 +107,7 @@ _eval_exprs(FilterXCompoundExpr *self, FilterXObject **result)
 }
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_compound(FilterXExpr *s)
 {
   FilterXCompoundExpr *self = (FilterXCompoundExpr *) s;
   FilterXObject *result = NULL;
@@ -220,7 +220,7 @@ filterx_compound_expr_new(gboolean return_value_of_last_expr)
   FilterXCompoundExpr *self = g_new0(FilterXCompoundExpr, 1);
 
   filterx_expr_init_instance(&self->super, "compound");
-  self->super.eval = _eval;
+  self->super.eval = _eval_compound;
   self->super.optimize = _optimize;
   self->super.init = _init;
   self->super.deinit = _deinit;

--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -86,7 +86,7 @@ _free(FilterXExpr *s)
 }
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_conditional(FilterXExpr *s)
 {
   FilterXConditional *self = (FilterXConditional *) s;
   FilterXObject *condition_value = filterx_expr_eval(self->condition);
@@ -201,7 +201,7 @@ filterx_conditional_new(FilterXExpr *condition)
 {
   FilterXConditional *self = g_new0(FilterXConditional, 1);
   filterx_expr_init_instance(&self->super, "conditional");
-  self->super.eval = _eval;
+  self->super.eval = _eval_conditional;
   self->super.optimize = _optimize;
   self->super.init = _init;
   self->super.deinit = _deinit;
@@ -215,7 +215,7 @@ FilterXExpr *
 filterx_conditional_find_tail(FilterXExpr *s)
 {
   /* check if this is a FilterXConditional instance */
-  if (s->eval != _eval)
+  if (s->eval != _eval_conditional)
     return NULL;
 
   FilterXConditional *self = (FilterXConditional *) s;

--- a/lib/filterx/expr-done.c
+++ b/lib/filterx/expr-done.c
@@ -28,7 +28,7 @@
 #include "filterx/object-primitive.h"
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_done(FilterXExpr *s)
 {
   FilterXEvalContext *context = filterx_eval_get_context();
   context->eval_control_modifier = FXC_DONE;
@@ -41,7 +41,7 @@ filterx_expr_done(void)
 {
   FilterXExpr *self = g_new0(FilterXExpr, 1);
   filterx_expr_init_instance(self, "done");
-  self->eval = _eval;
+  self->eval = _eval_done;
 
   return self;
 }

--- a/lib/filterx/expr-drop.c
+++ b/lib/filterx/expr-drop.c
@@ -27,7 +27,7 @@
 #include "filterx/object-primitive.h"
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_drop(FilterXExpr *s)
 {
   FilterXEvalContext *context = filterx_eval_get_context();
   context->eval_control_modifier = FXC_DROP;
@@ -40,7 +40,7 @@ filterx_expr_drop_msg(void)
 {
   FilterXExpr *self = g_new0(FilterXExpr, 1);
   filterx_expr_init_instance(self, "drop");
-  self->eval = _eval;
+  self->eval = _eval_drop;
 
   return self;
 }

--- a/lib/filterx/expr-generator.c
+++ b/lib/filterx/expr-generator.c
@@ -34,7 +34,7 @@ filterx_generator_set_fillable(FilterXExpr *s, FilterXExpr *fillable)
 }
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_generator(FilterXExpr *s)
 {
   FilterXExprGenerator *self = (FilterXExprGenerator *) s;
 
@@ -52,7 +52,7 @@ _eval(FilterXExpr *s)
 gboolean
 filterx_expr_is_generator(FilterXExpr *s)
 {
-  return s && s->eval == _eval;
+  return s && s->eval == _eval_generator;
 }
 
 FilterXExpr *
@@ -71,7 +71,7 @@ filterx_generator_init_instance(FilterXExpr *s)
   s->optimize = filterx_generator_optimize_method;
   s->init = filterx_generator_init_method;
   s->deinit = filterx_generator_deinit_method;
-  s->eval = _eval;
+  s->eval = _eval_generator;
   s->ignore_falsy_result = TRUE;
 }
 

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -33,7 +33,7 @@ typedef struct _FilterXGetSubscript
 } FilterXGetSubscript;
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_get_subscript(FilterXExpr *s)
 {
   FilterXGetSubscript *self = (FilterXGetSubscript *) s;
   FilterXObject *result = NULL;
@@ -158,7 +158,7 @@ filterx_get_subscript_new(FilterXExpr *operand, FilterXExpr *key)
   FilterXGetSubscript *self = g_new0(FilterXGetSubscript, 1);
 
   filterx_expr_init_instance(&self->super, "get_subscript");
-  self->super.eval = _eval;
+  self->super.eval = _eval_get_subscript;
   self->super.is_set = _isset;
   self->super.unset = _unset;
   self->super.optimize = _optimize;

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -34,7 +34,7 @@ typedef struct _FilterXGetAttr
 } FilterXGetAttr;
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_getattr(FilterXExpr *s)
 {
   FilterXGetAttr *self = (FilterXGetAttr *) s;
 
@@ -137,7 +137,7 @@ filterx_getattr_new(FilterXExpr *operand, FilterXString *attr_name)
   FilterXGetAttr *self = g_new0(FilterXGetAttr, 1);
 
   filterx_expr_init_instance(&self->super, "getattr");
-  self->super.eval = _eval;
+  self->super.eval = _eval_getattr;
   self->super.unset = _unset;
   self->super.is_set = _isset;
   self->super.optimize = _optimize;

--- a/lib/filterx/expr-isset.c
+++ b/lib/filterx/expr-isset.c
@@ -25,7 +25,7 @@
 #include "filterx/object-primitive.h"
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_isset(FilterXExpr *s)
 {
   FilterXUnaryOp *self = (FilterXUnaryOp *) s;
 
@@ -37,6 +37,6 @@ filterx_isset_new(FilterXExpr *expr)
 {
   FilterXUnaryOp *self = g_new0(FilterXUnaryOp, 1);
   filterx_unary_op_init_instance(self, "isset", expr);
-  self->super.eval = _eval;
+  self->super.eval = _eval_isset;
   return &self->super;
 }

--- a/lib/filterx/expr-literal.c
+++ b/lib/filterx/expr-literal.c
@@ -29,7 +29,7 @@ typedef struct _FilterXLiteral
 } FilterXLiteral;
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_literal(FilterXExpr *s)
 {
   FilterXLiteral *self = (FilterXLiteral *) s;
   return filterx_object_ref(self->object);
@@ -50,7 +50,7 @@ filterx_literal_new(FilterXObject *object)
   FilterXLiteral *self = g_new0(FilterXLiteral, 1);
 
   filterx_expr_init_instance(&self->super, "literal");
-  self->super.eval = _eval;
+  self->super.eval = _eval_literal;
   self->super.free_fn = _free;
   self->object = object;
   return &self->super;
@@ -59,5 +59,5 @@ filterx_literal_new(FilterXObject *object)
 gboolean
 filterx_expr_is_literal(FilterXExpr *expr)
 {
-  return expr->eval == _eval;
+  return expr->eval == _eval_literal;
 }

--- a/lib/filterx/expr-null-coalesce.c
+++ b/lib/filterx/expr-null-coalesce.c
@@ -37,7 +37,7 @@ struct _FilterXNullCoalesce
 };
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_null_coalesce(FilterXExpr *s)
 {
   FilterXNullCoalesce *self = (FilterXNullCoalesce *) s;
 
@@ -86,7 +86,7 @@ filterx_null_coalesce_new(FilterXExpr *lhs, FilterXExpr *rhs)
 {
   FilterXNullCoalesce *self = g_new0(FilterXNullCoalesce, 1);
   filterx_binary_op_init_instance(&self->super, "null_coalesce", lhs, rhs);
-  self->super.super.eval = _eval;
+  self->super.super.eval = _eval_null_coalesce;
   self->super.super.optimize = _optimize;
   return &self->super.super;
 }

--- a/lib/filterx/expr-plus.c
+++ b/lib/filterx/expr-plus.c
@@ -34,7 +34,7 @@ typedef struct FilterXOperatorPlus
 } FilterXOperatorPlus;
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_plus(FilterXExpr *s)
 {
   FilterXOperatorPlus *self = (FilterXOperatorPlus *) s;
 
@@ -72,7 +72,7 @@ _optimize(FilterXExpr *s)
     self->literal_rhs = filterx_expr_eval(self->super.rhs);
 
   if (self->literal_lhs && self->literal_rhs)
-    return filterx_literal_new(_eval(&self->super.super));
+    return filterx_literal_new(_eval_plus(&self->super.super));
   return NULL;
 }
 
@@ -92,7 +92,7 @@ filterx_operator_plus_new(FilterXExpr *lhs, FilterXExpr *rhs)
   FilterXOperatorPlus *self = g_new0(FilterXOperatorPlus, 1);
   filterx_binary_op_init_instance(&self->super, "plus", lhs, rhs);
   self->super.super.optimize = _optimize;
-  self->super.super.eval = _eval;
+  self->super.super.eval = _eval_plus;
   self->super.super.free_fn = _filterx_operator_plus_free;
 
   return &self->super.super;

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -206,24 +206,6 @@ _free(FilterXExpr *s)
 }
 
 FilterXExpr *
-filterx_nullv_set_subscript_new(FilterXExpr *object, FilterXExpr *key, FilterXExpr *new_value)
-{
-  FilterXSetSubscript *self = g_new0(FilterXSetSubscript, 1);
-
-  filterx_expr_init_instance(&self->super, "nullv_set_subscript");
-  self->super.eval = _nullv_set_subscript_eval;
-  self->super.optimize = _optimize;
-  self->super.init = _init;
-  self->super.deinit = _deinit;
-  self->super.free_fn = _free;
-  self->object = object;
-  self->key = key;
-  self->new_value = new_value;
-  self->super.ignore_falsy_result = TRUE;
-  return &self->super;
-}
-
-FilterXExpr *
 filterx_set_subscript_new(FilterXExpr *object, FilterXExpr *key, FilterXExpr *new_value)
 {
   FilterXSetSubscript *self = g_new0(FilterXSetSubscript, 1);
@@ -239,4 +221,14 @@ filterx_set_subscript_new(FilterXExpr *object, FilterXExpr *key, FilterXExpr *ne
   self->new_value = new_value;
   self->super.ignore_falsy_result = TRUE;
   return &self->super;
+}
+
+FilterXExpr *
+filterx_nullv_set_subscript_new(FilterXExpr *object, FilterXExpr *key, FilterXExpr *new_value)
+{
+  FilterXExpr *self = filterx_set_subscript_new(object, key, new_value);
+
+  self->type = "nullv_set_subscript";
+  self->eval = _nullv_set_subscript_eval;
+  return self;
 }

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -179,28 +179,6 @@ _free(FilterXExpr *s)
   filterx_expr_free_method(s);
 }
 
-FilterXExpr *
-filterx_nullv_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterXExpr *new_value)
-{
-  FilterXSetAttr *self = g_new0(FilterXSetAttr, 1);
-
-  filterx_expr_init_instance(&self->super, "nullv_setattr");
-  self->super.eval = _nullv_setattr_eval;
-  self->super.optimize = _optimize;
-  self->super.init = _init;
-  self->super.deinit = _deinit;
-  self->super.free_fn = _free;
-  self->object = object;
-
-  self->attr = (FilterXObject *) attr_name;
-
-  self->new_value = new_value;
-  self->super.ignore_falsy_result = TRUE;
-  /* NOTE: name borrows the string value from the string object */
-  self->super.name = filterx_string_get_value_ref(self->attr, NULL);
-  return &self->super;
-}
-
 /* Takes reference of object and new_value */
 FilterXExpr *
 filterx_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterXExpr *new_value)
@@ -219,5 +197,17 @@ filterx_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterXExpr *
 
   self->new_value = new_value;
   self->super.ignore_falsy_result = TRUE;
+
+  /* NOTE: name borrows the string value from the string object */
+  self->super.name = filterx_string_get_value_ref(self->attr, NULL);
   return &self->super;
+}
+
+FilterXExpr *
+filterx_nullv_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterXExpr *new_value)
+{
+  FilterXExpr *self = filterx_setattr_new(object, attr_name, new_value);
+  self->type = "nullv_setattr";
+  self->eval = _nullv_setattr_eval;
+  return self;
 }

--- a/lib/filterx/expr-template.c
+++ b/lib/filterx/expr-template.c
@@ -35,7 +35,7 @@ typedef struct _FilterXTemplate
 } FilterXTemplate;
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_template(FilterXExpr *s)
 {
   FilterXTemplate *self = (FilterXTemplate *) s;
   FilterXEvalContext *context = filterx_eval_get_context();
@@ -72,7 +72,7 @@ filterx_template_new(LogTemplate *template)
   FilterXTemplate *self = g_new0(FilterXTemplate, 1);
 
   filterx_expr_init_instance(&self->super, "template");
-  self->super.eval = _eval;
+  self->super.eval = _eval_template;
   self->super.free_fn = _free;
   self->template = template;
   return &self->super;

--- a/lib/filterx/expr-unset.c
+++ b/lib/filterx/expr-unset.c
@@ -32,7 +32,7 @@ typedef struct FilterXExprUnset_
 } FilterXExprUnset;
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_unset(FilterXExpr *s)
 {
   FilterXExprUnset *self = (FilterXExprUnset *) s;
 
@@ -110,7 +110,7 @@ filterx_function_unset_new(FilterXFunctionArgs *args, GError **error)
   FilterXExprUnset *self = g_new0(FilterXExprUnset, 1);
   filterx_function_init_instance(&self->super, "unset");
 
-  self->super.super.eval = _eval;
+  self->super.super.eval = _eval_unset;
   self->super.super.optimize = _optimize;
   self->super.super.init = _init;
   self->super.super.deinit = _deinit;

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -66,7 +66,7 @@ _whiteout_variable(FilterXVariableExpr *self, FilterXEvalContext *context)
 }
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_variable(FilterXExpr *s)
 {
   FilterXVariableExpr *self = (FilterXVariableExpr *) s;
   FilterXEvalContext *context = filterx_eval_get_context();
@@ -193,7 +193,7 @@ filterx_variable_expr_new(FilterXString *name, FilterXVariableType variable_type
 
   filterx_expr_init_instance(&self->super, "variable");
   self->super.free_fn = _free;
-  self->super.eval = _eval;
+  self->super.eval = _eval_variable;
   self->super._update_repr = _update_repr;
   self->super.assign = _assign;
   self->super.is_set = _isset;
@@ -228,7 +228,7 @@ filterx_variable_expr_declare(FilterXExpr *s)
 {
   FilterXVariableExpr *self = (FilterXVariableExpr *) s;
 
-  g_assert(s->eval == _eval);
+  g_assert(s->eval == _eval_variable);
   /* we can only declare a floating variable */
   g_assert(self->variable_type == FX_VAR_FLOATING);
   self->variable_type = FX_VAR_DECLARED_FLOATING;

--- a/lib/filterx/func-flatten.c
+++ b/lib/filterx/func-flatten.c
@@ -184,7 +184,7 @@ exit:
 }
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_fx_flatten(FilterXExpr *s)
 {
   FilterXFunctionFlatten *self = (FilterXFunctionFlatten *) s;
 
@@ -291,7 +291,7 @@ filterx_function_flatten_new(FilterXFunctionArgs *args, GError **error)
 {
   FilterXFunctionFlatten *self = g_new0(FilterXFunctionFlatten, 1);
   filterx_function_init_instance(&self->super, "flatten");
-  self->super.super.eval = _eval;
+  self->super.super.eval = _eval_fx_flatten;
   self->super.super.optimize = _optimize;
   self->super.super.init = _init;
   self->super.super.deinit = _deinit;

--- a/lib/filterx/func-istype.c
+++ b/lib/filterx/func-istype.c
@@ -41,7 +41,7 @@ typedef struct FilterXFunctionIsType_
 } FilterXFunctionIsType;
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_fx_istype(FilterXExpr *s)
 {
   FilterXFunctionIsType *self = (FilterXFunctionIsType *) s;
 
@@ -68,7 +68,7 @@ _optimize(FilterXExpr *s)
 
   if (filterx_expr_is_literal(self->object_expr))
     {
-      FilterXObject *optimized_object = _eval(s);
+      FilterXObject *optimized_object = _eval_fx_istype(s);
       g_assert(optimized_object);
       return filterx_literal_new(optimized_object);
     }
@@ -165,7 +165,7 @@ filterx_function_istype_new(FilterXFunctionArgs *args, GError **error)
 {
   FilterXFunctionIsType *self = g_new0(FilterXFunctionIsType, 1);
   filterx_function_init_instance(&self->super, "istype");
-  self->super.super.eval = _eval;
+  self->super.super.eval = _eval_fx_istype;
   self->super.super.optimize = _optimize;
   self->super.super.init = _init;
   self->super.super.deinit = _deinit;

--- a/lib/filterx/func-sdata.c
+++ b/lib/filterx/func-sdata.c
@@ -67,7 +67,7 @@ _extract_args(FilterXFunctionIsSdataFromEnteprise *self, FilterXFunctionArgs *ar
 }
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_fx_is_sdata_from(FilterXExpr *s)
 {
   FilterXFunctionIsSdataFromEnteprise *self = (FilterXFunctionIsSdataFromEnteprise *) s;
 
@@ -105,7 +105,7 @@ filterx_function_is_sdata_from_enterprise_new(FilterXFunctionArgs *args, GError 
 
   if (!_extract_args(self, args, error) || !filterx_function_args_check(args, error))
     goto error;
-  self->super.super.eval = _eval;
+  self->super.super.eval = _eval_fx_is_sdata_from;
   self->super.super.free_fn = _free;
   filterx_function_args_free(args);
   return &self->super.super;

--- a/lib/filterx/func-set-fields.c
+++ b/lib/filterx/func-set-fields.c
@@ -206,7 +206,7 @@ _process_field(Field *field, FilterXObject *dict)
 }
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_fx_set_fields(FilterXExpr *s)
 {
   FilterXFunctionSetFields *self = (FilterXFunctionSetFields *) s;
 
@@ -495,7 +495,7 @@ filterx_function_set_fields_new(FilterXFunctionArgs *args, GError **error)
   FilterXFunctionSetFields *self = g_new0(FilterXFunctionSetFields, 1);
   filterx_function_init_instance(&self->super, "set_fields");
 
-  self->super.super.eval = _eval;
+  self->super.super.eval = _eval_fx_set_fields;
   self->super.super.optimize = _optimize;
   self->super.super.init = _init;
   self->super.super.deinit = _deinit;

--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -221,7 +221,7 @@ _process_list(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
 }
 
 static FilterXObject *
-_eval(FilterXExpr *s)
+_eval_fx_unset_empties(FilterXExpr *s)
 {
   FilterXFunctionUnsetEmpties *self = (FilterXFunctionUnsetEmpties *) s;
 
@@ -505,7 +505,7 @@ filterx_function_unset_empties_new(FilterXFunctionArgs *args, GError **error)
 {
   FilterXFunctionUnsetEmpties *self = g_new0(FilterXFunctionUnsetEmpties, 1);
   filterx_function_init_instance(&self->super, "unset_empties");
-  self->super.super.eval = _eval;
+  self->super.super.eval = _eval_fx_unset_empties;
   self->super.super.optimize = _optimize;
   self->super.super.init = _init;
   self->super.super.deinit = _deinit;


### PR DESCRIPTION
Next out of #434, this time it is based on #444 that needs to go in first.

There are two patches here (on top of #444):
* the nullv style constructors are reimplemented as a "delta" to the normal constructor to avoid code duplication
* _eval() methods are renamed everywhere so it's easier to read perf stackdumps
