### PR TITLE
Filterx initial string cache

### DIFF
--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -22,6 +22,7 @@
  */
 #include "filterx/expr-getattr.h"
 #include "filterx/object-string.h"
+#include "filterx/filterx-object-istype.h"
 #include "filterx/filterx-eval.h"
 #include "stats/stats-registry.h"
 #include "stats/stats-cluster-single.h"
@@ -132,7 +133,7 @@ _free(FilterXExpr *s)
 
 /* NOTE: takes the object reference */
 FilterXExpr *
-filterx_getattr_new(FilterXExpr *operand, FilterXString *attr_name)
+filterx_getattr_new(FilterXExpr *operand, FilterXObject *attr_name)
 {
   FilterXGetAttr *self = g_new0(FilterXGetAttr, 1);
 
@@ -146,7 +147,8 @@ filterx_getattr_new(FilterXExpr *operand, FilterXString *attr_name)
   self->super.free_fn = _free;
   self->operand = operand;
 
-  self->attr = (FilterXObject *) attr_name;
+  filterx_object_is_type(attr_name, &FILTERX_TYPE_NAME(string));
+  self->attr = attr_name;
   /* NOTE: name borrows the string value from the string object */
   self->super.name = filterx_string_get_value_ref(self->attr, NULL);
   return &self->super;

--- a/lib/filterx/expr-getattr.h
+++ b/lib/filterx/expr-getattr.h
@@ -26,7 +26,7 @@
 #include "filterx/filterx-expr.h"
 #include "filterx/object-string.h"
 
-FilterXExpr *filterx_getattr_new(FilterXExpr *lhs, FilterXString *attr_name);
+FilterXExpr *filterx_getattr_new(FilterXExpr *lhs, FilterXObject *attr_name);
 
 
 #endif

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -181,7 +181,7 @@ _free(FilterXExpr *s)
 
 /* Takes reference of object and new_value */
 FilterXExpr *
-filterx_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterXExpr *new_value)
+filterx_setattr_new(FilterXExpr *object, FilterXObject *attr_name, FilterXExpr *new_value)
 {
   FilterXSetAttr *self = g_new0(FilterXSetAttr, 1);
 
@@ -193,7 +193,8 @@ filterx_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterXExpr *
   self->super.free_fn = _free;
   self->object = object;
 
-  self->attr = (FilterXObject *) attr_name;
+  g_assert(filterx_object_is_type(attr_name, &FILTERX_TYPE_NAME(string)));
+  self->attr = attr_name;
 
   self->new_value = new_value;
   self->super.ignore_falsy_result = TRUE;
@@ -204,7 +205,7 @@ filterx_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterXExpr *
 }
 
 FilterXExpr *
-filterx_nullv_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterXExpr *new_value)
+filterx_nullv_setattr_new(FilterXExpr *object, FilterXObject *attr_name, FilterXExpr *new_value)
 {
   FilterXExpr *self = filterx_setattr_new(object, attr_name, new_value);
   self->type = "nullv_setattr";

--- a/lib/filterx/expr-setattr.h
+++ b/lib/filterx/expr-setattr.h
@@ -26,7 +26,7 @@
 #include "filterx/filterx-expr.h"
 #include "filterx/object-string.h"
 
-FilterXExpr *filterx_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterXExpr *new_value);
-FilterXExpr *filterx_nullv_setattr_new(FilterXExpr *object, FilterXString *attr_name, FilterXExpr *new_value);
+FilterXExpr *filterx_setattr_new(FilterXExpr *object, FilterXObject *attr_name, FilterXExpr *new_value);
+FilterXExpr *filterx_nullv_setattr_new(FilterXExpr *object, FilterXObject *attr_name, FilterXExpr *new_value);
 
 #endif

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -187,7 +187,7 @@ _free(FilterXExpr *s)
 }
 
 static FilterXExpr *
-filterx_variable_expr_new(FilterXString *name, FilterXVariableType variable_type)
+filterx_variable_expr_new(FilterXObject *name, FilterXVariableType variable_type)
 {
   FilterXVariableExpr *self = g_new0(FilterXVariableExpr, 1);
 
@@ -200,7 +200,7 @@ filterx_variable_expr_new(FilterXString *name, FilterXVariableType variable_type
   self->super.unset = _unset;
 
   self->variable_type = variable_type;
-  self->variable_name = (FilterXObject *) name;
+  self->variable_name = name;
   self->handle = filterx_map_varname_to_handle(filterx_string_get_value_ref(self->variable_name, NULL), variable_type);
   if (variable_type == FX_VAR_MESSAGE_TIED)
     self->handle_is_macro = log_msg_is_handle_macro(filterx_variable_handle_to_nv_handle(self->handle));
@@ -212,13 +212,13 @@ filterx_variable_expr_new(FilterXString *name, FilterXVariableType variable_type
 }
 
 FilterXExpr *
-filterx_msg_variable_expr_new(FilterXString *name)
+filterx_msg_variable_expr_new(FilterXObject *name)
 {
   return filterx_variable_expr_new(name, FX_VAR_MESSAGE_TIED);
 }
 
 FilterXExpr *
-filterx_floating_variable_expr_new(FilterXString *name)
+filterx_floating_variable_expr_new(FilterXObject *name)
 {
   return filterx_variable_expr_new(name, FX_VAR_FLOATING);
 }

--- a/lib/filterx/expr-variable.h
+++ b/lib/filterx/expr-variable.h
@@ -28,15 +28,15 @@
 #include "filterx/object-string.h"
 #include "cfg.h"
 
-FilterXExpr *filterx_msg_variable_expr_new(FilterXString *name);
-FilterXExpr *filterx_floating_variable_expr_new(FilterXString *name);
+FilterXExpr *filterx_msg_variable_expr_new(FilterXObject *name);
+FilterXExpr *filterx_floating_variable_expr_new(FilterXObject *name);
 void filterx_variable_expr_declare(FilterXExpr *s);
 
-static inline FilterXString *
+static inline FilterXObject *
 filterx_frozen_dollar_msg_varname(GlobalConfig *cfg, const gchar *name)
 {
   gchar *dollar_name = g_strdup_printf("$%s", name);
-  FilterXString *dollar_name_obj = filterx_config_frozen_string(cfg, dollar_name);
+  FilterXObject *dollar_name_obj = filterx_config_frozen_string(cfg, dollar_name);
   g_free(dollar_name);
 
   return dollar_name_obj;

--- a/lib/filterx/filterx-config.c
+++ b/lib/filterx/filterx-config.c
@@ -65,11 +65,8 @@ filterx_config_freeze_object(GlobalConfig *cfg, FilterXObject *object)
   return object;
 }
 
-FilterXString *
+FilterXObject *
 filterx_config_frozen_string(GlobalConfig *cfg, const gchar *str)
 {
-  FilterXString *frozen_str = filterx_string_typed_new(str);
-  filterx_config_freeze_object(cfg, (FilterXObject *) frozen_str);
-
-  return frozen_str;
+  return filterx_config_freeze_object(cfg, filterx_string_new(str, -1));
 }

--- a/lib/filterx/filterx-config.h
+++ b/lib/filterx/filterx-config.h
@@ -35,6 +35,6 @@ typedef struct _FilterXConfig
 
 FilterXConfig *filterx_config_get(GlobalConfig *cfg);
 FilterXObject *filterx_config_freeze_object(GlobalConfig *cfg, FilterXObject *object);
-FilterXString *filterx_config_frozen_string(GlobalConfig *cfg, const gchar *str);
+FilterXObject *filterx_config_frozen_string(GlobalConfig *cfg, const gchar *str);
 
 #endif

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -263,6 +263,7 @@ filterx_global_init(void)
   filterx_type_init(&FILTERX_TYPE_NAME(message_value));
 
   filterx_type_init(&FILTERX_TYPE_NAME(metrics_labels));
+  filterx_string_global_init();
 
   filterx_primitive_global_init();
   filterx_null_global_init();
@@ -275,6 +276,7 @@ filterx_global_deinit(void)
   filterx_builtin_functions_deinit();
   filterx_null_global_deinit();
   filterx_primitive_global_deinit();
+  filterx_string_global_deinit();
   filterx_types_deinit();
 }
 

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -40,6 +40,16 @@ struct _FilterXString
 enum
 {
   FX_STR_ZERO_LENGTH,
+  FX_STR_NUMBER0,
+  FX_STR_NUMBER1,
+  FX_STR_NUMBER2,
+  FX_STR_NUMBER3,
+  FX_STR_NUMBER4,
+  FX_STR_NUMBER5,
+  FX_STR_NUMBER6,
+  FX_STR_NUMBER7,
+  FX_STR_NUMBER8,
+  FX_STR_NUMBER9,
   FX_STR_MAX,
 };
 
@@ -177,6 +187,11 @@ filterx_string_new(const gchar *str, gssize str_len)
   if (str_len == 0 || str[0] == 0)
     {
       return filterx_object_ref(string_cache[FX_STR_ZERO_LENGTH]);
+    }
+  else if (str_len == 1 && str[0] >= '0' && str[0] < '9')
+    {
+      gint index = str[0] - '0';
+      return filterx_object_ref(string_cache[FX_STR_NUMBER0 + index]);
     }
   return &_string_new(str, str_len, NULL)->super;
 }
@@ -383,6 +398,11 @@ void
 filterx_string_global_init(void)
 {
   filterx_cache_object(&string_cache[FX_STR_ZERO_LENGTH], &_string_new("", 0, NULL)->super);
+  for (gint i = 0; i < 10; i++)
+    {
+      gchar number[2] = { i+'0', 0 };
+      filterx_cache_object(&string_cache[FX_STR_NUMBER0+i], &_string_new(number, 1, NULL)->super);
+    }
 }
 
 void

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -36,6 +36,15 @@ struct _FilterXString
   gchar str[];
 };
 
+/* cache indices */
+enum
+{
+  FX_STR_ZERO_LENGTH,
+  FX_STR_MAX,
+};
+
+static FilterXObject *string_cache[FX_STR_MAX];
+
 /* NOTE: Consider using filterx_object_extract_string_ref() to also support message_value. */
 const gchar *
 filterx_string_get_value_ref(FilterXObject *s, gsize *length)
@@ -165,6 +174,10 @@ _string_new(const gchar *str, gssize str_len, FilterXStringTranslateFunc transla
 FilterXObject *
 filterx_string_new(const gchar *str, gssize str_len)
 {
+  if (str_len == 0 || str[0] == 0)
+    {
+      return filterx_object_ref(string_cache[FX_STR_ZERO_LENGTH]);
+    }
   return &_string_new(str, str_len, NULL)->super;
 }
 
@@ -365,3 +378,18 @@ FILTERX_DEFINE_TYPE(protobuf, FILTERX_TYPE_NAME(object),
                     .truthy = _truthy,
                     .repr = _bytes_repr,
                    );
+
+void
+filterx_string_global_init(void)
+{
+  filterx_cache_object(&string_cache[FX_STR_ZERO_LENGTH], &_string_new("", 0, NULL)->super);
+}
+
+void
+filterx_string_global_deinit(void)
+{
+  for (gint i = 0; i < FX_STR_MAX; i++)
+    {
+      filterx_uncache_object(&string_cache[i]);
+    }
+}

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -174,12 +174,6 @@ filterx_string_new_translated(const gchar *str, gssize str_len, FilterXStringTra
   return &_string_new(str, str_len, translate)->super;
 }
 
-FilterXString *
-filterx_string_typed_new(const gchar *str)
-{
-  return _string_new(str, -1, NULL);
-}
-
 static inline gsize
 _get_base64_encoded_size(gsize len)
 {
@@ -257,7 +251,7 @@ FilterXObject *
 filterx_bytes_new(const gchar *mem, gssize mem_len)
 {
   g_assert(mem_len != -1);
-  FilterXString *self = (FilterXString *) filterx_string_new(mem, mem_len);
+  FilterXString *self = (FilterXString *) _string_new(mem, mem_len, NULL);
   self->super.type = &FILTERX_TYPE_NAME(bytes);
   return &self->super;
 }
@@ -266,7 +260,7 @@ FilterXObject *
 filterx_protobuf_new(const gchar *mem, gssize mem_len)
 {
   g_assert(mem_len != -1);
-  FilterXString *self = (FilterXString *) filterx_bytes_new(mem, mem_len);
+  FilterXString *self = (FilterXString *) _string_new(mem, mem_len, NULL);
   self->super.type = &FILTERX_TYPE_NAME(protobuf);
   return &self->super;
 }

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -44,6 +44,4 @@ FilterXObject *filterx_string_new_translated(const gchar *str, gssize str_len, F
 FilterXObject *filterx_bytes_new(const gchar *str, gssize str_len);
 FilterXObject *filterx_protobuf_new(const gchar *str, gssize str_len);
 
-FilterXString *filterx_string_typed_new(const gchar *str);
-
 #endif

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -44,4 +44,7 @@ FilterXObject *filterx_string_new_translated(const gchar *str, gssize str_len, F
 FilterXObject *filterx_bytes_new(const gchar *str, gssize str_len);
 FilterXObject *filterx_protobuf_new(const gchar *str, gssize str_len);
 
+void filterx_string_global_init(void);
+void filterx_string_global_deinit(void);
+
 #endif

--- a/lib/filterx/tests/test_expr_compound.c
+++ b/lib/filterx/tests/test_expr_compound.c
@@ -39,7 +39,7 @@
 FilterXExpr *
 _assert_assign_var(const char *var_name, FilterXExpr *value)
 {
-  FilterXExpr *control_variable = filterx_msg_variable_expr_new(filterx_string_typed_new(var_name));
+  FilterXExpr *control_variable = filterx_msg_variable_expr_new(filterx_string_new(var_name, -1));
   cr_assert(control_variable != NULL);
 
   return filterx_assign_new(control_variable, value);
@@ -77,7 +77,7 @@ _assert_set_test_variable(const char *var_name, FilterXExpr *expr)
 FilterXObject *
 _assert_get_test_variable(const char *var_name)
 {
-  FilterXExpr *control_variable = filterx_msg_variable_expr_new(filterx_string_typed_new(var_name));
+  FilterXExpr *control_variable = filterx_msg_variable_expr_new(filterx_string_new(var_name, -1));
   cr_assert(control_variable != NULL);
   FilterXObject *result = filterx_expr_eval(control_variable);
   filterx_expr_unref(control_variable);

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -63,7 +63,7 @@ _assert_cmp_string_to_filterx_object(const char *str, FilterXObject *obj)
 FilterXExpr *
 _assert_assign_var(const char *var_name, FilterXExpr *value)
 {
-  FilterXExpr *control_variable = filterx_msg_variable_expr_new(filterx_string_typed_new(var_name));
+  FilterXExpr *control_variable = filterx_msg_variable_expr_new(filterx_string_new(var_name, -1));
   cr_assert(control_variable != NULL);
 
   return filterx_assign_new(control_variable, value);
@@ -86,7 +86,7 @@ _assert_set_test_variable(const char *var_name, FilterXExpr *expr)
 FilterXObject *
 _assert_get_test_variable(const char *var_name)
 {
-  FilterXExpr *control_variable = filterx_msg_variable_expr_new(filterx_string_typed_new(var_name));
+  FilterXExpr *control_variable = filterx_msg_variable_expr_new(filterx_string_new(var_name, -1));
   cr_assert(control_variable != NULL);
   FilterXObject *result = filterx_expr_eval(control_variable);
   filterx_expr_unref(control_variable);

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -306,7 +306,7 @@ Test(filterx_expr, test_filterx_dict_merge)
 
 Test(filterx_expr, test_filterx_assign)
 {
-  FilterXExpr *result_var = filterx_msg_variable_expr_new(filterx_string_typed_new("$result-var"));
+  FilterXExpr *result_var = filterx_msg_variable_expr_new(filterx_string_new("$result-var", -1));
   cr_assert(result_var != NULL);
 
   FilterXExpr *assign = filterx_assign_new(result_var, filterx_literal_new(filterx_string_new("foobar", -1)));
@@ -335,7 +335,7 @@ Test(filterx_expr, test_filterx_setattr)
   FilterXObject *json = filterx_json_object_new_empty();
   FilterXExpr *fillable = filterx_literal_new(json);
 
-  FilterXExpr *setattr = filterx_setattr_new(fillable, filterx_string_typed_new("foo"),
+  FilterXExpr *setattr = filterx_setattr_new(fillable, filterx_string_new("foo", -1),
                                              filterx_literal_new(filterx_string_new("bar", -1)));
   cr_assert_not_null(setattr);
 
@@ -390,7 +390,7 @@ Test(filterx_expr, test_filterx_readonly)
 
 
   FilterXExpr *setattr = filterx_setattr_new(filterx_expr_ref(literal),
-                                             filterx_string_typed_new("bar"),
+                                             filterx_string_new("bar", -1),
                                              filterx_literal_new(filterx_object_ref(foo)));
   cr_assert_not(filterx_expr_eval(setattr));
   cr_assert(strstr(filterx_eval_get_last_error(), "readonly"));
@@ -407,7 +407,7 @@ Test(filterx_expr, test_filterx_readonly)
   filterx_expr_unref(set_subscript);
 
 
-  FilterXExpr *getattr = filterx_getattr_new(filterx_expr_ref(literal), filterx_string_typed_new("foo"));
+  FilterXExpr *getattr = filterx_getattr_new(filterx_expr_ref(literal), filterx_string_new("foo", -1));
   cr_assert_not(filterx_expr_unset(getattr));
   cr_assert(strstr(filterx_eval_get_last_error(), "readonly"));
   filterx_eval_clear_errors();
@@ -423,8 +423,8 @@ Test(filterx_expr, test_filterx_readonly)
 
 
   FilterXExpr *inner = filterx_setattr_new(filterx_getattr_new(filterx_expr_ref(literal),
-                                           filterx_string_typed_new("foo")),
-                                           filterx_string_typed_new("bar"),
+                                           filterx_string_new("foo", -1)),
+                                           filterx_string_new("bar", -1),
                                            filterx_literal_new(filterx_object_ref(bar)));
   cr_assert_not(filterx_expr_eval(inner));
   cr_assert(strstr(filterx_eval_get_last_error(), "readonly"));


### PR DESCRIPTION
This PR implements the caching of trivial FilterXString instances (e.g. zero-length and single character numbers), which are commonly found in our log patterns as string values. Instead of allocating these all the time, use a cached instance.

This is "initial" string cache, as I have some pending patches to implement a larger table of strings that could be cached
similarly, but I got to make more testing with those to see how they impact performance.

