### PR TITLE
Filterx scope to track message changes

### DIFF
--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -154,6 +154,7 @@ filterx_eval_init_context(FilterXEvalContext *context, FilterXEvalContext *previ
   else
     scope = filterx_scope_new();
   filterx_scope_make_writable(&scope);
+  filterx_scope_set_message(scope, msg);
 
   memset(context, 0, sizeof(*context));
   context->msg = msg;

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -70,9 +70,6 @@ log_filterx_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_o
   path_options = log_path_options_chain(&local_path_options, path_options);
   filterx_eval_init_context(&eval_context, path_options->filterx_context, msg);
 
-  if (filterx_scope_has_log_msg_changes(eval_context.scope))
-    filterx_scope_invalidate_log_msg_cache(eval_context.scope);
-
   msg_trace(">>>>>> filterx rule evaluation begin",
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),

--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -23,12 +23,6 @@
 #include "filterx/filterx-scope.h"
 #include "scratch-buffers.h"
 
-struct _FilterXScope
-{
-  GAtomicCounter ref_cnt;
-  GArray *variables;
-  guint32 generation:20, write_protected, dirty, syncable;
-};
 
 volatile gint filterx_scope_variables_max = 16;
 

--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -279,6 +279,7 @@ filterx_scope_clone(FilterXScope *other)
   if (other->variables->len > 0)
     self->dirty = other->dirty;
   self->syncable = other->syncable;
+  self->msg = log_msg_ref(other->msg);
 
   msg_trace("Filterx clone finished",
             evt_tag_printf("scope", "%p", self),
@@ -321,6 +322,8 @@ _free(FilterXScope *self)
   if (variables_max < self->variables->len)
     filterx_scope_variables_max = self->variables->len;
 
+  if (self->msg)
+    log_msg_unref(self->msg);
   g_array_free(self->variables, TRUE);
   g_free(self);
 }

--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -271,7 +271,6 @@ filterx_scope_clone(FilterXScope *other)
           g_array_append_val(self->variables, *v);
           FilterXVariable *v_clone = &g_array_index(self->variables, FilterXVariable, dst_index);
 
-          filterx_variable_set_generation(v_clone, 0);
           if (v->value)
             v_clone->value = filterx_object_clone(v->value);
           else
@@ -281,7 +280,8 @@ filterx_scope_clone(FilterXScope *other)
                     evt_tag_str("variable", log_msg_get_value_name((filterx_variable_get_nv_handle(v)), NULL)));
         }
     }
-
+  /* retain the generation counter */
+  self->generation = other->generation;
   if (other->variables->len > 0)
     self->dirty = other->dirty;
   self->syncable = other->syncable;

--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -59,18 +59,6 @@ _lookup_variable(FilterXScope *self, FilterXVariableHandle handle, FilterXVariab
   return FALSE;
 }
 
-void
-filterx_scope_set_dirty(FilterXScope *self)
-{
-  self->dirty = TRUE;
-}
-
-gboolean
-filterx_scope_is_dirty(FilterXScope *self)
-{
-  return self->dirty;
-}
-
 static gboolean
 _validate_variable(FilterXScope *self, FilterXVariable *variable)
 {

--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -43,6 +43,7 @@ typedef struct _FilterXScope FilterXScope;
 struct _FilterXScope
 {
   GAtomicCounter ref_cnt;
+  LogMessage *msg;
   GArray *variables;
   guint32 generation:20, write_protected, dirty, syncable;
 };
@@ -67,5 +68,13 @@ FilterXScope *filterx_scope_make_writable(FilterXScope **pself);
 FilterXScope *filterx_scope_new(void);
 FilterXScope *filterx_scope_ref(FilterXScope *self);
 void filterx_scope_unref(FilterXScope *self);
+
+static inline void
+filterx_scope_set_message(FilterXScope *self, LogMessage *msg)
+{
+  if (self->msg)
+    log_msg_unref(self->msg);
+  self->msg = log_msg_ref(msg);
+}
 
 #endif

--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -40,6 +40,12 @@
  */
 
 typedef struct _FilterXScope FilterXScope;
+struct _FilterXScope
+{
+  GAtomicCounter ref_cnt;
+  GArray *variables;
+  guint32 generation:20, write_protected, dirty, syncable;
+};
 
 typedef gboolean (*FilterXScopeForeachFunc)(FilterXVariable *variable, gpointer user_data);
 

--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -43,9 +43,6 @@ typedef struct _FilterXScope FilterXScope;
 
 typedef gboolean (*FilterXScopeForeachFunc)(FilterXVariable *variable, gpointer user_data);
 
-void filterx_scope_set_log_msg_has_changes(FilterXScope *self);
-void filterx_scope_clear_log_msg_has_changes(FilterXScope *self);
-gboolean filterx_scope_has_log_msg_changes(FilterXScope *self);
 void filterx_scope_set_dirty(FilterXScope *self);
 gboolean filterx_scope_is_dirty(FilterXScope *self);
 void filterx_scope_sync(FilterXScope *self, LogMessage *msg);
@@ -56,7 +53,6 @@ FilterXVariable *filterx_scope_register_variable(FilterXScope *self,
                                                  FilterXVariableHandle handle,
                                                  FilterXObject *initial_value);
 gboolean filterx_scope_foreach_variable(FilterXScope *self, FilterXScopeForeachFunc func, gpointer user_data);
-void filterx_scope_invalidate_log_msg_cache(FilterXScope *self);
 
 /* copy on write */
 void filterx_scope_write_protect(FilterXScope *self);

--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -50,8 +50,6 @@ struct _FilterXScope
 
 typedef gboolean (*FilterXScopeForeachFunc)(FilterXVariable *variable, gpointer user_data);
 
-void filterx_scope_set_dirty(FilterXScope *self);
-gboolean filterx_scope_is_dirty(FilterXScope *self);
 void filterx_scope_sync(FilterXScope *self, LogMessage *msg);
 
 FilterXVariable *filterx_scope_lookup_variable(FilterXScope *self, FilterXVariableHandle handle);
@@ -68,6 +66,18 @@ FilterXScope *filterx_scope_make_writable(FilterXScope **pself);
 FilterXScope *filterx_scope_new(void);
 FilterXScope *filterx_scope_ref(FilterXScope *self);
 void filterx_scope_unref(FilterXScope *self);
+
+static inline void
+filterx_scope_set_dirty(FilterXScope *self)
+{
+  self->dirty = TRUE;
+}
+
+static inline gboolean
+filterx_scope_is_dirty(FilterXScope *self)
+{
+  return self->dirty;
+}
 
 static inline void
 filterx_scope_set_message(FilterXScope *self, LogMessage *msg)

--- a/lib/filterx/filterx-variable.c
+++ b/lib/filterx/filterx-variable.c
@@ -47,13 +47,10 @@ filterx_variable_clear(FilterXVariable *v)
 void
 filterx_variable_init_instance(FilterXVariable *v,
                                FilterXVariableType variable_type,
-                               FilterXVariableHandle handle,
-                               FilterXObject *initial_value,
-                               guint32 generation)
+                               FilterXVariableHandle handle)
 {
-  v->handle = handle;
   v->variable_type = variable_type;
+  v->handle = handle;
   v->assigned = FALSE;
-  v->generation = generation;
-  v->value = filterx_object_ref(initial_value);
+  v->value = NULL;
 }

--- a/lib/filterx/filterx-variable.h
+++ b/lib/filterx/filterx-variable.h
@@ -36,9 +36,8 @@ typedef enum
   FX_VAR_DECLARED_FLOATING,
 } FilterXVariableType;
 
-#define FILTERX_SCOPE_MAX_GENERATION ((1UL << 20) - 1)
-
 typedef guint32 FilterXVariableHandle;
+typedef guint16 FilterXGenCounter;
 
 #define FILTERX_HANDLE_FLOATING_BIT (1UL << 31)
 
@@ -68,20 +67,16 @@ typedef struct _FilterXVariable
   FilterXVariableHandle handle;
   /*
    * assigned -- Indicates that the variable was assigned to a new value
-   *
-   * declared -- this variable is declared (e.g. retained for the entire input pipeline)
    */
-  guint32 assigned:1,
-          variable_type:2,
-          generation:20;
+  guint16 assigned:1,
+          variable_type:2;
+  FilterXGenCounter generation;
   FilterXObject *value;
 } FilterXVariable;
 
 void filterx_variable_init_instance(FilterXVariable *v,
                                     FilterXVariableType variable_type,
-                                    FilterXVariableHandle handle,
-                                    FilterXObject *initial_value,
-                                    guint32 generation);
+                                    FilterXVariableHandle handle);
 void filterx_variable_clear(FilterXVariable *v);
 
 static inline gboolean
@@ -115,17 +110,19 @@ filterx_variable_get_value(FilterXVariable *v)
 }
 
 static inline void
-filterx_variable_set_value(FilterXVariable *v, FilterXObject *new_value, gboolean assignment)
+filterx_variable_set_value(FilterXVariable *v, FilterXObject *new_value, gboolean assignment,
+                           FilterXGenCounter generation)
 {
   filterx_object_unref(v->value);
   v->value = filterx_object_ref(new_value);
   v->assigned = assignment;
+  v->generation = generation;
 }
 
 static inline void
-filterx_variable_unset_value(FilterXVariable *v)
+filterx_variable_unset_value(FilterXVariable *v, FilterXGenCounter generation)
 {
-  filterx_variable_set_value(v, NULL, TRUE);
+  filterx_variable_set_value(v, NULL, TRUE, generation);
 }
 
 static inline gboolean
@@ -147,13 +144,13 @@ filterx_variable_is_assigned(FilterXVariable *v)
 }
 
 static inline gboolean
-filterx_variable_is_same_generation(FilterXVariable *v, guint32 generation)
+filterx_variable_is_same_generation(FilterXVariable *v, FilterXGenCounter generation)
 {
   return v->generation == generation;
 }
 
 static inline void
-filterx_variable_set_generation(FilterXVariable *v, guint32 generation)
+filterx_variable_set_generation(FilterXVariable *v, FilterXGenCounter generation)
 {
   v->generation = generation;
 }

--- a/lib/filterx/filterx-variable.h
+++ b/lib/filterx/filterx-variable.h
@@ -41,18 +41,6 @@ typedef guint16 FilterXGenCounter;
 
 #define FILTERX_HANDLE_FLOATING_BIT (1UL << 31)
 
-static inline gboolean
-filterx_variable_handle_is_floating(FilterXVariableHandle handle)
-{
-  return !!(handle & FILTERX_HANDLE_FLOATING_BIT);
-}
-
-static inline gboolean
-filterx_variable_handle_is_message_tied(FilterXVariableHandle handle)
-{
-  return !filterx_variable_handle_is_floating(handle);
-}
-
 static inline NVHandle
 filterx_variable_handle_to_nv_handle(FilterXVariableHandle handle)
 {
@@ -82,13 +70,14 @@ void filterx_variable_clear(FilterXVariable *v);
 static inline gboolean
 filterx_variable_is_floating(FilterXVariable *v)
 {
-  return filterx_variable_handle_is_floating(v->handle);
+  /* matches both declared and undeclared floating values */
+  return v->variable_type != FX_VAR_MESSAGE_TIED;
 }
 
 static inline gboolean
 filterx_variable_is_message_tied(FilterXVariable *v)
 {
-  return filterx_variable_handle_is_message_tied(v->handle);
+  return v->variable_type == FX_VAR_MESSAGE_TIED;
 }
 
 static inline NVHandle

--- a/lib/filterx/filterx-variable.h
+++ b/lib/filterx/filterx-variable.h
@@ -34,7 +34,11 @@ typedef enum
   FX_VAR_MESSAGE_TIED,
   FX_VAR_FLOATING,
   FX_VAR_DECLARED_FLOATING,
+  __FX_VAR_MAX,
 } FilterXVariableType;
+
+/* currently we only have two bits in FilterXVariable to hold variable_type */
+G_STATIC_ASSERT(__FX_VAR_MAX < 4);
 
 typedef guint32 FilterXVariableHandle;
 typedef guint16 FilterXGenCounter;
@@ -55,12 +59,20 @@ typedef struct _FilterXVariable
   FilterXVariableHandle handle;
   /*
    * assigned -- Indicates that the variable was assigned to a new value
+   *
+   * variable_type -- one of the FilterXVariableType enum
+   *
+   * We are storing these in bitfields to keep FilterXVariable within 16
+   * bytes.
    */
   guint16 assigned:1,
           variable_type:2;
   FilterXGenCounter generation;
   FilterXObject *value;
 } FilterXVariable;
+
+/* NOTE: try to keep variable small */
+G_STATIC_ASSERT(sizeof(FilterXVariable) <= 16);
 
 void filterx_variable_init_instance(FilterXVariable *v,
                                     FilterXVariableType variable_type,

--- a/lib/filterx/func-vars.c
+++ b/lib/filterx/func-vars.c
@@ -114,18 +114,17 @@ _load_from_dict(FilterXObject *key, FilterXObject *value, gpointer user_data)
   FilterXVariableType variable_type = (key_str[0] == '$') ? FX_VAR_MESSAGE_TIED : FX_VAR_DECLARED_FLOATING;
   FilterXVariableHandle handle = filterx_map_varname_to_handle(key_str, variable_type);
 
-  FilterXVariable *variable = NULL;
-  variable = filterx_scope_register_variable(scope, variable_type, handle, NULL);
-
-  FilterXObject *cloned_value = filterx_object_clone(value);
-  filterx_variable_set_value(variable, cloned_value, TRUE);
-  filterx_object_unref(cloned_value);
-
+  FilterXVariable *variable = filterx_scope_register_variable(scope, variable_type, handle);
   if (!variable)
     {
       filterx_eval_push_error("Failed to register variable", NULL, key);
       return FALSE;
     }
+
+  FilterXObject *cloned_value = filterx_object_clone(value);
+  filterx_scope_set_variable(scope, variable, cloned_value, TRUE);
+  filterx_object_unref(cloned_value);
+
 
   if (debug_flag)
     {

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -86,12 +86,6 @@ Test(filterx_expr, test_filterx_template_evaluates_to_the_expanded_value)
   filterx_object_unref(fobj);
 }
 
-struct _FilterXScope
-{
-  GHashTable *value_cache;
-  GPtrArray *weak_refs;
-};
-
 Test(filterx_expr, test_filterx_list_merge)
 {
   // $fillable = json_array();

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -279,26 +279,6 @@ static StatsCounterItem *count_sdata_updates;
 static StatsCounterItem *count_allocated_bytes;
 static GPrivate priv_macro_value = G_PRIVATE_INIT(__free_macro_value);
 
-void
-log_msg_write_protect(LogMessage *self)
-{
-  self->write_protected = TRUE;
-}
-
-LogMessage *
-log_msg_make_writable(LogMessage **pself, const LogPathOptions *path_options)
-{
-  if (log_msg_is_write_protected(*pself))
-    {
-      LogMessage *new;
-
-      new = log_msg_clone_cow(*pself, path_options);
-      log_msg_unref(*pself);
-      *pself = new;
-    }
-  return *pself;
-}
-
 static void
 log_msg_update_sdata_slow(LogMessage *self, NVHandle handle, const gchar *name, gssize name_len)
 {

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -296,14 +296,8 @@ log_msg_make_writable(LogMessage **pself, const LogPathOptions *path_options)
       log_msg_unref(*pself);
       *pself = new;
     }
-  if(path_options->filterx_context && path_options->filterx_context->scope)
-    {
-      filterx_scope_make_writable(&path_options->filterx_context->scope);
-      filterx_scope_set_log_msg_has_changes(path_options->filterx_context->scope);
-    }
   return *pself;
 }
-
 
 static void
 log_msg_update_sdata_slow(LogMessage *self, NVHandle handle, const gchar *name, gssize name_len)

--- a/tests/light/functional_tests/filterx/test_filterx_scope.py
+++ b/tests/light/functional_tests/filterx/test_filterx_scope.py
@@ -59,6 +59,7 @@ source genmsg {{
             "values.bytes" => bytes("binary whatever"),
             "values.protobuf" => protobuf("this is not a valid protobuf!!"),
             "values.json" => json('{{"emb_key1": "emb_key1 value", "emb_key2": "emb_key2 value"}}'),
+            "values.json2" => json('{{"foo":{{"foo1":"foo1value","foo2":"foo2value"}},"bar":{{"bar1":"bar1value","bar2":"bar2value"}}}}'),
             "values.true_string" => string("boolean:true"),
             "values.false_string" => string("boolean:false"),
         )
@@ -186,6 +187,57 @@ def test_message_tied_variables_do_not_propagate_to_parallel_branches(config, sy
     assert file_false.get_stats()["processed"] == 1
     assert "processed" not in file_true.get_stats()
     assert file_false.read_log() == "kecske\n"
+
+
+def test_message_tied_variables_are_invalidated_if_message_is_changed(config, syslog_ng):
+    (file_true, file_false, file_final) = create_config(
+        config, init_exprs=[
+            """
+                declare foo = $MSG;
+                foo;
+                $MSG;
+                foo == "foobar";
+                $MSG == "foobar";
+            """,
+        ], init_log_exprs=[
+            """
+                rewrite {
+                    set("foobar replacement" value("MSG"));
+                };
+            """,
+        ], true_exprs=[
+            """
+                $MSG;
+                foo;
+                $MSG == "foobar replacement";
+                foo == "foobar";
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "foobar replacement\n"
+
+
+def test_message_tied_mutable_objects_are_synced_if_child_object_is_changed(config, syslog_ng):
+    (file_true, file_false, file_final) = create_config(
+        config, init_exprs=[
+            """
+                ${values.json2}.foo.foo1 = 'child-changed';
+            """,
+        ], true_exprs=[
+            """
+            """,
+        ],
+        template='''"${values.json2}\n"''',
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == """{"foo":{"foo1":"child-changed","foo2":"foo2value"},"bar":{"bar1":"bar1value","bar2":"bar2value"}}\n"""
 
 
 def test_message_tied_variables_are_not_considered_changed_just_by_unmarshaling(config, syslog_ng):


### PR DESCRIPTION
This pull request replaces the old "log_msg_has_changes" mechanism with the recently merged generation counter.

This has the following goals/benefits:
* it fixes a bug in message tracking, as previously we considered a message changed when it was cloned. But a message can change without being cloned.
* we delegate the message change tracking to FilterXScope, 
  * this requires that FilterXScope now has a reference to the message being processed. 
  * this becomes similar to what we do with "undeclared" floating variables
  * the scope will provide a higher level interface to manage variables, moving the complexity from FilterXVariable to FilterXScope
* it adds slight changes and makes a couple of functions inline.
* 