### PR TITLE
editorconfig: configure editors for the project's style

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -1,3 +1,5 @@
+# Keep this file in sync with .editorconfig
+
 # GNU style
 --style=gnu
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# Keep this file in sync with .astylerc
+
+root = true
+
+[*]
+end_of_line = "lf"
+charset = "utf-8"
+
+[*.{c,cpp,h,hpp}]
+indent_style = "space"
+indent_size = 2
+max_line_length = 120
+
+[news/*.md]
+max_line_length = 120

--- a/news/developer-note-550.md
+++ b/news/developer-note-550.md
@@ -1,0 +1,1 @@
+editorconfig: configure supported editors for the project's style

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -70,6 +70,7 @@ lib/multi-line/smart-multi-line\.fsm$
 doc/.*\.svg$
 charts/.*$
 docker/.*$
+.editorconfig
 
 ###########################################################################
 # These files are LGPLd and are external contributions _without_ a Balabit


### PR DESCRIPTION
See https://editorconfig.org/ for details about the format.

I guessed on end_of_line and charset after glancing at a few files. The C/C++ settings are from .astylerc. The news settings are from news/README.md.