### PR TITLE
Wallclocktime strftime

### DIFF
--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -426,18 +426,14 @@ _strftime_eval(FilterXExpr *s)
   convert_unix_time_to_wall_clock_time (&datetime, &wct);
 
   const gsize MAX_RESULT_STR_LEN = 256;
-  size_t date_size = 0;
   gchar result_str[MAX_RESULT_STR_LEN];
 
-  // TODO - implement wall_clock_time_strftime, because there is some inconsistency with the format accepted by wall_clock_time_strptime
-  date_size = strftime(result_str, MAX_RESULT_STR_LEN, self->format, &wct.tm);
+  size_t date_size = wall_clock_time_strftime(&wct, result_str, MAX_RESULT_STR_LEN, self->format);
 
   if (!date_size)
-    {
-      return filterx_null_new();
-    }
+    return filterx_null_new();
 
-  return filterx_string_new(result_str, strnlen(result_str, MAX_RESULT_STR_LEN));
+  return filterx_string_new(result_str, date_size);
 }
 
 static FilterXExpr *

--- a/lib/timeutils/tests/test_wallclocktime.c
+++ b/lib/timeutils/tests/test_wallclocktime.c
@@ -352,7 +352,6 @@ Test(wallclocktime, test_strptime_zone_parsing_takes_daylight_saving_into_accoun
   cr_expect(wct.wct_gmtoff == 1*3600, "Unexpected timezone offset: %ld, expected 1*3600", wct.wct_gmtoff);
 
 }
-
 static void
 _guess_missing_year(WallClockTime *wct, gint mon)
 {
@@ -494,6 +493,70 @@ Test(wallclocktime, test_strptime_percent_z_is_mandatory)
 
   WallClockTime wct = WALL_CLOCK_TIME_INIT;
   cr_assert_null(wall_clock_time_strptime(&wct, "%Y-%m-%d %T%z", "2011-06-25 20:00:04"));
+}
+
+Test(wallclocktime, test_strftime_percent_f)
+{
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+  gchar buf[128];
+
+  wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S.%f %z", "May  7 2021 09:29:12.123456 CEST");
+
+  wall_clock_time_strftime(&wct, buf, sizeof(buf), ".%f");
+  cr_assert_str_eq(buf, ".123456");
+  wall_clock_time_strftime(&wct, buf, sizeof(buf), ".%3f");
+  cr_assert_str_eq(buf, ".123");
+  wall_clock_time_strftime(&wct, buf, sizeof(buf), ".%6f");
+  cr_assert_str_eq(buf, ".123456");
+  wall_clock_time_strftime(&wct, buf, sizeof(buf), ".%9f");
+  cr_assert_str_eq(buf, ".123456");
+
+  wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S.%f %z", "May  7 2021 09:29:12.012345 CEST");
+
+  wall_clock_time_strftime(&wct, buf, sizeof(buf), ".%f");
+  cr_assert_str_eq(buf, ".012345");
+  wall_clock_time_strftime(&wct, buf, sizeof(buf), ".%3f");
+  cr_assert_str_eq(buf, ".012");
+  wall_clock_time_strftime(&wct, buf, sizeof(buf), ".%6f");
+  cr_assert_str_eq(buf, ".012345");
+  wall_clock_time_strftime(&wct, buf, sizeof(buf), ".%9f");
+  cr_assert_str_eq(buf, ".012345");
+}
+
+Test(wallclocktime, test_strftime_can_be_parsed_by_strptime)
+{
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+  WallClockTime wct2 = WALL_CLOCK_TIME_INIT;
+  gchar buf[128];
+
+  wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S.%f %z", "May  7 2021 09:29:12.123456+02:00");
+  wall_clock_time_strftime(&wct, buf, sizeof(buf), "%b %d %Y %H:%M:%S.%f %z");
+  wall_clock_time_strptime(&wct2, "%b %d %Y %H:%M:%S.%f %z", buf);
+
+  cr_expect(wct.wct_year == wct2.wct_year);
+  cr_expect(wct.wct_mon == wct2.wct_mon);
+  cr_expect(wct.wct_mday == wct2.wct_mday);
+
+  cr_expect(wct.wct_hour == wct2.wct_hour);
+  cr_expect(wct.wct_min == wct2.wct_min);
+  cr_expect(wct.wct_sec == wct2.wct_sec);
+  cr_expect(wct.wct_usec == wct2.wct_usec);
+
+  cr_expect(wct.wct_isdst == wct2.wct_isdst, "%d != %d", wct.wct_isdst, wct2.wct_isdst);
+  cr_expect(wct.wct_gmtoff == wct2.wct_gmtoff);
+}
+
+Test(wallclocktime, test_strftime_all_format_spec)
+{
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+  gchar buf[256];
+
+  wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S.%f %z", "Aug  7 2021 09:29:12.123456+02:00");
+  wall_clock_time_strftime(&wct, buf, sizeof(buf),
+                           "%a %A %b %B '%c' %C %d '%D' '%e' %f '%F' %g %G %h %H %I %j %m %M %n %p %r %R %s %S %t '%T' %u %U %W %V %w %x %X %y %Y %z %Z");
+  cr_assert_str_eq(buf,
+                   "Fri Friday Aug August 'Fri Aug  7 09:29:12 2021' 20 07 '08/07/21' ' 7' 123456 '2021-08-07' 21 2021 Aug 09 09 219 08 29 \n"
+                   " AM 09:29:12 AM 09:29 1628324952 12 \t '10:29:12' 6 31 31 31 6 08/07/21 10:29:12 21 2021 +0200 +02:00");
 }
 
 static void

--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -54,7 +54,6 @@
 
 /*
  * MIT: musl http://git.musl-libc.org/cgit/musl/tree/src/time/strftime.c?id=6ad514e4e278f0c3b18eb2db1d45638c9af1c07f#n19
- * The license below only applies for the ISO8601 week calculation in this file.
  *
  */
 /*
@@ -90,6 +89,7 @@
 #include <ctype.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
 
 void
@@ -1034,4 +1034,266 @@ dump_wall_clock_time(const WallClockTime *wct, GString *output)
 
   g_string_append_printf(output, "  GMT Offset: %ld\n", wct->wct_gmtoff);
   g_string_append_printf(output, "  Timezone: %s\n", wct->wct_zone ? wct->wct_zone : "(null)");
+}
+
+static const char *
+__strftime_fmt_1(WallClockTime *wct, char (*s)[100], size_t *l, int f, int pad)
+{
+  long long val;
+  const char *fmt = "-";
+  int width = 2, def_pad = '0';
+
+  switch (f)
+    {
+    case 'a':
+      if (wct->wct_wday > 6U) goto string;
+      fmt = _TIME_LOCALE(loc)->abday[wct->wct_wday];
+      goto nl_strcat;
+    case 'A':
+      if (wct->wct_wday > 6U) goto string;
+      fmt = _TIME_LOCALE(loc)->day[wct->wct_wday];
+      goto nl_strcat;
+    case 'h':
+    case 'b':
+      if (wct->wct_mon > 11U) goto string;
+      fmt = _TIME_LOCALE(loc)->abmon[wct->wct_mon];
+      goto nl_strcat;
+    case 'B':
+      if (wct->wct_mon > 11U) goto string;
+      fmt = _TIME_LOCALE(loc)->mon[wct->wct_mon];
+      goto nl_strcat;
+    case 'c':
+      fmt = _TIME_LOCALE(loc)->d_t_fmt;
+      goto nl_strftime;
+    case 'C':
+      val = (1900LL+wct->wct_year) / 100;
+      goto number;
+    case 'e':
+      def_pad = '_';
+    case 'd':
+      val = wct->wct_mday;
+      goto number;
+    case 'D':
+      fmt = "%m/%d/%y";
+      goto recu_strftime;
+    case 'F':
+      fmt = "%Y-%m-%d";
+      goto recu_strftime;
+    case 'g':
+    case 'G':
+      val = wct->wct_year + 1900LL;
+      if (wct->wct_yday < 3 && wall_clock_time_iso_week_number(wct) != 1) val--;
+      else if (wct->wct_yday > 360 && wall_clock_time_iso_week_number(wct) == 1) val++;
+      if (f=='g') val %= 100;
+      else width = 4;
+      goto number;
+    case 'H':
+      val = wct->wct_hour;
+      goto number;
+    case 'I':
+      val = wct->wct_hour;
+      if (!val) val = 12;
+      else if (val > 12) val -= 12;
+      goto number;
+    case 'j':
+      val = wct->wct_yday+1;
+      width = 3;
+      goto number;
+    case 'm':
+      val = wct->wct_mon+1;
+      goto number;
+    case 'M':
+      val = wct->wct_min;
+      goto number;
+    case 'n':
+      *l = 1;
+      return "\n";
+    case 'p':
+      fmt = wct->wct_hour >= 12 ? _TIME_LOCALE(loc)->am_pm[1] : _TIME_LOCALE(loc)->am_pm[0];
+      goto nl_strcat;
+    case 'r':
+      fmt = _TIME_LOCALE(loc)->t_fmt_ampm;
+      goto nl_strftime;
+    case 'R':
+      fmt = "%H:%M";
+      goto recu_strftime;
+    case 's':
+      val = cached_mktime(&wct->tm);
+      width = 1;
+      goto number;
+    case 'S':
+      val = wct->wct_sec;
+      goto number;
+    case 't':
+      *l = 1;
+      return "\t";
+    case 'T':
+      fmt = "%H:%M:%S";
+      goto recu_strftime;
+    case 'u':
+      val = wct->wct_wday ? wct->wct_wday : 7;
+      width = 1;
+      goto number;
+    case 'U':
+      val = (wct->wct_yday + 7U - wct->wct_wday) / 7;
+      goto number;
+    case 'W':
+      val = (wct->wct_yday + 7U - (wct->wct_wday+6U)%7) / 7;
+      goto number;
+    case 'V':
+      val = wall_clock_time_iso_week_number(wct);
+      goto number;
+    case 'w':
+      val = wct->wct_wday;
+      width = 1;
+      goto number;
+    case 'x':
+      fmt = _TIME_LOCALE(loc)->d_fmt;
+      goto nl_strftime;
+    case 'X':
+      fmt = _TIME_LOCALE(loc)->t_fmt;
+      goto nl_strftime;
+    case 'y':
+      val = (wct->wct_year + 1900LL) % 100;
+      if (val < 0) val = -val;
+      goto number;
+    case 'Y':
+      val = wct->wct_year + 1900LL;
+      if (val >= 10000)
+        {
+          *l = snprintf(*s, sizeof *s, "+%lld", val);
+          return *s;
+        }
+      width = 4;
+      goto number;
+    case 'z':
+      if (wct->wct_gmtoff == -1)
+        {
+          *l = 0;
+          return "";
+        }
+      *l = snprintf(*s, sizeof *s, "%+.4ld",
+                    wct->wct_gmtoff/3600*100 + wct->wct_gmtoff%3600/60);
+      return *s;
+    case 'Z':
+      if (wct->wct_gmtoff == -1)
+        {
+          *l = 0;
+          return "";
+        }
+      // fmt = __tm_to_tzname(tm);
+      // goto string;
+    case '%':
+      *l = 1;
+      return "%";
+    default:
+      return 0;
+    }
+number:
+  switch (pad ? pad : def_pad)
+    {
+    case '-':
+      *l = snprintf(*s, sizeof *s, "%lld", val);
+      break;
+    case '_':
+      *l = snprintf(*s, sizeof *s, "%*lld", width, val);
+      break;
+    case '0':
+    default:
+      *l = snprintf(*s, sizeof *s, "%0*lld", width, val);
+      break;
+    }
+  return *s;
+nl_strcat:
+  //  fmt = __nl_langinfo_l(item, loc);
+string:
+  *l = strlen(fmt);
+  return fmt;
+nl_strftime:
+  // fmt = __nl_langinfo_l(item, loc);
+recu_strftime:
+  *l = wall_clock_time_strftime(wct, *s, sizeof *s, fmt);
+  if (!*l) return 0;
+  return *s;
+}
+
+size_t
+wall_clock_time_strftime(WallClockTime *wct, char *s, size_t n, const char *f)
+{
+  size_t l, k;
+  char buf[100];
+  char *p;
+  const char *t;
+  int pad, plus;
+  unsigned long width;
+  for (l=0; l<n; f++)
+    {
+      if (!*f)
+        {
+          s[l] = 0;
+          return l;
+        }
+      if (*f != '%')
+        {
+          s[l++] = *f;
+          continue;
+        }
+      f++;
+      pad = 0;
+      if (*f == '-' || *f == '_' || *f == '0') pad = *f++;
+      if ((plus = (*f == '+'))) f++;
+      if (isdigit(*f))
+        {
+          width = strtoul(f, &p, 10);
+        }
+      else
+        {
+          width = 0;
+          p = (void *)f;
+        }
+      if (*p == 'C' || *p == 'F' || *p == 'G' || *p == 'Y')
+        {
+          if (!width && p!=f) width = 1;
+        }
+      else
+        {
+          width = 0;
+        }
+      f = p;
+      if (*f == 'E' || *f == 'O') f++;
+      t = __strftime_fmt_1(wct, &buf, &k, *f, pad);
+      if (!t) break;
+      if (width)
+        {
+          /* Trim off any sign and leading zeros, then
+           * count remaining digits to determine behavior
+           * for the + flag. */
+          if (*t=='+' || *t=='-') t++, k--;
+          for (; *t=='0' && t[1]-'0'<10U; t++, k--);
+          if (width < k) width = k;
+          size_t d;
+          for (d=0; t[d]-'0'<10U; d++);
+          if (wct->wct_year < -1900)
+            {
+              s[l++] = '-';
+              width--;
+            }
+          else if (plus && d+(width-k) >= (*p=='C'?3:5))
+            {
+              s[l++] = '+';
+              width--;
+            }
+          for (; width > k && l < n; width--)
+            s[l++] = '0';
+        }
+      if (k > n-l) k = n-l;
+      memcpy(s+l, t, k);
+      l += k;
+    }
+  if (n)
+    {
+      if (l==n) l=n-1;
+      s[l] = 0;
+    }
+  return 0;
 }

--- a/lib/timeutils/wallclocktime.h
+++ b/lib/timeutils/wallclocktime.h
@@ -134,6 +134,7 @@ wall_clock_time_is_set(WallClockTime *wct)
 
 void wall_clock_time_unset(WallClockTime *wct);
 gchar *wall_clock_time_strptime(WallClockTime *wct, const gchar *format, const gchar *input);
+size_t wall_clock_time_strftime(WallClockTime *wct, char *s, size_t n, const char *f);
 void wall_clock_time_guess_missing_year(WallClockTime *self);
 void wall_clock_time_guess_missing_fields(WallClockTime *self);
 void dump_wall_clock_time(const WallClockTime *wct, GString *output);


### PR DESCRIPTION
This PR pulls the strftime() implementation from musl and exposes it using the strftime() filterx function.

This adds '%f' and the %z/%Z behaviour similar to what strptime() can easily parse.

@jszigetvari 
