### PR TITLE
`webhook()`: proxy and headers support

### DIFF
--- a/modules/python-modules/syslogng/modules/webhook/scl/webhook.conf
+++ b/modules/python-modules/syslogng/modules/webhook/scl/webhook.conf
@@ -33,6 +33,7 @@ block source webhook(
     tls_ca_file("")
     tls_ca_dir("")
     proxy_header("")
+    include_request_headers(no)
     ...
 )
 {
@@ -50,6 +51,7 @@ block source webhook(
             "tls_ca_file" => "`tls_ca_file`"
             "tls_ca_dir" => "`tls_ca_dir`"
             "proxy_header" => "`proxy_header`"
+            "include_request_headers" => `include_request_headers`
         )
         `__VARARGS__`
     );

--- a/modules/python-modules/syslogng/modules/webhook/scl/webhook.conf
+++ b/modules/python-modules/syslogng/modules/webhook/scl/webhook.conf
@@ -32,6 +32,7 @@ block source webhook(
     tls_use_system_cert_store(no)
     tls_ca_file("")
     tls_ca_dir("")
+    proxy_header("")
     ...
 )
 {
@@ -48,6 +49,7 @@ block source webhook(
             "tls_use_system_cert_store" => `tls_use_system_cert_store`
             "tls_ca_file" => "`tls_ca_file`"
             "tls_ca_dir" => "`tls_ca_dir`"
+            "proxy_header" => "`proxy_header`"
         )
         `__VARARGS__`
     );

--- a/news/feature-524.md
+++ b/news/feature-524.md
@@ -1,0 +1,14 @@
+`webhook()`: headers support
+
+`include-request-headers(yes)` stores request headers under the `${webhook.headers}` key,
+allowing further processing, for example, in FilterX:
+
+```
+filterx {
+  headers = json(${webhook.headers});
+  $type = headers["Content-Type"][-1];
+};
+```
+
+`proxy-header("x-forwarded-for")` helps retain the sender's original IP and the proxy's IP address
+(`$SOURCEIP`, `$PEERIP`).


### PR DESCRIPTION
Depends on #523

```
webhook(port(8080) proxy-header("x-forwarded-for"));
webhook(port(8080) proxy-header(yes));

$ curl -H "x-forwarded-for: 4.3.3.2"
    -H "X-Forwarded-FOR: 1.2.3.4" -X POST --data "{}" http://127.0.0.1:8080

$PEERIP: 127.0.0.1, $SOURCEIP: 1.2.3.4
```

```
webhook(port(8080) include-request-headers(yes));

filterx {
    headers = json(${webhook.headers});

    $type = headers["Content-Type"][-1];
    $headers = headers;
};
```

$headers:
```json
{
  "Host": ["127.0.0.1:8080"],
  "User-Agent": ["curl/8.5.0"],
  "X-Forwarded-For": [
    "4.3.3.2",
    "1.2.3.4"
  ],
  "Content-Length": ["2"],
  "Content-Type": ["application/x-www-form-urlencoded"]
}
```
```
$type == "application/x-www-form-urlencoded"
```