### PR TITLE
filterx: add assertion on generation counter change in filterx_scope_…

### DIFF
--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -112,9 +112,15 @@ filterx_scope_unset_variable(FilterXScope *self, FilterXVariable *v)
 static inline void
 filterx_scope_set_message(FilterXScope *self, LogMessage *msg)
 {
-  if (self->msg)
-    log_msg_unref(self->msg);
-  self->msg = log_msg_ref(msg);
+  if (self->msg != msg)
+    {
+      if (self->msg)
+        {
+          g_assert(self->msg->generation == msg->generation);
+          log_msg_unref(self->msg);
+        }
+      self->msg = log_msg_ref(msg);
+    }
 }
 
 #endif


### PR DESCRIPTION
…set_message()

The message generation counter is embedded in FilterXVariable instances that are stored in the scope. We assume that those variables are in sync with the message under processing and a similar assertion exists in filterx_scope_sync().

The assertion in filterx_scope_sync() fired, but at that point it is difficult to know where the generation counter got out of sync.  One such point is in filterx_scope_set_message(), hopefully that's closer to the root cause.
