### PR TITLE
generic-number: make the gint64 path in the functions inline

### DIFF
--- a/lib/generic-number.c
+++ b/lib/generic-number.c
@@ -22,26 +22,8 @@
 #include "generic-number.h"
 #include <math.h>
 
-gdouble
-gn_as_double(const GenericNumber *number)
-{
-  if (number->type == GN_DOUBLE)
-    return number->value.raw_double;
-  else if (number->type == GN_INT64)
-    return (gdouble) number->value.raw_int64;
-  g_assert_not_reached();
-}
-
-void
-gn_set_double(GenericNumber *number, gdouble value, gint precision)
-{
-  number->type = GN_DOUBLE;
-  number->value.raw_double = value;
-  number->precision = precision > 0 ? precision : 20;
-}
-
 gint64
-gn_as_int64(const GenericNumber *number)
+_gn_as_int64(const GenericNumber *number)
 {
   if (number->type == GN_DOUBLE)
     {
@@ -53,56 +35,26 @@ gn_as_int64(const GenericNumber *number)
         return G_MAXINT64;
       return (gint64) r;
     }
-  else if (number->type == GN_INT64)
-    return number->value.raw_int64;
   g_assert_not_reached();
 }
 
-void
-gn_set_int64(GenericNumber *number, gint64 value)
-{
-  number->type = GN_INT64;
-  number->value.raw_int64 = value;
-  number->precision = 0;
-}
-
 gboolean
-gn_is_zero(const GenericNumber *number)
+_gn_is_zero(const GenericNumber *number)
 {
-  if (number->type == GN_INT64)
-    return number->value.raw_int64 == 0;
-
   if (number->type == GN_DOUBLE)
     return fabs(number->value.raw_double) < DBL_EPSILON;
 
   g_assert_not_reached();
 }
 
-void
-gn_set_nan(GenericNumber *number)
-{
-  number->type = GN_NAN;
-}
-
 gboolean
-gn_is_nan(const GenericNumber *number)
+_gn_is_nan(const GenericNumber *number)
 {
-  return number->type == GN_NAN || (number->type == GN_DOUBLE && isnan(number->value.raw_double));
+  return (number->type == GN_DOUBLE && isnan(number->value.raw_double));
 }
 
-static gint
-_compare_int64(gint64 l, gint64 r)
-{
-  if (l == r)
-    return 0;
-  else if (l < r)
-    return -1;
-
-  return 1;
-}
-
-static gint
-_compare_double(gdouble l, gdouble r)
+gint
+_gn_compare_double(gdouble l, gdouble r)
 {
   if (fabs(l - r) < DBL_EPSILON)
     return 0;
@@ -110,30 +62,4 @@ _compare_double(gdouble l, gdouble r)
     return -1;
 
   return 1;
-}
-
-gint
-gn_compare(const GenericNumber *left, const GenericNumber *right)
-{
-  if (left->type == right->type)
-    {
-      if (left->type == GN_INT64)
-        return _compare_int64(gn_as_int64(left), gn_as_int64(right));
-      else if (left->type == GN_DOUBLE)
-        return _compare_double(gn_as_double(left), gn_as_double(right));
-    }
-  else if (left->type == GN_NAN || right->type == GN_NAN)
-    {
-      ;
-    }
-  else if (left->type == GN_DOUBLE || right->type == GN_DOUBLE)
-    {
-      return _compare_double(gn_as_double(left), gn_as_double(right));
-    }
-  else
-    {
-      return _compare_int64(gn_as_int64(left), gn_as_int64(right));
-    }
-  /* NaNs cannot be compared */
-  g_assert_not_reached();
 }

--- a/lib/generic-number.h
+++ b/lib/generic-number.h
@@ -25,29 +25,122 @@
 
 #include "syslog-ng.h"
 
+enum
+{
+  GN_INT64,
+  GN_DOUBLE,
+  GN_NAN,
+};
+
 typedef struct _GenericNumber
 {
-  enum
-  {
-    GN_INT64,
-    GN_DOUBLE,
-    GN_NAN,
-  } type;
-  gint precision;
   union
   {
     gint64 raw_int64;
     gdouble raw_double;
   } value;
+  guint8 type, precision;
 } GenericNumber;
 
-void gn_set_double(GenericNumber *number, double value, gint precision);
-gdouble gn_as_double(const GenericNumber *number);
-void gn_set_int64(GenericNumber *number, gint64 value);
-gint64 gn_as_int64(const GenericNumber *number);
-gboolean gn_is_zero(const GenericNumber *number);
-void gn_set_nan(GenericNumber *number);
-gboolean gn_is_nan(const GenericNumber *number);
-gint gn_compare(const GenericNumber *left, const GenericNumber *right);
+static inline gdouble
+gn_as_double(const GenericNumber *number)
+{
+  if (number->type == GN_INT64)
+    return (gdouble) number->value.raw_int64;
+  if (number->type == GN_DOUBLE)
+    return number->value.raw_double;
+  g_assert_not_reached();
+}
+
+static inline void
+gn_set_double(GenericNumber *number, gdouble value, gint precision)
+{
+  number->type = GN_DOUBLE;
+  number->value.raw_double = value;
+  number->precision = precision > 0 ? precision : 20;
+}
+
+gint64 _gn_as_int64(const GenericNumber *number);
+
+static inline gint64
+gn_as_int64(const GenericNumber *number)
+{
+  if (number->type == GN_INT64)
+    return number->value.raw_int64;
+  return _gn_as_int64(number);
+}
+
+static inline void
+gn_set_int64(GenericNumber *number, gint64 value)
+{
+  number->type = GN_INT64;
+  number->value.raw_int64 = value;
+  number->precision = 0;
+}
+
+gboolean _gn_is_zero(const GenericNumber *number);
+
+static inline gboolean
+gn_is_zero(const GenericNumber *number)
+{
+  if (number->type == GN_INT64)
+    return number->value.raw_int64 == 0;
+  return _gn_is_zero(number);
+}
+
+static inline void
+gn_set_nan(GenericNumber *number)
+{
+  number->type = GN_NAN;
+}
+
+gboolean _gn_is_nan(const GenericNumber *number);
+
+static inline gboolean
+gn_is_nan(const GenericNumber *number)
+{
+  if (number->type == GN_NAN)
+    return TRUE;
+  return _gn_is_nan(number);
+}
+
+static inline gint
+_gn_compare_int64(gint64 l, gint64 r)
+{
+  if (l == r)
+    return 0;
+  else if (l < r)
+    return -1;
+
+  return 1;
+}
+
+gint _gn_compare_double(gdouble l, gdouble r);
+
+static inline gint
+gn_compare(const GenericNumber *left, const GenericNumber *right)
+{
+  if (left->type == right->type)
+    {
+      if (left->type == GN_INT64)
+        return _gn_compare_int64(gn_as_int64(left), gn_as_int64(right));
+      else if (left->type == GN_DOUBLE)
+        return _gn_compare_double(gn_as_double(left), gn_as_double(right));
+    }
+  else if (left->type == GN_NAN || right->type == GN_NAN)
+    {
+      ;
+    }
+  else if (left->type == GN_DOUBLE || right->type == GN_DOUBLE)
+    {
+      return _gn_compare_double(gn_as_double(left), gn_as_double(right));
+    }
+  else
+    {
+      return _gn_compare_int64(gn_as_int64(left), gn_as_int64(right));
+    }
+  /* NaNs cannot be compared */
+  g_assert_not_reached();
+}
 
 #endif


### PR DESCRIPTION
We are encapsulating a GenericNumber instance in our integer/boolean/double objects, basically having two layers of encapsulation.

I attempted to remove one of these but it was a lot more difficult and would require API changes, so for now I was satisfied with inlining the integer paths, which is exercised whenever we are using an integer in filterx (e.g. iterating over a list in parse_csv()).
