### PR TITLE
Fix `vars()`

### DIFF
--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -248,7 +248,7 @@ filterx_scope_register_variable(FilterXScope *self,
 }
 
 gboolean
-filterx_scope_foreach_variable(FilterXScope *self, FilterXScopeForeachFunc func, gpointer user_data)
+filterx_scope_foreach_variable_readonly(FilterXScope *self, FilterXScopeForeachFunc func, gpointer user_data)
 {
   FilterXVariable *variables = _get_variable_array(self);
 

--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -180,9 +180,13 @@ filterx_scope_lookup_variable(FilterXScope *self, FilterXVariableHandle handle)
   FilterXVariable *v;
   gint v_index;
 
-  if (_lookup_variable(self, handle, &v, &v_index) &&
-      _validate_variable(self, v))
-    return v;
+  if (_lookup_variable(self, handle, &v, &v_index))
+    {
+      if (_validate_variable(self, v))
+        return v;
+
+      return NULL;
+    }
 
   for (FilterXScope *scope = self->parent_scope; scope; scope = scope->parent_scope)
     {

--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -68,7 +68,9 @@ FilterXVariable *filterx_scope_lookup_variable(FilterXScope *self, FilterXVariab
 FilterXVariable *filterx_scope_register_variable(FilterXScope *self,
                                                  FilterXVariableType variable_type,
                                                  FilterXVariableHandle handle);
-gboolean filterx_scope_foreach_variable(FilterXScope *self, FilterXScopeForeachFunc func, gpointer user_data);
+
+/* variables and their objects must not be modified */
+gboolean filterx_scope_foreach_variable_readonly(FilterXScope *self, FilterXScopeForeachFunc func, gpointer user_data);
 
 gsize filterx_scope_get_alloc_size(void);
 void filterx_scope_init_instance(FilterXScope *storage, gsize storage_size, FilterXScope *parent_scope);

--- a/lib/filterx/func-vars.c
+++ b/lib/filterx/func-vars.c
@@ -79,7 +79,7 @@ filterx_simple_function_vars(FilterXExpr *s, FilterXObject *args[], gsize args_l
   GString *name_buf = scratch_buffers_alloc_and_mark(&marker);
 
   gpointer user_data[] = { vars, name_buf };
-  if (!filterx_scope_foreach_variable(context->scope, _add_to_dict, user_data))
+  if (!filterx_scope_foreach_variable_readonly(context->scope, _add_to_dict, user_data))
     {
       filterx_object_unref(vars);
       vars = NULL;

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -28,3 +28,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_expr_regexp_search DEPENDS json-plug
 add_unit_test(LIBTEST CRITERION TARGET test_expr_regexp_subst DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_dict_interface DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_func_keys DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_scope DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -30,7 +30,8 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_expr_plus \
 		lib/filterx/tests/test_metrics_labels \
 		lib/filterx/tests/test_object_dict_interface \
-		lib/filterx/tests/test_func_keys
+		lib/filterx/tests/test_func_keys \
+		lib/filterx/tests/test_scope
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt
 
@@ -125,3 +126,6 @@ lib_filterx_tests_test_object_dict_interface_LDADD   = $(TEST_LDADD) $(JSON_LIBS
 
 lib_filterx_tests_test_func_keys_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_func_keys_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_scope_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_scope_LDADD   = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/test_scope.c
+++ b/lib/filterx/tests/test_scope.c
@@ -89,6 +89,36 @@ Test(filterx_scope, test_scope_sync)
   filterx_scope_clear(s);
 }
 
+static gboolean
+_assert_var_false(FilterXVariable *variable, gpointer user_data)
+{
+  cr_assert_not(filterx_boolean_get_value(variable->value));
+  return TRUE;
+}
+
+Test(filterx_scope, test_scope_foreach_variable_with_parent_scope)
+{
+  gsize alloc_size = filterx_scope_get_alloc_size();
+
+  FilterXScope *s = g_alloca(alloc_size);
+  filterx_scope_init_instance(s, alloc_size, NULL);
+
+  FilterXVariableHandle var = filterx_map_varname_to_handle("var", FX_VAR_DECLARED_FLOATING);
+  FilterXVariable *v = filterx_scope_register_variable(s, FX_VAR_DECLARED_FLOATING, var);
+  filterx_scope_set_variable(s, v, filterx_boolean_new(TRUE), TRUE);
+
+  FilterXScope *s2 = g_alloca(alloc_size);
+  filterx_scope_init_instance(s2, alloc_size, s);
+
+  v = filterx_scope_register_variable(s2, FX_VAR_DECLARED_FLOATING, var);
+  filterx_scope_set_variable(s, v, filterx_boolean_new(FALSE), TRUE);
+
+  cr_assert(filterx_scope_foreach_variable_readonly(s2, _assert_var_false, NULL));
+
+  filterx_scope_clear(s2);
+  filterx_scope_clear(s);
+}
+
 static void
 setup(void)
 {

--- a/lib/filterx/tests/test_scope.c
+++ b/lib/filterx/tests/test_scope.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024 Axoflow
+ * Copyright (c) 2024 László Várady
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+
+#include "syslog-ng.h"
+#include "scratch-buffers.h"
+#include "libtest/filterx-lib.h"
+#include "apphook.h"
+#include "logmsg/logmsg.h"
+
+#include "filterx/filterx-scope.h"
+#include "filterx/filterx-variable.h"
+#include "filterx/object-primitive.h"
+
+Test(filterx_scope, test_scope_on_heap)
+{
+  FilterXScope *s = filterx_scope_new(NULL);
+  cr_assert_null(filterx_scope_lookup_variable(s, filterx_map_varname_to_handle("var", FX_VAR_DECLARED_FLOATING)));
+  filterx_scope_free(s);
+}
+
+Test(filterx_scope, test_scope_stacking)
+{
+  gsize alloc_size = filterx_scope_get_alloc_size();
+
+  FilterXScope *s = g_alloca(alloc_size);
+  filterx_scope_init_instance(s, alloc_size, NULL);
+
+  FilterXVariableHandle var = filterx_map_varname_to_handle("var", FX_VAR_DECLARED_FLOATING);
+  filterx_scope_register_variable(s, FX_VAR_DECLARED_FLOATING, var);
+
+  FilterXScope *s2 = g_alloca(alloc_size);
+  filterx_scope_init_instance(s2, alloc_size, s);
+
+  cr_assert_not_null(filterx_scope_lookup_variable(s2, var));
+
+  filterx_scope_clear(s2);
+  filterx_scope_clear(s);
+}
+
+Test(filterx_scope, test_scope_sync)
+{
+  gsize alloc_size = filterx_scope_get_alloc_size();
+  FilterXScope *s = g_alloca(alloc_size);
+  filterx_scope_init_instance(s, alloc_size, NULL);
+  LogMessage *msg = log_msg_new_empty();
+
+  filterx_scope_set_message(s, msg);
+
+  FilterXVariableHandle var = filterx_map_varname_to_handle("$var", FX_VAR_MESSAGE_TIED);
+  FilterXVariable *v = filterx_scope_register_variable(s, FX_VAR_MESSAGE_TIED, var);
+  filterx_scope_set_variable(s, v, filterx_boolean_new(TRUE), TRUE);
+
+  filterx_scope_set_dirty(s);
+  filterx_scope_sync(s, msg);
+
+  LogMessageValueType type;
+  const gchar *value = log_msg_get_value_with_type(msg, filterx_variable_get_nv_handle(v), NULL, &type);
+  cr_assert_eq(type, LM_VT_BOOLEAN);
+  cr_assert_str_eq(value, "true");
+
+  cr_assert(filterx_scope_lookup_variable(s, var));
+  log_msg_set_value_by_name(msg, "var", "newvalue", -1);
+  cr_assert_not(filterx_scope_lookup_variable(s, var));
+
+  log_msg_unref(msg);
+  filterx_scope_clear(s);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  init_libtest_filterx();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  deinit_libtest_filterx();
+  app_shutdown();
+}
+
+TestSuite(filterx_scope, .init = setup, .fini = teardown);


### PR DESCRIPTION
Follow-up for 145c50840708323e3f5f5bffff27f5ac72c1766a

If the GHashTable allocation appears to be costly, this can be reimplemented using a fix-sized heapqueue and a "merge" operation on the sorted variables arrays.