### PR TITLE
rename the table_name parameter of the azure monitor destination

### DIFF
--- a/scl/azure/azure-monitor.conf
+++ b/scl/azure/azure-monitor.conf
@@ -22,19 +22,22 @@
 #
 #############################################################################
 
-block destination _azure_monitor_internal(
+@requires http "The azure-monitor() driver depends on the AxoSyslog http module, please install the axosyslog-mod-http (Debian & derivatives) or the axosyslog-http (RHEL & co) package"
+@requires cloud_auth "The azure-monitor() driver depends on the AxoSyslog Cloud Auth module, please install the axosyslog-mod-cloud-auth (Debian & derivatives) or the axosyslog-cloud-auth (RHEL & co) package"
+
+block destination azure_monitor(
   dce_uri()
   dcr_id()
-  table_name()
-  template()
+  stream_name()
+  template("$MESSAGE")
   auth()
   ...
 ) {
   http(
     method("POST")
-    url("`dce_uri`/dataCollectionRules/`dcr_id`/streams/`table_name`?api-version=2023-01-01")
+    url("`dce_uri`/dataCollectionRules/`dcr_id`/streams/`stream_name`?api-version=2023-01-01")
     headers("Content-Type: application/json")
-    persist_name("azure-monitor,`dce_uri`,`dcr_id`,`table_name`")
+    persist_name("azure-monitor,`dce_uri`,`dcr_id`,`stream_name`")
     cloud-auth(
       azure(
         monitor(
@@ -62,10 +65,10 @@ block destination azure_monitor_builtin(
 @requires http "The azure-monitor-builtin() driver depends on the AxoSyslog http module, please install the axosyslog-mod-http (Debian & derivatives) or the axosyslog-http (RHEL & co) package"
 @requires cloud_auth "The azure-monitor-builtin() driver depends on the AxoSyslog Cloud Auth module, please install the axosyslog-mod-cloud-auth (Debian & derivatives) or the axosyslog-cloud-auth (RHEL & co) package"
 
-  _azure_monitor_internal(
+  azure_monitor(
     dce_uri(`dce_uri`)
     dcr_id(`dcr_id`)
-    table_name(`table_name`)
+    stream_name(`table_name`)
     template(`template`)
     auth(`auth`)
     `__VARARGS__`
@@ -84,10 +87,10 @@ block destination azure_monitor_custom(
 @requires http "The azure-monitor-custom() driver depends on the AxoSyslog http module, please install the axosyslog-mod-http (Debian & derivatives) or the axosyslog-http (RHEL & co) package"
 @requires cloud_auth "The azure-monitor-custom() driver depends on the AxoSyslog Cloud Auth module, please install the axosyslog-mod-cloud-auth (Debian & derivatives) or the axosyslog-cloud-auth (RHEL & co) package"
 
-  _azure_monitor_internal(
+  azure_monitor(
     dce_uri(`dce_uri`)
     dcr_id(`dcr_id`)
-    table_name("Custom-`table_name`_CL")
+    stream_name(`table_name`)
     template(`template`)
     auth(`auth`)
     `__VARARGS__`


### PR DESCRIPTION
The `table_name` parameter of the `azure-monitor` destination is actually referring to the stream name in the DCR, and not the table the logs end up getting written to. The actual destination table name is referenced in the DCR.
For this reason the `table_name` parameter should be rename to `stream_name`.