### PR TITLE
Debugger add list command

### DIFF
--- a/lib/cfg-source.c
+++ b/lib/cfg-source.c
@@ -55,13 +55,13 @@ _print_underline(const gchar *line, gint whitespace_before, gint number_of_caret
 }
 
 static void
-_print_underlined_source_block(const CFG_LTYPE *yylloc, gchar **lines, gint error_index)
+_print_underlined_source_block(const CFG_LTYPE *yylloc, gchar **lines, gsize num_lines, gint error_index)
 {
   gint line_ndx;
   gchar line_prefix[12];
   gint error_length = yylloc->last_line - yylloc->first_line + 1;
 
-  for (line_ndx = 0; lines[line_ndx]; line_ndx++)
+  for (line_ndx = 0; line_ndx < num_lines; line_ndx++)
     {
       gint lineno = yylloc->first_line + line_ndx - error_index;
       const gchar *line = lines[line_ndx];
@@ -84,8 +84,6 @@ _print_underlined_source_block(const CFG_LTYPE *yylloc, gchar **lines, gint erro
                            multi_line ? strlen(&line[yylloc->first_column]) + 1
                            : yylloc->last_column - yylloc->first_column);
         }
-      else if (line_ndx >= error_index + CONTEXT)
-        break;
     }
 }
 
@@ -116,11 +114,10 @@ _report_file_location(const gchar *filename, const CFG_LTYPE *yylloc)
       /* NOTE: do we have the appropriate number of lines? */
       if (lineno <= yylloc->first_line)
         goto exit;
-      g_ptr_array_add(context, NULL);
       fclose(f);
     }
   if (context->len > 0)
-    _print_underlined_source_block(yylloc, (gchar **) context->pdata, error_index);
+    _print_underlined_source_block(yylloc, (gchar **) context->pdata, context->len, error_index);
 
 exit:
   g_free(buf);
@@ -144,7 +141,7 @@ _report_buffer_location(const gchar *buffer_content, const CFG_LTYPE *file_lloc,
       error_index += start;
       start = 0;
     }
-  _print_underlined_source_block(file_lloc, &lines[start], error_index);
+  _print_underlined_source_block(file_lloc, &lines[start], num_lines - start, error_index);
 
 exit:
   g_strfreev(lines);

--- a/lib/cfg-source.c
+++ b/lib/cfg-source.c
@@ -157,6 +157,18 @@ exit:
 }
 
 gboolean
+cfg_source_print_source_text(const gchar *filename, gint line, gint column, gint start_line)
+{
+  CFG_LTYPE yylloc = {0};
+
+  yylloc.name = filename;
+  yylloc.first_line = yylloc.last_line = line;
+  yylloc.first_column = yylloc.last_column = column;
+  _report_file_location(yylloc.name, &yylloc, start_line);
+  return TRUE;
+}
+
+gboolean
 cfg_source_print_source_context(CfgLexer *lexer, CfgIncludeLevel *level, const CFG_LTYPE *yylloc)
 {
   if (level->include_type == CFGI_FILE)

--- a/lib/cfg-source.h
+++ b/lib/cfg-source.h
@@ -26,6 +26,8 @@
 
 #include "cfg-lexer.h"
 
+gboolean cfg_source_print_source_text(const gchar *filename, gint line, gint column, gint offset);
+
 /* These functions are only available during parsing */
 gboolean cfg_source_print_source_context(CfgLexer *lexer, CfgIncludeLevel *level, const CFG_LTYPE *yylloc);
 gboolean cfg_source_extract_source_text(CfgLexer *lexer, const CFG_LTYPE *yylloc, GString *result);

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -59,6 +59,14 @@ struct _Debugger
   LogTemplate *display_template;
 };
 
+static void
+_set_command(Debugger *self, gchar *new_command)
+{
+  if (self->command_buffer)
+    g_free(self->command_buffer);
+  self->command_buffer = g_strdup(new_command);
+}
+
 static gboolean
 _format_nvpair(NVHandle handle,
                const gchar *name,
@@ -368,16 +376,8 @@ _fetch_command(Debugger *self)
 
   command = fetch_command_func();
   if (command && strlen(command) > 0)
-    {
-      if (self->command_buffer)
-        g_free(self->command_buffer);
-      self->command_buffer = command;
-    }
-  else
-    {
-      if (command)
-        g_free(command);
-    }
+    _set_command(self, command);
+  g_free(command);
 }
 
 static gboolean
@@ -542,7 +542,7 @@ debugger_new(MainLoop *main_loop, GlobalConfig *cfg)
   self->tracer = tracer_new(cfg);
   self->cfg = cfg;
   self->display_template = log_template_new(cfg, NULL);
-  self->command_buffer = g_strdup("help");
+  _set_command(self, "help");
   log_template_compile(self->display_template, "$DATE $HOST $MSGHDR$MSG", NULL);
   return self;
 }

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -30,10 +30,12 @@
 #include "timeutils/misc.h"
 #include "compat/time.h"
 #include "scratch-buffers.h"
+#include "cfg-source.h"
 
 #include <iv_signal.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <ctype.h>
 
 struct _Debugger
 {
@@ -41,11 +43,20 @@ struct _Debugger
   struct iv_signal sigint;
   MainLoop *main_loop;
   GlobalConfig *cfg;
-  gchar *command_buffer;
-  LogTemplate *display_template;
+  GThread *debugger_thread;
   BreakpointSite *breakpoint_site;
   struct timespec last_trace_event;
-  GThread *debugger_thread;
+
+  /* user interface related state */
+  gchar *command_buffer;
+  struct
+  {
+    gchar *filename;
+    gint line;
+    gint column;
+    gint list_start;
+  } current_location;
+  LogTemplate *display_template;
 };
 
 static gboolean
@@ -108,34 +119,31 @@ _display_msg_with_template_string(Debugger *self, LogMessage *msg, const gchar *
 }
 
 static void
-_display_source_line(LogExprNode *expr_node)
+_set_current_location(Debugger *self, LogExprNode *expr_node)
 {
-  FILE *f;
-  gint lineno = 1;
-  gchar buf[1024];
-
-  if (!expr_node || !expr_node->filename)
-    return;
-
-  f = fopen(expr_node->filename, "r");
-  if (f)
+  g_free(self->current_location.filename);
+  if (expr_node)
     {
-      while (fgets(buf, sizeof(buf), f) && lineno < expr_node->line)
-        lineno++;
-      if (lineno != expr_node->line)
-        buf[0] = 0;
-      fclose(f);
+      self->current_location.filename = g_strdup(expr_node->filename);
+      self->current_location.line = expr_node->line;
+      self->current_location.column = expr_node->column;
+      self->current_location.list_start = expr_node->line - 5;
     }
   else
     {
-      buf[0] = 0;
+      memset(&self->current_location, 0, sizeof(self->current_location));
     }
-  printf("%-8d %s", expr_node->line, buf);
-  if (buf[0] == 0 || buf[strlen(buf) - 1] != '\n')
-    putc('\n', stdout);
-  fflush(stdout);
 }
 
+static void
+_display_source_line(Debugger *self)
+{
+  if (self->current_location.filename)
+    cfg_source_print_source_text(self->current_location.filename, self->current_location.line,
+                                 self->current_location.column, self->current_location.list_start);
+  else
+    puts("Unable to list source, no current location set");
+}
 
 static gboolean
 _cmd_help(Debugger *self, gint argc, gchar *argv[])
@@ -147,6 +155,7 @@ _cmd_help(Debugger *self, gint argc, gchar *argv[])
              "The following commands are available:\n\n"
              "  help, h, ?               Display this help\n"
              "  info, i                  Display information about the current execution state\n"
+             "  list, l                  Display source code at the current location\n"
              "  continue, c              Continue until the next breakpoint\n"
              "  display                  Set the displayed message template\n"
              "  trace, t                 Display timing information as the message traverses the config\n"
@@ -161,6 +170,7 @@ _cmd_help(Debugger *self, gint argc, gchar *argv[])
              "Stopped on an interrupt.\n"
              "The following commands are available:\n\n"
              "  help, h, ?               Display this help\n"
+             "  list, l                  Display source code at the current location\n"
              "  continue, c              Continue until the next breakpoint\n"
              "  quit, q                  Tell syslog-ng to exit\n"
             );
@@ -239,7 +249,7 @@ _cmd_info_pipe(Debugger *self, LogPipe *pipe)
   gchar buf[1024];
 
   printf("LogPipe %p at %s\n", pipe, log_expr_node_format_location(pipe->expr_node, buf, sizeof(buf)));
-  _display_source_line(pipe->expr_node);
+  _display_source_line(self);
 
   return TRUE;
 }
@@ -255,6 +265,38 @@ _cmd_info(Debugger *self, gint argc, gchar *argv[])
 
   printf("info: List of info subcommands\n"
          "info pipe -- display information about the current pipe\n");
+  return TRUE;
+}
+
+static gboolean
+_cmd_list(Debugger *self, gint argc, gchar *argv[])
+{
+  gint shift = 11;
+  if (argc >= 2)
+    {
+      if (strcmp(argv[1], "+") == 0)
+        shift = 11;
+      else if (strcmp(argv[1], "-") == 0)
+        shift = -11;
+      else if (strcmp(argv[1], ".") == 0)
+        {
+          shift = 0;
+          if (self->breakpoint_site)
+            _set_current_location(self, self->breakpoint_site->pipe->expr_node);
+        }
+      else if (isdigit(argv[1][0]))
+        {
+          gint target_lineno = atoi(argv[1]);
+          if (target_lineno <= 0)
+            target_lineno = 1;
+          self->current_location.list_start = target_lineno;
+        }
+      /* drop any arguments for repeated execution */
+      _set_command(self, "l");
+    }
+  _display_source_line(self);
+  if (shift)
+    self->current_location.list_start += shift;
   return TRUE;
 }
 
@@ -274,6 +316,8 @@ struct
   { "c",        _cmd_continue },
   { "print",    _cmd_print, .requires_breakpoint_site = TRUE },
   { "p",        _cmd_print, .requires_breakpoint_site = TRUE },
+  { "list",     _cmd_list, },
+  { "l",        _cmd_list, },
   { "display",  _cmd_display },
   { "drop",     _cmd_drop, .requires_breakpoint_site = TRUE },
   { "d",        _cmd_drop, .requires_breakpoint_site = TRUE },
@@ -315,6 +359,7 @@ debugger_register_command_fetcher(FetchCommandFunc fetcher)
 {
   fetch_command_func = fetcher;
 }
+
 
 static void
 _fetch_command(Debugger *self)
@@ -379,18 +424,19 @@ static void
 _handle_interactive_prompt(Debugger *self)
 {
   gchar buf[1024];
-  LogPipe *current_pipe;
 
   if (self->breakpoint_site)
     {
-      current_pipe = self->breakpoint_site->pipe;
+      LogPipe *current_pipe = self->breakpoint_site->pipe;
 
+      _set_current_location(self, current_pipe->expr_node);
       printf("Breakpoint hit %s\n", log_expr_node_format_location(current_pipe->expr_node, buf, sizeof(buf)));
-      _display_source_line(current_pipe->expr_node);
+      _display_source_line(self);
       _display_msg_with_template(self, self->breakpoint_site->msg, self->display_template);
     }
   else
     {
+      _set_current_location(self, NULL);
       printf("Stopping on interrupt, message related commands are unavailable...\n");
     }
   while (1)
@@ -504,6 +550,7 @@ debugger_new(MainLoop *main_loop, GlobalConfig *cfg)
 void
 debugger_free(Debugger *self)
 {
+  g_free(self->current_location.filename);
   log_template_unref(self->display_template);
   tracer_free(self->tracer);
   g_free(self->command_buffer);


### PR DESCRIPTION
This is spin off from #340 to make that easier to merge. This part of the PR focuses on the interactive "list" command, which will make it easy to navigate the source code (e.g. the syslog-ng.conf file) we are debugging.