### PR TITLE
Filterx allow stack based integer wrappers

### DIFF
--- a/lib/filterx/object-list-interface.c
+++ b/lib/filterx/object-list-interface.c
@@ -30,9 +30,8 @@
 FilterXObject *
 filterx_list_get_subscript(FilterXObject *s, gint64 index)
 {
-  FilterXObject *index_obj = filterx_integer_new(index);
+  FILTERX_INTEGER_DECLARE_ON_STACK(index_obj, index);
   FilterXObject *result = filterx_object_get_subscript(s, index_obj);
-
   filterx_object_unref(index_obj);
   return result;
 }
@@ -40,7 +39,7 @@ filterx_list_get_subscript(FilterXObject *s, gint64 index)
 gboolean
 filterx_list_set_subscript(FilterXObject *s, gint64 index, FilterXObject **new_value)
 {
-  FilterXObject *index_obj = filterx_integer_new(index);
+  FILTERX_INTEGER_DECLARE_ON_STACK(index_obj, index);
   gboolean result = filterx_object_set_subscript(s, index_obj, new_value);
 
   filterx_object_unref(index_obj);
@@ -56,7 +55,7 @@ filterx_list_append(FilterXObject *s, FilterXObject **new_value)
 gboolean
 filterx_list_unset_index(FilterXObject *s, gint64 index)
 {
-  FilterXObject *index_obj = filterx_integer_new(index);
+  FILTERX_INTEGER_DECLARE_ON_STACK(index_obj, index);
   gboolean result = filterx_object_unset_key(s, index_obj);
 
   filterx_object_unref(index_obj);

--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -83,6 +83,13 @@ _integer_add(FilterXObject *s, FilterXObject *object)
   return NULL;
 }
 
+static FilterXObject *
+_integer_clone(FilterXObject *s)
+{
+  FilterXPrimitive *self = (FilterXPrimitive *) s;
+  return filterx_integer_new(gn_as_int64(&self->value));
+}
+
 gboolean
 integer_repr(gint64 val, GString *repr)
 {
@@ -371,6 +378,7 @@ FILTERX_DEFINE_TYPE(integer, FILTERX_TYPE_NAME(primitive),
                     .marshal = _integer_marshal,
                     .map_to_json = _integer_map_to_json,
                     .add = _integer_add,
+                    .clone = _integer_clone,
                    );
 
 FILTERX_DEFINE_TYPE(double, FILTERX_TYPE_NAME(primitive),

--- a/lib/filterx/object-primitive.h
+++ b/lib/filterx/object-primitive.h
@@ -105,5 +105,20 @@ filterx_boolean_unwrap(FilterXObject *s, gboolean *value)
 void filterx_primitive_global_init(void);
 void filterx_primitive_global_deinit(void);
 
+#define FILTERX_INTEGER_STACK_INIT(v) \
+  { \
+    FILTERX_OBJECT_STACK_INIT(integer), \
+    .value = { \
+      { \
+        .raw_int64 = v, \
+      }, \
+      .type = GN_INT64, \
+      .precision = 0, \
+    }, \
+  }
+
+#define FILTERX_INTEGER_DECLARE_ON_STACK(_name, v) \
+  FilterXPrimitive __ ## _name ## storage = FILTERX_INTEGER_STACK_INIT(v); \
+  FilterXObject *_name = &__ ## _name ## storage .super;
 
 #endif

--- a/lib/generic-number.c
+++ b/lib/generic-number.c
@@ -22,26 +22,8 @@
 #include "generic-number.h"
 #include <math.h>
 
-gdouble
-gn_as_double(const GenericNumber *number)
-{
-  if (number->type == GN_DOUBLE)
-    return number->value.raw_double;
-  else if (number->type == GN_INT64)
-    return (gdouble) number->value.raw_int64;
-  g_assert_not_reached();
-}
-
-void
-gn_set_double(GenericNumber *number, gdouble value, gint precision)
-{
-  number->type = GN_DOUBLE;
-  number->value.raw_double = value;
-  number->precision = precision > 0 ? precision : 20;
-}
-
 gint64
-gn_as_int64(const GenericNumber *number)
+_gn_as_int64(const GenericNumber *number)
 {
   if (number->type == GN_DOUBLE)
     {
@@ -53,56 +35,26 @@ gn_as_int64(const GenericNumber *number)
         return G_MAXINT64;
       return (gint64) r;
     }
-  else if (number->type == GN_INT64)
-    return number->value.raw_int64;
   g_assert_not_reached();
 }
 
-void
-gn_set_int64(GenericNumber *number, gint64 value)
-{
-  number->type = GN_INT64;
-  number->value.raw_int64 = value;
-  number->precision = 0;
-}
-
 gboolean
-gn_is_zero(const GenericNumber *number)
+_gn_is_zero(const GenericNumber *number)
 {
-  if (number->type == GN_INT64)
-    return number->value.raw_int64 == 0;
-
   if (number->type == GN_DOUBLE)
     return fabs(number->value.raw_double) < DBL_EPSILON;
 
   g_assert_not_reached();
 }
 
-void
-gn_set_nan(GenericNumber *number)
-{
-  number->type = GN_NAN;
-}
-
 gboolean
-gn_is_nan(const GenericNumber *number)
+_gn_is_nan(const GenericNumber *number)
 {
-  return number->type == GN_NAN || (number->type == GN_DOUBLE && isnan(number->value.raw_double));
+  return (number->type == GN_DOUBLE && isnan(number->value.raw_double));
 }
 
-static gint
-_compare_int64(gint64 l, gint64 r)
-{
-  if (l == r)
-    return 0;
-  else if (l < r)
-    return -1;
-
-  return 1;
-}
-
-static gint
-_compare_double(gdouble l, gdouble r)
+gint
+_gn_compare_double(gdouble l, gdouble r)
 {
   if (fabs(l - r) < DBL_EPSILON)
     return 0;
@@ -110,30 +62,4 @@ _compare_double(gdouble l, gdouble r)
     return -1;
 
   return 1;
-}
-
-gint
-gn_compare(const GenericNumber *left, const GenericNumber *right)
-{
-  if (left->type == right->type)
-    {
-      if (left->type == GN_INT64)
-        return _compare_int64(gn_as_int64(left), gn_as_int64(right));
-      else if (left->type == GN_DOUBLE)
-        return _compare_double(gn_as_double(left), gn_as_double(right));
-    }
-  else if (left->type == GN_NAN || right->type == GN_NAN)
-    {
-      ;
-    }
-  else if (left->type == GN_DOUBLE || right->type == GN_DOUBLE)
-    {
-      return _compare_double(gn_as_double(left), gn_as_double(right));
-    }
-  else
-    {
-      return _compare_int64(gn_as_int64(left), gn_as_int64(right));
-    }
-  /* NaNs cannot be compared */
-  g_assert_not_reached();
 }

--- a/lib/generic-number.h
+++ b/lib/generic-number.h
@@ -25,29 +25,122 @@
 
 #include "syslog-ng.h"
 
+enum
+{
+  GN_INT64,
+  GN_DOUBLE,
+  GN_NAN,
+};
+
 typedef struct _GenericNumber
 {
-  enum
-  {
-    GN_INT64,
-    GN_DOUBLE,
-    GN_NAN,
-  } type;
-  gint precision;
   union
   {
     gint64 raw_int64;
     gdouble raw_double;
   } value;
+  guint8 type, precision;
 } GenericNumber;
 
-void gn_set_double(GenericNumber *number, double value, gint precision);
-gdouble gn_as_double(const GenericNumber *number);
-void gn_set_int64(GenericNumber *number, gint64 value);
-gint64 gn_as_int64(const GenericNumber *number);
-gboolean gn_is_zero(const GenericNumber *number);
-void gn_set_nan(GenericNumber *number);
-gboolean gn_is_nan(const GenericNumber *number);
-gint gn_compare(const GenericNumber *left, const GenericNumber *right);
+static inline gdouble
+gn_as_double(const GenericNumber *number)
+{
+  if (number->type == GN_INT64)
+    return (gdouble) number->value.raw_int64;
+  if (number->type == GN_DOUBLE)
+    return number->value.raw_double;
+  g_assert_not_reached();
+}
+
+static inline void
+gn_set_double(GenericNumber *number, gdouble value, gint precision)
+{
+  number->type = GN_DOUBLE;
+  number->value.raw_double = value;
+  number->precision = precision > 0 ? precision : 20;
+}
+
+gint64 _gn_as_int64(const GenericNumber *number);
+
+static inline gint64
+gn_as_int64(const GenericNumber *number)
+{
+  if (number->type == GN_INT64)
+    return number->value.raw_int64;
+  return _gn_as_int64(number);
+}
+
+static inline void
+gn_set_int64(GenericNumber *number, gint64 value)
+{
+  number->type = GN_INT64;
+  number->value.raw_int64 = value;
+  number->precision = 0;
+}
+
+gboolean _gn_is_zero(const GenericNumber *number);
+
+static inline gboolean
+gn_is_zero(const GenericNumber *number)
+{
+  if (number->type == GN_INT64)
+    return number->value.raw_int64 == 0;
+  return _gn_is_zero(number);
+}
+
+static inline void
+gn_set_nan(GenericNumber *number)
+{
+  number->type = GN_NAN;
+}
+
+gboolean _gn_is_nan(const GenericNumber *number);
+
+static inline gboolean
+gn_is_nan(const GenericNumber *number)
+{
+  if (number->type == GN_NAN)
+    return TRUE;
+  return _gn_is_nan(number);
+}
+
+static inline gint
+_gn_compare_int64(gint64 l, gint64 r)
+{
+  if (l == r)
+    return 0;
+  else if (l < r)
+    return -1;
+
+  return 1;
+}
+
+gint _gn_compare_double(gdouble l, gdouble r);
+
+static inline gint
+gn_compare(const GenericNumber *left, const GenericNumber *right)
+{
+  if (left->type == right->type)
+    {
+      if (left->type == GN_INT64)
+        return _gn_compare_int64(gn_as_int64(left), gn_as_int64(right));
+      else if (left->type == GN_DOUBLE)
+        return _gn_compare_double(gn_as_double(left), gn_as_double(right));
+    }
+  else if (left->type == GN_NAN || right->type == GN_NAN)
+    {
+      ;
+    }
+  else if (left->type == GN_DOUBLE || right->type == GN_DOUBLE)
+    {
+      return _gn_compare_double(gn_as_double(left), gn_as_double(right));
+    }
+  else
+    {
+      return _gn_compare_int64(gn_as_int64(left), gn_as_int64(right));
+    }
+  /* NaNs cannot be compared */
+  g_assert_not_reached();
+}
 
 #endif


### PR DESCRIPTION
Similar to #470 but this time with integer objects. It seems that we have a parse_csv() invocation with over a 100 integer
fields, so the integer cache does not cover it and I don't want to increase that cache infinitely.

This should go in after #470

