### PR TITLE
Add repr to FilterX Otel objects

### DIFF
--- a/modules/grpc/otel/filterx/CMakeLists.txt
+++ b/modules/grpc/otel/filterx/CMakeLists.txt
@@ -5,6 +5,8 @@ endif()
 # C++ code
 
 set(OTEL_LOGRECORD_CPP_SOURCES
+  object-otel-base.hpp
+  object-otel-base.cpp
   object-otel.h
   object-otel-logrecord.cpp
   object-otel-logrecord.hpp

--- a/modules/grpc/otel/filterx/Makefile.am
+++ b/modules/grpc/otel/filterx/Makefile.am
@@ -5,6 +5,8 @@ noinst_LTLIBRARIES += modules/grpc/otel/filterx/libfilterx.la
 
 modules_grpc_otel_filterx_libfilterx_la_SOURCES = \
   modules/grpc/otel/filterx/object-otel.h \
+  modules/grpc/otel/filterx/object-otel-base.cpp \
+  modules/grpc/otel/filterx/object-otel-base.hpp \
   modules/grpc/otel/filterx/object-otel-logrecord.cpp \
   modules/grpc/otel/filterx/object-otel-logrecord.hpp \
   modules/grpc/otel/filterx/object-otel-resource.cpp \

--- a/modules/grpc/otel/filterx/object-otel-array.hpp
+++ b/modules/grpc/otel/filterx/object-otel-array.hpp
@@ -31,6 +31,7 @@
 #include "compat/cpp-end.h"
 
 #include "protobuf-field.hpp"
+#include "object-otel-base.hpp"
 #include "opentelemetry/proto/common/v1/common.pb.h"
 
 typedef struct FilterXOtelArray_ FilterXOtelArray;
@@ -44,7 +45,7 @@ namespace filterx {
 
 using opentelemetry::proto::common::v1::ArrayValue;
 
-class Array
+class Array : public Base
 {
 public:
   Array(FilterXOtelArray *s);
@@ -72,6 +73,9 @@ private:
   bool borrowed;
 
   friend class OtelArrayField;
+
+protected:
+  const google::protobuf::Message &get_protobuf_value() const override;
 };
 
 class OtelArrayField : public ProtobufField

--- a/modules/grpc/otel/filterx/object-otel-base.cpp
+++ b/modules/grpc/otel/filterx/object-otel-base.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 shifter
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "object-otel-base.hpp"
+
+#include "compat/cpp-start.h"
+#include "compat/cpp-end.h"
+
+#include <google/protobuf/util/json_util.h>
+#include <tuple>
+#include <stdexcept>
+#include <string>
+
+using namespace syslogng::grpc::otel::filterx;
+using namespace google::protobuf;
+
+std::string
+Base::repr() const
+{
+  std::string json_output;
+  std::ignore = util::MessageToJsonString(get_protobuf_value(), &json_output);
+  if (json_output.empty())
+    {
+      throw std::runtime_error("MessageToJsonString failed: empty output");
+    }
+  return json_output;
+}

--- a/modules/grpc/otel/filterx/object-otel-base.hpp
+++ b/modules/grpc/otel/filterx/object-otel-base.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 shifter
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef OBJECT_OTEL_BASE_HPP
+#define OBJECT_OTEL_BASE_HPP
+
+#include "syslog-ng.h"
+
+#include "compat/cpp-start.h"
+#include "filterx/object-list-interface.h"
+#include "object-otel.h"
+#include "compat/cpp-end.h"
+
+#include "opentelemetry/proto/common/v1/common.pb.h"
+
+namespace syslogng {
+namespace grpc {
+namespace otel {
+namespace filterx {
+
+class Base
+{
+public:
+  virtual ~Base() = default;
+  std::string repr() const;
+protected:
+  virtual const google::protobuf::Message &get_protobuf_value() const = 0;
+};
+
+}
+}
+}
+}
+
+#endif

--- a/modules/grpc/otel/filterx/object-otel-kvlist.hpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.hpp
@@ -31,7 +31,9 @@
 #include "compat/cpp-end.h"
 
 #include "protobuf-field.hpp"
+#include "object-otel-base.hpp"
 #include "opentelemetry/proto/common/v1/common.pb.h"
+#include <mutex>
 
 typedef struct FilterXOtelKVList_ FilterXOtelKVList;
 
@@ -43,9 +45,10 @@ namespace otel {
 namespace filterx {
 
 using opentelemetry::proto::common::v1::KeyValue;
+using opentelemetry::proto::common::v1::KeyValueList;
 using google::protobuf::RepeatedPtrField;
 
-class KVList
+class KVList : public Base
 {
 
 public:
@@ -74,8 +77,12 @@ private:
   FilterXOtelKVList *super;
   RepeatedPtrField<KeyValue> *repeated_kv;
   bool borrowed;
+  thread_local static KeyValueList cached_value;
 
   friend class OtelKVListField;
+
+protected:
+  const google::protobuf::Message &get_protobuf_value() const override;
 };
 
 class OtelKVListField : public ProtobufField

--- a/modules/grpc/otel/filterx/object-otel-logrecord.hpp
+++ b/modules/grpc/otel/filterx/object-otel-logrecord.hpp
@@ -30,6 +30,7 @@
 #include "object-otel.h"
 #include "compat/cpp-end.h"
 
+#include "object-otel-base.hpp"
 #include "opentelemetry/proto/logs/v1/logs.pb.h"
 
 typedef struct FilterXOtelLogRecord_ FilterXOtelLogRecord;
@@ -41,7 +42,7 @@ namespace grpc {
 namespace otel {
 namespace filterx {
 
-class LogRecord
+class LogRecord : public Base
 {
 public:
   LogRecord(FilterXOtelLogRecord *super);
@@ -61,6 +62,9 @@ private:
   opentelemetry::proto::logs::v1::LogRecord logRecord;
   LogRecord(const LogRecord &o, FilterXOtelLogRecord *super);
   friend FilterXObject *::_filterx_otel_logrecord_clone(FilterXObject *s);
+
+protected:
+  const google::protobuf::Message &get_protobuf_value() const override;
 };
 
 }

--- a/modules/grpc/otel/filterx/object-otel-resource.hpp
+++ b/modules/grpc/otel/filterx/object-otel-resource.hpp
@@ -30,6 +30,7 @@
 #include "object-otel.h"
 #include "compat/cpp-end.h"
 
+#include "object-otel-base.hpp"
 #include "opentelemetry/proto/resource/v1/resource.pb.h"
 
 typedef struct FilterXOtelResource_ FilterXOtelResource;
@@ -41,7 +42,7 @@ namespace grpc {
 namespace otel {
 namespace filterx {
 
-class Resource
+class Resource : public Base
 {
 public:
   Resource(FilterXOtelResource *s);
@@ -65,6 +66,9 @@ private:
 private:
   FilterXOtelResource *super;
   opentelemetry::proto::resource::v1::Resource resource;
+
+protected:
+  const google::protobuf::Message &get_protobuf_value() const override;
 };
 
 }

--- a/modules/grpc/otel/filterx/object-otel-scope.cpp
+++ b/modules/grpc/otel/filterx/object-otel-scope.cpp
@@ -30,6 +30,7 @@
 #include "filterx/filterx-ref.h"
 #include "compat/cpp-end.h"
 
+#include <google/protobuf/util/json_util.h>
 #include <stdexcept>
 
 using namespace syslogng::grpc::otel::filterx;
@@ -151,6 +152,12 @@ const opentelemetry::proto::common::v1::InstrumentationScope &
 Scope::get_value() const
 {
   return scope;
+}
+
+const google::protobuf::Message &
+Scope::get_protobuf_value() const
+{
+  return get_value();
 }
 
 /* C Wrappers */
@@ -320,8 +327,26 @@ _dict_factory(FilterXObject *self)
   return filterx_otel_kvlist_new();
 }
 
-FILTERX_SIMPLE_FUNCTION(otel_scope, filterx_otel_scope_new_from_args);
+static gboolean
+_repr(FilterXObject *s, GString *repr)
+{
+  FilterXOtelScope *self = (FilterXOtelScope *) s;
 
+  try
+    {
+      std::string cstring = self->cpp->repr();
+      g_string_assign(repr, cstring.c_str());
+    }
+  catch (const std::runtime_error &e)
+    {
+      msg_error("FilterX: Failed to repr OTel Scope object", evt_tag_str("error", e.what()));
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+FILTERX_SIMPLE_FUNCTION(otel_scope, filterx_otel_scope_new_from_args);
 
 FILTERX_DEFINE_TYPE(otel_scope, FILTERX_TYPE_NAME(dict),
                     .is_mutable = TRUE,
@@ -330,5 +355,6 @@ FILTERX_DEFINE_TYPE(otel_scope, FILTERX_TYPE_NAME(dict),
                     .truthy = _truthy,
                     .list_factory = _list_factory,
                     .dict_factory = _dict_factory,
+                    .repr = _repr,
                     .free_fn = _free,
                    );

--- a/modules/grpc/otel/filterx/object-otel-scope.hpp
+++ b/modules/grpc/otel/filterx/object-otel-scope.hpp
@@ -30,6 +30,7 @@
 #include "object-otel.h"
 #include "compat/cpp-end.h"
 
+#include "object-otel-base.hpp"
 #include "opentelemetry/proto/common/v1/common.pb.h"
 
 typedef struct FilterXOtelScope_ FilterXOtelScope;
@@ -41,7 +42,7 @@ namespace grpc {
 namespace otel {
 namespace filterx {
 
-class Scope
+class Scope : public Base
 {
 public:
   Scope(FilterXOtelScope *s);
@@ -65,6 +66,9 @@ private:
 private:
   FilterXOtelScope *super;
   opentelemetry::proto::common::v1::InstrumentationScope scope;
+
+protected:
+  const google::protobuf::Message &get_protobuf_value() const override;
 };
 
 }

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -2625,6 +2625,7 @@ def test_otel_repr(config, syslog_ng):
     $MESSAGE = json();
     $MESSAGE.kvlist = string(kvlist);
     $MESSAGE.array = string(array);
+    $MESSAGE.logrecord = string(logrecord);
     $MESSAGE.scope = string(scope);
     """,
     )
@@ -2635,6 +2636,7 @@ def test_otel_repr(config, syslog_ng):
     exp = (
         r"""{"kvlist":"{\"values\":[{\"key\":\"test\",\"value\":{\"stringValue\":\"kvlist\"}},{\"key\":\"message\",\"value\":{\"stringValue\":\"foobar\"}}]}","""
         r""""array":"{\"values\":[{\"stringValue\":\"message\"},{\"stringValue\":\"foobar\"}]}","""
+        r""""logrecord":"{\"body\":{\"stringValue\":\"foobar\"},\"attributes\":[{\"key\":\"foo\",\"value\":{\"stringValue\":\"bar\"}}]}","""
         r""""scope":"{\"name\":\"foobar\",\"version\":\"one\",\"attributes\":[{\"key\":\"foo\",\"value\":{\"stringValue\":\"bar\"}}],\"droppedAttributesCount\":333}"}""" + "\n"
     )
     assert file_true.read_log() == exp

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -2623,6 +2623,7 @@ def test_otel_repr(config, syslog_ng):
     resource = otel_resource({"attributes":{"resource":$MESSAGE}, "dropped_attributes_count": 444});
     scope = otel_scope({"name":$MESSAGE, "version":"one", "attributes":{"foo":"bar"}, "dropped_attributes_count": 333});
     $MESSAGE = json();
+    $MESSAGE.kvlist = string(kvlist);
     $MESSAGE.scope = string(scope);
     """,
     )
@@ -2631,6 +2632,7 @@ def test_otel_repr(config, syslog_ng):
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
     exp = (
+        r"""{"kvlist":"{\"values\":[{\"key\":\"test\",\"value\":{\"stringValue\":\"kvlist\"}},{\"key\":\"message\",\"value\":{\"stringValue\":\"foobar\"}}]}","""
         r""""scope":"{\"name\":\"foobar\",\"version\":\"one\",\"attributes\":[{\"key\":\"foo\",\"value\":{\"stringValue\":\"bar\"}}],\"droppedAttributesCount\":333}"}""" + "\n"
     )
     assert file_true.read_log() == exp

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -2626,6 +2626,7 @@ def test_otel_repr(config, syslog_ng):
     $MESSAGE.kvlist = string(kvlist);
     $MESSAGE.array = string(array);
     $MESSAGE.logrecord = string(logrecord);
+    $MESSAGE.resource = string(resource);
     $MESSAGE.scope = string(scope);
     """,
     )
@@ -2637,6 +2638,7 @@ def test_otel_repr(config, syslog_ng):
         r"""{"kvlist":"{\"values\":[{\"key\":\"test\",\"value\":{\"stringValue\":\"kvlist\"}},{\"key\":\"message\",\"value\":{\"stringValue\":\"foobar\"}}]}","""
         r""""array":"{\"values\":[{\"stringValue\":\"message\"},{\"stringValue\":\"foobar\"}]}","""
         r""""logrecord":"{\"body\":{\"stringValue\":\"foobar\"},\"attributes\":[{\"key\":\"foo\",\"value\":{\"stringValue\":\"bar\"}}]}","""
+        r""""resource":"{\"attributes\":[{\"key\":\"resource\",\"value\":{\"stringValue\":\"foobar\"}}],\"droppedAttributesCount\":444}","""
         r""""scope":"{\"name\":\"foobar\",\"version\":\"one\",\"attributes\":[{\"key\":\"foo\",\"value\":{\"stringValue\":\"bar\"}}],\"droppedAttributesCount\":333}"}""" + "\n"
     )
     assert file_true.read_log() == exp

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -2624,6 +2624,7 @@ def test_otel_repr(config, syslog_ng):
     scope = otel_scope({"name":$MESSAGE, "version":"one", "attributes":{"foo":"bar"}, "dropped_attributes_count": 333});
     $MESSAGE = json();
     $MESSAGE.kvlist = string(kvlist);
+    $MESSAGE.array = string(array);
     $MESSAGE.scope = string(scope);
     """,
     )
@@ -2633,6 +2634,7 @@ def test_otel_repr(config, syslog_ng):
     assert "processed" not in file_false.get_stats()
     exp = (
         r"""{"kvlist":"{\"values\":[{\"key\":\"test\",\"value\":{\"stringValue\":\"kvlist\"}},{\"key\":\"message\",\"value\":{\"stringValue\":\"foobar\"}}]}","""
+        r""""array":"{\"values\":[{\"stringValue\":\"message\"},{\"stringValue\":\"foobar\"}]}","""
         r""""scope":"{\"name\":\"foobar\",\"version\":\"one\",\"attributes\":[{\"key\":\"foo\",\"value\":{\"stringValue\":\"bar\"}}],\"droppedAttributesCount\":333}"}""" + "\n"
     )
     assert file_true.read_log() == exp


### PR DESCRIPTION
Axorouter encountered an error:
filterx: unable to repr; from='otel_kvlist', to='string'.

Upon investigating the issue, I found relevant hints in Axorouter’s configuration. The configuration suggests that OTel objects still require a repr method, but currently, a JSON-based workaround is used:
```
      filterx {
        # Fallback if map-to-text is not defined for the appliance.
        # TODO: OTel based types do not support string() cast, so we fallback for format_json().
        #       Remove that when OTel types start supporting string() cast.
        log.body = string(log.body) ?? format_json(log.body);
```

To address this, I implemented repr methods for all OTel-related FilterX objects:
- array
- kvlist
- logrecord
- resource
- scope

Additionally, I provided light tests to validate repr methods using forced string typecasting.