### PR TITLE
Filterx function path lookup

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -62,6 +62,7 @@ set(FILTERX_HEADERS
     filterx/object-primitive.h
     filterx/object-string.h
     filterx/func-keys.h
+    filterx/func-path-lookup.h
     PARENT_SCOPE
     )
 
@@ -129,6 +130,7 @@ set(FILTERX_SOURCES
     filterx/object-primitive.c
     filterx/object-string.c
     filterx/func-keys.c
+    filterx/func-path-lookup.c
     PARENT_SCOPE
     )
 

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -48,6 +48,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/func-istype.h \
 	lib/filterx/func-keys.h	\
 	lib/filterx/func-len.h \
+	lib/filterx/func-path-lookup.h	\
 	lib/filterx/func-sdata.h \
 	lib/filterx/func-set-fields.h \
 	lib/filterx/func-str-transform.h \
@@ -114,6 +115,7 @@ filterx_sources = 				\
 	lib/filterx/func-istype.c \
 	lib/filterx/func-keys.c	\
 	lib/filterx/func-len.c \
+	lib/filterx/func-path-lookup.c	\
 	lib/filterx/func-sdata.c \
 	lib/filterx/func-set-fields.c \
 	lib/filterx/func-str-transform.c \

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -48,6 +48,7 @@
 #include "filterx/expr-unset.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/func-keys.h"
+#include "filterx/func-path-lookup.h"
 
 static GHashTable *filterx_builtin_simple_functions = NULL;
 static GHashTable *filterx_builtin_function_ctors = NULL;
@@ -152,6 +153,7 @@ _ctors_init(void)
   g_assert(filterx_builtin_function_ctor_register("includes", filterx_function_includes_new));
   g_assert(filterx_builtin_function_ctor_register("strftime", filterx_function_strftime_new));
   g_assert(filterx_builtin_function_ctor_register("keys", filterx_function_keys_new));
+  g_assert(filterx_builtin_function_ctor_register("path_lookup", filterx_function_path_lookup_new));
 }
 
 static void

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -354,4 +354,34 @@ filterx_object_set_modified_in_place(FilterXObject *self, gboolean modified)
   self->modified_in_place = modified;
 }
 
+static inline FilterXObject *
+filterx_object_path_lookup(FilterXObject *self, FilterXObject *keys[], size_t key_count)
+{
+  if (self == NULL)
+    {
+      return NULL;
+    }
+
+  if (!keys || key_count == 0)
+    {
+      return filterx_object_ref(self);
+    }
+
+  FilterXObject *next = filterx_object_get_subscript(self, keys[0]);
+  if (next == NULL)
+    {
+      return NULL;
+    }
+
+  FilterXObject *res = filterx_object_path_lookup(next, keys + 1, key_count - 1);
+  filterx_object_unref(next);
+  return res;
+}
+
+static inline FilterXObject *
+filterx_object_path_lookup_g(FilterXObject *self, GPtrArray *keys)
+{
+  return filterx_object_path_lookup(self, (FilterXObject **)keys->pdata, keys->len);
+}
+
 #endif

--- a/lib/filterx/func-path-lookup.c
+++ b/lib/filterx/func-path-lookup.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 shifter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/func-path-lookup.h"
+#include "filterx/object-dict-interface.h"
+#include "filterx/object-list-interface.h"
+#include "filterx/object-primitive.h"
+#include "filterx/filterx-eval.h"
+#include "filterx/object-json.h"
+#include "filterx/expr-literal-generator.h"
+#include "filterx/expr-literal.h"
+#include "filterx/filterx-object.h"
+
+typedef struct FilterXFunctionPathLookup_
+{
+  FilterXFunction super;
+  FilterXExpr *object_expr;
+  GPtrArray *keys;
+} FilterXFunctionPathLookup;
+
+static FilterXObject *
+_eval(FilterXExpr *s)
+{
+  FilterXFunctionPathLookup *self = (FilterXFunctionPathLookup *) s;
+
+  FilterXObject *object = filterx_expr_eval(self->object_expr);
+  if (!object)
+    {
+      filterx_eval_push_error("Failed to evaluate first argument. " FILTERX_FUNC_PATH_LOOKUP_USAGE, s, NULL);
+      return NULL;
+    }
+
+  FilterXObject *result = filterx_object_path_lookup_g(object, self->keys);
+  filterx_object_unref(object);
+  return result;
+}
+
+static gboolean
+_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionPathLookup *self = (FilterXFunctionPathLookup *) s;
+
+  if (!filterx_expr_init(self->object_expr, cfg))
+    return FALSE;
+
+  return filterx_function_init_method(&self->super, cfg);
+}
+
+static void
+_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionPathLookup *self = (FilterXFunctionPathLookup *) s;
+  filterx_expr_deinit(self->object_expr, cfg);
+  filterx_function_deinit_method(&self->super, cfg);
+}
+
+static void
+_free(FilterXExpr *s)
+{
+  FilterXFunctionPathLookup *self = (FilterXFunctionPathLookup *) s;
+  if (self->keys)
+    g_ptr_array_free(self->keys, TRUE);
+  filterx_expr_unref(self->object_expr);
+  filterx_function_free_method(&self->super);
+}
+
+static gboolean
+_add_iterator(FilterXExpr *key, FilterXExpr *value, gpointer user_data)
+{
+  FilterXFunctionPathLookup *self = ((gpointer *) user_data)[0];
+  GError **error = ((gpointer *) user_data)[1];
+
+  if (!filterx_expr_is_literal(value) && !filterx_expr_is_literal_generator(value))
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  FILTERX_FUNC_PATH_LOOKUP_ERR_LITERAL_LIST_ELTS FILTERX_FUNC_PATH_LOOKUP_USAGE);
+      return FALSE;
+    }
+
+  FilterXObject *target = filterx_expr_eval(value);
+  g_assert(target);
+
+  g_ptr_array_add(self->keys, target);
+
+  return TRUE;
+}
+
+static gboolean
+_extract_path(FilterXFunctionPathLookup *self, FilterXFunctionArgs *args, GError **error)
+{
+  gboolean exists;
+  FilterXExpr *path = filterx_function_args_get_expr(args, 1);
+
+  exists = !!path;
+
+  if (!exists)
+    return TRUE;
+
+  if (!filterx_expr_is_literal_list_generator(path))
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  FILTERX_FUNC_PATH_LOOKUP_ERR_LITERAL_LIST FILTERX_FUNC_PATH_LOOKUP_USAGE);
+      filterx_expr_unref(path);
+      return FALSE;
+    }
+
+  guint64 len = filterx_expr_literal_generator_len(path);
+  self->keys = g_ptr_array_new_full(len, (GDestroyNotify)filterx_object_unref);
+  gpointer user_data[] = { self, error };
+
+  gboolean result = TRUE;
+  if (!filterx_literal_dict_generator_foreach(path, _add_iterator, user_data))
+    result = FALSE;
+
+  filterx_expr_unref(path);
+
+  return result;
+}
+
+static FilterXExpr *
+_extract_object_expr(FilterXFunctionArgs *args, GError **error)
+{
+  FilterXExpr *object_expr = filterx_function_args_get_expr(args, 0);
+  if (!object_expr)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "argument must be set: object. " FILTERX_FUNC_PATH_LOOKUP_USAGE);
+      return NULL;
+    }
+
+  return object_expr;
+}
+
+static gboolean
+_extract_args(FilterXFunctionPathLookup *self, FilterXFunctionArgs *args, GError **error)
+{
+  if (filterx_function_args_len(args) != 2)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  FILTERX_FUNC_PATH_LOOKUP_ERR_NUM_ARGS FILTERX_FUNC_PATH_LOOKUP_USAGE);
+      return FALSE;
+    }
+
+  self->object_expr = _extract_object_expr(args, error);
+  if (!self->object_expr)
+    return FALSE;
+
+  if (!_extract_path(self, args, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+FilterXExpr *
+filterx_function_path_lookup_new(FilterXFunctionArgs *args, GError **error)
+{
+  FilterXFunctionPathLookup *self = g_new0(FilterXFunctionPathLookup, 1);
+  filterx_function_init_instance(&self->super, "path_lookup");
+  self->super.super.eval = _eval;
+  self->super.super.init = _init;
+  self->super.super.deinit = _deinit;
+  self->super.super.free_fn = _free;
+
+  if (!_extract_args(self, args, error) ||
+      !filterx_function_args_check(args, error))
+    goto error;
+
+  filterx_function_args_free(args);
+  return &self->super.super;
+
+error:
+  filterx_function_args_free(args);
+  filterx_expr_unref(&self->super.super);
+  return NULL;
+}

--- a/lib/filterx/func-path-lookup.h
+++ b/lib/filterx/func-path-lookup.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 shifter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_FUNC_PATH_LOOKUP_H_INCLUDED
+#define FILTERX_FUNC_PATH_LOOKUP_H_INCLUDED
+
+#include "filterx/expr-function.h"
+
+#define FILTERX_FUNC_PATH_LOOKUP_USAGE "Usage: path_lookup(dict_or_list, list)"
+#define FILTERX_FUNC_PATH_LOOKUP_ERR_NONDICT "Argument must be a dict."
+#define FILTERX_FUNC_PATH_LOOKUP_ERR_NUM_ARGS "Invalid number of arguments."
+#define FILTERX_FUNC_PATH_LOOKUP_ERR_LITERAL_LIST "List argument must be literal list."
+#define FILTERX_FUNC_PATH_LOOKUP_ERR_LITERAL_LIST_ELTS "List members must be literals."
+
+FilterXExpr *filterx_function_path_lookup_new(FilterXFunctionArgs *args, GError **error);
+
+#endif

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -29,3 +29,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_expr_regexp_subst DEPENDS json-plugi
 add_unit_test(LIBTEST CRITERION TARGET test_object_dict_interface DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_func_keys DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_filterx_object DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_func_path_lookup DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -28,3 +28,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_expr_regexp_search DEPENDS json-plug
 add_unit_test(LIBTEST CRITERION TARGET test_expr_regexp_subst DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_dict_interface DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_func_keys DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_filterx_object DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -30,7 +30,8 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_expr_plus \
 		lib/filterx/tests/test_metrics_labels \
 		lib/filterx/tests/test_object_dict_interface \
-		lib/filterx/tests/test_func_keys
+		lib/filterx/tests/test_func_keys \
+		lib/filterx/tests/test_filterx_object \
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt
 
@@ -125,3 +126,6 @@ lib_filterx_tests_test_object_dict_interface_LDADD   = $(TEST_LDADD) $(JSON_LIBS
 
 lib_filterx_tests_test_func_keys_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_func_keys_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_filterx_object_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_filterx_object_LDADD   = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -32,6 +32,7 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_object_dict_interface \
 		lib/filterx/tests/test_func_keys \
 		lib/filterx/tests/test_filterx_object \
+		lib/filterx/tests/test_func_path_lookup
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt
 
@@ -129,3 +130,6 @@ lib_filterx_tests_test_func_keys_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_filterx_object_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_filterx_object_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_func_path_lookup_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_func_path_lookup_LDADD   = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/test_filterx_object.c
+++ b/lib/filterx/tests/test_filterx_object.c
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 shifter <shifter@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include <criterion/criterion.h>
+#include "libtest/filterx-lib.h"
+
+#include "filterx/object-dict-interface.h"
+#include "filterx/object-list-interface.h"
+#include "filterx/object-string.h"
+#include "filterx/object-json.h"
+#include "apphook.h"
+#include "scratch-buffers.h"
+
+GPtrArray *
+_assert_filterx_list_to_ptrarray(FilterXObject *keys)
+{
+  guint64 len;
+  cr_assert(filterx_object_len(keys, &len));
+
+  GPtrArray *result = g_ptr_array_new_full(len, (GDestroyNotify)filterx_object_unref);
+
+  for (int i = 0; i < len; i++)
+    {
+      g_ptr_array_add(result, filterx_list_get_subscript(keys, i));
+    }
+
+  filterx_object_unref(keys);
+  return result;
+}
+
+Test(filterx_object, test_path_lookup_empty)
+{
+  const gchar *input = "{\"foo\":{\"bar\":\"baz\"},\"bar\":{\"baz\":null}}";
+  FilterXObject *json = filterx_json_new_from_repr(input, -1);
+  cr_assert_not_null(json);
+
+  GPtrArray *keys = _assert_filterx_list_to_ptrarray(filterx_json_array_new_from_repr("[]", -1));
+
+  FilterXObject *res = filterx_object_path_lookup_g(json, keys);
+  cr_assert(res);
+
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(res, repr));
+  cr_assert_str_eq(input, repr->str);
+
+  g_ptr_array_free(keys, TRUE);
+  filterx_object_unref(json);
+  filterx_object_unref(res);
+}
+
+Test(filterx_object, test_path_lookup)
+{
+  FilterXObject *json = filterx_json_new_from_repr("{\"foo\":{\"bar\":\"baz\"}, \"bar\":{\"baz\": null}}", -1);
+  cr_assert_not_null(json);
+
+  GPtrArray *keys = _assert_filterx_list_to_ptrarray(filterx_json_array_new_from_repr("[\"foo\"]", -1));
+  cr_assert_not_null(keys);
+
+  FilterXObject *res = filterx_object_path_lookup_g(json, keys);
+  cr_assert(res);
+
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(res, repr));
+  cr_assert_str_eq("{\"bar\":\"baz\"}", repr->str);
+
+  g_ptr_array_free(keys, TRUE);
+  filterx_object_unref(json);
+  filterx_object_unref(res);
+}
+
+Test(filterx_object, test_path_lookup_nested)
+{
+  FilterXObject *json = filterx_json_new_from_repr("{\"foo\":{\"bar\":{\"baz\":\"foo\"}}, \"bar\":{\"baz\": null}}", -1);
+  cr_assert_not_null(json);
+
+  GPtrArray *keys = _assert_filterx_list_to_ptrarray(filterx_json_array_new_from_repr("[\"foo\",\"bar\"]", -1));
+  cr_assert_not_null(keys);
+
+  FilterXObject *res = filterx_object_path_lookup_g(json, keys);
+  cr_assert(res);
+
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(res, repr));
+  cr_assert_str_eq("{\"baz\":\"foo\"}", repr->str);
+
+  g_ptr_array_free(keys, TRUE);
+  filterx_object_unref(json);
+  filterx_object_unref(res);
+}
+
+Test(filterx_object, test_path_lookup_list)
+{
+  FilterXObject *json = filterx_json_new_from_repr("[\"foo\", \"bar\", \"baz\"]", -1);
+  cr_assert_not_null(json);
+
+  GPtrArray *keys = _assert_filterx_list_to_ptrarray(filterx_json_array_new_from_repr("[1]", -1));
+  cr_assert_not_null(keys);
+
+  FilterXObject *res = filterx_object_path_lookup_g(json, keys);
+  cr_assert(res);
+
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(res, repr));
+  cr_assert_str_eq("bar", repr->str);
+
+  g_ptr_array_free(keys, TRUE);
+  filterx_object_unref(json);
+  filterx_object_unref(res);
+}
+
+Test(filterx_object, test_path_lookup_return_list)
+{
+  FilterXObject *json = filterx_json_new_from_repr("[\"foo\", [\"tik\", \"tak\", \"toe\"], \"baz\"]", -1);
+  cr_assert_not_null(json);
+
+  GPtrArray *keys = _assert_filterx_list_to_ptrarray(filterx_json_array_new_from_repr("[1]", -1));
+  cr_assert_not_null(keys);
+
+  FilterXObject *res = filterx_object_path_lookup_g(json, keys);
+  cr_assert(res);
+
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(res, repr));
+  cr_assert_str_eq("[\"tik\",\"tak\",\"toe\"]", repr->str);
+
+  g_ptr_array_free(keys, TRUE);
+  filterx_object_unref(json);
+  filterx_object_unref(res);
+}
+
+Test(filterx_object, test_path_lookup_nested_list)
+{
+  FilterXObject *json = filterx_json_new_from_repr("[\"foo\", [\"tik\", \"tak\", \"toe\"], \"baz\"]", -1);
+  cr_assert_not_null(json);
+
+  GPtrArray *keys = _assert_filterx_list_to_ptrarray(filterx_json_array_new_from_repr("[1,2]", -1));
+  cr_assert_not_null(keys);
+
+  FilterXObject *res = filterx_object_path_lookup_g(json, keys);
+  cr_assert(res);
+
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(res, repr));
+  cr_assert_str_eq("toe", repr->str);
+
+  g_ptr_array_free(keys, TRUE);
+  filterx_object_unref(json);
+  filterx_object_unref(res);
+}
+
+Test(filterx_object, test_path_lookup_mixed)
+{
+  FilterXObject *json = filterx_json_new_from_repr("[\"foo\", {\"tik\":33, \"tak\":44, \"toe\":55}, \"baz\"]", -1);
+  cr_assert_not_null(json);
+
+  GPtrArray *keys = _assert_filterx_list_to_ptrarray(filterx_json_array_new_from_repr("[1,\"tak\"]", -1));
+  cr_assert_not_null(keys);
+
+  FilterXObject *res = filterx_object_path_lookup_g(json, keys);
+  cr_assert(res);
+
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(res, repr));
+  cr_assert_str_eq("44", repr->str);
+
+  g_ptr_array_free(keys, TRUE);
+  filterx_object_unref(json);
+  filterx_object_unref(res);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  init_libtest_filterx();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  deinit_libtest_filterx();
+  app_shutdown();
+}
+
+TestSuite(filterx_object, .init = setup, .fini = teardown);

--- a/lib/filterx/tests/test_func_path_lookup.c
+++ b/lib/filterx/tests/test_func_path_lookup.c
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 shifter
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/filterx-lib.h"
+
+#include "filterx/func-flatten.h"
+#include "filterx/object-string.h"
+#include "filterx/object-primitive.h"
+#include "filterx/object-json.h"
+#include "filterx/expr-literal.h"
+#include "filterx/func-path-lookup.h"
+#include "filterx/filterx-eval.h"
+#include "filterx/object-dict-interface.h"
+#include "filterx/object-list-interface.h"
+#include "filterx/expr-literal-generator.h"
+
+#include "apphook.h"
+#include "scratch-buffers.h"
+
+FilterXExpr *
+_list_generator_helper(FilterXExpr *first, ...)
+{
+  FilterXExpr *result = filterx_literal_list_generator_new();
+  GList *target_vals = NULL;
+  va_list va;
+
+  va_start(va, first);
+  FilterXExpr *arg = first;
+  while (arg)
+    {
+      target_vals = g_list_append(target_vals, filterx_literal_generator_elem_new(NULL, arg, FALSE));
+      arg = va_arg(va, FilterXExpr *);
+    }
+  va_end(va);
+
+
+  filterx_literal_generator_set_elements(result, target_vals);
+  return result;
+}
+
+Test(filterx_func_path_lookup, empty_args)
+{
+  GList *args = NULL;
+
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_function_path_lookup_new(filterx_function_args_new(args, NULL), &error);
+  cr_assert_null(fn);
+  cr_assert_not_null(error);
+
+  cr_assert_str_eq(error->message, FILTERX_FUNC_PATH_LOOKUP_ERR_NUM_ARGS FILTERX_FUNC_PATH_LOOKUP_USAGE);
+  g_clear_error(&error);
+}
+
+Test(filterx_func_path_lookup, invalid_args_number)
+{
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_non_literal_new(filterx_string_new("not a dict",
+                                                      -1))));
+
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_function_path_lookup_new(filterx_function_args_new(args, NULL), &error);
+  cr_assert_null(fn);
+  cr_assert_not_null(error);
+
+  cr_assert_str_eq(error->message, FILTERX_FUNC_PATH_LOOKUP_ERR_NUM_ARGS FILTERX_FUNC_PATH_LOOKUP_USAGE);
+  g_clear_error(&error);
+}
+
+Test(filterx_func_path_lookup, invalid_arg_type_first_arg)
+{
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_non_literal_new(filterx_string_new("not a dict or list",
+                                                          -1))));
+
+  FilterXExpr *keys = _list_generator_helper(filterx_literal_new(filterx_string_new("anything", -1)), NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL, keys));
+
+
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_function_path_lookup_new(filterx_function_args_new(args, NULL), &error);
+  cr_assert_not_null(fn);
+  cr_assert_null(error);
+
+  FilterXObject *obj = filterx_expr_eval(fn);
+  cr_assert_null(obj);
+
+  filterx_expr_unref(fn);
+  g_clear_error(&error);
+}
+
+Test(filterx_func_path_lookup, empty_keys)
+{
+  GList *args = NULL;
+
+  FilterXObject *first = filterx_string_new("not a dict or list", -1);
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_non_literal_new(first)));
+
+  FilterXExpr *keys = _list_generator_helper(NULL, NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL, keys));
+
+
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_function_path_lookup_new(filterx_function_args_new(args, NULL), &error);
+  cr_assert_not_null(fn);
+  cr_assert_null(error);
+
+  FilterXObject *obj = filterx_expr_eval(fn);
+  cr_assert_not_null(obj);
+
+  cr_assert_eq(obj, first);
+
+  filterx_object_unref(first);
+  filterx_expr_unref(fn);
+  g_clear_error(&error);
+}
+
+Test(filterx_func_path_lookup, keys_not_literal_generator)
+{
+  FilterXObject *first = filterx_json_new_from_repr("{\"foo\":{\"bar\":{\"baz\":\"foo\"}}, \"bar\":{\"baz\": null}}", -1);
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_non_literal_new(first)));
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_json_array_new_from_repr("[\"foo\"]", -1))));
+
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_function_path_lookup_new(filterx_function_args_new(args, NULL), &error);
+  cr_assert_null(fn);
+  cr_assert_not_null(error);
+
+  cr_assert_str_eq(error->message, FILTERX_FUNC_PATH_LOOKUP_ERR_LITERAL_LIST FILTERX_FUNC_PATH_LOOKUP_USAGE);
+  g_clear_error(&error);
+}
+
+Test(filterx_func_path_lookup, some_of_keys_elts_are_not_literal_generator)
+{
+  FilterXObject *first = filterx_json_new_from_repr("{\"foo\":{\"bar\":{\"baz\":\"foo\"}}, \"bar\":{\"baz\": null}}", -1);
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_non_literal_new(first)));
+
+  FilterXExpr *keys = _list_generator_helper(filterx_literal_new(filterx_string_new("foo", -1)),
+                                             filterx_non_literal_new(filterx_string_new("bar", -1)), NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL, keys));
+
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_function_path_lookup_new(filterx_function_args_new(args, NULL), &error);
+  cr_assert_null(fn);
+  cr_assert_not_null(error);
+
+  cr_assert_str_eq(error->message, FILTERX_FUNC_PATH_LOOKUP_ERR_LITERAL_LIST_ELTS FILTERX_FUNC_PATH_LOOKUP_USAGE);
+  g_clear_error(&error);
+}
+
+Test(filterx_func_path_lookup, nested_dict_lookup)
+{
+  FilterXObject *first = filterx_json_new_from_repr("{\"foo\":{\"bar\":{\"baz\":\"foo\"}}, \"bar\":{\"baz\": null}}", -1);
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_non_literal_new(first)));
+
+  FilterXExpr *keys = _list_generator_helper(filterx_literal_new(filterx_string_new("foo", -1)),
+                                             filterx_literal_new(filterx_string_new("bar", -1)), NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL, keys));
+
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_function_path_lookup_new(filterx_function_args_new(args, NULL), &error);
+  cr_assert_not_null(fn);
+  cr_assert_null(error);
+
+  FilterXObject *obj = filterx_expr_eval(fn);
+  cr_assert_not_null(obj);
+
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(obj, repr));
+
+  cr_assert_str_eq(repr->str, "{\"baz\":\"foo\"}");
+
+  filterx_object_unref(obj);
+  filterx_expr_unref(fn);
+  g_clear_error(&error);
+}
+
+Test(filterx_func_path_lookup, nested_list_lookup)
+{
+  FilterXObject *first = filterx_json_new_from_repr("[[3,2,1],[4,5,6],[7,8,9]]", -1);
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_non_literal_new(first)));
+
+  FilterXExpr *keys = _list_generator_helper(filterx_literal_new(filterx_integer_new(1)),
+                                             filterx_literal_new(filterx_integer_new(-1)), NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL, keys));
+
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_function_path_lookup_new(filterx_function_args_new(args, NULL), &error);
+  cr_assert_not_null(fn);
+  cr_assert_null(error);
+
+  FilterXObject *obj = filterx_expr_eval(fn);
+  cr_assert_not_null(obj);
+
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(obj, repr));
+
+  cr_assert_str_eq(repr->str, "6");
+
+  filterx_object_unref(obj);
+  filterx_expr_unref(fn);
+  g_clear_error(&error);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  init_libtest_filterx();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  deinit_libtest_filterx();
+  app_shutdown();
+}
+
+TestSuite(filterx_func_path_lookup, .init = setup, .fini = teardown);


### PR DESCRIPTION
Add path_lookup to the filterx_object Namespace as an Alternative to get_subscript

This PR introduces a new function, path_lookup, to the filterx_object namespace. It allows retrieving elements from nested filterx lists or dictionaries in a single call, providing a more convenient and expressive alternative to using get_subscript repeatedly.

Key Features:
* Flexible First Argument: The first argument must be a list or dictionary. Mixed structures (e.g., nested combinations of lists and dictionaries) are fully supported.
* Dynamic Path Lookup: The second parameter accepts a list literal containing both filterx strings (for dictionary keys) and integers (for list indices).
* Deep Nested Access: Enables seamless access to deeply nested elements in hybrid list-dictionary structures.
* Reverse Indexing Support: Integer indices support negative values for reverse indexing in lists, mirroring Python-like behavior.

example:
```
filterx {
d = {"foo":1,"bar":[3,2,1],"baz":{"tik":"tak"}};
a = path_lookup(d, ["bar", 0]); # returns 3
b = path_lookup(d, ["baz", "tik"]); # returns "tak"
c = path_lookup(d, ["bar", -1]); # returns 1
}
```