### PR TITLE
Filterx stack based string allocation fixes

### DIFF
--- a/lib/filterx/func-set-fields.c
+++ b/lib/filterx/func-set-fields.c
@@ -358,7 +358,7 @@ exit:
 static gboolean
 _are_field_keys_equal(FilterXObject *key_a, FilterXObject *key_b)
 {
-  gsize len_a, len_b;
+  gsize len_a = 0, len_b = 0;
   const gchar *key_a_str = filterx_string_get_value_ref(key_a, &len_a);
   const gchar *key_b_str = filterx_string_get_value_ref(key_b, &len_b);
 

--- a/lib/filterx/func-vars.c
+++ b/lib/filterx/func-vars.c
@@ -146,7 +146,7 @@ _load_from_dict(FilterXObject *key, FilterXObject *value, gpointer user_data)
       return FALSE;
     }
 
-  gsize key_len;
+  gsize key_len = 0;
   const gchar *key_str = filterx_string_get_value_ref(key, &key_len);
   APPEND_ZERO(key_str, key_str, key_len);
 

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -132,7 +132,7 @@ _string_clone(FilterXObject *s)
 static inline FilterXString *
 _string_new(const gchar *str, gssize str_len, FilterXStringTranslateFunc translate)
 {
-  if (str_len < 0)
+  if (str_len == -1)
     str_len = strlen(str);
 
   FilterXString *self = g_malloc(sizeof(FilterXString) + str_len + 1);

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -95,7 +95,7 @@ void filterx_string_global_deinit(void);
   { \
     FILTERX_OBJECT_STACK_INIT(string), \
     .str = (cstr), \
-    .str_len = ((cstr_len) < 0 ? strlen(cstr) : (cstr_len)), \
+    .str_len = (((gssize) cstr_len) == -1 ? strlen(cstr) : (cstr_len)), \
   }
 
 #define FILTERX_STRING_DECLARE_ON_STACK(_name, cstr, cstr_len) \

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -53,7 +53,11 @@ FilterXObject *filterx_string_new_translated(const gchar *str, gssize str_len, F
 FilterXObject *filterx_bytes_new(const gchar *str, gssize str_len);
 FilterXObject *filterx_protobuf_new(const gchar *str, gssize str_len);
 
-/* NOTE: Consider using filterx_object_extract_string_ref() to also support message_value. */
+/* NOTE: Consider using filterx_object_extract_string_ref() to also support message_value.
+ *
+ * Also NOTE: the returned string may not be NUL terminated, although often
+ * it will be. Generic code should handle the cases where it is not.
+ */
 static inline const gchar *
 filterx_string_get_value_ref(FilterXObject *s, gsize *length)
 {
@@ -64,6 +68,8 @@ filterx_string_get_value_ref(FilterXObject *s, gsize *length)
 
   if (length)
     *length = self->str_len;
+  else
+    g_assert(self->str[self->str_len] == 0);
   return self->str;
 }
 


### PR DESCRIPTION

There are two patches in this PR that fix two distinct issues:
* when moving filterx_string_get_value_ref() to be inline, I removed the check for NUL termination, as all strings are NUL terminated, when constructed normally. Unfortunately stack allocated ones may rely on the explicit length without NUL termination, such as the ones in get_sdata() function.
* sometimes "-1" as an extremal value to the stack allocation macro comes in an unsigned variable, causing the check in the macro not to fire. Avoid these cases by an explicit cast.

