### PR TITLE
str-utils: fix always true condition warning (-Wtype-limits)

### DIFF
--- a/lib/str-utils.h
+++ b/lib/str-utils.h
@@ -169,7 +169,7 @@ ch_isalpha(gchar c)
 static inline gboolean
 ch_isascii(gchar c)
 {
-  return c >= 0 && c <= 127;
+  return c >= 0 && (guchar ) c <= 127;
 }
 
 static inline gchar


### PR DESCRIPTION
gchar is either signed or unsigned (127 may be the max value), guchar can be ASCII-checked, but then the 0-check is not needed.