### PR TITLE
Filterx error reporting improvements

### DIFF
--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -50,7 +50,7 @@ _assign(FilterXBinaryOp *self, FilterXObject *value)
 static inline FilterXObject *
 _suppress_error(void)
 {
-  msg_debug("FILTERX null coalesce assignment supressing error", filterx_format_last_error());
+  msg_debug("FILTERX null coalesce assignment supressing error", filterx_eval_format_last_error_tag());
   filterx_eval_clear_errors();
 
   return filterx_null_new();

--- a/lib/filterx/expr-null-coalesce.c
+++ b/lib/filterx/expr-null-coalesce.c
@@ -47,8 +47,8 @@ _eval_null_coalesce(FilterXExpr *s)
     {
       if (!lhs_object)
         {
-          msg_debug("FilterX: null-coalesce suppressing error",
-                    filterx_format_last_error());
+          msg_debug("FILTERX null coalesce supressing error:",
+                    filterx_eval_format_last_error_tag());
           filterx_eval_clear_errors();
         }
       FilterXObject *rhs_object = filterx_expr_eval(self->super.rhs);

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -70,7 +70,7 @@ _set_subscript(FilterXSetSubscript *self, FilterXObject *object, FilterXObject *
 static inline FilterXObject *
 _suppress_error(void)
 {
-  msg_debug("FILTERX null coalesce assignment supressing error", filterx_format_last_error());
+  msg_debug("FILTERX null coalesce assignment supressing error", filterx_eval_format_last_error_tag());
   filterx_eval_clear_errors();
 
   return filterx_null_new();

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -71,7 +71,7 @@ _setattr(FilterXSetAttr *self, FilterXObject *object, FilterXObject **new_value)
 static inline FilterXObject *
 _suppress_error(void)
 {
-  msg_debug("FILTERX null coalesce assignment supressing error", filterx_format_last_error());
+  msg_debug("FILTERX null coalesce assignment supressing error", filterx_eval_format_last_error_tag());
   filterx_eval_clear_errors();
 
   return filterx_null_new();

--- a/lib/filterx/filterx-error.c
+++ b/lib/filterx/filterx-error.c
@@ -34,7 +34,7 @@ filterx_error_clear(FilterXError *error)
 }
 
 EVTTAG *
-filterx_error_format(FilterXError *error)
+filterx_error_format_tag(FilterXError *error)
 {
 
   if (!error->message)
@@ -66,7 +66,7 @@ filterx_error_format(FilterXError *error)
 }
 
 EVTTAG *
-filterx_error_format_location(FilterXError *error)
+filterx_error_format_location_tag(FilterXError *error)
 {
   return filterx_expr_format_location_tag(error->expr);
 }

--- a/lib/filterx/filterx-error.h
+++ b/lib/filterx/filterx-error.h
@@ -39,8 +39,8 @@ typedef struct _FilterXError
 } FilterXError;
 
 void filterx_error_clear(FilterXError *error);
-EVTTAG *filterx_error_format(FilterXError *error);
-EVTTAG *filterx_error_format_location(FilterXError *error);
+EVTTAG *filterx_error_format_tag(FilterXError *error);
+EVTTAG *filterx_error_format_location_tag(FilterXError *error);
 void filterx_error_set_info(FilterXError *error, gchar *info, gboolean free_info);
 void filterx_error_set_values(FilterXError *error, const gchar *message, FilterXExpr *expr, FilterXObject *object);
 

--- a/lib/filterx/filterx-error.h
+++ b/lib/filterx/filterx-error.h
@@ -39,6 +39,7 @@ typedef struct _FilterXError
 } FilterXError;
 
 void filterx_error_clear(FilterXError *error);
+const gchar *filterx_error_format(FilterXError *error);
 EVTTAG *filterx_error_format_tag(FilterXError *error);
 EVTTAG *filterx_error_format_location_tag(FilterXError *error);
 void filterx_error_set_info(FilterXError *error, gchar *info, gboolean free_info);

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -99,7 +99,7 @@ filterx_eval_get_last_error(void)
 {
   FilterXEvalContext *context = filterx_eval_get_context();
 
-  return context->error.message;
+  return filterx_error_format(&context->error);
 }
 
 EVTTAG *

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -103,19 +103,19 @@ filterx_eval_get_last_error(void)
 }
 
 EVTTAG *
-filterx_format_last_error(void)
+filterx_eval_format_last_error_tag(void)
 {
   FilterXEvalContext *context = filterx_eval_get_context();
 
-  return filterx_error_format(&context->error);
+  return filterx_error_format_tag(&context->error);
 }
 
 EVTTAG *
-filterx_format_last_error_location(void)
+filterx_eval_format_last_error_location_tag(void)
 {
   FilterXEvalContext *context = filterx_eval_get_context();
 
-  return filterx_error_format_location(&context->error);
+  return filterx_error_format_location_tag(&context->error);
 }
 
 FilterXEvalResult
@@ -127,8 +127,8 @@ filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr)
   if (!res)
     {
       msg_debug("FILTERX ERROR",
-                filterx_format_last_error_location(),
-                filterx_format_last_error());
+                filterx_eval_format_last_error_location_tag(),
+                filterx_eval_format_last_error_tag());
       filterx_eval_clear_errors();
       goto fail;
     }

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -68,8 +68,8 @@ void filterx_eval_push_error_info(const gchar *message, FilterXExpr *expr, gchar
 void filterx_eval_set_context(FilterXEvalContext *context);
 FilterXEvalResult filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr);
 const gchar *filterx_eval_get_last_error(void);
-EVTTAG *filterx_format_last_error(void);
-EVTTAG *filterx_format_last_error_location(void);
+EVTTAG *filterx_eval_format_last_error_tag(void);
+EVTTAG *filterx_eval_format_last_error_location_tag(void);
 void filterx_eval_clear_errors(void);
 EVTTAG *filterx_format_eval_result(FilterXEvalResult result);
 

--- a/lib/filterx/func-set-fields.c
+++ b/lib/filterx/func-set-fields.c
@@ -177,7 +177,7 @@ _set_with_fallbacks(FilterXObject *dict, FilterXObject *key, GPtrArray *values)
         {
           msg_debug("FilterX: set_fields(): eval error, skipping",
                     evt_tag_str("key", _object_to_string(key)),
-                    filterx_format_last_error());
+                    filterx_eval_format_last_error_tag());
           filterx_eval_clear_errors();
           continue;
         }

--- a/modules/metrics-probe/filterx/func-update-metric.c
+++ b/modules/metrics-probe/filterx/func-update-metric.c
@@ -87,7 +87,7 @@ exit:
   if (!success)
     {
       /* It would be nice to introduce a counter for this. */
-      msg_debug("FilterX: Failed to process update_metric()", filterx_format_last_error());
+      msg_debug("FilterX: Failed to process update_metric()", filterx_eval_format_last_error_tag());
       filterx_eval_clear_errors();
     }
 


### PR DESCRIPTION
I've extracted this from one of my longer debugger PRs (#356) to be merged separately.

This only improves the error reporting API, but does not really change how errors are emitted by filterx.