### PR TITLE
fix osx build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew update --preinstall
+          brew update
           brew bundle --force --file=contrib/Brewfile
 
       - name: Set ENV variables


### PR DESCRIPTION
fix: remove unrecognized brew flag `--preinstall` from osx build workflow