### PR TITLE
package-indexer: fix setting of value for integrity check

### DIFF
--- a/packaging/package-indexer/remote_storage_synchronizer/s3_bucket_synchronizer.py
+++ b/packaging/package-indexer/remote_storage_synchronizer/s3_bucket_synchronizer.py
@@ -66,10 +66,8 @@ class S3BucketSynchronizer(RemoteStorageSynchronizer):
             aws_secret_access_key=secret_key,
         )
         client_config = Config(
-            client_context_params={
-                "request_checksum_calculation": "when_required",
-                "response_checksum_validation": "when_required",
-            },
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
         )
         self.__client = self.__session.client(
             service_name="s3",


### PR DESCRIPTION
It seems like we need to set these on top level instead of in `client_context_params`.

This is now properly tested locally.

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
