### PR TITLE
light: release workflow

### DIFF
--- a/.github/workflows/release-light.yml
+++ b/.github/workflows/release-light.yml
@@ -1,0 +1,68 @@
+# DO NOT RENAME THIS FILE, THE FILE NAME IS USED BY PYPI for OIDC AUTH!
+# Based on https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-pypi
+name: Release axosyslog-light to PyPi
+
+on:
+  push:
+    tags:
+      - 'light-*.*.*'
+  workflow_dispatch:
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Install dependencies
+        run: poetry install
+        working-directory: tests/light
+
+      - name: Check tag matches version
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/light-}
+          SOURCE_VERSION=$(poetry version -s)
+          if [ "$TAG_VERSION" != "$SOURCE_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match the source's version ($SOURCE_VERSION). Either update the source version or the tag."
+            exit 1
+          fi
+        working-directory: tests/light
+
+      - name: Build package
+        run: poetry build
+        working-directory: tests/light
+
+      - name: Upload dists as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: tests/light/dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        # https://github.com/pypa/gh-action-pypi-publish/tree/release/v1.12
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc

--- a/tests/light/README.md
+++ b/tests/light/README.md
@@ -1,0 +1,16 @@
+# axosyslog-light
+
+**axosyslog-light** is AxoSyslog's lightweight end-to-end (E2E) test framework.
+It is designed to facilitate the testing of AxoSyslog components and ensure their reliability and performance.
+
+## Features
+
+- **Configuration**: Easily customizable AxoSyslog configuration to suit various testing needs.
+- **Lightweight**: Minimal dependencies and easy to set up.
+- **E2E Testing**: Comprehensive end-to-end testing capabilities.
+- **Integration with Poetry**: Simplified dependency management and packaging.
+- **Support for Valgrind, GDB, and Strace**: Advanced debugging and profiling tools.
+
+## License
+
+This project is licensed under the GNU General Public License version 2.

--- a/tests/light/axosyslog_light/fixtures.py
+++ b/tests/light/axosyslog_light/fixtures.py
@@ -26,11 +26,11 @@ import argparse
 import logging
 import os
 import re
-import psutil
 import subprocess
 from datetime import datetime
 from pathlib import Path
 
+import psutil
 import pytest
 
 import axosyslog_light.testcase_parameters.testcase_parameters as tc_parameters

--- a/tests/light/functional_tests/conftest.py
+++ b/tests/light/functional_tests/conftest.py
@@ -20,4 +20,5 @@
 # COPYING for details.
 #
 #############################################################################
+# flake8: noqa: F401, F403
 from axosyslog_light.fixtures import *

--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -29,13 +29,3 @@ pylint = "^3.3.4"
 astroid = "^3.3.8"
 logilab-common = "^2.0.0"
 pre-commit = "^4.1.0"
-
-# Only needed for local development
-
-[project]
-name = "axosyslog-light"
-version = "0.0.0-dev"
-
-[tool.setuptools.packages.find]
-include = ["axosyslog_light"]
-namespaces = false


### PR DESCRIPTION
Triggered either by a tag starting with "light-" or by manually on the same tags.

Based on:
https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-pypi

---

Example run: https://github.com/alltilla/axosyslog/actions/runs/13970900983
