### PR TITLE
Fix rpm build

### DIFF
--- a/dbld/rules
+++ b/dbld/rules
@@ -27,7 +27,7 @@ CONTAINER_REGISTRY ?= ghcr.io/axoflow
 MODE ?= snapshot
 VERSION ?= $(shell MODE=${MODE} scripts/version.sh)
 DOCKER_RUN_ARGS=-e USER_NAME_ON_HOST=$(shell whoami)	\
-        --network=host --privileged \
+        --network=host \
 	--ulimit nofile=1024:1024 \
 	-v $(ROOT_DIR):/source \
         -v $(DBLD_DIR):/dbld \
@@ -55,7 +55,7 @@ CONFIGURE_OPTS=--enable-debug --enable-manpages --with-python=3 --prefix=/instal
 DBLD_RULES=$(MAKE) --no-print-directory -f $(DBLD_DIR)/rules
 
 DOCKER_INTERACTIVE=$(shell if tty -s; then echo "-ti"; else echo "-i"; fi)
-DOCKER_SHELL=$(DOCKER) run $(DOCKER_RUN_ARGS) --rm $(DOCKER_INTERACTIVE) ${CONTAINER_REGISTRY}/axosyslog-dbld-$* /dbld/shell $(if $(SHELL_COMMAND),"$(SHELL_COMMAND)",bash)
+DOCKER_SHELL=$(DOCKER) run $(DOCKER_RUN_ARGS) --privileged --rm $(DOCKER_INTERACTIVE) ${CONTAINER_REGISTRY}/axosyslog-dbld-$* /dbld/shell $(if $(SHELL_COMMAND),"$(SHELL_COMMAND)",bash)
 
 -include $(if $(RULES_CONF),$(RULES_CONF),$(DBLD_DIR)/rules.conf)
 


### PR DESCRIPTION
This is only needed for gdb sessions, but it interferes with auth modules
in sudo, for example.

The issue will be still reproducible in `dbld shell-*`, let's investigate it separately.