### PR TITLE
package-indexer: disable R2 default integrity check

### DIFF
--- a/packaging/package-indexer/remote_storage_synchronizer/s3_bucket_synchronizer.py
+++ b/packaging/package-indexer/remote_storage_synchronizer/s3_bucket_synchronizer.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from boto3 import Session
+from botocore.config import Config
 from botocore.exceptions import ClientError, EndpointConnectionError
 
 from .remote_storage_synchronizer import RemoteStorageSynchronizer
@@ -64,9 +65,16 @@ class S3BucketSynchronizer(RemoteStorageSynchronizer):
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
         )
+        client_config = Config(
+            client_context_params={
+                "request_checksum_calculation": "when_required",
+                "response_checksum_validation": "when_required",
+            },
+        )
         self.__client = self.__session.client(
             service_name="s3",
             endpoint_url=endpoint,
+            config=client_config,
         )
         self.__bucket = bucket
         super().__init__(


### PR DESCRIPTION
boto3 v1.36.0 introduced a new default integrity check for S3 operations. This breaks R2's S3 compatibility API, as it does not support integrity checks.

See https://github.com/boto/boto3/issues/4392

Hopefully fixes the nightly package indexing CI job.

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
