### PR TITLE
filterx: fix switch eval errors

### DIFF
--- a/lib/filterx/expr-switch.c
+++ b/lib/filterx/expr-switch.c
@@ -187,6 +187,8 @@ _find_matching_case(FilterXSwitch *self, FilterXObject *selector)
       FilterXSwitchCase *switch_case = (FilterXSwitchCase *) g_ptr_array_index(self->cases, i);
 
       FilterXObject *value = _eval_switch_case(switch_case);
+      if (!value)
+        continue;
 
       if (filterx_compare_objects(selector, value, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_EQ))
         {

--- a/lib/filterx/expr-switch.c
+++ b/lib/filterx/expr-switch.c
@@ -187,8 +187,13 @@ _find_matching_case(FilterXSwitch *self, FilterXObject *selector)
       FilterXSwitchCase *switch_case = (FilterXSwitchCase *) g_ptr_array_index(self->cases, i);
 
       FilterXObject *value = _eval_switch_case(switch_case);
+
       if (filterx_compare_objects(selector, value, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_EQ))
-        return switch_case;
+        {
+          filterx_object_unref(value);
+          return switch_case;
+        }
+
       filterx_object_unref(value);
     }
   return NULL;

--- a/lib/filterx/expr-switch.c
+++ b/lib/filterx/expr-switch.c
@@ -205,7 +205,10 @@ static FilterXObject *
 _eval_switch(FilterXExpr *s)
 {
   FilterXSwitch *self = (FilterXSwitch *) s;
+
   FilterXObject *selector = filterx_expr_eval_typed(self->selector);
+  if (!selector)
+    return NULL;
 
   FilterXSwitchCase *switch_case;
 

--- a/news/fx-bugfix-527.md
+++ b/news/fx-bugfix-527.md
@@ -1,0 +1,1 @@
+`switch`: Fixed a crash that occurred when the selector or case failed to evaluate.


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
