### PR TITLE
filterx: fix racy writing of readonly JSON object caches 

### DIFF
--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -109,6 +109,8 @@ void filterx_object_unfreeze_and_free(FilterXObject *self);
 void filterx_object_init_instance(FilterXObject *self, FilterXType *type);
 void filterx_object_free_method(FilterXObject *self);
 
+void filterx_json_associate_cached_object(struct json_object *jso, FilterXObject *filterx_object);
+
 static inline gboolean
 filterx_object_is_frozen(FilterXObject *self)
 {
@@ -289,6 +291,10 @@ filterx_object_map_to_json(FilterXObject *self, struct json_object **object, Fil
       gboolean result = self->type->map_to_json(self, object, assoc_object);
       if (!(*assoc_object))
         *assoc_object = filterx_object_ref(self);
+
+      if (!self->readonly)
+        filterx_json_associate_cached_object(*object, *assoc_object);
+
       return result;
     }
   return FALSE;

--- a/lib/filterx/object-dict-interface.c
+++ b/lib/filterx/object-dict-interface.c
@@ -202,9 +202,6 @@ _add_elem_to_json_object(FilterXObject *key_obj, FilterXObject *value_obj, gpoin
   if (!filterx_object_map_to_json(value_obj, &value, &assoc_object))
     return FALSE;
 
-  if (!value_obj->readonly)
-    filterx_json_associate_cached_object(value, assoc_object);
-
   filterx_object_unref(assoc_object);
 
   if (json_object_object_add(object, key, value) != 0)

--- a/lib/filterx/object-dict-interface.c
+++ b/lib/filterx/object-dict-interface.c
@@ -202,7 +202,7 @@ _add_elem_to_json_object(FilterXObject *key_obj, FilterXObject *value_obj, gpoin
   if (!filterx_object_map_to_json(value_obj, &value, &assoc_object))
     return FALSE;
 
-  filterx_json_associate_cached_object(object, assoc_object);
+  filterx_json_associate_cached_object(value, assoc_object);
   filterx_object_unref(assoc_object);
 
   if (json_object_object_add(object, key, value) != 0)

--- a/lib/filterx/object-dict-interface.c
+++ b/lib/filterx/object-dict-interface.c
@@ -202,7 +202,9 @@ _add_elem_to_json_object(FilterXObject *key_obj, FilterXObject *value_obj, gpoin
   if (!filterx_object_map_to_json(value_obj, &value, &assoc_object))
     return FALSE;
 
-  filterx_json_associate_cached_object(value, assoc_object);
+  if (!value_obj->readonly)
+    filterx_json_associate_cached_object(value, assoc_object);
+
   filterx_object_unref(assoc_object);
 
   if (json_object_object_add(object, key, value) != 0)

--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -158,9 +158,6 @@ _append(FilterXList *s, FilterXObject **new_value)
   if (!filterx_object_map_to_json(*new_value, &jso, &assoc_object))
     return FALSE;
 
-  if (!(*new_value)->readonly)
-    filterx_json_associate_cached_object(jso, assoc_object);
-
   if (json_object_array_add(self->jso, jso) != 0)
     {
       filterx_object_unref(assoc_object);
@@ -194,9 +191,6 @@ _set_subscript(FilterXList *s, guint64 index, FilterXObject **new_value)
   FilterXObject *assoc_object = NULL;
   if (!filterx_object_map_to_json(*new_value, &jso, &assoc_object))
     return FALSE;
-
-  if (!(*new_value)->readonly)
-    filterx_json_associate_cached_object(jso, assoc_object);
 
   if (json_object_array_put_idx(self->jso, index, jso) != 0)
     {

--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -158,7 +158,8 @@ _append(FilterXList *s, FilterXObject **new_value)
   if (!filterx_object_map_to_json(*new_value, &jso, &assoc_object))
     return FALSE;
 
-  filterx_json_associate_cached_object(jso, assoc_object);
+  if (!(*new_value)->readonly)
+    filterx_json_associate_cached_object(jso, assoc_object);
 
   if (json_object_array_add(self->jso, jso) != 0)
     {
@@ -194,7 +195,8 @@ _set_subscript(FilterXList *s, guint64 index, FilterXObject **new_value)
   if (!filterx_object_map_to_json(*new_value, &jso, &assoc_object))
     return FALSE;
 
-  filterx_json_associate_cached_object(jso, assoc_object);
+  if (!(*new_value)->readonly)
+    filterx_json_associate_cached_object(jso, assoc_object);
 
   if (json_object_array_put_idx(self->jso, index, jso) != 0)
     {

--- a/lib/filterx/object-json-object.c
+++ b/lib/filterx/object-json-object.c
@@ -140,9 +140,6 @@ _set_subscript(FilterXDict *s, FilterXObject *key, FilterXObject **new_value)
   if (!filterx_object_map_to_json(*new_value, &jso, &assoc_object))
     return FALSE;
 
-  if (!(*new_value)->readonly)
-    filterx_json_associate_cached_object(jso, assoc_object);
-
   if (json_object_object_add(self->jso, key_str, jso) != 0)
     {
       filterx_object_unref(assoc_object);

--- a/lib/filterx/object-json-object.c
+++ b/lib/filterx/object-json-object.c
@@ -140,7 +140,8 @@ _set_subscript(FilterXDict *s, FilterXObject *key, FilterXObject **new_value)
   if (!filterx_object_map_to_json(*new_value, &jso, &assoc_object))
     return FALSE;
 
-  filterx_json_associate_cached_object(jso, assoc_object);
+  if (!(*new_value)->readonly)
+    filterx_json_associate_cached_object(jso, assoc_object);
 
   if (json_object_object_add(self->jso, key_str, jso) != 0)
     {

--- a/lib/filterx/object-json.c
+++ b/lib/filterx/object-json.c
@@ -146,6 +146,9 @@ filterx_json_associate_cached_object(struct json_object *jso, FilterXObject *fil
   if (!_is_json_cacheable(jso))
     return;
 
+  if (json_object_get_userdata(jso) == filterx_obj)
+    return;
+
   filterx_eval_store_weak_ref(filterx_obj);
 
   /* we are not storing a reference in userdata to avoid circular

--- a/lib/filterx/object-list-interface.c
+++ b/lib/filterx/object-list-interface.c
@@ -267,7 +267,7 @@ _map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **asso
           goto error;
         }
 
-      filterx_json_associate_cached_object(*object, elem_assoc_object);
+      filterx_json_associate_cached_object(value, elem_assoc_object);
 
       filterx_object_unref(elem_assoc_object);
       filterx_object_unref(value_obj);

--- a/lib/filterx/object-list-interface.c
+++ b/lib/filterx/object-list-interface.c
@@ -267,7 +267,8 @@ _map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **asso
           goto error;
         }
 
-      filterx_json_associate_cached_object(value, elem_assoc_object);
+      if (!value_obj->readonly)
+        filterx_json_associate_cached_object(value, elem_assoc_object);
 
       filterx_object_unref(elem_assoc_object);
       filterx_object_unref(value_obj);

--- a/lib/filterx/object-list-interface.c
+++ b/lib/filterx/object-list-interface.c
@@ -267,9 +267,6 @@ _map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **asso
           goto error;
         }
 
-      if (!value_obj->readonly)
-        filterx_json_associate_cached_object(value, elem_assoc_object);
-
       filterx_object_unref(elem_assoc_object);
       filterx_object_unref(value_obj);
 

--- a/lib/filterx/tests/test_object_json.c
+++ b/lib/filterx/tests/test_object_json.c
@@ -217,11 +217,14 @@ static void
 setup(void)
 {
   app_startup();
+  init_libtest_filterx();
 }
 
 static void
 teardown(void)
 {
+  scratch_buffers_explicit_gc();
+  deinit_libtest_filterx();
   app_shutdown();
 }
 


### PR DESCRIPTION
This may not be the best way to fix the race, but this whole caching mess will be reimplemented/removed soon.