### PR TITLE
filterx: fix `filterx_dict_keys()`

### DIFF
--- a/lib/filterx/object-dict-interface.c
+++ b/lib/filterx/object-dict-interface.c
@@ -66,7 +66,11 @@ _add_elem_to_list(FilterXObject *key_obj, FilterXObject *value_obj, gpointer use
 {
   FilterXObject *list = (FilterXObject *) user_data;
 
-  return filterx_list_append(list, &key_obj);
+  FilterXObject *key_to_add = filterx_object_ref(key_obj);
+  gboolean success = filterx_list_append(list, &key_to_add);
+  filterx_object_unref(key_to_add);
+
+  return success;
 }
 
 gboolean


### PR DESCRIPTION
`set_subscript()`, `setattr()` or `list_append()` can convert the passed value to a different `FilterXObject`, either because of a different dict/list type or in the future because of stack allocation resoluton. This is why we pass a `FilterXObject **` as the value, with it the function can show if the value was converted, and can consume the old value's reference and return a new reference to the new value.

Each `_iter()` implementation prepares and lends the key and value for the callback (`_add_elem_to_list()` in this case). Each `_iter()` implementation wants to free its own prepared key or value immediately after the iter callback call, so they do not need to know if there was a conversion. This is why the iter interface is written in a way that the callback cannot show if the key or value was converted (no `FilterXObject **`).

Saying so, if an iter callback expects to call an operation that wants to consume the reference of the borrowed key or value, it must put a reference on them before calling the operation. This was missing from `_add_elem_to_list()`.

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
