### PR TITLE
Filterx allow stack based string wrappers

### DIFF
--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -119,7 +119,7 @@ filterx_object_freeze(FilterXObject *self)
   if (filterx_object_is_frozen(self))
     return FALSE;
   g_assert(g_atomic_counter_get(&self->ref_cnt) == 1);
-  g_atomic_counter_set(&self->ref_cnt, FILTERX_OBJECT_MAGIC_BIAS);
+  g_atomic_counter_set(&self->ref_cnt, FILTERX_OBJECT_REFCOUNT_FROZEN);
   return TRUE;
 }
 

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -74,7 +74,7 @@ void _filterx_type_init_methods(FilterXType *type);
       __VA_ARGS__       \
     }
 
-#define FILTERX_OBJECT_MAGIC_BIAS G_MAXINT32
+#define FILTERX_OBJECT_REFCOUNT_FROZEN (G_MAXINT32)
 
 
 FILTERX_DECLARE_TYPE(object);
@@ -110,7 +110,7 @@ void filterx_object_free_method(FilterXObject *self);
 static inline gboolean
 filterx_object_is_frozen(FilterXObject *self)
 {
-  return g_atomic_counter_get(&self->ref_cnt) == FILTERX_OBJECT_MAGIC_BIAS;
+  return g_atomic_counter_get(&self->ref_cnt) == FILTERX_OBJECT_REFCOUNT_FROZEN;
 }
 
 static inline FilterXObject *

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -377,4 +377,14 @@ filterx_object_set_modified_in_place(FilterXObject *self, gboolean modified)
   self->modified_in_place = modified;
 }
 
+#define FILTERX_OBJECT_STACK_INIT(_type) \
+  { \
+    .ref_cnt = { .counter = FILTERX_OBJECT_REFCOUNT_STACK }, \
+    .fx_ref_cnt = { .counter = 0 }, \
+    .modified_in_place = FALSE, \
+    .readonly = TRUE, \
+    .weak_referenced = FALSE, \
+    .type = &FILTERX_TYPE_NAME(_type) \
+  }
+
 #endif

--- a/lib/filterx/object-json-object.c
+++ b/lib/filterx/object-json-object.c
@@ -200,7 +200,7 @@ static gboolean
 _iter_inner(FilterXJsonObject *self, const gchar *obj_key, struct json_object *jso,
             FilterXDictIterFunc func, gpointer user_data)
 {
-  FilterXObject *key = filterx_string_new(obj_key, -1);
+  FILTERX_STRING_DECLARE_ON_STACK(key, obj_key, strlen(obj_key));
   FilterXObject *value = filterx_json_convert_json_to_object_cached(&self->super.super, &self->root_container,
                          jso);
 

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -32,8 +32,9 @@
 struct _FilterXString
 {
   FilterXObject super;
+  const gchar *str;
   gsize str_len;
-  gchar str[];
+  gchar storage[];
 };
 
 /* NOTE: Consider using filterx_object_extract_string_ref() to also support message_value. */
@@ -154,10 +155,11 @@ _string_new(const gchar *str, gssize str_len, FilterXStringTranslateFunc transla
 
   self->str_len = str_len;
   if (translate)
-    translate(self->str, str, str_len);
+    translate(self->storage, str, str_len);
   else
-    memcpy(self->str, str, str_len);
-  self->str[str_len] = 0;
+    memcpy(self->storage, str, str_len);
+  self->storage[str_len] = 0;
+  self->str = self->storage;
 
   return self;
 }

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -136,6 +136,15 @@ _string_add(FilterXObject *s, FilterXObject *object)
   return filterx_string_new(buffer->str, buffer->len);
 }
 
+/* we support clone of stack allocated strings */
+static FilterXObject *
+_string_clone(FilterXObject *s)
+{
+  FilterXString *self = (FilterXString *) s;
+
+  return filterx_string_new(self->str, self->str_len);
+}
+
 static inline FilterXString *
 _string_new(const gchar *str, gssize str_len, FilterXStringTranslateFunc translate)
 {
@@ -348,6 +357,7 @@ FILTERX_DEFINE_TYPE(string, FILTERX_TYPE_NAME(object),
                     .truthy = _truthy,
                     .repr = _string_repr,
                     .add = _string_add,
+                    .clone = _string_clone,
                    );
 
 FILTERX_DEFINE_TYPE(bytes, FILTERX_TYPE_NAME(object),

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -29,13 +29,6 @@
 #include "str-format.h"
 #include "str-utils.h"
 
-struct _FilterXString
-{
-  FilterXObject super;
-  const gchar *str;
-  gsize str_len;
-  gchar storage[];
-};
 
 /* NOTE: Consider using filterx_object_extract_string_ref() to also support message_value. */
 const gchar *

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -291,7 +291,7 @@ filterx_typecast_string(FilterXExpr *s, FilterXObject *args[], gsize args_len)
       return NULL;
     }
 
-  return filterx_string_new(buf->str, -1);
+  return filterx_string_new(buf->str, buf->len);
 }
 
 FilterXObject *

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -54,4 +54,15 @@ FilterXObject *filterx_protobuf_new(const gchar *str, gssize str_len);
 
 FilterXString *filterx_string_typed_new(const gchar *str);
 
+#define FILTERX_STRING_STACK_INIT(cstr, cstr_len) \
+  { \
+    FILTERX_OBJECT_STACK_INIT(string), \
+    .str = (cstr), \
+    .str_len = ((cstr_len) < 0 ? strlen(cstr) : (cstr_len)), \
+  }
+
+#define FILTERX_STRING_DECLARE_ON_STACK(_name, cstr, cstr_len) \
+  FilterXString __ ## _name ## storage = FILTERX_STRING_STACK_INIT(cstr, cstr_len); \
+  FilterXObject *_name = &__ ## _name ## storage .super;
+
 #endif

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -26,6 +26,14 @@
 #include "filterx-object.h"
 
 typedef struct _FilterXString FilterXString;
+struct _FilterXString
+{
+  FilterXObject super;
+  const gchar *str;
+  gsize str_len;
+  gchar storage[];
+};
+
 typedef void (*FilterXStringTranslateFunc)(gchar *target, const gchar *source, gsize source_len);
 
 FILTERX_DECLARE_TYPE(string);

--- a/lib/str-format.c
+++ b/lib/str-format.c
@@ -262,7 +262,7 @@ format_int32_padded(GString *result, gint field_len, gchar pad_char, gint base, 
 }
 
 gchar *
-format_hex_string_with_delimiter(gpointer data, gsize data_len, gchar *result, gsize result_len, gchar delimiter)
+format_hex_string_with_delimiter(gconstpointer data, gsize data_len, gchar *result, gsize result_len, gchar delimiter)
 {
   gint i;
   gint pos = 0;
@@ -285,7 +285,7 @@ format_hex_string_with_delimiter(gpointer data, gsize data_len, gchar *result, g
 }
 
 gchar *
-format_hex_string(gpointer data, gsize data_len, gchar *result, gsize result_len)
+format_hex_string(gconstpointer data, gsize data_len, gchar *result, gsize result_len)
 {
   return format_hex_string_with_delimiter(data, data_len, result, result_len, 0);
 }

--- a/lib/str-format.h
+++ b/lib/str-format.h
@@ -33,8 +33,9 @@ gint format_int32_padded(GString *result, gint field_len, gchar pad_char, gint b
 gint format_uint64_padded(GString *result, gint field_len, gchar pad_char, gint base, guint64 value);
 gint format_int64_padded(GString *result, gint field_len, gchar pad_char, gint base, gint64 value);
 
-gchar *format_hex_string(gpointer str, gsize str_len, gchar *result, gsize result_len);
-gchar *format_hex_string_with_delimiter(gpointer str, gsize str_len, gchar *result, gsize result_len, gchar delimiter);
+gchar *format_hex_string(gconstpointer str, gsize str_len, gchar *result, gsize result_len);
+gchar *format_hex_string_with_delimiter(gconstpointer str, gsize str_len, gchar *result, gsize result_len,
+                                        gchar delimiter);
 
 gboolean scan_positive_int(const gchar **buf, gint *left, gint field_width, gint *num);
 gboolean scan_expect_char(const gchar **buf, gint *left, gchar value);

--- a/modules/csvparser/filterx-func-parse-csv.c
+++ b/modules/csvparser/filterx-func-parse-csv.c
@@ -172,8 +172,9 @@ _fill_object_col(FilterXFunctionParseCSV *self, FilterXObject *cols, gint64 inde
   else
     col = filterx_list_get_subscript(cols, index);
 
-  FilterXObject *val = filterx_string_new(csv_scanner_get_current_value(scanner),
-                                          csv_scanner_get_current_value_len(scanner));
+  FILTERX_STRING_DECLARE_ON_STACK(val,
+                                  csv_scanner_get_current_value(scanner),
+                                  csv_scanner_get_current_value_len(scanner));
 
   gboolean ok = filterx_object_set_subscript(result, col, &val);
 
@@ -186,9 +187,9 @@ _fill_object_col(FilterXFunctionParseCSV *self, FilterXObject *cols, gint64 inde
 static inline gboolean
 _fill_array_element(CSVScanner *scanner, FilterXObject *result)
 {
-  const gchar *current_value = csv_scanner_get_current_value(scanner);
-  gint current_value_len = csv_scanner_get_current_value_len(scanner);
-  FilterXObject *val = filterx_string_new(current_value, current_value_len);
+  FILTERX_STRING_DECLARE_ON_STACK(val,
+                                  csv_scanner_get_current_value(scanner),
+                                  csv_scanner_get_current_value_len(scanner));
 
   gboolean ok = filterx_list_append(result, &val);
 

--- a/modules/xml/filterx-parse-windows-eventlog-xml.c
+++ b/modules/xml/filterx-parse-windows-eventlog-xml.c
@@ -72,7 +72,7 @@ static gboolean
 _convert_to_dict(GMarkupParseContext *context, XmlElemContext *elem_context, GError **error)
 {
   const gchar *parent_elem_name = (const gchar *) g_markup_parse_context_get_element_stack(context)->next->data;
-  FilterXObject *key = filterx_string_new(parent_elem_name, -1);
+  FILTERX_STRING_DECLARE_ON_STACK(key, parent_elem_name, -1);
 
   FilterXObject *dict_obj = filterx_object_create_dict(elem_context->parent_obj);
   if (!dict_obj)
@@ -106,7 +106,7 @@ _prepare_elem(const gchar *new_elem_name, XmlElemContext *last_elem_context, Xml
 {
   xml_elem_context_init(new_elem_context, last_elem_context->current_obj, NULL);
 
-  FilterXObject *new_elem_key = filterx_string_new(new_elem_name, -1);
+  FILTERX_STRING_DECLARE_ON_STACK(new_elem_key, new_elem_name, -1);
   FilterXObject *existing_obj = NULL;
 
   if (!filterx_object_is_key_set(new_elem_context->parent_obj, new_elem_key))
@@ -330,8 +330,8 @@ _text(FilterXGeneratorFunctionParseXml *s,
       return;
     }
 
-  FilterXObject *key = filterx_string_new(state->last_data_name->str, state->last_data_name->len);
-  FilterXObject *text_obj = filterx_string_new(text, text_len);
+  FILTERX_STRING_DECLARE_ON_STACK(key, state->last_data_name->str, state->last_data_name->len);
+  FILTERX_STRING_DECLARE_ON_STACK(text_obj, text, text_len);
 
   if (!filterx_object_set_subscript(elem_context->current_obj, key, &text_obj))
     {


### PR DESCRIPTION
This PR enables filterx code to create short-lived FilterXString instances on the stack. 

Such instances 
* clone themselves on filterx_object_ref()
* can only be unreferenced once
* free_fn() is not called (this could be changed though and is up for debate)

The PR also contains a number of conversions from allocation based FilterXString instances to these, reducing the
total number of malloc() calls significantly for unset_empties(), parse_csv() and parse_kv()
