### PR TITLE
Filterx: unset-empties() performance changes

### DIFF
--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -511,7 +511,14 @@ filterx_function_unset_empties_new(FilterXFunctionArgs *args, GError **error)
   self->super.super.deinit = _deinit;
   self->super.super.free_fn = _free;
 
-  reset_flags(&self->flags, ALL_FLAG_SET(FilterXFunctionUnsetEmptiesFlags));
+  /* everything is enabled except ignorecase */
+  reset_flags(&self->flags,
+              FLAG_VAL(FILTERX_FUNC_UNSET_EMPTIES_FLAG_RECURSIVE) |
+              FLAG_VAL(FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_NULL) |
+              FLAG_VAL(FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_STRING) |
+              FLAG_VAL(FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_LIST) |
+              FLAG_VAL(FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_DICT)
+             );
 
   if (!_extract_args(self, args, error) ||
       !filterx_function_args_check(args, error))

--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -67,7 +67,8 @@ static gboolean _process_list(FilterXFunctionUnsetEmpties *self, FilterXObject *
 
 typedef int (*str_cmp_fn)(const char *, const char *);
 
-static gboolean _string_compare(FilterXFunctionUnsetEmpties *self, const gchar *str, str_cmp_fn cmp_fn)
+static inline gboolean
+_string_compare(FilterXFunctionUnsetEmpties *self, const gchar *str, str_cmp_fn cmp_fn)
 {
   guint num_targets = self->targets ? self->targets->len : 0;
   for (guint i = 0; i < num_targets; i++)
@@ -79,11 +80,11 @@ static gboolean _string_compare(FilterXFunctionUnsetEmpties *self, const gchar *
   return FALSE;
 }
 
-static gboolean _should_unset_string(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
+static gboolean
+_should_unset_string(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
 {
   gsize str_len = 0;
   const gchar *str = NULL;
-  gchar *casefold_str = NULL;
   if (!filterx_object_extract_string_ref(obj, &str, &str_len))
     return FALSE;
   g_assert(str);
@@ -91,16 +92,12 @@ static gboolean _should_unset_string(FilterXFunctionUnsetEmpties *self, FilterXO
   if (check_flag(self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_STRING) && (str_len == 0))
     return TRUE;
 
-  if (!g_utf8_validate(str, -1, NULL))
-    return FALSE;
   if (check_flag(self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_IGNORECASE))
     {
-      casefold_str = g_utf8_casefold(str, str_len);
-      gboolean result = _string_compare(self, casefold_str, g_utf8_collate);
-      g_free(casefold_str);
+      gboolean result = _string_compare(self, str, strcasecmp);
       return result;
     }
-  return _string_compare(self, str, g_strcmp0);
+  return _string_compare(self, str, strcmp);
 }
 
 static gboolean
@@ -404,18 +401,12 @@ _handle_target_object(FilterXFunctionUnsetEmpties *self, FilterXObject *target, 
           set_flag(&self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_STRING, TRUE);
           return TRUE;
         }
-      if (!g_utf8_validate(str, -1, NULL))
-        {
-          g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
-                      FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS" strings must be valid utf8 strings! " FILTERX_FUNC_UNSET_EMPTIES_USAGE);
-          return FALSE;
-        }
       if (check_flag(self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_IGNORECASE))
         {
-          g_ptr_array_add(self->targets, g_utf8_casefold(str, len));
+          g_ptr_array_add(self->targets, g_strndup(str, len));
           return TRUE;
         }
-      g_ptr_array_add(self->targets, g_strdup(str));
+      g_ptr_array_add(self->targets, g_strndup(str, len));
     }
   else
     {

--- a/news/fx-feature-452.md
+++ b/news/fx-feature-452.md
@@ -1,0 +1,4 @@
+`unset_empties()`: change the default for ignorecase to FALSE, remove utf8
+support.  UTF8 validation and case folding is expensive and most use-cases
+do not really need that. If there's a specific use-case, an explicit utf8
+flag can be added back.

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -1664,33 +1664,6 @@ def test_macro_caching(config, syslog_ng):
     assert output["1"] == output["2"] == output["3"] == output["4"] == {"SEVERITY": "notice", "FACILITY": "user"}
 
 
-def test_unset_empties_invalid_utf8(config, syslog_ng):
-    (file_true, file_false) = create_config(
-        config, r"""
-            invalid_utf8 = "ba\xC080az";
-            dict = {"foo":invalid_utf8};
-            unset_empties(dict, targets=["baz"]);
-            $MSG = dict;
-    """,
-    )
-    syslog_ng.start(config)
-
-    assert file_true.get_stats()["processed"] == 1
-    assert "processed" not in file_false.get_stats()
-
-
-def test_unset_empties_invalid_utf8_target(config, syslog_ng):
-    (file_true, file_false) = create_config(
-        config, r"""
-            dict = {};
-            unset_empties(dict, targets=["b\xC080az"], recursive=true);
-            $MSG = dict;
-    """,
-    )
-    with pytest.raises(Exception):
-        syslog_ng.start(config)
-
-
 def test_unset_empties(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, r"""


### PR DESCRIPTION
UTF8 aware case folding are expensive, remove that feature for now. The branch also changes the default for the ignorecase parameter.