### PR TITLE
filterx: support optimized strings in `regexp_search()` and `regexp_subst()` pattern

### DIFF
--- a/lib/filterx/expr-regexp-search.c
+++ b/lib/filterx/expr-regexp-search.c
@@ -24,6 +24,7 @@
 
 #include "expr-regexp-search.h"
 #include "filterx/expr-regexp.h"
+#include "filterx/expr-literal.h"
 #include "filterx/object-primitive.h"
 #include "filterx/object-extractor.h"
 #include "filterx/object-string.h"
@@ -50,6 +51,7 @@ typedef struct FilterXExprRegexpSearchGenerator_
   FilterXGeneratorFunction super;
   FilterXExpr *lhs;
   pcre2_code_8 *pattern;
+  FilterXExpr *pattern_expr;
   FLAGSET flags;
 } FilterXExprRegexpSearchGenerator;
 
@@ -220,6 +222,7 @@ _regexp_search_generator_optimize(FilterXExpr *s)
   FilterXExprRegexpSearchGenerator *self = (FilterXExprRegexpSearchGenerator *) s;
 
   self->lhs = filterx_expr_optimize(self->lhs);
+  self->pattern_expr = filterx_expr_optimize(self->pattern_expr);
   return filterx_generator_optimize_method(s);
 }
 
@@ -228,10 +231,44 @@ _regexp_search_generator_init(FilterXExpr *s, GlobalConfig *cfg)
 {
   FilterXExprRegexpSearchGenerator *self = (FilterXExprRegexpSearchGenerator *) s;
 
+  FilterXObject *pattern_obj = NULL;
+
   if (!filterx_expr_init(self->lhs, cfg))
-    return FALSE;
+    goto error;
+
+  if (!filterx_expr_init(self->pattern_expr, cfg))
+    goto error;
+
+  if (!filterx_expr_is_literal(self->pattern_expr))
+    {
+      msg_error("regexp_search(): pattern argument must be a literal string. " FILTERX_FUNC_REGEXP_SEARCH_USAGE);
+      goto error;
+    }
+
+  pattern_obj = filterx_expr_eval(self->pattern_expr);
+
+  gsize pattern_len;
+  const gchar *pattern = filterx_string_get_value_ref(pattern_obj, &pattern_len);
+  if (!pattern)
+    {
+      msg_error("regexp_search(): pattern argument must be a literal string. " FILTERX_FUNC_REGEXP_SEARCH_USAGE);
+      goto error;
+    }
+
+  self->pattern = filterx_regexp_compile_pattern_defaults(pattern);
+  if (!self->pattern)
+    {
+      msg_error("regexp_search(): failed to compile pattern. " FILTERX_FUNC_REGEXP_SEARCH_USAGE);
+      goto error;
+    }
 
   return filterx_generator_init_method(s, cfg);
+
+error:
+  filterx_object_unref(pattern_obj);
+  filterx_expr_deinit(self->lhs, cfg);
+  filterx_expr_deinit(self->pattern_expr, cfg);
+  return FALSE;
 }
 
 static void
@@ -240,6 +277,7 @@ _regexp_search_generator_deinit(FilterXExpr *s, GlobalConfig *cfg)
   FilterXExprRegexpSearchGenerator *self = (FilterXExprRegexpSearchGenerator *) s;
 
   filterx_expr_deinit(self->lhs, cfg);
+  filterx_expr_deinit(self->pattern_expr, cfg);
   filterx_generator_deinit_method(s, cfg);
 }
 
@@ -249,6 +287,7 @@ _regexp_search_generator_free(FilterXExpr *s)
   FilterXExprRegexpSearchGenerator *self = (FilterXExprRegexpSearchGenerator *) s;
 
   filterx_expr_unref(self->lhs);
+  filterx_expr_unref(self->pattern_expr);
   if (self->pattern)
     pcre2_code_free(self->pattern);
   filterx_generator_function_free_method(&self->super);
@@ -273,25 +312,9 @@ _extract_search_args(FilterXExprRegexpSearchGenerator *self, FilterXFunctionArgs
     }
 
   self->lhs = filterx_function_args_get_expr(args, 0);
-
-  const gchar *pattern = filterx_function_args_get_literal_string(args, 1, NULL);
-  if (!pattern)
-    {
-      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
-                  "pattern must be string literal. " FILTERX_FUNC_REGEXP_SEARCH_USAGE);
-      return FALSE;
-    }
-
-  self->pattern = filterx_regexp_compile_pattern_defaults(pattern);
-  if (!self->pattern)
-    {
-      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
-                  "failed to compile pattern. " FILTERX_FUNC_REGEXP_SEARCH_USAGE);
-      return FALSE;
-    }
+  self->pattern_expr = filterx_function_args_get_expr(args, 1);
 
   return TRUE;
-
 }
 
 /* Takes reference of lhs */

--- a/lib/filterx/expr-regexp-subst.c
+++ b/lib/filterx/expr-regexp-subst.c
@@ -24,6 +24,7 @@
 
 #include "expr-regexp-subst.h"
 #include "filterx/expr-regexp.h"
+#include "filterx/expr-literal.h"
 #include "filterx/object-primitive.h"
 #include "filterx/object-extractor.h"
 #include "filterx/object-string.h"
@@ -61,6 +62,7 @@ typedef struct FilterXFuncRegexpSubst_
   FilterXFunction super;
   FilterXExpr *string_expr;
   pcre2_code_8 *pattern;
+  FilterXExpr *pattern_expr;
   gchar *replacement;
   FLAGSET flags;
 } FilterXFuncRegexpSubst;
@@ -241,18 +243,35 @@ _create_compile_opts(FLAGSET flags)
 }
 
 static pcre2_code_8 *
-_extract_subst_pattern_arg(FilterXFuncRegexpSubst *self, FilterXFunctionArgs *args, GError **error)
+_init_subst_pattern(FilterXFuncRegexpSubst *self, GlobalConfig *cfg)
 {
-  const gchar *pattern = filterx_function_args_get_literal_string(args, 1, NULL);
-  if (!pattern)
+  if (!filterx_expr_init(self->pattern_expr, cfg))
     {
-      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
-                  "argument must be a string literal: pattern. " FILTERX_FUNC_REGEXP_SUBST_USAGE);
+      msg_error("regexp_subst(): failed to initialize pattern expression. " FILTERX_FUNC_REGEXP_SUBST_USAGE);
       return NULL;
     }
 
-  return filterx_regexp_compile_pattern(pattern, check_flag(self->flags, FILTERX_FUNC_REGEXP_SUBST_FLAG_JIT),
-                                        _create_compile_opts(self->flags));
+  if (!filterx_expr_is_literal(self->pattern_expr))
+    {
+      msg_error("regexp_subst(): pattern argument must be a literal string. " FILTERX_FUNC_REGEXP_SUBST_USAGE);
+      return NULL;
+    }
+
+  gsize pattern_len;
+  FilterXObject *pattern_obj = filterx_expr_eval(self->pattern_expr);
+  const gchar *pattern = filterx_string_get_value_ref(pattern_obj, &pattern_len);
+  if (!pattern)
+    {
+      msg_error("regexp_subst(): pattern argument must be a literal string. " FILTERX_FUNC_REGEXP_SUBST_USAGE);
+      filterx_object_unref(pattern_obj);
+      return NULL;
+    }
+
+  pcre2_code_8 *compiled_pattern = filterx_regexp_compile_pattern(pattern, check_flag(self->flags,
+                                   FILTERX_FUNC_REGEXP_SUBST_FLAG_JIT),
+                                   _create_compile_opts(self->flags));
+  filterx_object_unref(pattern_obj);
+  return compiled_pattern;
 }
 
 static gchar *
@@ -319,9 +338,7 @@ _extract_subst_args(FilterXFuncRegexpSubst *self, FilterXFunctionArgs *args, GEr
   if (!_extract_optional_flags(self, args, error))
     return FALSE;
 
-  self->pattern = _extract_subst_pattern_arg(self, args, error);
-  if (!self->pattern)
-    return FALSE;
+  self->pattern_expr = filterx_function_args_get_expr(args, 1);
 
   self->replacement = _extract_subst_replacement_arg(args, error);
   if (!self->replacement)
@@ -339,6 +356,7 @@ _subst_optimize(FilterXExpr *s)
   FilterXFuncRegexpSubst *self = (FilterXFuncRegexpSubst *) s;
 
   self->string_expr = filterx_expr_optimize(self->string_expr);
+  self->pattern_expr = filterx_expr_optimize(self->pattern_expr);
   return filterx_function_optimize_method(&self->super);
 }
 
@@ -350,6 +368,13 @@ _subst_init(FilterXExpr *s, GlobalConfig *cfg)
   if (!filterx_expr_init(self->string_expr, cfg))
     return FALSE;
 
+  self->pattern = _init_subst_pattern(self, cfg);
+  if (!self->pattern)
+    {
+      filterx_expr_deinit(self->string_expr, cfg);
+      return FALSE;
+    }
+
   return filterx_function_init_method(&self->super, cfg);
 }
 
@@ -358,6 +383,7 @@ _subst_deinit(FilterXExpr *s, GlobalConfig *cfg)
 {
   FilterXFuncRegexpSubst *self = (FilterXFuncRegexpSubst *) s;
   filterx_expr_deinit(self->string_expr, cfg);
+  filterx_expr_deinit(self->pattern_expr, cfg);
   filterx_function_deinit_method(&self->super, cfg);
 }
 
@@ -366,6 +392,7 @@ _subst_free(FilterXExpr *s)
 {
   FilterXFuncRegexpSubst *self = (FilterXFuncRegexpSubst *) s;
   filterx_expr_unref(self->string_expr);
+  filterx_expr_unref(self->pattern_expr);
   if (self->pattern)
     pcre2_code_free(self->pattern);
   g_free(self->replacement);

--- a/lib/filterx/tests/test_expr_regexp_subst.c
+++ b/lib/filterx/tests/test_expr_regexp_subst.c
@@ -76,6 +76,10 @@ _build_subst_func(const gchar *pattern, const gchar *repr, const gchar *str, Fil
   GError *err = NULL;
   FilterXExpr *func = filterx_function_regexp_subst_new(filterx_function_args_new(args, NULL), &err);
   cr_assert_null(err);
+
+  func = filterx_expr_optimize(func);
+  cr_assert(filterx_expr_init(func, configuration));
+
   return func;
 }
 
@@ -85,6 +89,8 @@ _sub(const gchar *pattern, const gchar *repr, const gchar *str, FilterXFuncRegex
   FilterXExpr *func = _build_subst_func(pattern, repr, str, opts);
 
   FilterXObject *res = filterx_expr_eval(func);
+
+  filterx_expr_deinit(func, configuration);
   filterx_expr_unref(func);
   return res;
 }
@@ -279,12 +285,14 @@ Test(filterx_expr_regexp_subst, regexp_subst_nojit_arg)
   FilterXExpr *func = _build_subst_func("o", "X", "foobarbaz", opts);
   cr_assert_not_null(func);
   cr_assert(filterx_regexp_subst_is_jit_enabled(func));
+  filterx_expr_deinit(func, configuration);
   filterx_expr_unref(func);
 
   FilterXFuncRegexpSubstOpts opts_nojit = {};
   FilterXExpr *func_nojit = _build_subst_func("o", "X", "foobarbaz", opts_nojit);
   cr_assert_not_null(func_nojit);
   cr_assert(!filterx_regexp_subst_is_jit_enabled(func_nojit));
+  filterx_expr_deinit(func_nojit, configuration);
   filterx_expr_unref(func_nojit);
 }
 

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -1836,6 +1836,7 @@ def test_regexp_subst(config, syslog_ng):
         $MSG.mixed_grps = regexp_subst("25-02-2022", /(\d{2})-(\d{2})-(\d{4})/, "foo:\\3-\\2-\\1:bar:baz");
         $MSG.multi_digit_grps = regexp_subst("010203040506070809101112", /(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/, "\\10-\\11-\\12");
         $MSG.prefixing_zeros = regexp_subst("foobar", /^(.*)$/, "\\001012345");
+        $MSG.optimized_pattern = regexp_subst("foobarbaz", "o" + "b", "");
     """,
     )
     syslog_ng.start(config)
@@ -1859,7 +1860,8 @@ def test_regexp_subst(config, syslog_ng):
         r""""groups_on":"2022-02-25","""
         r""""mixed_grps":"foo:2022-02-25:bar:baz","""
         r""""multi_digit_grps":"10-11-12","""
-        r""""prefixing_zeros":"foobar012345"}""" + "\n"
+        r""""prefixing_zeros":"foobar012345","""
+        r""""optimized_pattern":"foarbaz"}""" + "\n"
     )
     assert file_true.read_log() == exp
 

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -1195,6 +1195,7 @@ def test_regexp_search(config, syslog_ng):
     $MSG.force_list = json_array(regexp_search("foobarbaz", /(?<first>foo)(bar)(?<third>baz)/));
     $MSG.force_dict = json(regexp_search("foobarbaz", /(foo)(bar)(baz)/));
     $MSG.force_dict_list_mode = json(regexp_search("foobarbaz", /(foo)(bar)(baz)/, list_mode=true));
+    $MSG.optimized_pattern = regexp_search("foobarbaz", /(foo)/ + /(bar)/ + /(baz)/);
 
     $MSG.no_match_unnamed = regexp_search("foobarbaz", /(almafa)/);
     if (len($MSG.no_match_unnamed) == 0) {
@@ -1251,6 +1252,7 @@ def test_regexp_search(config, syslog_ng):
         "no_match_named_list_mode_handling": True,
         "full_match": {"0": "foobarbaz"},  # does not suppress grp 0 when it's the only result
         "full_match_list_mode": ["foobarbaz"],  # does not suppress grp 0 when it's the only result
+        "optimized_pattern": {"1": "foo", "2": "bar", "3": "baz"},
     }
 
 


### PR DESCRIPTION
I don't think we need a news file entry for this.