### PR TITLE
filterx/expr-function: simple functions should get unmarshalled values

### DIFF
--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -84,7 +84,7 @@ _get_arg_object(FilterXSimpleFunction *self, guint64 index)
   if (!expr)
     return NULL;
 
-  return filterx_expr_eval(expr);
+  return filterx_expr_eval_typed(expr);
 }
 
 static gboolean

--- a/lib/filterx/func-vars.c
+++ b/lib/filterx/func-vars.c
@@ -209,33 +209,10 @@ filterx_simple_function_load_vars(FilterXExpr *s, FilterXObject *args[], gsize a
 
   FilterXObject *vars = args[0];
   FilterXObject *vars_unwrapped = filterx_ref_unwrap_ro(vars);
-  FilterXObject *vars_unmarshalled = NULL;
-
-  if (!filterx_object_is_type(vars_unwrapped, &FILTERX_TYPE_NAME(dict)))
-    {
-      if (!filterx_object_is_type(vars_unwrapped, &FILTERX_TYPE_NAME(message_value)))
-        {
-          filterx_simple_function_argument_error(s, g_strdup_printf("Argument must be dict typed, got %s instead",
-                                                                    vars_unwrapped->type->name), TRUE);
-          return NULL;
-        }
-
-      vars_unmarshalled = filterx_object_unmarshal(vars_unwrapped);
-      vars_unwrapped = NULL;
-
-      if (!filterx_object_is_type(vars_unmarshalled, &FILTERX_TYPE_NAME(dict)))
-        {
-          filterx_simple_function_argument_error(s, g_strdup_printf("Argument must be dict typed, got %s instead",
-                                                                    vars_unmarshalled->type->name), TRUE);
-          filterx_object_unref(vars_unmarshalled);
-          return NULL;
-        }
-    }
 
   FilterXScope *scope = filterx_eval_get_scope();
   gpointer user_data[] = { s, scope };
-  gboolean success = filterx_dict_iter(vars_unwrapped ? : vars_unmarshalled, _load_from_dict, user_data);
+  gboolean success = filterx_dict_iter(vars_unwrapped, _load_from_dict, user_data);
 
-  filterx_object_unref(vars_unmarshalled);
   return success ? filterx_boolean_new(TRUE) : NULL;
 }

--- a/lib/filterx/object-extractor.h
+++ b/lib/filterx/object-extractor.h
@@ -30,10 +30,8 @@
 #include "filterx/object-primitive.h"
 #include "filterx/object-datetime.h"
 #include "filterx/object-null.h"
-#include "filterx/object-json.h"
 
 #include "generic-number.h"
-#include "compat/json.h"
 
 static inline gboolean
 filterx_object_extract_string_ref(FilterXObject *obj, const gchar **value, gsize *len)
@@ -150,36 +148,6 @@ filterx_object_extract_null(FilterXObject *obj)
     return filterx_message_value_get_null(obj);
 
   return filterx_object_is_type(obj, &FILTERX_TYPE_NAME(null));
-}
-
-static inline gboolean
-filterx_object_extract_json_array(FilterXObject *obj, struct json_object **value)
-{
-  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
-    {
-      if (!filterx_message_value_get_json(obj, value))
-        return FALSE;
-
-      if (json_object_is_type(*value, json_type_array))
-        return TRUE;
-
-      json_object_put(*value);
-      *value = NULL;
-      return FALSE;
-    }
-
-  *value = filterx_json_array_get_value(obj);
-  return !!(*value);
-}
-
-static inline gboolean
-filterx_object_extract_json_object(FilterXObject *obj, struct json_object **value)
-{
-  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)))
-    return filterx_message_value_get_json(obj, value);
-
-  *value = filterx_json_object_get_value(obj);
-  return !!(*value);
 }
 
 #endif

--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -327,13 +327,10 @@ filterx_json_array_new_from_args(FilterXExpr *s, FilterXObject *args[], gsize ar
   if (filterx_object_is_type(json_arr, &FILTERX_TYPE_NAME(json_array)))
     return filterx_object_ref(arg);
 
-  struct json_object *jso;
-  if (filterx_object_extract_json_array(arg, &jso))
-    return filterx_json_array_new_sub(jso, NULL);
-
   const gchar *repr;
   gsize repr_len;
-  if (filterx_object_extract_string_ref(arg, &repr, &repr_len))
+  repr = filterx_string_get_value_ref(arg, &repr_len);
+  if (repr)
     return filterx_json_array_new_from_repr(repr, repr_len);
 
   filterx_eval_push_error_info("Argument must be a json array, a string or a syslog-ng list", s,

--- a/lib/filterx/object-json.c
+++ b/lib/filterx/object-json.c
@@ -227,13 +227,10 @@ filterx_json_new_from_args(FilterXExpr *s, FilterXObject *args[], gsize args_len
       return self;
     }
 
-  struct json_object *jso;
-  if (filterx_object_extract_json_object(arg, &jso))
-    return filterx_json_new_from_object(jso);
-
   const gchar *repr;
   gsize repr_len;
-  if (filterx_object_extract_string_ref(arg, &repr, &repr_len))
+  repr = filterx_string_get_value_ref(arg, &repr_len);
+  if (repr)
     return filterx_json_new_from_repr(repr, repr_len);
 
   filterx_eval_push_error_info("Argument must be a json, a string or a syslog-ng list", s,

--- a/lib/filterx/object-message-value.c
+++ b/lib/filterx/object-message-value.c
@@ -134,20 +134,6 @@ filterx_message_value_get_null(FilterXObject *s)
 }
 
 gboolean
-filterx_message_value_get_json(FilterXObject *s, struct json_object **value)
-{
-  FilterXMessageValue *self = (FilterXMessageValue *) s;
-
-  if (self->type == LM_VT_JSON)
-    return type_cast_to_json(self->repr, self->repr_len, value, NULL);
-
-  if (self->type == LM_VT_LIST)
-    return type_cast_to_json_from_list(self->repr, self->repr_len, value, NULL);
-
-  return FALSE;
-}
-
-gboolean
 _is_value_type_pair_truthy(const gchar  *repr, gssize repr_len, LogMessageValueType type)
 {
   gboolean b;

--- a/lib/filterx/tests/test_expr_plus_generator.c
+++ b/lib/filterx/tests/test_expr_plus_generator.c
@@ -213,14 +213,7 @@ Test(expr_plus_generator, test_nested_dict_add_two_generators_with_post_set_fill
   cr_assert_not_null(res_object);
   cr_assert(filterx_object_is_type(res_object, &FILTERX_TYPE_NAME(dict)));
 
-  struct json_object *jso = NULL;
-  FilterXObject *assoc_object = NULL;
-  cr_assert(filterx_object_map_to_json(res_object, &jso, &assoc_object));
-
-  const gchar *json_repr = json_object_to_json_string_ext(jso, JSON_C_TO_STRING_PLAIN);
-  cr_assert_str_eq(json_repr, "{\"foo\":{\"bar\":\"baz\"},\"tik\":{\"tak\":\"toe\"}}");
-  json_object_put(jso);
-  filterx_object_unref(assoc_object);
+  assert_object_json_equals(res_object, "{\"foo\":{\"bar\":\"baz\"},\"tik\":{\"tak\":\"toe\"}}");
 
   filterx_expr_unref(expr);
   filterx_expr_unref(fillable);

--- a/lib/filterx/tests/test_object_json.c
+++ b/lib/filterx/tests/test_object_json.c
@@ -103,32 +103,12 @@ Test(filterx_json, test_json_function)
   assert_object_json_equals(fobj, "{\"foo\":1}");
   filterx_object_unref(fobj);
 
+  /* message_value is being unmarshalled before passing it to a simple
+   * function, so no need to handle FilterXMessageValue instances */
   fobj = _exec_json_func(filterx_message_value_new("{\"foo\": 1}", -1, LM_VT_JSON));
-  cr_assert(filterx_object_is_type(fobj, &FILTERX_TYPE_NAME(json_object)));
-  assert_object_json_equals(fobj, "{\"foo\":1}");
-  filterx_object_unref(fobj);
+  cr_assert(fobj == NULL);
 
   fobj = _exec_json_func(filterx_string_new("[1, 2]", -1));
-  cr_assert(filterx_object_is_type(fobj, &FILTERX_TYPE_NAME(json_array)));
-  assert_object_json_equals(fobj, "[1,2]");
-  filterx_object_unref(fobj);
-
-  fobj = _exec_json_func(filterx_message_value_new("[1, 2]", -1, LM_VT_JSON));
-  cr_assert(filterx_object_is_type(fobj, &FILTERX_TYPE_NAME(json_array)));
-  assert_object_json_equals(fobj, "[1,2]");
-  filterx_object_unref(fobj);
-
-  fobj = _exec_json_func(filterx_message_value_new("foo,bar", -1, LM_VT_LIST));
-  cr_assert(filterx_object_is_type(fobj, &FILTERX_TYPE_NAME(json_array)));
-  assert_object_json_equals(fobj, "[\"foo\",\"bar\"]");
-  filterx_object_unref(fobj);
-
-  fobj = _exec_json_func(filterx_message_value_new("{\"foo\": 1}", -1, LM_VT_STRING));
-  cr_assert(filterx_object_is_type(fobj, &FILTERX_TYPE_NAME(json_object)));
-  assert_object_json_equals(fobj, "{\"foo\":1}");
-  filterx_object_unref(fobj);
-
-  fobj = _exec_json_func(filterx_message_value_new("[1, 2]", -1, LM_VT_STRING));
   cr_assert(filterx_object_is_type(fobj, &FILTERX_TYPE_NAME(json_array)));
   assert_object_json_equals(fobj, "[1,2]");
   filterx_object_unref(fobj);
@@ -158,20 +138,10 @@ Test(filterx_json, test_json_array_function)
   assert_object_json_equals(fobj, "[1,2]");
   filterx_object_unref(fobj);
 
+  /* message_value is being unmarshalled before passing it to a simple
+   * function, so no need to handle FilterXMessageValue instances */
   fobj = _exec_json_array_func(filterx_message_value_new("[1, 2]", -1, LM_VT_JSON));
-  cr_assert(filterx_object_is_type(fobj, &FILTERX_TYPE_NAME(json_array)));
-  assert_object_json_equals(fobj, "[1,2]");
-  filterx_object_unref(fobj);
-
-  fobj = _exec_json_array_func(filterx_message_value_new("foo,bar", -1, LM_VT_LIST));
-  cr_assert(filterx_object_is_type(fobj, &FILTERX_TYPE_NAME(json_array)));
-  assert_object_json_equals(fobj, "[\"foo\",\"bar\"]");
-  filterx_object_unref(fobj);
-
-  fobj = _exec_json_func(filterx_message_value_new("[1, 2]", -1, LM_VT_STRING));
-  cr_assert(filterx_object_is_type(fobj, &FILTERX_TYPE_NAME(json_array)));
-  assert_object_json_equals(fobj, "[1,2]");
-  filterx_object_unref(fobj);
+  cr_assert(fobj == NULL);
 
   fobj = _exec_json_array_func(filterx_json_array_new_from_repr("[1, 2]", -1));
   cr_assert(filterx_object_is_type(fobj, &FILTERX_TYPE_NAME(json_array)));

--- a/modules/grpc/pubsub/filterx/object-pubsub-message.cpp
+++ b/modules/grpc/pubsub/filterx/object-pubsub-message.cpp
@@ -29,6 +29,7 @@
 #include "filterx/object-string.h"
 #include "filterx/object-datetime.h"
 #include "filterx/object-primitive.h"
+#include "filterx/object-json.h"
 #include "scratch-buffers.h"
 #include "generic-number.h"
 


### PR DESCRIPTION
Right now, arguments to simple functions are evaluated at the time of the call, but that means that FilterXMessageValue objects are encountered when evaluating them.

This is:
1) inconvinient, as we have to consider both native objects and
   message values
2) somewhat incorrect, as the unmarshalled version of the arguments are
   not cached in a filterx variable.
3) if the function changes the copy, it will not be impacting the
   filterx variable, e.g. unset_empties($json) will be a noop, if $json
   is an LM_VT_JSON

I understand this may have a performance impact, but if it does, we can look into creating FilterXStrings with a borrowed string pointer.
