### PR TITLE
filterx: fix compilation error on 32-bit platforms (gsize vs. guint64)

### DIFF
--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -372,14 +372,13 @@ static gboolean
 _handle_target_object(FilterXFunctionUnsetEmpties *self, FilterXObject *target, GError **error)
 {
   g_assert(target);
-  guint64 len;
-
   target = filterx_ref_unwrap_ro(target);
 
   if (filterx_object_is_type(target, &FILTERX_TYPE_NAME(null)))
     set_flag(&self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_NULL, TRUE);
   else if (filterx_object_is_type(target, &FILTERX_TYPE_NAME(list)))
     {
+      guint64 len;
       g_assert(filterx_object_len(target, &len));
       if (len != 0)
         {
@@ -391,6 +390,7 @@ _handle_target_object(FilterXFunctionUnsetEmpties *self, FilterXObject *target, 
     }
   else if (filterx_object_is_type(target, &FILTERX_TYPE_NAME(dict)))
     {
+      guint64 len;
       g_assert(filterx_object_len(target, &len));
       if (len != 0)
         {
@@ -402,6 +402,7 @@ _handle_target_object(FilterXFunctionUnsetEmpties *self, FilterXObject *target, 
     }
   else if (filterx_object_is_type(target, &FILTERX_TYPE_NAME(string)))
     {
+      gsize len;
       const gchar *str = filterx_string_get_value_ref(target, &len);
       if (len == 0)
         {


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
