### PR TITLE
`vars()`: add `exclude_message_values` parameter

### DIFF
--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -110,7 +110,6 @@ _simple_init(void)
   g_assert(filterx_builtin_simple_function_register("dedup_metrics_labels",
                                                     filterx_simple_function_dedup_metrics_labels));
   g_assert(filterx_builtin_simple_function_register("len", filterx_simple_function_len));
-  g_assert(filterx_builtin_simple_function_register("vars", filterx_simple_function_vars));
   g_assert(filterx_builtin_simple_function_register("load_vars", filterx_simple_function_load_vars));
   g_assert(filterx_builtin_simple_function_register("lower", filterx_simple_function_lower));
   g_assert(filterx_builtin_simple_function_register("upper", filterx_simple_function_upper));
@@ -154,6 +153,7 @@ _ctors_init(void)
   g_assert(filterx_builtin_function_ctor_register("includes", filterx_function_includes_new));
   g_assert(filterx_builtin_function_ctor_register("strftime", filterx_function_strftime_new));
   g_assert(filterx_builtin_function_ctor_register("keys", filterx_function_keys_new));
+  g_assert(filterx_builtin_function_ctor_register("vars", filterx_function_vars_new));
 }
 
 static void

--- a/lib/filterx/func-vars.c
+++ b/lib/filterx/func-vars.c
@@ -37,13 +37,18 @@
 typedef struct _FilterXFunctionVars
 {
   FilterXFunction super;
+  gboolean exclude_msg_values;
 } FilterXFunctionVars;
 
 static gboolean
 _add_to_dict(FilterXVariable *variable, gpointer user_data)
 {
-  FilterXObject *vars = ((gpointer *)(user_data))[0];
-  GString *name_buf = ((gpointer *)(user_data))[1];
+  FilterXFunctionVars *self = ((gpointer *)(user_data))[0];
+  FilterXObject *vars = ((gpointer *)(user_data))[1];
+  GString *name_buf = ((gpointer *)(user_data))[2];
+
+  if (filterx_variable_is_message_tied(variable) && self->exclude_msg_values)
+    return TRUE;
 
   gssize name_len;
   const gchar *name_str = filterx_variable_get_name(variable, &name_len);
@@ -79,7 +84,7 @@ _filterx_function_vars_eval(FilterXExpr *s)
   ScratchBuffersMarker marker;
   GString *name_buf = scratch_buffers_alloc_and_mark(&marker);
 
-  gpointer user_data[] = { vars, name_buf };
+  gpointer user_data[] = { self, vars, name_buf };
   if (!filterx_scope_foreach_variable_readonly(context->scope, _add_to_dict, user_data))
     {
       filterx_object_unref(vars);
@@ -98,6 +103,13 @@ filterx_function_vars_new(FilterXFunctionArgs *args, GError **error)
 
   self->super.super.eval = _filterx_function_vars_eval;
 
+  gboolean exists, eval_error;
+  self->exclude_msg_values = filterx_function_args_get_named_literal_boolean(args, "exclude_msg_values", &exists,
+                             &eval_error);
+
+  if (!filterx_function_args_check(args, error))
+    goto error;
+
   if (filterx_function_args_len(args) != 0)
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
@@ -108,7 +120,7 @@ filterx_function_vars_new(FilterXFunctionArgs *args, GError **error)
   if (eval_error)
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
-                  "floating_only argument must be boolean literal");
+                  "exclude_msg_values argument must be boolean literal");
       goto error;
     }
 

--- a/lib/filterx/func-vars.c
+++ b/lib/filterx/func-vars.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024 Attila Szakacs
+ * Copyright (c) 2025 László Várady
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -33,6 +34,11 @@
 #include "scratch-buffers.h"
 #include "str-utils.h"
 
+typedef struct _FilterXFunctionVars
+{
+  FilterXFunction super;
+} FilterXFunctionVars;
+
 static gboolean
 _add_to_dict(FilterXVariable *variable, gpointer user_data)
 {
@@ -63,15 +69,10 @@ _add_to_dict(FilterXVariable *variable, gpointer user_data)
   return success;
 }
 
-FilterXObject *
-filterx_simple_function_vars(FilterXExpr *s, FilterXObject *args[], gsize args_len)
+static FilterXObject *
+_filterx_function_vars_eval(FilterXExpr *s)
 {
-  if (args && args_len != 0)
-    {
-      filterx_simple_function_argument_error(s, "Incorrect number of arguments", FALSE);
-      return NULL;
-    }
-
+  FilterXFunctionVars *self = (FilterXFunctionVars *) s;
   FilterXEvalContext *context = filterx_eval_get_context();
   FilterXObject *vars = filterx_json_object_new_empty();
 
@@ -88,6 +89,38 @@ filterx_simple_function_vars(FilterXExpr *s, FilterXObject *args[], gsize args_l
   scratch_buffers_reclaim_marked(marker);
   return vars;
 }
+
+FilterXExpr *
+filterx_function_vars_new(FilterXFunctionArgs *args, GError **error)
+{
+  FilterXFunctionVars *self = g_new0(FilterXFunctionVars, 1);
+  filterx_function_init_instance(&self->super, "vars");
+
+  self->super.super.eval = _filterx_function_vars_eval;
+
+  if (filterx_function_args_len(args) != 0)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "function has only optional parameters");
+      goto error;
+    }
+
+  if (eval_error)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "floating_only argument must be boolean literal");
+      goto error;
+    }
+
+  filterx_function_args_free(args);
+  return &self->super.super;
+
+error:
+  filterx_function_args_free(args);
+  filterx_expr_unref(&self->super.super);
+  return NULL;
+}
+
 
 static gboolean
 _load_from_dict(FilterXObject *key, FilterXObject *value, gpointer user_data)

--- a/lib/filterx/func-vars.h
+++ b/lib/filterx/func-vars.h
@@ -26,7 +26,7 @@
 
 #include "filterx/expr-function.h"
 
-FilterXObject *filterx_simple_function_vars(FilterXExpr *s, FilterXObject *args[], gsize args_len);
+FilterXExpr *filterx_function_vars_new(FilterXFunctionArgs *args, GError **error);
 FilterXObject *filterx_simple_function_load_vars(FilterXExpr *s, FilterXObject *args[], gsize args_len);
 
 #endif


### PR DESCRIPTION
Depens on #504

Note: `vars()` lies a little, because it formats both floating and message-tied variables, but NOT ALL message variables as they might have never appeared inside FilterX.