### PR TITLE
test_object_string: fix uninitialized variable warnings

### DIFF
--- a/lib/filterx/tests/test_object_string.c
+++ b/lib/filterx/tests/test_object_string.c
@@ -117,7 +117,7 @@ Test(filterx_string, test_filterx_string_typecast_from_bytes)
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)));
 
-  gsize size;
+  gsize size = 0;
   const gchar *str = filterx_string_get_value_ref(obj, &size);
   cr_assert(memcmp("001f2062797465205c73657175656e6365207f20ff", str, size) == 0);
 
@@ -133,7 +133,7 @@ Test(filterx_string, test_filterx_string_typecast_from_protobuf)
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)));
 
-  gsize size;
+  gsize size = 0;
   const gchar *str = filterx_string_get_value_ref(obj, &size);
   cr_assert(memcmp("ff6e6f7420612076616c69642070726f746f6275662120d9", str, size) == 0);
 


### PR DESCRIPTION
Seems to be bogus, because the only case where this goes uninitialized is when the pointer to size is NULL, which is obviously not the case.

/source/lib/filterx/tests/test_object_string.c: In function ‘filterx_string_test_filterx_string_typecast_from_bytes_impl’: /source/lib/filterx/tests/test_object_string.c:122:13: warning: ‘size’ may be used uninitialized [-Wmaybe-uninitialized]
  122 |   cr_assert(memcmp("001f2062797465205c73657175656e6365207f20ff", str, size) == 0);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/source/lib/filterx/tests/test_object_string.c:120:9: note: ‘size’ was declared here

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
