### PR TITLE
afsocket/transport-mapper: fix auto transport with tls

### DIFF
--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -529,6 +529,15 @@ transport_mapper_syslog_apply_transport(TransportMapper *s, GlobalConfig *cfg)
       self->allow_tls = TRUE;
       self->super.transport_name = g_strdup("rfc5425+proxied-tls-passthrough");
     }
+  else if (strcasecmp(transport, "auto") == 0 && self->tls_context)
+    {
+      self->server_port = SYSLOG_TRANSPORT_TLS_PORT;
+      self->super.logproto = self->super.transport;
+      self->super.sock_type = SOCK_STREAM;
+      self->super.sock_proto = IPPROTO_TCP;
+      self->require_tls_when_has_tls_context = TRUE;
+      self->super.transport_name = g_strdup_printf("rfc5424+%s", self->super.transport);
+    }
   else
     {
       self->super.logproto = self->super.transport;

--- a/news/bugfix-482.md
+++ b/news/bugfix-482.md
@@ -1,0 +1,1 @@
+`syslog()` source driver: fix `transport(auto)` with `tls()`


### PR DESCRIPTION
This patch makes sure that TLS transport is used for reading, not plain-text.

`transport(auto)` and `tls()` didn't work in conjunction.
```
@version: 4.9

log {
  source{syslog(flags(no-parse) port(5143) transport(auto) tls(
    cert-file(/server-cert.pem)
    key-file(/server-key.pem)
    ca-file(/ca-cert.pem)
    peer-verify(optional-untrusted)
  ));};
  destination{stdout();};
  };
```

Without this patch it fails:
```
[2025-01-30T20:44:35.119972] Transport switch requested; active-transport='none', requested-transport='stream-socket'
[2025-01-30T20:44:35.119972] Transport switch successful; new-active-transport='stream-socket'
[2025-01-30T20:44:35.119972] Syslog connection accepted; fd='14', client='AF_INET(127.0.0.1:33288)', local='AF_INET(0.0.0.0:5143)'
[2025-01-30T20:44:35.122761] Unable to detect framing on RFC6587 connection, falling back to simple text transport; fd='14', detect_buffer='\x16\x03\x01\x01 \x01.\x01'
[2025-01-30T20:44:35.122936] Incoming log entry; input='\x16\x03\x01\x01 \x01', msg='0x7e88bc0126f0', rcptid='5820'
```
(use `loggen -P -r 1 -n 1 --debug -U localhost 5143`)

TLS transport was not used as the last `else` branch constructs a `logproto` from the `transport` (`auto` in this case), `require_tls_when_has_tls_context` takes care of this.

After the patch:
```
[2025-01-30T20:50:03.722272] Transport switch requested; active-transport='none', requested-transport='tls'
[2025-01-30T20:50:03.722272] Transport switch successful; new-active-transport='tls'
[2025-01-30T20:50:03.722272] Syslog connection accepted; fd='14', client='AF_INET(127.0.0.1:56162)', local='AF_INET(0.0.0.0:5143)'
[2025-01-30T20:50:03.726768] Auto-detected octet-counted-framing on RFC6587 connection, using framed protocol; fd='14'
[2025-01-30T20:50:03.726886] Incoming log entry; input='<38>1 2025-01-30T20:50:03+01:00 localhost prg00000 1234 - - seq: 0000000000, thread: 0000, runid: 1738266603, stamp: 2025-01-30T20:50:03 PADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPAD\x0a', msg='0x72eec001a0e0', rcptid='5868'
[....]
[2025-01-30T20:50:03.727673] Outgoing message; message='Jan 30 20:50:03 localhost <38>1 2025-01-30T20:50:03+01:00 localhost prg00000 1234 - - seq: 0000000000, thread: 0000, runid: 1738266603, stamp: 2025-01-30T20:50:03 PADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPAD\x0a'
[2025-01-30T20:50:03.727675] Syslog connection closed; fd='14', client='AF_INET(127.0.0.1:56162)', local='AF_INET(0.0.0.0:5143)'
[2025-01-30T20:50:03.727675] Closing log transport fd; fd='14'
Jan 30 20:50:03 localhost <38>1 2025-01-30T20:50:03+01:00 localhost prg00000 1234 - - seq: 0000000000, thread: 0000, runid: 1738266603, stamp: 2025-01-30T20:50:03 PADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPADDPAD
```