### PR TITLE
Filterx list allow setting the tail item by index

### DIFF
--- a/lib/filterx/object-list-interface.c
+++ b/lib/filterx/object-list-interface.c
@@ -94,18 +94,18 @@ _len(FilterXObject *s, guint64 *len)
 }
 
 static inline gboolean
-_normalize_index(FilterXList *self, gint64 index, guint64 *normalized_index, const gchar **error)
+_normalize_index(FilterXList *self, gint64 index, guint64 *normalized_index, gboolean allow_tail, const gchar **error)
 {
   guint64 len = self->len(self);
 
   if (index >= 0)
     {
-      if (index >= len)
+      if (index > len ||
+          (index == len && !allow_tail))
         {
           *error = "Index out of range";
           return FALSE;
         }
-
       *normalized_index = (guint64) index;
       return TRUE;
     }
@@ -142,7 +142,7 @@ _get_subscript(FilterXObject *s, FilterXObject *key)
 
   guint64 normalized_index;
   const gchar *error;
-  if (!_normalize_index(self, index, &normalized_index, &error))
+  if (!_normalize_index(self, index, &normalized_index, FALSE, &error))
     {
       msg_error("FilterX: Failed to get element from list",
                 evt_tag_str("error", error),
@@ -173,7 +173,7 @@ _set_subscript(FilterXObject *s, FilterXObject *key, FilterXObject **new_value)
 
   guint64 normalized_index;
   const gchar *error;
-  if (!_normalize_index(self, index, &normalized_index, &error))
+  if (!_normalize_index(self, index, &normalized_index, TRUE, &error))
     {
       msg_error("FilterX: Failed to set element of list",
                 evt_tag_str("error", error),
@@ -208,7 +208,7 @@ _is_key_set(FilterXObject *s, FilterXObject *key)
 
   guint64 normalized_index;
   const gchar *error;
-  return _normalize_index(self, index, &normalized_index, &error);
+  return _normalize_index(self, index, &normalized_index, FALSE, &error);
 }
 
 static gboolean
@@ -234,7 +234,7 @@ _unset_key(FilterXObject *s, FilterXObject *key)
 
   guint64 normalized_index;
   const gchar *error;
-  if (!_normalize_index(self, index, &normalized_index, &error))
+  if (!_normalize_index(self, index, &normalized_index, FALSE, &error))
     {
       msg_error("FilterX: Failed to unset element of list",
                 evt_tag_str("error", error),

--- a/lib/filterx/object-list-interface.c
+++ b/lib/filterx/object-list-interface.c
@@ -25,6 +25,8 @@
 #include "filterx/object-primitive.h"
 #include "filterx/object-json.h"
 
+#define FILTERX_LIST_MAX_LENGTH  65536
+
 FilterXObject *
 filterx_list_get_subscript(FilterXObject *s, gint64 index)
 {
@@ -108,7 +110,7 @@ _normalize_index(FilterXList *self, gint64 index, guint64 *normalized_index, con
       return TRUE;
     }
 
-  if (len > G_MAXINT64)
+  if (len > FILTERX_LIST_MAX_LENGTH)
     {
       *error = "Index exceeds maximal supported value";
       return FALSE;

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -705,6 +705,24 @@ $MSG = $list;
     assert file_true.read_log() == """foo,bar,baz\n"""
 
 
+def test_list_set_subscript_with_tail_element_appends_an_element(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+$list = [];
+$list[0] = "foo";
+$list[1] = "bar";
+$list[2] = "baz";
+$MSG = $list;
+""",
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    # foo remains unchanged while baz is changed
+    assert file_true.read_log() == """foo,bar,baz\n"""
+
+
 def test_literal_generator_assignment(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, r"""


### PR DESCRIPTION
This branch allows the indexing of the tail element of the list to append a new value.

e.g.

```
l = list();
l[0] = "elem";
```

Here, the assignment was not permitted previously, as the list has no elements at all, so l[0] is undefined, but this is exactly what we want to achieve, set a new one.

At the moment, addressing any other items outside of the range is still not permitted (but is in JavaScript), but that's still up for discussion.

The PR also limits the length of the arrays to 65536 elements.  We can easily increase this eventually, but I don't see use-cases where this limit would not be enough when handling logs/metrics/traces.
