### PR TITLE
Filterx expr type macros

### DIFF
--- a/lib/filterx/expr-generator.c
+++ b/lib/filterx/expr-generator.c
@@ -49,12 +49,6 @@ _eval_generator(FilterXExpr *s)
   return NULL;
 }
 
-gboolean
-filterx_expr_is_generator(FilterXExpr *s)
-{
-  return s && s->eval == _eval_generator;
-}
-
 FilterXExpr *
 filterx_generator_optimize_method(FilterXExpr *s)
 {
@@ -67,7 +61,7 @@ filterx_generator_optimize_method(FilterXExpr *s)
 void
 filterx_generator_init_instance(FilterXExpr *s)
 {
-  filterx_expr_init_instance(s, "generator");
+  filterx_expr_init_instance(s, FILTERX_EXPR_TYPE_NAME(generator));
   s->optimize = filterx_generator_optimize_method;
   s->init = filterx_generator_init_method;
   s->deinit = filterx_generator_deinit_method;
@@ -103,6 +97,8 @@ filterx_generator_free_method(FilterXExpr *s)
   filterx_expr_unref(self->fillable);
   filterx_expr_free_method(s);
 }
+
+FILTERX_EXPR_DEFINE_TYPE(generator);
 
 typedef struct FilterXExprGeneratorCreateContainer_
 {

--- a/lib/filterx/expr-generator.h
+++ b/lib/filterx/expr-generator.h
@@ -41,7 +41,8 @@ FilterXExpr *filterx_generator_optimize_method(FilterXExpr *s);
 gboolean filterx_generator_init_method(FilterXExpr *s, GlobalConfig *cfg);
 void filterx_generator_deinit_method(FilterXExpr *s, GlobalConfig *cfg);
 void filterx_generator_free_method(FilterXExpr *s);
-gboolean filterx_expr_is_generator(FilterXExpr *s);
+
+FILTERX_EXPR_DECLARE_TYPE(generator);
 
 FilterXExpr *filterx_generator_create_container_new(FilterXExpr *g, FilterXExpr *fillable_parent);
 

--- a/lib/filterx/expr-generator.h
+++ b/lib/filterx/expr-generator.h
@@ -46,6 +46,11 @@ FILTERX_EXPR_DECLARE_TYPE(generator);
 
 FilterXExpr *filterx_generator_create_container_new(FilterXExpr *g, FilterXExpr *fillable_parent);
 
+static inline gboolean
+filterx_expr_is_generator(FilterXExpr *expr)
+{
+  return expr && expr->type == FILTERX_EXPR_TYPE_NAME(generator);
+}
 
 /* protected */
 FilterXObject *filterx_generator_create_dict_container(FilterXExprGenerator *s, FilterXExpr *fillable_parent);

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -157,7 +157,7 @@ filterx_get_subscript_new(FilterXExpr *operand, FilterXExpr *key)
 {
   FilterXGetSubscript *self = g_new0(FilterXGetSubscript, 1);
 
-  filterx_expr_init_instance(&self->super, "get_subscript");
+  filterx_expr_init_instance(&self->super, FILTERX_EXPR_TYPE_NAME(get_subscript));
   self->super.eval = _eval_get_subscript;
   self->super.is_set = _isset;
   self->super.unset = _unset;
@@ -169,3 +169,5 @@ filterx_get_subscript_new(FilterXExpr *operand, FilterXExpr *key)
   self->key = key;
   return &self->super;
 }
+
+FILTERX_EXPR_DEFINE_TYPE(get_subscript);

--- a/lib/filterx/expr-get-subscript.h
+++ b/lib/filterx/expr-get-subscript.h
@@ -27,5 +27,6 @@
 
 FilterXExpr *filterx_get_subscript_new(FilterXExpr *lhs, FilterXExpr *key);
 
+FILTERX_EXPR_DECLARE_TYPE(get_subscript);
 
 #endif

--- a/lib/filterx/expr-get-subscript.h
+++ b/lib/filterx/expr-get-subscript.h
@@ -29,4 +29,10 @@ FilterXExpr *filterx_get_subscript_new(FilterXExpr *lhs, FilterXExpr *key);
 
 FILTERX_EXPR_DECLARE_TYPE(get_subscript);
 
+static inline gboolean
+filterx_expr_is_get_subscript(FilterXExpr *expr)
+{
+  return expr && expr->type == FILTERX_EXPR_TYPE_NAME(get_subscript);
+}
+
 #endif

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -136,7 +136,7 @@ filterx_getattr_new(FilterXExpr *operand, FilterXString *attr_name)
 {
   FilterXGetAttr *self = g_new0(FilterXGetAttr, 1);
 
-  filterx_expr_init_instance(&self->super, "getattr");
+  filterx_expr_init_instance(&self->super, FILTERX_EXPR_TYPE_NAME(getattr));
   self->super.eval = _eval_getattr;
   self->super.unset = _unset;
   self->super.is_set = _isset;
@@ -151,3 +151,5 @@ filterx_getattr_new(FilterXExpr *operand, FilterXString *attr_name)
   self->super.name = filterx_string_get_value_ref(self->attr, NULL);
   return &self->super;
 }
+
+FILTERX_EXPR_DEFINE_TYPE(getattr);

--- a/lib/filterx/expr-getattr.h
+++ b/lib/filterx/expr-getattr.h
@@ -30,4 +30,10 @@ FilterXExpr *filterx_getattr_new(FilterXExpr *lhs, FilterXString *attr_name);
 
 FILTERX_EXPR_DECLARE_TYPE(getattr);
 
+static inline gboolean
+filterx_expr_is_getattr(FilterXExpr *expr)
+{
+  return expr && expr->type == FILTERX_EXPR_TYPE_NAME(getattr);
+}
+
 #endif

--- a/lib/filterx/expr-getattr.h
+++ b/lib/filterx/expr-getattr.h
@@ -28,5 +28,6 @@
 
 FilterXExpr *filterx_getattr_new(FilterXExpr *lhs, FilterXString *attr_name);
 
+FILTERX_EXPR_DECLARE_TYPE(getattr);
 
 #endif

--- a/lib/filterx/expr-literal-generator.c
+++ b/lib/filterx/expr-literal-generator.c
@@ -250,6 +250,9 @@ typedef struct FilterXLiteralInnerGenerator_
   GList *elements;
 } FilterXLiteralInnerGenerator;
 
+FILTERX_EXPR_DEFINE_TYPE(literal_inner_dict_generator);
+FILTERX_EXPR_DEFINE_TYPE(literal_inner_list_generator);
+
 void
 _literal_inner_generator_free(FilterXExpr *s)
 {
@@ -261,9 +264,9 @@ _literal_inner_generator_free(FilterXExpr *s)
 
 static void
 _literal_inner_generator_init_instance(FilterXLiteralInnerGenerator *self, FilterXExpr *root_literal_generator,
-                                       GList *elements)
+                                       GList *elements, const gchar *type)
 {
-  filterx_expr_init_instance(&self->super, "literal_inner_generator");
+  filterx_expr_init_instance(&self->super, type);
   self->super.free_fn = _literal_inner_generator_free;
 
   /*
@@ -322,7 +325,9 @@ filterx_literal_inner_dict_generator_new(FilterXExpr *root_literal_generator, GL
 {
   FilterXLiteralInnerGenerator *self = g_new0(FilterXLiteralInnerGenerator, 1);
 
-  _literal_inner_generator_init_instance(self, root_literal_generator, elements);
+  _literal_inner_generator_init_instance(self,
+                                         root_literal_generator, elements,
+                                         FILTERX_EXPR_TYPE_NAME(literal_inner_dict_generator));
   self->super.eval = _inner_dict_generator_eval;
 
   return &self->super;
@@ -334,51 +339,19 @@ filterx_literal_inner_list_generator_new(FilterXExpr *root_literal_generator, GL
 {
   FilterXLiteralInnerGenerator *self = g_new0(FilterXLiteralInnerGenerator, 1);
 
-  _literal_inner_generator_init_instance(self, root_literal_generator, elements);
+  _literal_inner_generator_init_instance(self,
+                                         root_literal_generator, elements,
+                                         FILTERX_EXPR_TYPE_NAME(literal_inner_list_generator));
   self->super.eval = _inner_list_generator_eval;
 
   return &self->super;
-}
-
-gboolean
-_filterx_expr_is_inner_dict_generator(FilterXExpr *s)
-{
-  return s && (s->eval == _inner_dict_generator_eval);
-}
-
-gboolean
-_filterx_expr_is_inner_list_generator(FilterXExpr *s)
-{
-  return s && (s->eval == _inner_list_generator_eval);
-}
-
-gboolean
-filterx_expr_is_literal_dict_generator(FilterXExpr *s)
-{
-  FilterXExprGenerator *generator = (FilterXExprGenerator *) s;
-  return (filterx_expr_is_generator(s) && generator->create_container == filterx_generator_create_dict_container)
-         || _filterx_expr_is_inner_dict_generator(s);
-}
-
-gboolean
-filterx_expr_is_literal_list_generator(FilterXExpr *s)
-{
-  FilterXExprGenerator *generator = (FilterXExprGenerator *) s;
-  return (filterx_expr_is_generator(s) && generator->create_container == filterx_generator_create_list_container)
-         || _filterx_expr_is_inner_list_generator(s);
-}
-
-gboolean
-filterx_expr_is_literal_generator(FilterXExpr *s)
-{
-  return filterx_expr_is_literal_list_generator(s) || filterx_expr_is_literal_dict_generator(s);
 }
 
 guint
 filterx_expr_literal_generator_len(FilterXExpr *s)
 {
   GList *elements = NULL;
-  if (_filterx_expr_is_inner_dict_generator(s))
+  if (filterx_expr_is_literal_inner_dict_generator(s))
     elements = ((FilterXLiteralInnerGenerator *) s)->elements;
   else
     elements = ((FilterXExprLiteralGenerator *) s)->elements;
@@ -390,7 +363,7 @@ gboolean
 filterx_literal_dict_generator_foreach(FilterXExpr *s, FilterXLiteralDictGeneratorForeachFunc func, gpointer user_data)
 {
   GList *elements = NULL;
-  if (_filterx_expr_is_inner_dict_generator(s))
+  if (filterx_expr_is_literal_inner_dict_generator(s))
     elements = ((FilterXLiteralInnerGenerator *) s)->elements;
   else
     elements = ((FilterXExprLiteralGenerator *) s)->elements;
@@ -410,7 +383,7 @@ gboolean
 filterx_literal_list_generator_foreach(FilterXExpr *s, FilterXLiteralListGeneratorForeachFunc func, gpointer user_data)
 {
   GList *elements = NULL;
-  if (_filterx_expr_is_inner_list_generator(s))
+  if (filterx_expr_is_literal_inner_list_generator(s))
     elements = ((FilterXLiteralInnerGenerator *) s)->elements;
   else
     elements = ((FilterXExprLiteralGenerator *) s)->elements;

--- a/lib/filterx/expr-literal-generator.h
+++ b/lib/filterx/expr-literal-generator.h
@@ -52,6 +52,18 @@ FILTERX_EXPR_DECLARE_TYPE(literal_inner_dict_generator);
 FILTERX_EXPR_DECLARE_TYPE(literal_inner_list_generator);
 
 static inline gboolean
+filterx_expr_is_literal_inner_dict_generator(FilterXExpr *expr)
+{
+  return expr && expr->type == FILTERX_EXPR_TYPE_NAME(literal_inner_dict_generator);
+}
+
+static inline gboolean
+filterx_expr_is_literal_inner_list_generator(FilterXExpr *expr)
+{
+  return expr && expr->type == FILTERX_EXPR_TYPE_NAME(literal_inner_list_generator);
+}
+
+static inline gboolean
 filterx_expr_is_literal_dict_generator(FilterXExpr *s)
 {
   FilterXExprGenerator *generator = (FilterXExprGenerator *) s;

--- a/lib/filterx/expr-literal-generator.h
+++ b/lib/filterx/expr-literal-generator.h
@@ -46,10 +46,31 @@ gboolean filterx_literal_list_generator_foreach(FilterXExpr *s, FilterXLiteralLi
 FilterXExpr *filterx_literal_inner_dict_generator_new(FilterXExpr *root_literal_generator, GList *elements);
 FilterXExpr *filterx_literal_inner_list_generator_new(FilterXExpr *root_literal_generator, GList *elements);
 
-gboolean filterx_expr_is_literal_dict_generator(FilterXExpr *s);
-gboolean filterx_expr_is_literal_list_generator(FilterXExpr *s);
-
 guint filterx_expr_literal_generator_len(FilterXExpr *s);
-gboolean filterx_expr_is_literal_generator(FilterXExpr *s);
+
+FILTERX_EXPR_DECLARE_TYPE(literal_inner_dict_generator);
+FILTERX_EXPR_DECLARE_TYPE(literal_inner_list_generator);
+
+static inline gboolean
+filterx_expr_is_literal_dict_generator(FilterXExpr *s)
+{
+  FilterXExprGenerator *generator = (FilterXExprGenerator *) s;
+  return (filterx_expr_is_generator(s) && generator->create_container == filterx_generator_create_dict_container)
+         || filterx_expr_is_literal_inner_dict_generator(s);
+}
+
+static inline gboolean
+filterx_expr_is_literal_list_generator(FilterXExpr *s)
+{
+  FilterXExprGenerator *generator = (FilterXExprGenerator *) s;
+  return (filterx_expr_is_generator(s) && generator->create_container == filterx_generator_create_list_container)
+         || filterx_expr_is_literal_inner_list_generator(s);
+}
+
+static inline gboolean
+filterx_expr_is_literal_generator(FilterXExpr *s)
+{
+  return filterx_expr_is_literal_list_generator(s) || filterx_expr_is_literal_dict_generator(s);
+}
 
 #endif

--- a/lib/filterx/expr-literal.c
+++ b/lib/filterx/expr-literal.c
@@ -20,7 +20,7 @@
  * COPYING for details.
  *
  */
-#include "filterx/filterx-expr.h"
+#include "filterx/expr-literal.h"
 
 typedef struct _FilterXLiteral
 {
@@ -49,15 +49,11 @@ filterx_literal_new(FilterXObject *object)
 {
   FilterXLiteral *self = g_new0(FilterXLiteral, 1);
 
-  filterx_expr_init_instance(&self->super, "literal");
+  filterx_expr_init_instance(&self->super, FILTERX_EXPR_TYPE_NAME(literal));
   self->super.eval = _eval_literal;
   self->super.free_fn = _free;
   self->object = object;
   return &self->super;
 }
 
-gboolean
-filterx_expr_is_literal(FilterXExpr *expr)
-{
-  return expr->eval == _eval_literal;
-}
+FILTERX_EXPR_DEFINE_TYPE(literal);

--- a/lib/filterx/expr-literal.h
+++ b/lib/filterx/expr-literal.h
@@ -30,4 +30,10 @@ FilterXExpr *filterx_literal_new(FilterXObject *object);
 
 FILTERX_EXPR_DECLARE_TYPE(literal);
 
+static inline gboolean
+filterx_expr_is_literal(FilterXExpr *expr)
+{
+  return expr && expr->type == FILTERX_EXPR_TYPE_NAME(literal);
+}
+
 #endif

--- a/lib/filterx/expr-literal.h
+++ b/lib/filterx/expr-literal.h
@@ -27,6 +27,7 @@
 #include "filterx/filterx-expr.h"
 
 FilterXExpr *filterx_literal_new(FilterXObject *object);
-gboolean filterx_expr_is_literal(FilterXExpr *expr);
+
+FILTERX_EXPR_DECLARE_TYPE(literal);
 
 #endif

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -191,7 +191,7 @@ filterx_variable_expr_new(FilterXString *name, FilterXVariableType variable_type
 {
   FilterXVariableExpr *self = g_new0(FilterXVariableExpr, 1);
 
-  filterx_expr_init_instance(&self->super, "variable");
+  filterx_expr_init_instance(&self->super, FILTERX_EXPR_TYPE_NAME(variable));
   self->super.free_fn = _free;
   self->super.eval = _eval_variable;
   self->super._update_repr = _update_repr;
@@ -228,8 +228,10 @@ filterx_variable_expr_declare(FilterXExpr *s)
 {
   FilterXVariableExpr *self = (FilterXVariableExpr *) s;
 
-  g_assert(s->eval == _eval_variable);
+  g_assert(filterx_expr_is_variable(s));
   /* we can only declare a floating variable */
   g_assert(self->variable_type == FX_VAR_FLOATING);
   self->variable_type = FX_VAR_DECLARED_FLOATING;
 }
+
+FILTERX_EXPR_DEFINE_TYPE(variable);

--- a/lib/filterx/expr-variable.h
+++ b/lib/filterx/expr-variable.h
@@ -44,4 +44,10 @@ filterx_frozen_dollar_msg_varname(GlobalConfig *cfg, const gchar *name)
 
 FILTERX_EXPR_DECLARE_TYPE(variable);
 
+static inline gboolean
+filterx_expr_is_variable(FilterXExpr *expr)
+{
+  return expr && expr->type == FILTERX_EXPR_TYPE_NAME(variable);
+}
+
 #endif

--- a/lib/filterx/expr-variable.h
+++ b/lib/filterx/expr-variable.h
@@ -42,4 +42,6 @@ filterx_frozen_dollar_msg_varname(GlobalConfig *cfg, const gchar *name)
   return dollar_name_obj;
 }
 
+FILTERX_EXPR_DECLARE_TYPE(variable);
+
 #endif

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -68,6 +68,20 @@ struct _FilterXExpr
   gchar *expr_text;
 };
 
+#define FILTERX_EXPR_TYPE_NAME(_type) filterx_expr_type_ ## _type
+
+#define FILTERX_EXPR_DECLARE_TYPE(_type) \
+  extern const gchar *FILTERX_EXPR_TYPE_NAME(_type); \
+  \
+  static inline gboolean \
+  filterx_expr_is_ ## _type(FilterXExpr *expr) \
+  { \
+    return expr && expr->type == FILTERX_EXPR_TYPE_NAME(_type); \
+  }
+
+#define FILTERX_EXPR_DEFINE_TYPE(_type) \
+  const gchar *FILTERX_EXPR_TYPE_NAME(_type) = # _type
+
 /*
  * Evaluate the expression and return the result as a FilterXObject.  The
  * result can either be a

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -71,13 +71,7 @@ struct _FilterXExpr
 #define FILTERX_EXPR_TYPE_NAME(_type) filterx_expr_type_ ## _type
 
 #define FILTERX_EXPR_DECLARE_TYPE(_type) \
-  extern const gchar *FILTERX_EXPR_TYPE_NAME(_type); \
-  \
-  static inline gboolean \
-  filterx_expr_is_ ## _type(FilterXExpr *expr) \
-  { \
-    return expr && expr->type == FILTERX_EXPR_TYPE_NAME(_type); \
-  }
+  extern const gchar *FILTERX_EXPR_TYPE_NAME(_type);
 
 #define FILTERX_EXPR_DEFINE_TYPE(_type) \
   const gchar *FILTERX_EXPR_TYPE_NAME(_type) = # _type


### PR DESCRIPTION
The current convention is to decide whether we are looking at a specific FilterXExpr instance based on the value of the
"eval" function pointer.

Issue is that #433 will change that pointer at runtime to incorporate expr level visibility into perf backtraces.

This could also be the beginning of a real FilterXExprType struct (to avoid repeating the function pointers into all expr instances), but this PR does not go that far.

NOTE: this does not create FILTERX_EXPR_TYPE_DECLARE() for all exprs, only those which had a filterx_expr_is_XXX() function. As long as noone is checking if an expr is of a specific type, this is optional.

