### PR TITLE
Filterx func str performance improvements

### DIFF
--- a/lib/filterx/func-str.c
+++ b/lib/filterx/func-str.c
@@ -483,7 +483,7 @@ _function_includes_process(const gchar *haystack, gsize haystack_len, const gcha
 {
   if (needle_len > haystack_len)
     return FALSE;
-  return g_strstr_len(haystack, haystack_len, needle) != NULL;
+  return strstr(haystack, needle) != NULL;
 }
 
 FilterXExpr *

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -2432,40 +2432,6 @@ def test_parse_windows_eventlog_xml(config, syslog_ng):
     }
 
 
-def test_startswith_endswith_includes(config, syslog_ng):
-    (file_true, file_false) = create_config(
-        config, r"""
-    result = json();
-    if (startswith($MSG, ["dummy_prefix", "foo"]))
-    {
-        result.startswith_foo = true;
-    };
-    bar_var = "bar";
-    if (includes($MSG, bar_var, ignorecase=true))
-    {
-        result.contains_bar = true;
-    };
-    baz_var = "baz";
-    baz_list = ["dummy_suffix", baz_var];
-    if (endswith($MSG, baz_list, ignorecase=true))
-    {
-        result.endswith_baz = true;
-    };
-    log_msg_value = ${values.str};
-    if (includes(log_msg_value, log_msg_value))
-    {
-        result.works_with_message_value = true;
-    };
-    $MSG = json();
-    $MSG = result;
-    """, msg="fooBARbAz",
-    )
-    syslog_ng.start(config)
-
-    assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"startswith_foo":true,"contains_bar":true,"endswith_baz":true,"works_with_message_value":true}\n'
-
-
 def test_parse_cef(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, r"""

--- a/tests/light/functional_tests/filterx/test_filterx_funcs.py
+++ b/tests/light/functional_tests/filterx/test_filterx_funcs.py
@@ -105,3 +105,157 @@ def test_lower(config, syslog_ng):
 
     assert file_final.get_stats()["processed"] == 1
     assert file_final.read_log() == """{"literal":"abc","variable":"foobar","host":"hostname"}\n"""
+
+
+def test_startswith_with_various_arguments(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    result = json();
+    foo = "foo";
+    bar = "bar";
+    # literal string
+    if (startswith($MSG, "foo"))
+    {
+        result.startswith_foo1 = true;
+    };
+    # literal array
+    if (startswith($MSG, ["foo"]))
+    {
+        result.startswith_foo2 = true;
+    };
+    # literal array, not the first element
+    if (startswith($MSG, ["bar", "foo"]))
+    {
+        result.startswith_foo3 = true;
+    };
+    # non-literal
+    if (startswith($MSG, foo))
+    {
+        result.startswith_foo4 = true;
+    };
+    # non-literal
+    if (startswith($MSG, [bar, foo]))
+    {
+        result.startswith_foo4 = true;
+    };
+    $MSG = result;
+    """, msg="fooBARbAz",
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == '{"startswith_foo1":true,"startswith_foo2":true,"startswith_foo3":true,"startswith_foo4":true}\n'
+
+
+def test_endswith_with_various_arguments(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    result = json();
+    foo = "foo";
+    bar = "bar";
+    # literal string
+    if (endswith($MSG, "foo"))
+    {
+        result.endswith_foo1 = true;
+    };
+    # literal array
+    if (endswith($MSG, ["foo"]))
+    {
+        result.endswith_foo2 = true;
+    };
+    # literal array, not the first element
+    if (endswith($MSG, ["bar", "foo"]))
+    {
+        result.endswith_foo3 = true;
+    };
+    # non-literal
+    if (endswith($MSG, foo))
+    {
+        result.endswith_foo4 = true;
+    };
+    # non-literal
+    if (endswith($MSG, [bar, foo]))
+    {
+        result.endswith_foo4 = true;
+    };
+    $MSG = result;
+    """, msg="bAzBARfoo",
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == '{"endswith_foo1":true,"endswith_foo2":true,"endswith_foo3":true,"endswith_foo4":true}\n'
+
+
+def test_includes_with_various_arguments(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    result = json();
+    foo = "foo";
+    bar = "bar";
+    # literal string
+    if (includes($MSG, "foo"))
+    {
+        result.includes_foo1 = true;
+    };
+    # literal array
+    if (includes($MSG, ["foo"]))
+    {
+        result.includes_foo2 = true;
+    };
+    # literal array, not the first element
+    if (includes($MSG, ["bar", "foo"]))
+    {
+        result.includes_foo3 = true;
+    };
+    # non-literal
+    if (includes($MSG, foo))
+    {
+        result.includes_foo4 = true;
+    };
+    # non-literal
+    if (includes($MSG, [bar, foo]))
+    {
+        result.includes_foo4 = true;
+    };
+    $MSG = result;
+    """, msg="bAzBARfoo",
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == '{"includes_foo1":true,"includes_foo2":true,"includes_foo3":true,"includes_foo4":true}\n'
+
+
+def test_startswith_endswith_includes(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    result = json();
+    if (startswith($MSG, ["dummy_prefix", "foo"]))
+    {
+        result.startswith_foo = true;
+    };
+    bar_var = "bar";
+    if (includes($MSG, bar_var, ignorecase=true))
+    {
+        result.contains_bar = true;
+    };
+    baz_var = "baz";
+    baz_list = ["dummy_suffix", baz_var];
+    if (endswith($MSG, baz_list, ignorecase=true))
+    {
+        result.endswith_baz = true;
+    };
+    log_msg_value = ${values.str};
+    if (includes(log_msg_value, log_msg_value))
+    {
+        result.works_with_message_value = true;
+    };
+    $MSG = json();
+    $MSG = result;
+    """, msg="fooBARbAz",
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == '{"startswith_foo":true,"contains_bar":true,"endswith_baz":true,"works_with_message_value":true}\n'


### PR DESCRIPTION
This improves test coverage for startswith/endswith/includes as well as includes their performance by:
* not using dynamically allocated GString and GPtrArray instances
* using the glibc provided strstr() call instead of the one in glib
