### PR TITLE
light: syslog source

### DIFF
--- a/tests/light/functional_tests/destination_drivers/snmp_destination/v2c/test_snmp_destination_v2c_using_macro_snmp_obj.py
+++ b/tests/light/functional_tests/destination_drivers/snmp_destination/v2c/test_snmp_destination_v2c_using_macro_snmp_obj.py
@@ -30,7 +30,7 @@ def test_snmp_dest_v2c_using_macros_in_snmp_obj(config, syslog_ng, snmptrapd, sn
     default_severity = "0"
     program = "testprogram"
     message = "test message"
-    input_message = "<38>Feb 11 21:27:22 testhost {}[9999]: {}\n".format(program, message)
+    input_message = "<38>Feb 11 21:27:22 testhost {}[9999]: {}".format(program, message)
 
     file_source = config.create_file_source(file_name="input.log")
 

--- a/tests/light/functional_tests/filters/rate-limit/test_rate_limit_filter_acceptance.py
+++ b/tests/light/functional_tests/filters/rate-limit/test_rate_limit_filter_acceptance.py
@@ -26,13 +26,13 @@ from axosyslog_light.message_builder.log_message import LogMessage
 
 
 def generate_messages_with_different_program_fields(bsd_formatter, number_of_all_messages, different_program_fields):
-    input_messages = ""
+    input_messages = []
     program_idx = 1
     for message_idx in range(1, number_of_all_messages + 1):
         if program_idx == different_program_fields + 1:
             program_idx = 1
         log_message = LogMessage().program(program_idx).message("message idx: %s" % message_idx)
-        input_messages += bsd_formatter.format_message(log_message, add_new_line=True)
+        input_messages.append(bsd_formatter.format_message(log_message, add_new_line=False))
         program_idx += 1
     return input_messages
 
@@ -59,6 +59,6 @@ def test_rate_limit_filter_acceptance(config, syslog_ng, port_allocator, bsd_for
     syslog_ng.start(config)
 
     input_messages = generate_messages_with_different_program_fields(bsd_formatter=bsd_formatter, number_of_all_messages=message_counter, different_program_fields=different_program_fields)
-    s_network.write_log(input_messages, rate=message_rate_by_sec)
+    s_network.write_logs(input_messages, rate=message_rate_by_sec)
 
     assert wait_until_true(lambda: f_rate_limit.get_stats() == {'matched': expected_number_of_matched_messages, 'not_matched': expected_number_of_not_matched_messages})

--- a/tests/light/functional_tests/filters/rate-limit/test_rate_limit_filter_acceptance.py
+++ b/tests/light/functional_tests/filters/rate-limit/test_rate_limit_filter_acceptance.py
@@ -32,7 +32,7 @@ def generate_messages_with_different_program_fields(bsd_formatter, number_of_all
         if program_idx == different_program_fields + 1:
             program_idx = 1
         log_message = LogMessage().program(program_idx).message("message idx: %s" % message_idx)
-        input_messages.append(bsd_formatter.format_message(log_message, add_new_line=False))
+        input_messages.append(bsd_formatter.format_message(log_message))
         program_idx += 1
     return input_messages
 

--- a/tests/light/functional_tests/filters/test_filter_reference.py
+++ b/tests/light/functional_tests/filters/test_filter_reference.py
@@ -38,13 +38,14 @@ def test_filter_multiple_reference(config, syslog_ng):
 
     log_msg = LogMessage().program("PROGRAM").message("MESSAGE")
     bsd_msg = BSDFormat.format_message(log_msg.remove_priority())
+    expected_msg = bsd_msg + "\n"
 
     file_source.write_log(bsd_msg)
 
     syslog_ng.start(config)
 
     dest1_logs = file_destination1.read_logs(counter=1)
-    assert bsd_msg in dest1_logs
+    assert expected_msg in dest1_logs
 
     dest2_logs = file_destination2.read_logs(counter=1)
-    assert bsd_msg in dest2_logs
+    assert expected_msg in dest2_logs

--- a/tests/light/functional_tests/filters/test_filter_reference.py
+++ b/tests/light/functional_tests/filters/test_filter_reference.py
@@ -38,14 +38,13 @@ def test_filter_multiple_reference(config, syslog_ng):
 
     log_msg = LogMessage().program("PROGRAM").message("MESSAGE")
     bsd_msg = BSDFormat.format_message(log_msg.remove_priority())
-    expected_msg = bsd_msg + "\n"
 
     file_source.write_log(bsd_msg)
 
     syslog_ng.start(config)
 
     dest1_logs = file_destination1.read_logs(counter=1)
-    assert expected_msg in dest1_logs
+    assert bsd_msg in dest1_logs
 
     dest2_logs = file_destination2.read_logs(counter=1)
-    assert expected_msg in dest2_logs
+    assert bsd_msg in dest2_logs

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -30,7 +30,7 @@ import pytest
 from axosyslog_light.syslog_ng_config.renderer import render_statement
 
 
-def create_config(config, filterx_expr_1, filterx_expr_2=None, msg="foobar", template="'$MSG\n'"):
+def create_config(config, filterx_expr_1, filterx_expr_2=None, msg="foobar", template='"$MSG\n"'):
     file_true = config.create_file_destination(file_name="dest-true.log", template=template)
     file_false = config.create_file_destination(file_name="dest-false.log", template=template)
 
@@ -94,7 +94,7 @@ def test_otel_logrecord_int32_setter_getter(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "5\n"
+    assert file_true.read_log() == "5"
 
 
 def test_otel_logrecord_string_setter_getter(config, syslog_ng):
@@ -108,7 +108,7 @@ def test_otel_logrecord_string_setter_getter(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "string\n"
+    assert file_true.read_log() == "string"
 
 
 def test_otel_logrecord_bytes_setter_getter(config, syslog_ng):
@@ -123,7 +123,7 @@ def test_otel_logrecord_bytes_setter_getter(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "binary whatever\n"
+    assert file_true.read_log() == "binary whatever"
 
 
 def test_otel_logrecord_datetime_setter_getter(config, syslog_ng):
@@ -137,7 +137,7 @@ def test_otel_logrecord_datetime_setter_getter(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "1701350398.123000+00:00\n"
+    assert file_true.read_log() == "1701350398.123000+00:00"
 
 
 def test_otel_logrecord_body_string_setter_getter(config, syslog_ng):
@@ -151,7 +151,7 @@ def test_otel_logrecord_body_string_setter_getter(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "string\n"
+    assert file_true.read_log() == "string"
 
 
 def test_otel_logrecord_body_bool_setter_getter(config, syslog_ng):
@@ -165,7 +165,7 @@ def test_otel_logrecord_body_bool_setter_getter(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "true\n"
+    assert file_true.read_log() == "true"
 
 
 def test_otel_logrecord_body_int_setter_getter(config, syslog_ng):
@@ -179,7 +179,7 @@ def test_otel_logrecord_body_int_setter_getter(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "5\n"
+    assert file_true.read_log() == "5"
 
 
 def test_otel_logrecord_body_double_setter_getter(config, syslog_ng):
@@ -193,7 +193,7 @@ def test_otel_logrecord_body_double_setter_getter(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "32.5\n"
+    assert file_true.read_log() == "32.5"
 
 
 def test_otel_logrecord_body_datetime_setter_getter(config, syslog_ng):
@@ -209,7 +209,7 @@ def test_otel_logrecord_body_datetime_setter_getter(config, syslog_ng):
     # does not distinguish int_value and datetime.
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "1701350398123000\n"
+    assert file_true.read_log() == "1701350398123000"
 
 
 def test_otel_logrecord_body_bytes_setter_getter(config, syslog_ng):
@@ -224,7 +224,7 @@ def test_otel_logrecord_body_bytes_setter_getter(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "binary whatever\n"
+    assert file_true.read_log() == "binary whatever"
 
 
 def test_otel_logrecord_body_protobuf_setter_getter(config, syslog_ng):
@@ -240,7 +240,7 @@ def test_otel_logrecord_body_protobuf_setter_getter(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "this is not a valid protobuf!!\n"
+    assert file_true.read_log() == "this is not a valid protobuf!!"
 
 
 def test_otel_logrecord_body_json_setter_getter(config, syslog_ng):
@@ -255,7 +255,7 @@ def test_otel_logrecord_body_json_setter_getter(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"emb_key1":"emb_key1 value","emb_key2":"emb_key2 value"}\n'
+    assert file_true.read_log() == '{"emb_key1":"emb_key1 value","emb_key2":"emb_key2 value"}'
 
 
 def test_json_to_otel(config, syslog_ng):
@@ -281,7 +281,7 @@ def test_json_to_otel(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"js":{"foo":42,"bar":1337},"js_arr":[1,2,3,4]}\n'
+    assert file_true.read_log() == '{"js":{"foo":42,"bar":1337},"js_arr":[1,2,3,4]}'
 
 
 def test_otel_to_json(config, syslog_ng):
@@ -307,7 +307,7 @@ def test_otel_to_json(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"otel_kvl":{"foo":42,"bar":1337},"otel_arr":[1,2,3,4]}\n'
+    assert file_true.read_log() == '{"otel_kvl":{"foo":42,"bar":1337},"otel_arr":[1,2,3,4]}'
 
 
 def test_otel_resource_scope_log_to_json(config, syslog_ng):
@@ -463,7 +463,7 @@ def test_simple_true_condition(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
 
 
 def test_empty_block(config, syslog_ng):
@@ -472,7 +472,7 @@ def test_empty_block(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
 
 
 def test_simple_false_condition(config, syslog_ng):
@@ -481,7 +481,7 @@ def test_simple_false_condition(config, syslog_ng):
 
     assert "processed" not in file_true.get_stats()
     assert file_false.get_stats()["processed"] == 1
-    assert file_false.read_log() == "foobar\n"
+    assert file_false.read_log() == "foobar"
 
 
 def test_simple_assignment(config, syslog_ng):
@@ -491,7 +491,7 @@ def test_simple_assignment(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "rewritten message!\n"
+    assert file_true.read_log() == "rewritten message!"
 
 
 def test_json_assignment_from_template(config, syslog_ng):
@@ -501,7 +501,7 @@ def test_json_assignment_from_template(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """{"true_string":"boolean:true","str":"string","null":null,"list":["foo","bar","baz"],"json":{"emb_key1": "emb_key1 value", "emb_key2": "emb_key2 value"},"int":5,"false_string":"boolean:false","double":32.5,"datetime":"1701350398.123000+01:00","bool":true}\n"""
+    assert file_true.read_log() == """{"true_string":"boolean:true","str":"string","null":null,"list":["foo","bar","baz"],"json":{"emb_key1": "emb_key1 value", "emb_key2": "emb_key2 value"},"int":5,"false_string":"boolean:false","double":32.5,"datetime":"1701350398.123000+01:00","bool":true}"""
 
 
 def test_json_assignment_from_another_name_value_pair(config, syslog_ng):
@@ -511,7 +511,7 @@ def test_json_assignment_from_another_name_value_pair(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """{"emb_key1": "emb_key1 value", "emb_key2": "emb_key2 value"}\n"""
+    assert file_true.read_log() == """{"emb_key1": "emb_key1 value", "emb_key2": "emb_key2 value"}"""
 
 
 def test_json_getattr_returns_the_embedded_json(config, syslog_ng):
@@ -526,7 +526,7 @@ $MSG = $envelope.json.emb_key1;
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """emb_key1 value\n"""
+    assert file_true.read_log() == """emb_key1 value"""
 
 
 def test_json_setattr_sets_the_embedded_json(config, syslog_ng):
@@ -542,7 +542,7 @@ $MSG = $envelope.json;
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """{"emb_key1":"emb_key1 value","emb_key2":"emb_key2 value","new_key":"this is a new key!"}\n"""
+    assert file_true.read_log() == """{"emb_key1":"emb_key1 value","emb_key2":"emb_key2 value","new_key":"this is a new key!"}"""
 
 
 def test_json_assign_performs_a_deep_copy(config, syslog_ng):
@@ -559,7 +559,7 @@ $envelope.json.another_key = "this is another new key which is not added to $MSG
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """{"emb_key1":"emb_key1 value","emb_key2":"emb_key2 value","new_key":"this is a new key!"}\n"""
+    assert file_true.read_log() == """{"emb_key1":"emb_key1 value","emb_key2":"emb_key2 value","new_key":"this is a new key!"}"""
 
 
 def test_json_simple_literal_assignment(config, syslog_ng):
@@ -576,7 +576,7 @@ $MSG = json({
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """{"foo":"foovalue","bar":"barvalue","baz":"bazvalue"}\n"""
+    assert file_true.read_log() == """{"foo":"foovalue","bar":"barvalue","baz":"bazvalue"}"""
 
 
 def test_json_recursive_literal_assignment(config, syslog_ng):
@@ -603,7 +603,7 @@ $MSG = json({
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """{"foo":"foovalue","bar":"barvalue","baz":"bazvalue","recursive":{"foo":"foovalue","bar":"barvalue","baz":"bazvalue","recursive":{"foo":"foovalue","bar":"barvalue","baz":"bazvalue"}}}\n"""
+    assert file_true.read_log() == """{"foo":"foovalue","bar":"barvalue","baz":"bazvalue","recursive":{"foo":"foovalue","bar":"barvalue","baz":"bazvalue","recursive":{"foo":"foovalue","bar":"barvalue","baz":"bazvalue"}}}"""
 
 
 def test_json_change_recursive_literal(config, syslog_ng):
@@ -636,7 +636,7 @@ $MSG.recursive.recursive.newattr = "newattrvalue";
     assert file_true.read_log() == """\
 {"foo":"foovalue","bar":"barvalue","baz":"bazvalue",\
 "recursive":{"foo":"foovalue","bar":"barvalue","baz":"bazvalue",\
-"recursive":{"foo":"changedfoovalue","bar":"barvalue","baz":"bazvalue","newattr":"newattrvalue"}}}\n"""
+"recursive":{"foo":"changedfoovalue","bar":"barvalue","baz":"bazvalue","newattr":"newattrvalue"}}}"""
 
 
 def test_list_literal_becomes_syslogng_list_as_string(config, syslog_ng):
@@ -649,7 +649,7 @@ $MSG = ["foo", "bar", "baz"];
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """foo,bar,baz\n"""
+    assert file_true.read_log() == """foo,bar,baz"""
 
 
 def test_list_literal_becomes_json_list_as_a_part_of_json(config, syslog_ng):
@@ -666,7 +666,7 @@ $MSG = json({
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """{"key":"value","list":["foo","bar","baz"]}\n"""
+    assert file_true.read_log() == """{"key":"value","list":["foo","bar","baz"]}"""
 
 
 def test_list_is_cloned_upon_assignment(config, syslog_ng):
@@ -683,7 +683,7 @@ $MSG[2] = "changed baz";
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
     # foo remains unchanged while baz is changed
-    assert file_true.read_log() == """foo,bar,"changed baz"\n"""
+    assert file_true.read_log() == 'foo,bar,"changed baz"'
 
 
 def test_list_subscript_without_index_appends_an_element(config, syslog_ng):
@@ -701,7 +701,7 @@ $MSG = $list;
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
     # foo remains unchanged while baz is changed
-    assert file_true.read_log() == """foo,bar,baz\n"""
+    assert file_true.read_log() == """foo,bar,baz"""
 
 
 def test_list_set_subscript_with_tail_element_appends_an_element(config, syslog_ng):
@@ -719,7 +719,7 @@ $MSG = $list;
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
     # foo remains unchanged while baz is changed
-    assert file_true.read_log() == """foo,bar,baz\n"""
+    assert file_true.read_log() == """foo,bar,baz"""
 
 
 def test_literal_generator_assignment(config, syslog_ng):
@@ -737,7 +737,7 @@ $MSG.list[] = [4, 5, 6];
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """{"foo":{"answer":42,"leet":1337},"bar":{"answer+1":43,"leet+1":1338},"list":[[1,2,3],[4,5,6]]}\n"""
+    assert file_true.read_log() == """{"foo":{"answer":42,"leet":1337},"bar":{"answer+1":43,"leet+1":1338},"list":[[1,2,3],[4,5,6]]}"""
 
 
 def test_literal_generator_casted_assignment(config, syslog_ng):
@@ -755,7 +755,7 @@ $MSG.list[] = json_array([4, 5, 6]);
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """{"foo":{"answer":42,"leet":1337},"bar":{"answer+1":43,"leet+1":1338},"list":[[1,2,3],[4,5,6]]}\n"""
+    assert file_true.read_log() == """{"foo":{"answer":42,"leet":1337},"bar":{"answer+1":43,"leet+1":1338},"list":[[1,2,3],[4,5,6]]}"""
 
 
 def test_function_call(config, syslog_ng):
@@ -773,7 +773,7 @@ $MSG = example_echo($list);
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
     # foo remains unchanged while baz is changed
-    assert file_true.read_log() == """foo,bar,baz\n"""
+    assert file_true.read_log() == """foo,bar,baz"""
 
 
 def test_ternary_operator_true(config, syslog_ng):
@@ -786,7 +786,7 @@ def test_ternary_operator_true(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "boolean:true\n"
+    assert file_true.read_log() == "boolean:true"
 
 
 def test_ternary_operator_false(config, syslog_ng):
@@ -799,7 +799,7 @@ def test_ternary_operator_false(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "boolean:false\n"
+    assert file_true.read_log() == "boolean:false"
 
 
 def test_ternary_operator_expression_true(config, syslog_ng):
@@ -812,7 +812,7 @@ def test_ternary_operator_expression_true(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "boolean:true\n"
+    assert file_true.read_log() == "boolean:true"
 
 
 def test_ternary_operator_expression_false(config, syslog_ng):
@@ -825,7 +825,7 @@ def test_ternary_operator_expression_false(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "boolean:false\n"
+    assert file_true.read_log() == "boolean:false"
 
 
 def test_ternary_operator_inline_ternary_expression_true(config, syslog_ng):
@@ -838,7 +838,7 @@ def test_ternary_operator_inline_ternary_expression_true(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "boolean:true\n"
+    assert file_true.read_log() == "boolean:true"
 
 
 def test_ternary_operator_inline_ternary_expression_false(config, syslog_ng):
@@ -851,7 +851,7 @@ def test_ternary_operator_inline_ternary_expression_false(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "inner:false\n"
+    assert file_true.read_log() == "inner:false"
 
 
 def test_ternary_return_condition_expression_value_without_true_branch(config, syslog_ng):
@@ -865,7 +865,7 @@ def test_ternary_return_condition_expression_value_without_true_branch(config, s
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "boolean:true\n"
+    assert file_true.read_log() == "boolean:true"
 
 
 def test_isset_existing_value_not_in_scope_yet(config, syslog_ng):
@@ -948,7 +948,7 @@ def test_unset_value_not_in_scope_yet(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "\n"
+    assert file_true.read_log() == ""
 
 
 def test_unset_value_already_in_scope(config, syslog_ng):
@@ -962,7 +962,7 @@ def test_unset_value_already_in_scope(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "\n"
+    assert file_true.read_log() == ""
 
 
 def test_unset_existing_key(config, syslog_ng):
@@ -978,7 +978,7 @@ def test_unset_existing_key(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "{}\n"
+    assert file_true.read_log() == "{}"
 
 
 def test_unset_inexisting_key(config, syslog_ng):
@@ -993,7 +993,7 @@ def test_unset_inexisting_key(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "{}\n"
+    assert file_true.read_log() == "{}"
 
 
 def test_setting_an_unset_key_will_contain_the_right_value(config, syslog_ng):
@@ -1010,7 +1010,7 @@ def test_setting_an_unset_key_will_contain_the_right_value(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"foo":"second"}\n'
+    assert file_true.read_log() == '{"foo":"second"}'
 
 
 def test_unset(config, syslog_ng):
@@ -1037,7 +1037,7 @@ def test_unset(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "\n"
+    assert file_true.read_log() == ""
 
 
 def test_strptime_error_result(config, syslog_ng):
@@ -1070,7 +1070,7 @@ def test_strptime_success_result(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "1712736550.000000+00:00\n"
+    assert file_true.read_log() == "1712736550.000000+00:00"
 
 
 def test_strftime_success_result(config, syslog_ng):
@@ -1084,7 +1084,7 @@ def test_strftime_success_result(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "2000-01-01T00:00:00 +0200\n"
+    assert file_true.read_log() == "2000-01-01T00:00:00 +0200"
 
 
 def test_strptime_guess_missing_year(config, syslog_ng):
@@ -1112,7 +1112,7 @@ def test_strptime_failure_result(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "null\n"
+    assert file_true.read_log() == "null"
 
 
 def test_set_timestamp_wrong_param_error_result(config, syslog_ng):
@@ -1149,7 +1149,7 @@ def test_set_timestamp_set_stamp(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "2000-01-01T00:00:00+02:00\n"
+    assert file_true.read_log() == "2000-01-01T00:00:00+02:00"
 
 
 def test_set_timestamp_set_stamp_default(config, syslog_ng):
@@ -1164,7 +1164,7 @@ def test_set_timestamp_set_stamp_default(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "2000-01-01T00:00:00+02:00\n"
+    assert file_true.read_log() == "2000-01-01T00:00:00+02:00"
 
 
 def test_set_timestamp_set_recvd(config, syslog_ng):
@@ -1179,7 +1179,7 @@ def test_set_timestamp_set_recvd(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "2000-01-01T00:00:00+02:00\n"
+    assert file_true.read_log() == "2000-01-01T00:00:00+02:00"
 
 
 def test_set_pri_no_arg_error_result(config, syslog_ng):
@@ -1229,7 +1229,7 @@ def test_set_pri_succes_result(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "50\n"
+    assert file_true.read_log() == "50"
 
 
 def test_len(config, syslog_ng):
@@ -1254,7 +1254,7 @@ def test_len(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "success\n"
+    assert file_true.read_log() == "success"
 
 
 def test_regexp_match(config, syslog_ng):
@@ -1271,7 +1271,7 @@ def test_regexp_match(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "success\n"
+    assert file_true.read_log() == "success"
 
 
 def test_regexp_nomatch(config, syslog_ng):
@@ -1292,7 +1292,7 @@ def test_regexp_nomatch(config, syslog_ng):
         r""""match_any":false,"""
         r""""nomatch":true,"""
         r""""match_inverse":true,"""
-        r""""nomatch_inverse":false}""" + "\n"
+        r""""nomatch_inverse":false}""" + ""
     )
 
     assert file_true.get_stats()["processed"] == 1
@@ -1410,7 +1410,7 @@ def test_parse_kv_default_option_set_is_skippable(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"foo":"bar","bar":"baz"}\n'
+    assert file_true.read_log() == '{"foo":"bar","bar":"baz"}'
 
 
 def test_parse_kv_value_separator(config, syslog_ng):
@@ -1423,7 +1423,7 @@ def test_parse_kv_value_separator(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "{\"foo\":\"bar\",\"bar\":\"baz\"}\n"
+    assert file_true.read_log() == "{\"foo\":\"bar\",\"bar\":\"baz\"}"
 
 
 def test_parse_kv_value_separator_use_first_character(config, syslog_ng):
@@ -1436,7 +1436,7 @@ def test_parse_kv_value_separator_use_first_character(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "{\"foo\":\"bar\",\"bar\":\"baz\"}\n"
+    assert file_true.read_log() == "{\"foo\":\"bar\",\"bar\":\"baz\"}"
 
 
 def test_parse_kv_pair_separator(config, syslog_ng):
@@ -1449,7 +1449,7 @@ def test_parse_kv_pair_separator(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "{\"foo\":\"bar\",\"bar\":\"baz\"}\n"
+    assert file_true.read_log() == "{\"foo\":\"bar\",\"bar\":\"baz\"}"
 
 
 def test_parse_kv_stray_words_value_name(config, syslog_ng):
@@ -1462,7 +1462,7 @@ def test_parse_kv_stray_words_value_name(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "{\"foo\":\"bar\",\"bar\":\"baz\",\"stray_words\":\"thisisstray\"}\n"
+    assert file_true.read_log() == "{\"foo\":\"bar\",\"bar\":\"baz\",\"stray_words\":\"thisisstray\"}"
 
 
 def test_parse_csv_default_arguments(config, syslog_ng):
@@ -1476,7 +1476,7 @@ def test_parse_csv_default_arguments(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "foo,bar,baz\n"
+    assert file_true.read_log() == "foo,bar,baz"
 
 
 def test_parse_csv_optional_arg_columns(config, syslog_ng):
@@ -1491,7 +1491,7 @@ def test_parse_csv_optional_arg_columns(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"1st":"foo","2nd":"bar","3rd":"baz"}\n'
+    assert file_true.read_log() == '{"1st":"foo","2nd":"bar","3rd":"baz"}'
 
 
 def test_parse_csv_optional_arg_delimiters(config, syslog_ng):
@@ -1505,7 +1505,7 @@ def test_parse_csv_optional_arg_delimiters(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == 'foo,bar,baz,tik;tak!toe\n'
+    assert file_true.read_log() == 'foo,bar,baz,tik;tak!toe'
 
 
 def test_parse_csv_optional_arg_non_greedy(config, syslog_ng):
@@ -1520,7 +1520,7 @@ def test_parse_csv_optional_arg_non_greedy(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"1st":"foo","2nd":"bar","3rd":"baz"}\n'
+    assert file_true.read_log() == '{"1st":"foo","2nd":"bar","3rd":"baz"}'
 
 
 def test_parse_csv_optional_arg_greedy(config, syslog_ng):
@@ -1535,7 +1535,7 @@ def test_parse_csv_optional_arg_greedy(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"1st":"foo","2nd":"bar","3rd":"baz","rest":"tik,tak,toe"}\n'
+    assert file_true.read_log() == '{"1st":"foo","2nd":"bar","3rd":"baz","rest":"tik,tak,toe"}'
 
 
 def test_parse_csv_optional_arg_strip_whitespace(config, syslog_ng):
@@ -1549,7 +1549,7 @@ def test_parse_csv_optional_arg_strip_whitespace(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == 'foo,bar,baz,tik,tak,toe\n'
+    assert file_true.read_log() == 'foo,bar,baz,tik,tak,toe'
 
 
 def test_parse_csv_dialect(config, syslog_ng):
@@ -1563,7 +1563,7 @@ def test_parse_csv_dialect(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "'PTHREAD \"support initialized'\n"
+    assert file_true.read_log() == "'PTHREAD \"support initialized'"
 
 
 def test_vars(config, syslog_ng):
@@ -1584,7 +1584,7 @@ def test_vars(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"$logmsg_variable":"foo","pipeline_level_variable":"baz","log":{"body":"foobar","attributes":{"attribute":42}},"js_array":[1,2,3,[4,5,6]]}\n'
+    assert file_true.read_log() == '{"$logmsg_variable":"foo","pipeline_level_variable":"baz","log":{"body":"foobar","attributes":{"attribute":42}},"js_array":[1,2,3,[4,5,6]]}'
 
 
 def test_load_vars(config, syslog_ng):
@@ -1617,7 +1617,7 @@ def test_load_vars(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"$logmsg_variable":"foo","pipeline_level_variable":"baz","log":{"body":"foobar","attributes":{"attribute":42}},"js_array":[1,2,3,[4,5,6]]}\n'
+    assert file_true.read_log() == '{"$logmsg_variable":"foo","pipeline_level_variable":"baz","log":{"body":"foobar","attributes":{"attribute":42}},"js_array":[1,2,3,[4,5,6]]}'
 
 
 def test_macro_caching(config, syslog_ng):
@@ -1715,7 +1715,7 @@ def test_unset_empties(config, syslog_ng):
         r""",[]"""
         r""",["do","do","do","do",{"a":{"s":{"d":"do"}}},[["do"]]]"""
         r"""]"""
-        """\n"""
+        """"""
     )
 
     assert file_true.read_log() == exp
@@ -1733,7 +1733,7 @@ def test_null_coalesce_use_default_on_null(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "bar\n"
+    assert file_true.read_log() == "bar"
 
 
 def test_nullv_coalesce_assignment(config, syslog_ng):
@@ -1756,7 +1756,7 @@ def test_nullv_coalesce_assignment(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == 'bar{"b":"bar"}\n'
+    assert file_true.read_log() == 'bar{"b":"bar"}'
 
 
 def test_null_coalesce_use_default_on_error_and_supress_error(config, syslog_ng):
@@ -1770,7 +1770,7 @@ def test_null_coalesce_use_default_on_error_and_supress_error(config, syslog_ng)
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "bar\n"
+    assert file_true.read_log() == "bar"
 
 
 def test_null_coalesce_get_happy_paths(config, syslog_ng):
@@ -1789,7 +1789,7 @@ def test_null_coalesce_get_happy_paths(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"a":"2","b":"bar"}\n'
+    assert file_true.read_log() == '{"a":"2","b":"bar"}'
 
 
 def test_null_coalesce_get_subscript_error(config, syslog_ng):
@@ -1805,7 +1805,7 @@ def test_null_coalesce_get_subscript_error(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "default\n"
+    assert file_true.read_log() == "default"
 
 
 def test_null_coalesce_use_nested_coalesce(config, syslog_ng):
@@ -1822,7 +1822,7 @@ def test_null_coalesce_use_nested_coalesce(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "default\n"
+    assert file_true.read_log() == "default"
 
 
 def test_null_coalesce_use_nested_coalesce_return_mid_match(config, syslog_ng):
@@ -1839,7 +1839,7 @@ def test_null_coalesce_use_nested_coalesce_return_mid_match(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "3\n"
+    assert file_true.read_log() == "3"
 
 
 def test_null_coalesce_do_not_supress_last_error(config, syslog_ng):
@@ -1887,7 +1887,7 @@ def test_null_coalesce_precedence_versus_ternary(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"a":"default","b":"2","c":"2","d":"3","e":"1"}\n'
+    assert file_true.read_log() == '{"a":"default","b":"2","c":"2","d":"3","e":"1"}'
 
 
 def test_slash_string_features(config, syslog_ng):
@@ -1943,7 +1943,7 @@ bar/;
         r""""backspace":"foo\bbar","""
         r""""alert":"foo\u0007bar","""
         r""""hexadecimal_value":"foo@bar","""
-        r""""octal_value":"foo@bar"}""" + "\n"
+        r""""octal_value":"foo@bar"}""" + ""
     )
     res = file_true.read_log()
     assert res == exp
@@ -1995,7 +1995,7 @@ def test_regexp_subst(config, syslog_ng):
         r""""mixed_grps":"foo:2022-02-25:bar:baz","""
         r""""multi_digit_grps":"10-11-12","""
         r""""prefixing_zeros":"foobar012345","""
-        r""""optimized_pattern":"foarbaz"}""" + "\n"
+        r""""optimized_pattern":"foarbaz"}""" + ""
     )
     assert file_true.read_log() == exp
 
@@ -2044,7 +2044,7 @@ def test_add_operator_for_base_types(config, syslog_ng):
         r""""double_integer":5.5,"""
         r""""double_double":4.0,"""
         r""""list_list":["foo","bar","baz","other"],"""
-        r""""dict_dict":{"foo":"bar","baz":"other"}}""" + "\n"
+        r""""dict_dict":{"foo":"bar","baz":"other"}}""" + ""
     )
     assert file_true.read_log() == exp
 
@@ -2070,7 +2070,7 @@ def test_flatten(config, syslog_ng):
     assert file_true.read_log() == '[' \
         '{"top_level_field":42,"top_level_dict.inner_field":1337,"top_level_dict.inner_dict.inner_inner_field":1},' \
         '{"top_level_field":42,"top_level_dict->inner_field":1337,"top_level_dict->inner_dict->inner_inner_field":1}' \
-        ']\n'
+        ']'
 
 
 def test_add_operator_for_generators(config, syslog_ng):
@@ -2099,7 +2099,7 @@ def test_add_operator_for_generators(config, syslog_ng):
         r""""list_gen_gen":["foo3","bar3","baz3","other3"],"""
         r""""dict_var_gen":{"foo":{"bar":"baz"},"tik1":{"tak1":"toe1"}},"""
         r""""dict_gen_var":{"foo2":{"bar2":"baz2"},"tik":{"tak":"toe"}},"""
-        r""""dict_gen_gen":{"foo3":{"bar3":"baz3"},"tik3":{"tak3":"toe3"}}}""" + "\n"
+        r""""dict_gen_gen":{"foo3":{"bar3":"baz3"},"tik3":{"tak3":"toe3"}}}""" + ""
     )
     assert file_true.read_log() == exp
 
@@ -2160,14 +2160,14 @@ def test_plus_equal_grammar_rules(config, syslog_ng):
         r""""attr":"tiktak","""
         r""""subs":"barbaz","""
         r""""sub_gen_var":["control","baz","other","wtf","happened"],"""
-        r""""attr_gen_var":["some","basic","foo","bar","and","add","to","plus"]}""" + "\n"
+        r""""attr_gen_var":["some","basic","foo","bar","and","add","to","plus"]}""" + ""
     )
     assert file_true.read_log() == exp
 
 
 def test_get_sdata(config, syslog_ng):
-    file_true = config.create_file_destination(file_name="dest-true.log", template="'$MSG\n'")
-    file_false = config.create_file_destination(file_name="dest-false.log", template="'$MSG\n'")
+    file_true = config.create_file_destination(file_name="dest-true.log", template='"$MSG\n"')
+    file_false = config.create_file_destination(file_name="dest-false.log", template='"$MSG\n"')
 
     raw_conf = f"""
 @version: {config.get_version()}
@@ -2240,7 +2240,7 @@ def test_list_range_check_with_nulls(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"caseA":null,"caseB":null,"caseC":"bar"}\n'
+    assert file_true.read_log() == '{"caseA":null,"caseB":null,"caseC":"bar"}'
 
 
 def test_list_range_check_out_of_range(config, syslog_ng):
@@ -2253,7 +2253,7 @@ def test_list_range_check_out_of_range(config, syslog_ng):
     )
     syslog_ng.start(config)
     assert file_false.get_stats()["processed"] == 1
-    assert file_false.read_log() == "foobar\n"
+    assert file_false.read_log() == "foobar"
 
 
 def test_parse_xml(config, syslog_ng):
@@ -2267,7 +2267,7 @@ def test_parse_xml(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "{\"a\":{\"b\":[{\"@attr\":\"attr_val\",\"#text\":\"c\"},\"e\"]}}\n"
+    assert file_true.read_log() == "{\"a\":{\"b\":[{\"@attr\":\"attr_val\",\"#text\":\"c\"},\"e\"]}}"
 
 
 def test_parse_windows_eventlog_xml(config, syslog_ng):
@@ -2377,7 +2377,7 @@ def test_parse_cef(config, syslog_ng):
         r""""foo":"foo=bar","""
         r""""bar":"bar=baz","""
         r""""baz":"test"}"""
-        r"""}""" + "\n"
+        r"""}""" + ""
     )
     assert file_true.read_log() == exp
 
@@ -2406,7 +2406,7 @@ def test_parse_leef(config, syslog_ng):
         r""""srcPort":"81","""
         r""""dstPort":"21","""
         r""""usrName":"joe.black"}"""
-        r"""}""" + "\n"
+        r"""}""" + ""
     )
     assert file_true.read_log() == exp
 
@@ -2460,7 +2460,7 @@ log {{
 
     assert "processed" in file_true.get_stats()
     assert file_true.get_stats()["processed"] == 1
-    assert file_true.read_log() == '{"from_nvtable":"almafa","from_a_macro":"2000-01-01T00:00:00+01:00","unset_then_set":"kortefa"}\n'
+    assert file_true.read_log() == '{"from_nvtable":"almafa","from_a_macro":"2000-01-01T00:00:00+01:00","unset_then_set":"kortefa"}'
 
 
 def test_set_fields(config, syslog_ng):
@@ -2490,7 +2490,7 @@ def test_set_fields(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"foo":"foo_override","bar":"bar_exists","baz":"baz_override","almafa":"almafa_default"}\n'
+    assert file_true.read_log() == '{"foo":"foo_override","bar":"bar_exists","baz":"baz_override","almafa":"almafa_default"}'
 
 
 def test_keys(config, syslog_ng):
@@ -2512,7 +2512,7 @@ def test_keys(config, syslog_ng):
         r"""{"empty":[],"""
         r""""top_level":["foo","tik"],"""
         r""""nested":["bar"],"""
-        r""""direct_access":"foo"}""" + "\n"
+        r""""direct_access":"foo"}""" + ""
     )
     assert file_true.read_log() == exp
 
@@ -2531,7 +2531,7 @@ def test_pubsub_message(config, syslog_ng):
     assert "processed" not in file_false.get_stats()
     exp = (
         r"""{"msg":{"data":"my pubsub message","attributes":{"foo":"bar"}},"""
-        """"empty":{"data":"empty attribute value","attributes":{"empty":""}}}""" + "\n"
+        """"empty":{"data":"empty attribute value","attributes":{"empty":""}}}""" + ""
     )
     assert file_true.read_log() == exp
 
@@ -2561,6 +2561,6 @@ def test_otel_repr(config, syslog_ng):
         r""""array":"{\"values\":[{\"stringValue\":\"message\"},{\"stringValue\":\"foobar\"}]}","""
         r""""logrecord":"{\"body\":{\"stringValue\":\"foobar\"},\"attributes\":[{\"key\":\"foo\",\"value\":{\"stringValue\":\"bar\"}}]}","""
         r""""resource":"{\"attributes\":[{\"key\":\"resource\",\"value\":{\"stringValue\":\"foobar\"}}],\"droppedAttributesCount\":444}","""
-        r""""scope":"{\"name\":\"foobar\",\"version\":\"one\",\"attributes\":[{\"key\":\"foo\",\"value\":{\"stringValue\":\"bar\"}}],\"droppedAttributesCount\":333}"}""" + "\n"
+        r""""scope":"{\"name\":\"foobar\",\"version\":\"one\",\"attributes\":[{\"key\":\"foo\",\"value\":{\"stringValue\":\"bar\"}}],\"droppedAttributesCount\":333}"}""" + ""
     )
     assert file_true.read_log() == exp

--- a/tests/light/functional_tests/filterx/test_filterx_control.py
+++ b/tests/light/functional_tests/filterx/test_filterx_control.py
@@ -93,7 +93,7 @@ def test_if_condition_without_else_branch_match(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "matched\n"
+    assert file_true.read_log() == "matched"
 
 
 def test_if_condition_without_else_branch_nomatch(config, syslog_ng):
@@ -110,7 +110,7 @@ def test_if_condition_without_else_branch_nomatch(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "default\n"
+    assert file_true.read_log() == "default"
 
 
 def test_if_condition_no_matching_condition(config, syslog_ng):
@@ -129,7 +129,7 @@ def test_if_condition_no_matching_condition(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "default\n"
+    assert file_true.read_log() == "default"
 
 
 def test_if_condition_matching_main_condition(config, syslog_ng):
@@ -150,7 +150,7 @@ def test_if_condition_matching_main_condition(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "matched\n"
+    assert file_true.read_log() == "matched"
 
 
 def test_if_condition_matching_elif_condition(config, syslog_ng):
@@ -173,7 +173,7 @@ def test_if_condition_matching_elif_condition(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "elif-matched\n"
+    assert file_true.read_log() == "elif-matched"
 
 
 def test_if_condition_matching_else_condition(config, syslog_ng):
@@ -194,7 +194,7 @@ def test_if_condition_matching_else_condition(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "else-matched\n"
+    assert file_true.read_log() == "else-matched"
 
 
 def test_if_condition_matching_expression(config, syslog_ng):
@@ -211,7 +211,7 @@ def test_if_condition_matching_expression(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "matched\n"
+    assert file_true.read_log() == "matched"
 
 
 def test_if_condition_non_matching_expression(config, syslog_ng):
@@ -228,7 +228,7 @@ def test_if_condition_non_matching_expression(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "default\n"
+    assert file_true.read_log() == "default"
 
 
 def test_drop(config, syslog_ng):
@@ -269,7 +269,7 @@ log {{
 
     assert "processed" in file_true.get_stats()
     assert file_true.get_stats()["processed"] == 1
-    assert file_true.read_log() == 'bar\n'
+    assert file_true.read_log() == 'bar'
     assert syslog_ng.wait_for_message_in_console_log("filterx rule evaluation result; result='explicitly dropped'") != []
 
 
@@ -292,7 +292,7 @@ def test_done(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"$MESSAGE":"foo","var_wont_change":true}\n'
+    assert file_true.read_log() == '{"$MESSAGE":"foo","var_wont_change":true}'
 
 
 def test_break(config, syslog_ng):
@@ -316,7 +316,7 @@ def test_break(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"$MESSAGE":"foo","var_wont_change":true,"new_variable":true}\n'
+    assert file_true.read_log() == '{"$MESSAGE":"foo","var_wont_change":true,"new_variable":true}'
 
 
 def test_switch_right_case_is_picked_from_the_middle(config, syslog_ng):
@@ -345,7 +345,7 @@ def test_switch_right_case_is_picked_from_the_middle(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "that's right\n"
+    assert file_true.read_log() == "that's right"
 
 
 def test_switch_fallthrough(config, syslog_ng):
@@ -370,7 +370,7 @@ def test_switch_fallthrough(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "fallthrough\n"
+    assert file_true.read_log() == "fallthrough"
 
 
 def test_switch_fallthrough_twice(config, syslog_ng):
@@ -395,7 +395,7 @@ def test_switch_fallthrough_twice(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "fallthrough2\n"
+    assert file_true.read_log() == "fallthrough2"
 
 
 def test_switch_default_case(config, syslog_ng):
@@ -420,7 +420,7 @@ def test_switch_default_case(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "default-case\n"
+    assert file_true.read_log() == "default-case"
 
 
 def test_switch_no_match_case_no_default_case(config, syslog_ng):
@@ -443,7 +443,7 @@ def test_switch_no_match_case_no_default_case(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "no-match-no-default\n"
+    assert file_true.read_log() == "no-match-no-default"
 
 
 def test_switch_variable_in_case(config, syslog_ng):
@@ -466,7 +466,7 @@ def test_switch_variable_in_case(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "that's right\n"
+    assert file_true.read_log() == "that's right"
 
 
 # Implicitly testing optimized expression caching
@@ -527,7 +527,7 @@ def test_switch_invalid_selector(config, syslog_ng):
 
     assert file_false.get_stats()["processed"] == 1
     assert "processed" not in file_true.get_stats()
-    assert file_false.read_log() == "orig_msg\n"
+    assert file_false.read_log() == "orig_msg"
 
 
 def test_switch_invalid_case(config, syslog_ng):
@@ -550,4 +550,4 @@ def test_switch_invalid_case(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "default\n"
+    assert file_true.read_log() == "default"

--- a/tests/light/functional_tests/filterx/test_filterx_funcs.py
+++ b/tests/light/functional_tests/filterx/test_filterx_funcs.py
@@ -87,7 +87,7 @@ def test_upper(config, syslog_ng):
     syslog_ng.start(config)
 
     assert file_final.get_stats()["processed"] == 1
-    assert file_final.read_log() == """{"literal":"ABC","variable":"FOOBAR","host":"HOSTNAME"}\n"""
+    assert file_final.read_log() == """{"literal":"ABC","variable":"FOOBAR","host":"HOSTNAME"}"""
 
 
 def test_lower(config, syslog_ng):
@@ -104,7 +104,7 @@ def test_lower(config, syslog_ng):
     syslog_ng.start(config)
 
     assert file_final.get_stats()["processed"] == 1
-    assert file_final.read_log() == """{"literal":"abc","variable":"foobar","host":"hostname"}\n"""
+    assert file_final.read_log() == """{"literal":"abc","variable":"foobar","host":"hostname"}"""
 
 
 def test_repr(config, syslog_ng):
@@ -119,7 +119,7 @@ def test_repr(config, syslog_ng):
     syslog_ng.start(config)
 
     assert file_final.get_stats()["processed"] == 1
-    assert file_final.read_log() == """{"repr":"2000-01-01T00:00:00.000+00:00","str":"946684800.000000"}\n"""
+    assert file_final.read_log() == """{"repr":"2000-01-01T00:00:00.000+00:00","str":"946684800.000000"}"""
 
 
 def test_startswith_with_various_arguments(config, syslog_ng):
@@ -159,7 +159,7 @@ def test_startswith_with_various_arguments(config, syslog_ng):
     syslog_ng.start(config)
 
     assert file_final.get_stats()["processed"] == 1
-    assert file_final.read_log() == '{"startswith_foo1":true,"startswith_foo2":true,"startswith_foo3":true,"startswith_foo4":true}\n'
+    assert file_final.read_log() == '{"startswith_foo1":true,"startswith_foo2":true,"startswith_foo3":true,"startswith_foo4":true}'
 
 
 def test_endswith_with_various_arguments(config, syslog_ng):
@@ -199,7 +199,7 @@ def test_endswith_with_various_arguments(config, syslog_ng):
     syslog_ng.start(config)
 
     assert file_final.get_stats()["processed"] == 1
-    assert file_final.read_log() == '{"endswith_foo1":true,"endswith_foo2":true,"endswith_foo3":true,"endswith_foo4":true}\n'
+    assert file_final.read_log() == '{"endswith_foo1":true,"endswith_foo2":true,"endswith_foo3":true,"endswith_foo4":true}'
 
 
 def test_includes_with_various_arguments(config, syslog_ng):
@@ -239,7 +239,7 @@ def test_includes_with_various_arguments(config, syslog_ng):
     syslog_ng.start(config)
 
     assert file_final.get_stats()["processed"] == 1
-    assert file_final.read_log() == '{"includes_foo1":true,"includes_foo2":true,"includes_foo3":true,"includes_foo4":true}\n'
+    assert file_final.read_log() == '{"includes_foo1":true,"includes_foo2":true,"includes_foo3":true,"includes_foo4":true}'
 
 
 def test_startswith_endswith_includes(config, syslog_ng):
@@ -273,4 +273,4 @@ def test_startswith_endswith_includes(config, syslog_ng):
     syslog_ng.start(config)
 
     assert file_final.get_stats()["processed"] == 1
-    assert file_final.read_log() == '{"startswith_foo":true,"contains_bar":true,"endswith_baz":true,"works_with_message_value":true}\n'
+    assert file_final.read_log() == '{"startswith_foo":true,"contains_bar":true,"endswith_baz":true,"works_with_message_value":true}'

--- a/tests/light/functional_tests/filterx/test_filterx_scope.py
+++ b/tests/light/functional_tests/filterx/test_filterx_scope.py
@@ -115,7 +115,7 @@ def test_message_tied_variables_are_propagated_to_the_output(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "kecske\n"
+    assert file_true.read_log() == "kecske"
 
 
 def test_message_tied_variables_in_braces_are_propagated_to_the_output(config, syslog_ng):
@@ -135,7 +135,7 @@ def test_message_tied_variables_in_braces_are_propagated_to_the_output(config, s
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "kecske\n"
+    assert file_true.read_log() == "kecske"
 
 
 def test_message_tied_variables_are_propagated_to_the_output_in_junctions(config, syslog_ng):
@@ -156,7 +156,7 @@ def test_message_tied_variables_are_propagated_to_the_output_in_junctions(config
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "kecske\n"
+    assert file_true.read_log() == "kecske"
 
 
 def test_message_tied_variables_do_not_propagate_to_parallel_branches(config, syslog_ng):
@@ -186,7 +186,7 @@ def test_message_tied_variables_do_not_propagate_to_parallel_branches(config, sy
 
     assert file_false.get_stats()["processed"] == 1
     assert "processed" not in file_true.get_stats()
-    assert file_false.read_log() == "kecske\n"
+    assert file_false.read_log() == "kecske"
 
 
 def test_message_tied_variables_are_invalidated_if_message_is_changed(config, syslog_ng):
@@ -218,7 +218,7 @@ def test_message_tied_variables_are_invalidated_if_message_is_changed(config, sy
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "foobar replacement\n"
+    assert file_true.read_log() == "foobar replacement"
 
 
 def test_message_tied_mutable_objects_are_synced_if_child_object_is_changed(config, syslog_ng):
@@ -237,7 +237,7 @@ def test_message_tied_mutable_objects_are_synced_if_child_object_is_changed(conf
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """{"foo":{"foo1":"child-changed","foo2":"foo2value"},"bar":{"bar1":"bar1value","bar2":"bar2value"}}\n"""
+    assert file_true.read_log() == """{"foo":{"foo1":"child-changed","foo2":"foo2value"},"bar":{"bar1":"bar1value","bar2":"bar2value"}}"""
 
 
 def test_message_tied_variables_are_not_considered_changed_just_by_unmarshaling(config, syslog_ng):
@@ -290,7 +290,7 @@ def test_floating_variables_are_dropped_at_the_end_of_the_scope(config, syslog_n
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
 
 
 def test_floating_variables_are_dropped_at_the_end_of_the_scope_but_can_be_recreated(config, syslog_ng):
@@ -312,7 +312,7 @@ def test_floating_variables_are_dropped_at_the_end_of_the_scope_but_can_be_recre
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "barka\n"
+    assert file_true.read_log() == "barka"
 
 
 def test_declared_variables_are_retained_across_scopes(config, syslog_ng):
@@ -336,7 +336,7 @@ def test_declared_variables_are_retained_across_scopes(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "barka\n"
+    assert file_true.read_log() == "barka"
 
 
 def test_declared_variables_are_retained_across_scopes_and_junctions(config, syslog_ng):
@@ -361,7 +361,7 @@ def test_declared_variables_are_retained_across_scopes_and_junctions(config, sys
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "barka\n"
+    assert file_true.read_log() == "barka"
 
 
 def test_changes_in_abandoned_branches_are_ignored(config, syslog_ng):
@@ -393,7 +393,7 @@ def test_changes_in_abandoned_branches_are_ignored(config, syslog_ng):
 
     assert file_false.get_stats()["processed"] == 1
     assert "processed" not in file_true.get_stats()
-    assert file_false.read_log() == "foobar\n"
+    assert file_false.read_log() == "foobar"
 
     assert file_final.get_stats()["processed"] == 1
-    assert file_final.read_log() == '{"common":"common","iffalse":"false"}\n'
+    assert file_final.read_log() == '{"common":"common","iffalse":"false"}'

--- a/tests/light/functional_tests/filterx/test_filterx_update_metric.py
+++ b/tests/light/functional_tests/filterx/test_filterx_update_metric.py
@@ -121,7 +121,7 @@ def test_filterx_update_metric_increment(config, port_allocator, syslog_ng):
     )
 
     syslog_ng.start(config)
-    network_source.write_log("3\n2\n1\n0\n")
+    network_source.write_logs(["3", "2", "1", "0"])
     file_destination.read_logs(4)
 
     samples = config.get_prometheus_samples([MetricFilter("syslogng_const", {})])
@@ -149,7 +149,7 @@ def test_filterx_update_metric_level(config, port_allocator, syslog_ng):
     )
 
     syslog_ng.start(config)
-    network_source.write_log("foo\n")
+    network_source.write_log("foo")
     file_destination.read_log()
 
     samples = config.get_prometheus_samples([MetricFilter("syslogng_metric", {})])
@@ -167,7 +167,7 @@ def test_filterx_update_metric_level(config, port_allocator, syslog_ng):
     )
 
     syslog_ng.reload(config)
-    network_source.write_log("foo\n")
+    network_source.write_log("foo")
     file_destination.read_log()
 
     # stats(level(2));
@@ -182,7 +182,7 @@ def test_filterx_update_metric_level(config, port_allocator, syslog_ng):
     )
 
     syslog_ng.reload(config)
-    network_source.write_log("foo\n")
+    network_source.write_log("foo")
     file_destination.read_log()
 
     assert wait_until_true(lambda: config.get_prometheus_samples([MetricFilter("syslogng_metric", {})]) != [])

--- a/tests/light/functional_tests/logpath/test_conditionals.py
+++ b/tests/light/functional_tests/logpath/test_conditionals.py
@@ -96,8 +96,8 @@ log {
     assert file_after.get_stats()["processed"] == 1
     assert "processed" not in file_fallback.get_stats()
 
-    assert file_true.read_log() == "foobar\n"
-    assert file_after.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
+    assert file_after.read_log() == "foobar"
 
 
 def test_simple_if_negated(config, syslog_ng):
@@ -121,8 +121,8 @@ log {
     assert file_false.get_stats()["processed"] == 1
     assert file_after.get_stats()["processed"] == 1
     assert "processed" not in file_fallback.get_stats()
-    assert file_false.read_log() == "foobar\n"
-    assert file_after.read_log() == "foobar\n"
+    assert file_false.read_log() == "foobar"
+    assert file_after.read_log() == "foobar"
 
 
 def test_simple_if_that_drops_in_all_branches(config, syslog_ng):
@@ -148,7 +148,7 @@ log {
     assert "processed" not in file_after.get_stats()
     assert file_fallback.get_stats()["processed"] == 1
 
-    assert file_fallback.read_log() == "foobar\n"
+    assert file_fallback.read_log() == "foobar"
 
 
 def test_compound_if(config, syslog_ng):
@@ -174,8 +174,8 @@ log {
     assert file_after.get_stats()["processed"] == 1
     assert "processed" not in file_fallback.get_stats()
 
-    assert file_true.read_log() == "foobar\n"
-    assert file_after.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
+    assert file_after.read_log() == "foobar"
 
 
 def test_compound_if_negated_continues_in_the_false_expr(config, syslog_ng):
@@ -200,8 +200,8 @@ log {
     assert file_false.get_stats()["processed"] == 1
     assert file_after.get_stats()["processed"] == 1
     assert "processed" not in file_fallback.get_stats()
-    assert file_false.read_log() == "foobar\n"
-    assert file_after.read_log() == "foobar\n"
+    assert file_false.read_log() == "foobar"
+    assert file_after.read_log() == "foobar"
 
 
 def test_compound_if_that_drops_in_all_branches(config, syslog_ng):
@@ -228,7 +228,7 @@ log {
     assert "processed" not in file_after.get_stats()
     assert file_fallback.get_stats()["processed"] == 1
 
-    assert file_fallback.read_log() == "foobar\n"
+    assert file_fallback.read_log() == "foobar"
 
 
 def test_compound_if_with_messages_dropped_after_if(config, syslog_ng):
@@ -255,8 +255,8 @@ log {
     assert "processed" not in file_after.get_stats()
     assert file_fallback.get_stats()["processed"] == 1
 
-    assert file_true.read_log() == "foobar\n"
-    assert file_fallback.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
+    assert file_fallback.read_log() == "foobar"
 
 
 def test_three_levels_of_conditionals_drop_after_the_innermost_if(config, syslog_ng):
@@ -289,8 +289,8 @@ log {
     assert "processed" not in file_false.get_stats()
     assert file_after.get_stats()["processed"] == 1
 
-    assert file_true.read_log() == "foobar\n"
-    assert file_after.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
+    assert file_after.read_log() == "foobar"
 
 
 def test_three_levels_of_conditionals_drop_after_the_middle_if(config, syslog_ng):
@@ -323,8 +323,8 @@ log {
     assert "processed" not in file_false.get_stats()
     assert file_after.get_stats()["processed"] == 1
 
-    assert file_true.read_log() == "foobar\n"
-    assert file_after.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
+    assert file_after.read_log() == "foobar"
 
 
 def test_three_levels_of_simple_conditionals_drop_after_the_middle_if(config, syslog_ng):
@@ -361,8 +361,8 @@ log {
     assert "processed" not in file_false.get_stats()
     assert file_after.get_stats()["processed"] == 1
 
-    assert file_true.read_log() == "foobar\n"
-    assert file_after.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
+    assert file_after.read_log() == "foobar"
 
 
 def test_three_levels_of_conditionals_drop_after_the_innermost_junction(config, syslog_ng):
@@ -410,8 +410,8 @@ log {
     assert file_after.get_stats()["processed"] == 1
     assert "processed" not in file_fallback.get_stats()
 
-    assert file_true.read_log() == "foobar\n"
-    assert file_after.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
+    assert file_after.read_log() == "foobar"
 
 
 def test_three_levels_of_conditionals_drop_after_the_middle_junction(config, syslog_ng):
@@ -460,8 +460,8 @@ log {
     assert file_after.get_stats()["processed"] == 1
     assert "processed" not in file_fallback.get_stats()
 
-    assert file_true.read_log() == "foobar\n"
-    assert file_after.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
+    assert file_after.read_log() == "foobar"
 
 
 def test_consuming_messages_into_correlation_state_does_not_cause_else_branches_to_be_processed(config, syslog_ng):
@@ -501,5 +501,5 @@ log {
     assert file_after.get_stats()["processed"] == 1
     assert "processed" not in file_fallback.get_stats()
 
-    assert file_true.read_log() == "foobar correlated\n"
-    assert file_after.read_log() == "foobar correlated\n"
+    assert file_true.read_log() == "foobar correlated"
+    assert file_after.read_log() == "foobar correlated"

--- a/tests/light/functional_tests/logpath/test_midpoint_destinations.py
+++ b/tests/light/functional_tests/logpath/test_midpoint_destinations.py
@@ -103,7 +103,7 @@ log {
     assert file_after.get_stats()["processed"] == 1
     assert "processed" not in file_fallback.get_stats()
 
-    assert file_after.read_log() == "foobar\n"
+    assert file_after.read_log() == "foobar"
 
 
 def test_midpoint_inline_destination_that_drops_all_messages_does_not_cause_message_to_be_unmatched(config, syslog_ng):
@@ -130,7 +130,7 @@ log {
     assert file_after.get_stats()["processed"] == 1
     assert "processed" not in file_fallback.get_stats()
 
-    assert file_after.read_log() == "foobar\n"
+    assert file_after.read_log() == "foobar"
 
 
 def test_filter_between_destinations_that_drops_all_messages_causes_the_message_to_be_unmatched(config, syslog_ng):
@@ -159,8 +159,8 @@ log {
     assert "processed" not in file_after.get_stats()
     assert file_fallback.get_stats()["processed"] == 1
 
-    assert file_true.read_log() == "foobar\n"
-    assert file_fallback.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
+    assert file_fallback.read_log() == "foobar"
 
 
 def test_junction_that_drops_messages_in_all_branches_causes_the_message_to_be_unmatched(config, syslog_ng):
@@ -184,8 +184,8 @@ log {
     assert "processed" not in file_after.get_stats()
     assert file_fallback.get_stats()["processed"] == 1
 
-    assert file_true.read_log() == "foobar\n"
-    assert file_fallback.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
+    assert file_fallback.read_log() == "foobar"
 
 
 def test_junction_that_drops_messages_in_all_branches_causes_the_message_to_be_unmatched_even_if_they_reference_destinations(config, syslog_ng):
@@ -213,8 +213,8 @@ log {
     assert "processed" not in file_after.get_stats()
     assert file_fallback.get_stats()["processed"] == 1
 
-    assert file_true.read_log() == "foobar\n"
-    assert file_fallback.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
+    assert file_fallback.read_log() == "foobar"
 
 
 def test_junction_that_contains_message_dropping_destination_continues_to_deliver_messages_on_the_same_path(config, syslog_ng):
@@ -243,5 +243,5 @@ log {
     assert file_after.get_stats()["processed"] == 1
     assert "processed" not in file_fallback.get_stats()
 
-    assert file_true.read_log() == "foobar\n"
-    assert file_after.read_log() == "foobar\n"
+    assert file_true.read_log() == "foobar"
+    assert file_after.read_log() == "foobar"

--- a/tests/light/functional_tests/logpath/test_multiple_embedded_logpaths.py
+++ b/tests/light/functional_tests/logpath/test_multiple_embedded_logpaths.py
@@ -26,7 +26,7 @@ from axosyslog_light.message_builder.log_message import LogMessage
 def write_msg_with_fields(file_source, bsd_formatter, hostname, program):
     log_message = LogMessage().hostname(hostname).program(program)
     input_message = bsd_formatter.format_message(log_message)
-    expected_message = bsd_formatter.format_message(log_message.remove_priority()) + "\n"
+    expected_message = bsd_formatter.format_message(log_message.remove_priority())
     file_source.write_log(input_message)
     return expected_message
 

--- a/tests/light/functional_tests/logpath/test_multiple_embedded_logpaths.py
+++ b/tests/light/functional_tests/logpath/test_multiple_embedded_logpaths.py
@@ -26,7 +26,7 @@ from axosyslog_light.message_builder.log_message import LogMessage
 def write_msg_with_fields(file_source, bsd_formatter, hostname, program):
     log_message = LogMessage().hostname(hostname).program(program)
     input_message = bsd_formatter.format_message(log_message)
-    expected_message = bsd_formatter.format_message(log_message.remove_priority())
+    expected_message = bsd_formatter.format_message(log_message.remove_priority()) + "\n"
     file_source.write_log(input_message)
     return expected_message
 

--- a/tests/light/functional_tests/logpath/test_multiple_flags.py
+++ b/tests/light/functional_tests/logpath/test_multiple_flags.py
@@ -26,7 +26,7 @@ from axosyslog_light.message_builder.log_message import LogMessage
 def write_msg_with_fields(file_source, bsd_formatter, hostname, program):
     log_message = LogMessage().hostname(hostname).program(program)
     input_message = bsd_formatter.format_message(log_message)
-    expected_message = bsd_formatter.format_message(log_message.remove_priority()) + "\n"
+    expected_message = bsd_formatter.format_message(log_message.remove_priority())
     file_source.write_log(input_message)
     return expected_message
 

--- a/tests/light/functional_tests/logpath/test_multiple_flags.py
+++ b/tests/light/functional_tests/logpath/test_multiple_flags.py
@@ -26,7 +26,7 @@ from axosyslog_light.message_builder.log_message import LogMessage
 def write_msg_with_fields(file_source, bsd_formatter, hostname, program):
     log_message = LogMessage().hostname(hostname).program(program)
     input_message = bsd_formatter.format_message(log_message)
-    expected_message = bsd_formatter.format_message(log_message.remove_priority())
+    expected_message = bsd_formatter.format_message(log_message.remove_priority()) + "\n"
     file_source.write_log(input_message)
     return expected_message
 

--- a/tests/light/functional_tests/parsers/app-parser/test_app_parser.py
+++ b/tests/light/functional_tests/parsers/app-parser/test_app_parser.py
@@ -87,7 +87,7 @@ def test_app_parser_allow_overlaps_causes_all_apps_to_be_traversed(config, syslo
     config.create_logpath(statements=[generator_source, syslog_parser, app_parser, file_destination])
 
     syslog_ng.start(config)
-    assert file_destination.read_log()[:-1] == expected_value
+    assert file_destination.read_log() == expected_value
 
 
 def test_app_parser_dont_match_causes_the_message_to_be_dropped(config, syslog_ng):

--- a/tests/light/functional_tests/parsers/group-lines-parser/test_group_lines_parser.py
+++ b/tests/light/functional_tests/parsers/group-lines-parser/test_group_lines_parser.py
@@ -42,6 +42,6 @@ ValueError: This is the exception text at the end
     config.create_logpath(statements=[file_source, group_lines_parser, file_destination])
 
     syslog_ng.start(config)
-    file_source.write_log('\n'.join(map(lambda line: 'python: ' + line, traceback.split('\n'))))
-    file_source.write_log("whatvever: the exception text at the end\n")
+    file_source.write_logs(map(lambda line: 'python: ' + line, traceback.split('\n')))
+    file_source.write_log("whatvever: the exception text at the end")
     assert file_destination.read_log().strip() == 'MESSAGE="' + traceback.strip().replace('"', "\\\"").replace('\n', '\\n') + '"'

--- a/tests/light/functional_tests/source_drivers/file_source/test_acceptance.py
+++ b/tests/light/functional_tests/source_drivers/file_source/test_acceptance.py
@@ -23,7 +23,7 @@
 import pytest
 
 input_log = "<38>Feb 11 21:27:22 testhost testprogram[9999]: test message"
-expected_log = "Feb 11 21:27:22 testhost testprogram[9999]: test message\n"
+expected_log = "Feb 11 21:27:22 testhost testprogram[9999]: test message"
 
 
 @pytest.mark.parametrize(

--- a/tests/light/functional_tests/source_drivers/file_source/test_acceptance.py
+++ b/tests/light/functional_tests/source_drivers/file_source/test_acceptance.py
@@ -22,7 +22,7 @@
 #############################################################################
 import pytest
 
-input_log = "<38>Feb 11 21:27:22 testhost testprogram[9999]: test message\n"
+input_log = "<38>Feb 11 21:27:22 testhost testprogram[9999]: test message"
 expected_log = "Feb 11 21:27:22 testhost testprogram[9999]: test message\n"
 
 

--- a/tests/light/functional_tests/source_drivers/file_source/test_no_header_flag.py
+++ b/tests/light/functional_tests/source_drivers/file_source/test_no_header_flag.py
@@ -32,7 +32,7 @@ def test_no_header_flag(config, syslog_ng, log_message, bsd_formatter):
     file_source.write_log(input_message)
     syslog_ng.start(config)
 
-    expected_msg_value_for_no_header_flag = "%s %s %s[%s]: %s\n" % (
+    expected_msg_value_for_no_header_flag = "%s %s %s[%s]: %s" % (
         log_message.bsd_timestamp_value,
         log_message.hostname_value,
         log_message.program_value,

--- a/tests/light/functional_tests/source_drivers/generator_source/test_generator_source.py
+++ b/tests/light/functional_tests/source_drivers/generator_source/test_generator_source.py
@@ -29,4 +29,4 @@ def test_generator_source(config, syslog_ng):
     config.create_logpath(statements=[generator_source, file_destination])
     syslog_ng.start(config)
     log = file_destination.read_log()
-    assert log == generator_source.DEFAULT_MESSAGE + "\n"
+    assert log == generator_source.DEFAULT_MESSAGE

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_acceptance.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_acceptance.py
@@ -28,7 +28,7 @@ PROXY_DST_IP = "2.2.2.2"
 PROXY_SRC_PORT = 3333
 PROXY_DST_PORT = 4444
 INPUT_MESSAGES = ["message 0"]
-EXPECTED_MESSAGE0 = "1.1.1.1 3333 2.2.2.2 4444 4 message 0\n"
+EXPECTED_MESSAGE0 = "1.1.1.1 3333 2.2.2.2 4444 4 message 0"
 
 
 def test_pp_acceptance(config, syslog_ng, loggen, port_allocator):

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_acceptance.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_acceptance.py
@@ -22,8 +22,12 @@
 #############################################################################
 
 TEMPLATE = r'"${SOURCEIP} ${SOURCEPORT} ${DESTIP} ${DESTPORT} ${IP_PROTO} ${MESSAGE}\n"'
-INPUT_MESSAGES = "PROXY TCP4 1.1.1.1 2.2.2.2 3333 4444\r\n" \
-                 "message 0"
+PROXY_VERSION = 1
+PROXY_SRC_IP = "1.1.1.1"
+PROXY_DST_IP = "2.2.2.2"
+PROXY_SRC_PORT = 3333
+PROXY_DST_PORT = 4444
+INPUT_MESSAGES = ["message 0"]
 EXPECTED_MESSAGE0 = "1.1.1.1 3333 2.2.2.2 4444 4 message 0\n"
 
 
@@ -34,6 +38,6 @@ def test_pp_acceptance(config, syslog_ng, loggen, port_allocator):
 
     syslog_ng.start(config)
 
-    network_source.write_log(INPUT_MESSAGES)
+    network_source.write_logs_with_proxy_header(PROXY_VERSION, PROXY_SRC_IP, PROXY_DST_IP, PROXY_SRC_PORT, PROXY_DST_PORT, INPUT_MESSAGES)
 
     assert file_destination.read_log() == EXPECTED_MESSAGE0

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_acceptance.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_acceptance.py
@@ -31,7 +31,7 @@ INPUT_MESSAGES = ["message 0"]
 EXPECTED_MESSAGE0 = "1.1.1.1 3333 2.2.2.2 4444 4 message 0"
 
 
-def test_pp_acceptance(config, syslog_ng, loggen, port_allocator):
+def test_pp_acceptance(config, syslog_ng, port_allocator):
     network_source = config.create_network_source(ip="localhost", port=port_allocator(), transport='"proxied-tcp"', flags="no-parse")
     file_destination = config.create_file_destination(file_name="output.log", template=TEMPLATE)
     config.create_logpath(statements=[network_source, file_destination])

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_reload.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_reload.py
@@ -28,9 +28,9 @@ PROXY_DST_IP = "2.2.2.2"
 PROXY_SRC_PORT = 3333
 PROXY_DST_PORT = 4444
 INPUT_MESSAGES = ["message 0", "message 1", "message 2"]
-EXPECTED_MESSAGE0 = "1.1.1.1 3333 2.2.2.2 4444 4 message 0\n"
-EXPECTED_MESSAGE1 = "1.1.1.1 3333 2.2.2.2 4444 4 message 1\n"
-EXPECTED_MESSAGE2 = "1.1.1.1 3333 2.2.2.2 4444 4 message 2\n"
+EXPECTED_MESSAGE0 = "1.1.1.1 3333 2.2.2.2 4444 4 message 0"
+EXPECTED_MESSAGE1 = "1.1.1.1 3333 2.2.2.2 4444 4 message 1"
+EXPECTED_MESSAGE2 = "1.1.1.1 3333 2.2.2.2 4444 4 message 2"
 
 
 def test_pp_reload(config, syslog_ng, loggen, port_allocator):

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_reload.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_reload.py
@@ -22,10 +22,12 @@
 #############################################################################
 
 TEMPLATE = r'"${SOURCEIP} ${SOURCEPORT} ${DESTIP} ${DESTPORT} ${IP_PROTO} ${MESSAGE}\n"'
-INPUT_MESSAGES = "PROXY TCP4 1.1.1.1 2.2.2.2 3333 4444\r\n" \
-                 "message 0\n" \
-                 "message 1\n" \
-                 "message 2\n"
+PROXY_VERSION = 1
+PROXY_SRC_IP = "1.1.1.1"
+PROXY_DST_IP = "2.2.2.2"
+PROXY_SRC_PORT = 3333
+PROXY_DST_PORT = 4444
+INPUT_MESSAGES = ["message 0", "message 1", "message 2"]
 EXPECTED_MESSAGE0 = "1.1.1.1 3333 2.2.2.2 4444 4 message 0\n"
 EXPECTED_MESSAGE1 = "1.1.1.1 3333 2.2.2.2 4444 4 message 1\n"
 EXPECTED_MESSAGE2 = "1.1.1.1 3333 2.2.2.2 4444 4 message 2\n"
@@ -38,7 +40,7 @@ def test_pp_reload(config, syslog_ng, loggen, port_allocator):
 
     syslog_ng.start(config)
 
-    network_source.write_log(INPUT_MESSAGES, rate=1)
+    network_source.write_logs_with_proxy_header(PROXY_VERSION, PROXY_SRC_IP, PROXY_DST_IP, PROXY_SRC_PORT, PROXY_DST_PORT, INPUT_MESSAGES, rate=1)
 
     # With the current loggen implementation there is no way to properly timing messages.
     # Here I made an assumption that with rate=1, there will be messages which will arrive

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_reload.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_reload.py
@@ -33,7 +33,7 @@ EXPECTED_MESSAGE1 = "1.1.1.1 3333 2.2.2.2 4444 4 message 1"
 EXPECTED_MESSAGE2 = "1.1.1.1 3333 2.2.2.2 4444 4 message 2"
 
 
-def test_pp_reload(config, syslog_ng, loggen, port_allocator):
+def test_pp_reload(config, syslog_ng, port_allocator):
     network_source = config.create_network_source(ip="localhost", port=port_allocator(), transport='"proxied-tcp"', flags="no-parse")
     file_destination = config.create_file_destination(file_name="output.log", template=TEMPLATE)
     config.create_logpath(statements=[network_source, file_destination])

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_multiple_clients.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_multiple_clients.py
@@ -38,12 +38,12 @@ CLIENT_B_PROXY_DST_PORT = 8888
 CLIENT_B_INPUT = ["message B 0", "message B 1"]
 
 CLIENT_A_EXPECTED = (
-    "1.1.1.1 3333 2.2.2.2 4444 4 message A 0\n",
-    "1.1.1.1 3333 2.2.2.2 4444 4 message A 1\n",
+    "1.1.1.1 3333 2.2.2.2 4444 4 message A 0",
+    "1.1.1.1 3333 2.2.2.2 4444 4 message A 1",
 )
 CLIENT_B_EXPECTED = (
-    "5.5.5.5 7777 6.6.6.6 8888 4 message B 0\n",
-    "5.5.5.5 7777 6.6.6.6 8888 4 message B 1\n",
+    "5.5.5.5 7777 6.6.6.6 8888 4 message B 0",
+    "5.5.5.5 7777 6.6.6.6 8888 4 message B 1",
 )
 
 

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_multiple_clients.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_multiple_clients.py
@@ -23,12 +23,19 @@
 
 TEMPLATE = r'"${SOURCEIP} ${SOURCEPORT} ${DESTIP} ${DESTPORT} ${IP_PROTO} ${MESSAGE}\n"'
 
-CLIENT_A_INPUT = "PROXY TCP4 1.1.1.1 2.2.2.2 3333 4444\r\n" \
-                 "message A 0\n" \
-                 "message A 1\n"
-CLIENT_B_INPUT = "PROXY TCP4 5.5.5.5 6.6.6.6 7777 8888\r\n" \
-                 "message B 0\n" \
-                 "message B 1\n"
+PROXY_VERSION = 1
+
+CLIENT_A_PROXY_SRC_IP = "1.1.1.1"
+CLIENT_A_PROXY_DST_IP = "2.2.2.2"
+CLIENT_A_PROXY_SRC_PORT = 3333
+CLIENT_A_PROXY_DST_PORT = 4444
+CLIENT_A_INPUT = ["message A 0", "message A 1"]
+
+CLIENT_B_PROXY_SRC_IP = "5.5.5.5"
+CLIENT_B_PROXY_DST_IP = "6.6.6.6"
+CLIENT_B_PROXY_SRC_PORT = 7777
+CLIENT_B_PROXY_DST_PORT = 8888
+CLIENT_B_INPUT = ["message B 0", "message B 1"]
 
 CLIENT_A_EXPECTED = (
     "1.1.1.1 3333 2.2.2.2 4444 4 message A 0\n",
@@ -48,8 +55,8 @@ def test_pp_with_multiple_clients(config, port_allocator, syslog_ng):
     syslog_ng.start(config)
 
     # These 2 run simultaneously
-    network_source.write_log(CLIENT_A_INPUT, rate=1)
-    network_source.write_log(CLIENT_B_INPUT, rate=1)
+    network_source.write_logs_with_proxy_header(PROXY_VERSION, CLIENT_A_PROXY_SRC_IP, CLIENT_A_PROXY_DST_IP, CLIENT_A_PROXY_SRC_PORT, CLIENT_A_PROXY_DST_PORT, CLIENT_A_INPUT, rate=1)
+    network_source.write_logs_with_proxy_header(PROXY_VERSION, CLIENT_B_PROXY_SRC_IP, CLIENT_B_PROXY_DST_IP, CLIENT_B_PROXY_SRC_PORT, CLIENT_B_PROXY_DST_PORT, CLIENT_B_INPUT, rate=1)
 
     output_messages = file_destination.read_logs(counter=4)
     assert sorted(output_messages) == sorted(CLIENT_A_EXPECTED + CLIENT_B_EXPECTED)

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_syslog_proto.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_syslog_proto.py
@@ -21,8 +21,12 @@
 #
 #############################################################################
 
-PROXY_PROTO_HEADER = "PROXY TCP4 192.168.1.1 192.168.1.2 20000 20001\r\n"
-RFC3164_EXAMPLE = "<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8\n"
+PROXY_VERSION = 1
+PROXY_SRC_IP = "192.168.1.1"
+PROXY_DST_IP = "192.168.1.2"
+PROXY_SRC_PORT = 20000
+PROXY_DST_PORT = 20001
+RFC3164_EXAMPLE = ["<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8"]
 RFC3164_EXAMPLE_WITHOUT_PRI = "Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8\n"
 
 
@@ -34,6 +38,6 @@ def test_pp_with_syslog_proto(config, port_allocator, syslog_ng, loggen):
 
     syslog_ng.start(config)
 
-    network_source.write_log(PROXY_PROTO_HEADER + RFC3164_EXAMPLE)
+    network_source.write_logs_with_proxy_header(PROXY_VERSION, PROXY_SRC_IP, PROXY_DST_IP, PROXY_SRC_PORT, PROXY_DST_PORT, RFC3164_EXAMPLE)
 
     assert file_destination.read_log() == RFC3164_EXAMPLE_WITHOUT_PRI

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_syslog_proto.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_syslog_proto.py
@@ -30,7 +30,7 @@ RFC3164_EXAMPLE = ["<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvi
 RFC3164_EXAMPLE_WITHOUT_PRI = "Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8"
 
 
-def test_pp_with_syslog_proto(config, port_allocator, syslog_ng, loggen):
+def test_pp_with_syslog_proto(config, port_allocator, syslog_ng):
     network_source = config.create_network_source(ip="localhost", port=port_allocator(), transport="proxied-tcp")
     file_destination = config.create_file_destination(file_name="output.log")
     config.create_logpath(statements=[network_source, file_destination])

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_syslog_proto.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_syslog_proto.py
@@ -27,7 +27,7 @@ PROXY_DST_IP = "192.168.1.2"
 PROXY_SRC_PORT = 20000
 PROXY_DST_PORT = 20001
 RFC3164_EXAMPLE = ["<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8"]
-RFC3164_EXAMPLE_WITHOUT_PRI = "Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8\n"
+RFC3164_EXAMPLE_WITHOUT_PRI = "Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8"
 
 
 def test_pp_with_syslog_proto(config, port_allocator, syslog_ng, loggen):

--- a/tests/light/functional_tests/source_drivers/network_source/test_network_transports.py
+++ b/tests/light/functional_tests/source_drivers/network_source/test_network_transports.py
@@ -91,7 +91,7 @@ def _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_
 
 
 TEMPLATE = r'"${SOURCEIP} ${SOURCEPORT} ${DESTIP} ${DESTPORT} ${IP_PROTO} ${MESSAGE}\n"'
-EXPECTED_MESSAGES = "1.1.1.1 3333 2.2.2.2 4444 4 message 0\n"
+EXPECTED_MESSAGES = "1.1.1.1 3333 2.2.2.2 4444 4 message 0"
 INPUT_MESSAGES = "message 0\n"
 NUMBER_OF_MESSAGES = 2
 
@@ -114,28 +114,28 @@ def test_pp_network_tls_passthrough(config, syslog_ng, syslog_ng_ctl, port_alloc
 
 def test_network_tcp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0\n"
+    EXPECTED_MESSAGES = "message 0"
     NUMBER_OF_MESSAGES = 1
     _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"tcp"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
 
 
 def test_network_tls(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0\n"
+    EXPECTED_MESSAGES = "message 0"
     NUMBER_OF_MESSAGES = 1
     _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"tls"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
 
 
 def test_network_auto_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0\n"
+    EXPECTED_MESSAGES = "message 0"
     NUMBER_OF_MESSAGES = 1
     _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
 
 
 def test_network_auto_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0\n"
+    EXPECTED_MESSAGES = "message 0"
     INPUT_MESSAGES = "10 message 0\n"
     NUMBER_OF_MESSAGES = 1
     _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
@@ -143,14 +143,14 @@ def test_network_auto_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator
 
 def test_network_auto_tls_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0\n"
+    EXPECTED_MESSAGES = "message 0"
     NUMBER_OF_MESSAGES = 1
     _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE, use_ssl=True)
 
 
 def test_network_auto_tls_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0\n"
+    EXPECTED_MESSAGES = "message 0"
     INPUT_MESSAGES = "10 message 0\n"
     NUMBER_OF_MESSAGES = 1
     _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE, use_ssl=True)

--- a/tests/light/functional_tests/source_drivers/network_source/test_network_transports.py
+++ b/tests/light/functional_tests/source_drivers/network_source/test_network_transports.py
@@ -20,137 +20,113 @@
 # COPYING for details.
 #
 #############################################################################
-from pathlib import Path
-
-from axosyslog_light.common.blocking import wait_until_true
 from axosyslog_light.common.file import copy_shared_file
-from axosyslog_light.common.file import File
-from axosyslog_light.common.random_id import get_unique_id
+from axosyslog_light.driver_io.network.network_io import NetworkIO
 
 
-def _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, transport, input_messages, number_of_messages, expected_messages, template=None, password=None, use_ssl=False):
-    if password:
-        server_key_path = copy_shared_file(testcase_parameters, "server-protected-asdfg.key")
-        server_cert_path = copy_shared_file(testcase_parameters, "server-protected-asdfg.crt")
-    else:
-        server_key_path = copy_shared_file(testcase_parameters, "server.key")
-        server_cert_path = copy_shared_file(testcase_parameters, "server.crt")
-    output_file = "output.log"
-    use_ssl = True if "tls" in transport or use_ssl else None
-    use_inet = None if use_ssl else True
-    use_passthrough = True if "passthrough" in transport else None
-    proxied = 'proxied' in transport
+def _test_network_transports(
+        config,
+        syslog_ng,
+        syslog_ng_ctl,
+        port_allocator,
+        testcase_parameters,
+        source_transport,
+        framed=None,
+        client_transport=None,
+        password=None,
+):
+    TEMPLATE = r'"${SOURCEIP} ${SOURCEPORT} ${DESTIP} ${DESTPORT} ${IP_PROTO} ${MESSAGE}\n"'
+    PROXY_VERSION = 1
+    PROXY_SRC_IP = "1.1.1.1"
+    PROXY_DST_IP = "2.2.2.2"
+    PROXY_SRC_PORT = 3333
+    PROXY_DST_PORT = 4444
+    EXPECTED_PROXIED_MESSAGE = "1.1.1.1 3333 2.2.2.2 4444 4 message 0"
+    INPUT_MESSAGE = "message 0"
+    OUTPUT_FILE = "output.log"
 
-    if (use_ssl):
-        network_source = config.create_network_source(
-            ip="localhost",
-            port=port_allocator(),
-            transport=transport,
-            flags="no-parse",
-            tls={
-                "key-file": server_key_path,
-                "cert-file": server_cert_path,
-                "peer-verify": '"optional-untrusted"',
-            },
-        )
-    else:
-        network_source = config.create_network_source(
-            ip="localhost",
-            port=port_allocator(),
-            transport=transport,
-            flags="no-parse",
-        )
+    extra_opts = {}
+    if "tls" in source_transport or (client_transport is not None and "use_ssl" in client_transport.value):
+        if password:
+            server_key_path = copy_shared_file(testcase_parameters, "server-protected-asdfg.key")
+            server_cert_path = copy_shared_file(testcase_parameters, "server-protected-asdfg.crt")
+        else:
+            server_key_path = copy_shared_file(testcase_parameters, "server.key")
+            server_cert_path = copy_shared_file(testcase_parameters, "server.crt")
 
-    if (template):
-        file_destination = config.create_file_destination(file_name=output_file, template=template)
-    else:
-        file_destination = config.create_file_destination(file_name=output_file)
-    config.create_logpath(statements=[network_source, file_destination])
+        extra_opts["tls"] = {
+            "key-file": server_key_path,
+            "cert-file": server_cert_path,
+            "peer-verify": "optional-untrusted",
+        }
+
+    source = config.create_network_source(
+        ip="localhost",
+        port=port_allocator(),
+        transport=source_transport,
+        flags="no-parse",
+        **extra_opts,
+    )
+
+    file_destination = config.create_file_destination(file_name=OUTPUT_FILE, template=TEMPLATE)
+    config.create_logpath(statements=[source, file_destination])
 
     syslog_ng.start(config)
     if password is not None:
         syslog_ng_ctl.credentials_add(credential=server_key_path, secret=password)
 
-    loggen_input_file_path = Path("loggen_input_{}.txt".format(get_unique_id()))
-    loggen_input_file = File(loggen_input_file_path)
-    loggen_input_file.write_content_and_close(input_messages)
-    loggen.start(
-        network_source.options["ip"], network_source.options["port"], number=number_of_messages,
-        inet=use_inet,
-        use_ssl=use_ssl,
-        read_file=str(loggen_input_file_path),
-        dont_parse=True,
-        proxied=int(proxied),
-        proxied_tls_passthrough=use_passthrough,
-        proxy_src_ip="1.1.1.1", proxy_dst_ip="2.2.2.2", proxy_src_port="3333", proxy_dst_port="4444",
-    )
-    # seems proxy header is counted in get_sent_message_count(), so we need '-1'
-    wait_until_true(lambda: loggen.get_sent_message_count() == number_of_messages - 1)
-
-    assert file_destination.read_log() == expected_messages
+    if "proxied" in source_transport:
+        source.write_logs_with_proxy_header(
+            PROXY_VERSION,
+            PROXY_SRC_IP,
+            PROXY_DST_IP,
+            PROXY_SRC_PORT,
+            PROXY_DST_PORT,
+            [INPUT_MESSAGE],
+            transport=client_transport,
+            framed=framed,
+        )
+        assert file_destination.read_log() == EXPECTED_PROXIED_MESSAGE
+    else:
+        source.write_log(INPUT_MESSAGE, transport=client_transport)
+        assert file_destination.read_log().endswith(INPUT_MESSAGE)
 
 
-TEMPLATE = r'"${SOURCEIP} ${SOURCEPORT} ${DESTIP} ${DESTPORT} ${IP_PROTO} ${MESSAGE}\n"'
-EXPECTED_MESSAGES = "1.1.1.1 3333 2.2.2.2 4444 4 message 0"
-INPUT_MESSAGES = "message 0\n"
-NUMBER_OF_MESSAGES = 2
+def test_pp_network_tcp(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_network_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "proxied-tcp")
 
 
-def test_pp_network_tcp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"proxied-tcp"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_pp_network_tls(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_network_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "proxied-tls")
 
 
-def test_pp_network_tls(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"proxied-tls"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_pp_network_tls_with_passphrase(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_network_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "proxied-tls", password="asdfg")
 
 
-def test_pp_network_tls_with_passphrase(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"proxied-tls"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE, password="asdfg")
+def test_pp_network_tls_passthrough(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_network_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "proxied-tls-passthrough")
 
 
-def test_pp_network_tls_passthrough(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"proxied-tls-passthrough"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_network_tcp(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_network_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "tcp")
 
 
-def test_network_tcp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0"
-    NUMBER_OF_MESSAGES = 1
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"tcp"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_network_tls(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_network_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "tls")
 
 
-def test_network_tls(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0"
-    NUMBER_OF_MESSAGES = 1
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"tls"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_network_auto_tcp_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_network_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "auto", framed=False, client_transport=NetworkIO.Transport.TCP)
 
 
-def test_network_auto_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0"
-    NUMBER_OF_MESSAGES = 1
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_network_auto_tcp_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_network_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "auto", framed=True, client_transport=NetworkIO.Transport.TCP)
 
 
-def test_network_auto_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0"
-    INPUT_MESSAGES = "10 message 0\n"
-    NUMBER_OF_MESSAGES = 1
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_network_auto_tls_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_network_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "auto", framed=False, client_transport=NetworkIO.Transport.TLS)
 
 
-def test_network_auto_tls_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0"
-    NUMBER_OF_MESSAGES = 1
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE, use_ssl=True)
-
-
-def test_network_auto_tls_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0"
-    INPUT_MESSAGES = "10 message 0\n"
-    NUMBER_OF_MESSAGES = 1
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE, use_ssl=True)
+def test_network_auto_tls_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_network_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "auto", framed=True, client_transport=NetworkIO.Transport.TLS)

--- a/tests/light/functional_tests/source_drivers/network_source/test_syslog_parser_timestamp_spinning.py
+++ b/tests/light/functional_tests/source_drivers/network_source/test_syslog_parser_timestamp_spinning.py
@@ -22,7 +22,7 @@
 #############################################################################
 
 LOG_MSG_SIZE = 65536
-INPUT_MESSAGES = "1" * (LOG_MSG_SIZE + 12) + "\n<167>2022-08-21T00:07:06.7"
+INPUT_MESSAGE = "1" * (LOG_MSG_SIZE + 12) + "\n<167>2022-08-21T00:07:06.7"
 
 
 def test_syslog_parser_timestamp_spinning(config, syslog_ng, port_allocator):
@@ -32,6 +32,6 @@ def test_syslog_parser_timestamp_spinning(config, syslog_ng, port_allocator):
 
     syslog_ng.start(config)
 
-    network_source.write_log(INPUT_MESSAGES)
+    network_source.write_log(INPUT_MESSAGE)
     syslog_ng.stop()
     assert not syslog_ng.is_process_running()

--- a/tests/light/functional_tests/source_drivers/network_source/text_with_nuls/test_nul_acceptance.py
+++ b/tests/light/functional_tests/source_drivers/network_source/text_with_nuls/test_nul_acceptance.py
@@ -22,7 +22,7 @@
 #############################################################################
 
 TEMPLATE = r'"${MESSAGE}\n"'
-INPUT_MESSAGES = "prog message\x00embedded\x00nul"
+INPUT_MESSAGE = "prog message\x00embedded\x00nul"
 EXPECTED_MESSAGE0 = "message embedded nul\n"
 
 
@@ -33,6 +33,6 @@ def test_nul_acceptance(config, syslog_ng, loggen, port_allocator):
 
     syslog_ng.start(config)
 
-    network_source.write_log(INPUT_MESSAGES)
+    network_source.write_log(INPUT_MESSAGE)
 
     assert file_destination.read_log() == EXPECTED_MESSAGE0

--- a/tests/light/functional_tests/source_drivers/network_source/text_with_nuls/test_nul_acceptance.py
+++ b/tests/light/functional_tests/source_drivers/network_source/text_with_nuls/test_nul_acceptance.py
@@ -23,7 +23,7 @@
 
 TEMPLATE = r'"${MESSAGE}\n"'
 INPUT_MESSAGE = "prog message\x00embedded\x00nul"
-EXPECTED_MESSAGE0 = "message embedded nul\n"
+EXPECTED_MESSAGE0 = "message embedded nul"
 
 
 def test_nul_acceptance(config, syslog_ng, loggen, port_allocator):

--- a/tests/light/functional_tests/source_drivers/network_source/text_with_nuls/test_nul_acceptance.py
+++ b/tests/light/functional_tests/source_drivers/network_source/text_with_nuls/test_nul_acceptance.py
@@ -26,7 +26,7 @@ INPUT_MESSAGE = "prog message\x00embedded\x00nul"
 EXPECTED_MESSAGE0 = "message embedded nul"
 
 
-def test_nul_acceptance(config, syslog_ng, loggen, port_allocator):
+def test_nul_acceptance(config, syslog_ng, port_allocator):
     network_source = config.create_network_source(ip="localhost", port=port_allocator(), transport='"text-with-nuls"', flags="no-multi-line")
     file_destination = config.create_file_destination(file_name="output.log", template=TEMPLATE)
     config.create_logpath(statements=[network_source, file_destination])

--- a/tests/light/functional_tests/source_drivers/syslog_source/auto/test_auto_proto.py
+++ b/tests/light/functional_tests/source_drivers/syslog_source/auto/test_auto_proto.py
@@ -61,13 +61,13 @@ def _test_auto_detect(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, 
 
 def test_auto_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     INPUT_MESSAGES = "53 <2>Oct 11 22:14:15 myhostname sshd[1234]: message 0\r\n" * 10
-    EXPECTED_MESSAGES = "Oct 11 22:14:15 myhostname sshd[1234]: message 0\n"
+    EXPECTED_MESSAGES = "Oct 11 22:14:15 myhostname sshd[1234]: message 0"
     NUMBER_OF_MESSAGES = 10
     _test_auto_detect(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES)
 
 
 def test_auto_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     INPUT_MESSAGES = "<2>Oct 11 22:14:15 myhostname sshd[1234]: message 0\r\n" * 10
-    EXPECTED_MESSAGES = "Oct 11 22:14:15 myhostname sshd[1234]: message 0\n"
+    EXPECTED_MESSAGES = "Oct 11 22:14:15 myhostname sshd[1234]: message 0"
     NUMBER_OF_MESSAGES = 10
     _test_auto_detect(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES)

--- a/tests/light/functional_tests/source_drivers/syslog_source/auto/test_auto_proto.py
+++ b/tests/light/functional_tests/source_drivers/syslog_source/auto/test_auto_proto.py
@@ -21,53 +21,35 @@
 # COPYING for details.
 #
 #############################################################################
-from pathlib import Path
-
-from axosyslog_light.common.blocking import wait_until_true
-from axosyslog_light.common.file import File
-from axosyslog_light.common.random_id import get_unique_id
+from axosyslog_light.driver_io.network.network_io import NetworkIO
 
 
-def _test_auto_detect(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, transport, input_messages, number_of_messages, expected_messages):
-    output_file = "output.log"
+def _test_auto_detect(config, syslog_ng, port_allocator, framed):
+    NUMBER_OF_MESSAGES = 10
+    INPUT_MESSAGES = ["<2>Oct 11 22:14:15 myhostname sshd[1234]: message 0"] * NUMBER_OF_MESSAGES
+    EXPECTED_MESSAGES = ["Oct 11 22:14:15 myhostname sshd[1234]: message 0"] * NUMBER_OF_MESSAGES
+
+    OUTPUT_FILE = "output.log"
 
     syslog_source = config.create_syslog_source(
         ip="localhost",
         port=port_allocator(),
         keep_hostname="yes",
-        transport=transport,
+        transport="auto",
     )
-    file_destination = config.create_file_destination(file_name=output_file)
+    file_destination = config.create_file_destination(file_name=OUTPUT_FILE)
     config.create_logpath(statements=[syslog_source, file_destination])
 
     syslog_ng.start(config)
 
-    loggen_input_file_path = Path("loggen_input_{}.txt".format(get_unique_id()))
-    loggen_input_file = File(loggen_input_file_path)
-    loggen_input_file.write_content_and_close(input_messages)
-    loggen.start(
-        syslog_source.options["ip"], syslog_source.options["port"],
-        number=number_of_messages,
-        dont_parse=True,
-        read_file=str(loggen_input_file_path),
-        syslog_proto=True,
-        inet=True,
-    )
+    syslog_source.write_logs(INPUT_MESSAGES, transport=NetworkIO.Transport.TCP, framed=framed)
 
-    wait_until_true(lambda: loggen.get_sent_message_count() == number_of_messages)
-
-    assert file_destination.read_log() == expected_messages
+    assert file_destination.read_logs(NUMBER_OF_MESSAGES) == EXPECTED_MESSAGES
 
 
-def test_auto_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    INPUT_MESSAGES = "53 <2>Oct 11 22:14:15 myhostname sshd[1234]: message 0\r\n" * 10
-    EXPECTED_MESSAGES = "Oct 11 22:14:15 myhostname sshd[1234]: message 0"
-    NUMBER_OF_MESSAGES = 10
-    _test_auto_detect(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES)
+def test_auto_framing(config, syslog_ng, port_allocator):
+    _test_auto_detect(config, syslog_ng, port_allocator, True)
 
 
-def test_auto_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    INPUT_MESSAGES = "<2>Oct 11 22:14:15 myhostname sshd[1234]: message 0\r\n" * 10
-    EXPECTED_MESSAGES = "Oct 11 22:14:15 myhostname sshd[1234]: message 0"
-    NUMBER_OF_MESSAGES = 10
-    _test_auto_detect(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES)
+def test_auto_no_framing(config, syslog_ng, port_allocator):
+    _test_auto_detect(config, syslog_ng, port_allocator, False)

--- a/tests/light/functional_tests/source_drivers/syslog_source/test_syslog_transports.py
+++ b/tests/light/functional_tests/source_drivers/syslog_source/test_syslog_transports.py
@@ -20,144 +20,113 @@
 # COPYING for details.
 #
 #############################################################################
-from pathlib import Path
-
-from axosyslog_light.common.blocking import wait_until_true
 from axosyslog_light.common.file import copy_shared_file
-from axosyslog_light.common.file import File
-from axosyslog_light.common.random_id import get_unique_id
+from axosyslog_light.driver_io.network.network_io import NetworkIO
 
 
-def _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, transport, input_messages, number_of_messages, expected_messages, template=None, password=None, use_ssl=False):
-    if password:
-        server_key_path = copy_shared_file(testcase_parameters, "server-protected-asdfg.key")
-        server_cert_path = copy_shared_file(testcase_parameters, "server-protected-asdfg.crt")
-    else:
-        server_key_path = copy_shared_file(testcase_parameters, "server.key")
-        server_cert_path = copy_shared_file(testcase_parameters, "server.crt")
-    output_file = "output.log"
-    use_ssl = True if "tls" in transport or use_ssl else None
-    use_inet = None if use_ssl else True
-    use_passthrough = True if "passthrough" in transport else None
-    proxied = 'proxied' in transport
+def _test_syslog_transports(
+        config,
+        syslog_ng,
+        syslog_ng_ctl,
+        port_allocator,
+        testcase_parameters,
+        source_transport,
+        framed=None,
+        client_transport=None,
+        password=None,
+):
+    TEMPLATE = r'"${SOURCEIP} ${SOURCEPORT} ${DESTIP} ${DESTPORT} ${IP_PROTO} ${MESSAGE}\n"'
+    PROXY_VERSION = 1
+    PROXY_SRC_IP = "1.1.1.1"
+    PROXY_DST_IP = "2.2.2.2"
+    PROXY_SRC_PORT = 3333
+    PROXY_DST_PORT = 4444
+    EXPECTED_PROXIED_MESSAGE = "1.1.1.1 3333 2.2.2.2 4444 4 message 0"
+    INPUT_MESSAGE = "message 0"
+    OUTPUT_FILE = "output.log"
 
-    if (use_ssl):
-        syslog_source = config.create_syslog_source(
-            ip="localhost",
-            port=port_allocator(),
-            transport=transport,
-            flags="no-parse",
-            tls={
-                "key-file": server_key_path,
-                "cert-file": server_cert_path,
-                "peer-verify": '"optional-untrusted"',
-            },
-        )
-    else:
-        syslog_source = config.create_syslog_source(
-            ip="localhost",
-            port=port_allocator(),
-            transport=transport,
-            flags="no-parse",
-        )
-    if template:
-        file_destination = config.create_file_destination(file_name=output_file, template=template)
-    else:
-        file_destination = config.create_file_destination(file_name=output_file)
-    config.create_logpath(statements=[syslog_source, file_destination])
+    extra_opts = {}
+    if "tls" in source_transport or (client_transport is not None and "use_ssl" in client_transport.value):
+        if password:
+            server_key_path = copy_shared_file(testcase_parameters, "server-protected-asdfg.key")
+            server_cert_path = copy_shared_file(testcase_parameters, "server-protected-asdfg.crt")
+        else:
+            server_key_path = copy_shared_file(testcase_parameters, "server.key")
+            server_cert_path = copy_shared_file(testcase_parameters, "server.crt")
+
+        extra_opts["tls"] = {
+            "key-file": server_key_path,
+            "cert-file": server_cert_path,
+            "peer-verify": "optional-untrusted",
+        }
+
+    source = config.create_syslog_source(
+        ip="localhost",
+        port=port_allocator(),
+        transport=source_transport,
+        flags="no-parse",
+        **extra_opts,
+    )
+
+    file_destination = config.create_file_destination(file_name=OUTPUT_FILE, template=TEMPLATE)
+    config.create_logpath(statements=[source, file_destination])
 
     syslog_ng.start(config)
     if password is not None:
         syslog_ng_ctl.credentials_add(credential=server_key_path, secret=password)
 
-    loggen_input_file_path = Path("loggen_input_{}.txt".format(get_unique_id()))
-    loggen_input_file = File(loggen_input_file_path)
-    loggen_input_file.write_content_and_close(input_messages)
-    loggen.start(
-        syslog_source.options["ip"], syslog_source.options["port"],
-        number=number_of_messages,
-        dont_parse=True,
-        read_file=str(loggen_input_file_path),
-        syslog_proto=True,
-        inet=use_inet,
-        use_ssl=use_ssl,
-        proxied=int(proxied),
-        proxied_tls_passthrough=use_passthrough,
-        proxy_src_ip="1.1.1.1", proxy_dst_ip="2.2.2.2", proxy_src_port="3333", proxy_dst_port="4444",
-    )
-
-    # seems proxy header is counted in get_sent_message_count(), so we need '-1'
-    wait_until_true(lambda: loggen.get_sent_message_count() == number_of_messages - 1)
-
-    assert file_destination.read_log() == expected_messages
+    if "proxied" in source_transport:
+        source.write_logs_with_proxy_header(
+            PROXY_VERSION,
+            PROXY_SRC_IP,
+            PROXY_DST_IP,
+            PROXY_SRC_PORT,
+            PROXY_DST_PORT,
+            [INPUT_MESSAGE],
+            transport=client_transport,
+            framed=framed,
+        )
+        assert file_destination.read_log() == EXPECTED_PROXIED_MESSAGE
+    else:
+        source.write_log(INPUT_MESSAGE, transport=client_transport)
+        assert file_destination.read_log().endswith(INPUT_MESSAGE)
 
 
-TEMPLATE = r'"${SOURCEIP} ${SOURCEPORT} ${DESTIP} ${DESTPORT} ${MESSAGE}\n"'
-INPUT_MESSAGES = "53 <2>Oct 11 22:14:15 myhostname sshd[1234]: message 0\r\n"
-EXPECTED_MESSAGES = "1.1.1.1 3333 2.2.2.2 4444 <2>Oct 11 22:14:15 myhostname sshd[1234]: message 0"
-NUMBER_OF_MESSAGES = 2
+def test_pp_syslog_tcp(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_syslog_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "proxied-tcp")
 
 
-def test_pp_syslog_tcp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"proxied-tcp"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_pp_syslog_tls(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_syslog_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "proxied-tls")
 
 
-def test_pp_syslog_tls(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"proxied-tls"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_pp_syslog_tls_with_passphrase(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_syslog_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "proxied-tls", password="asdfg")
 
 
-def test_pp_syslog_tls_with_passphrase(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"proxied-tls"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE, password="asdfg")
+def test_pp_syslog_tls_passthrough(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_syslog_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "proxied-tls-passthrough")
 
 
-def test_pp_syslog_tls_passthrough(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"proxied-tls-passthrough"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_syslog_tcp(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_syslog_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "tcp")
 
 
-def test_syslog_tcp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0"
-    NUMBER_OF_MESSAGES = 1
-    # 10 is the octet count
-    INPUT_MESSAGES = "10 message 0\n"
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"tcp"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_syslog_tls(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_syslog_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "tls")
 
 
-def test_syslog_tls(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0"
-    NUMBER_OF_MESSAGES = 1
-    INPUT_MESSAGES = "10 message 0\n"
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"tls"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_syslog_auto_tcp_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_syslog_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "auto", framed=False, client_transport=NetworkIO.Transport.TCP)
 
 
-def test_syslog_auto_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0"
-    NUMBER_OF_MESSAGES = 1
-    INPUT_MESSAGES = "message 0\n"
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_syslog_auto_tcp_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_syslog_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "auto", framed=True, client_transport=NetworkIO.Transport.TCP)
 
 
-def test_syslog_auto_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0"
-    NUMBER_OF_MESSAGES = 1
-    INPUT_MESSAGES = "10 message 0\n"
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
+def test_syslog_auto_tls_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_syslog_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "auto", framed=False, client_transport=NetworkIO.Transport.TLS)
 
 
-def test_syslog_auto_tls_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0"
-    NUMBER_OF_MESSAGES = 1
-    INPUT_MESSAGES = "message 0\n"
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE, use_ssl=True)
-
-
-def test_syslog_auto_tls_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
-    TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0"
-    NUMBER_OF_MESSAGES = 1
-    INPUT_MESSAGES = "10 message 0\n"
-    _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE, use_ssl=True)
+def test_syslog_auto_tls_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters):
+    _test_syslog_transports(config, syslog_ng, syslog_ng_ctl, port_allocator, testcase_parameters, "auto", framed=True, client_transport=NetworkIO.Transport.TLS)

--- a/tests/light/functional_tests/source_drivers/syslog_source/test_syslog_transports.py
+++ b/tests/light/functional_tests/source_drivers/syslog_source/test_syslog_transports.py
@@ -94,7 +94,7 @@ def _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_
 
 TEMPLATE = r'"${SOURCEIP} ${SOURCEPORT} ${DESTIP} ${DESTPORT} ${MESSAGE}\n"'
 INPUT_MESSAGES = "53 <2>Oct 11 22:14:15 myhostname sshd[1234]: message 0\r\n"
-EXPECTED_MESSAGES = "1.1.1.1 3333 2.2.2.2 4444 <2>Oct 11 22:14:15 myhostname sshd[1234]: message 0\n"
+EXPECTED_MESSAGES = "1.1.1.1 3333 2.2.2.2 4444 <2>Oct 11 22:14:15 myhostname sshd[1234]: message 0"
 NUMBER_OF_MESSAGES = 2
 
 
@@ -116,7 +116,7 @@ def test_pp_syslog_tls_passthrough(config, syslog_ng, syslog_ng_ctl, port_alloca
 
 def test_syslog_tcp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0\n"
+    EXPECTED_MESSAGES = "message 0"
     NUMBER_OF_MESSAGES = 1
     # 10 is the octet count
     INPUT_MESSAGES = "10 message 0\n"
@@ -125,7 +125,7 @@ def test_syslog_tcp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, te
 
 def test_syslog_tls(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0\n"
+    EXPECTED_MESSAGES = "message 0"
     NUMBER_OF_MESSAGES = 1
     INPUT_MESSAGES = "10 message 0\n"
     _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"tls"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
@@ -133,7 +133,7 @@ def test_syslog_tls(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, te
 
 def test_syslog_auto_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0\n"
+    EXPECTED_MESSAGES = "message 0"
     NUMBER_OF_MESSAGES = 1
     INPUT_MESSAGES = "message 0\n"
     _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
@@ -141,7 +141,7 @@ def test_syslog_auto_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator
 
 def test_syslog_auto_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0\n"
+    EXPECTED_MESSAGES = "message 0"
     NUMBER_OF_MESSAGES = 1
     INPUT_MESSAGES = "10 message 0\n"
     _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE)
@@ -149,7 +149,7 @@ def test_syslog_auto_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator,
 
 def test_syslog_auto_tls_no_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0\n"
+    EXPECTED_MESSAGES = "message 0"
     NUMBER_OF_MESSAGES = 1
     INPUT_MESSAGES = "message 0\n"
     _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE, use_ssl=True)
@@ -157,7 +157,7 @@ def test_syslog_auto_tls_no_framing(config, syslog_ng, syslog_ng_ctl, port_alloc
 
 def test_syslog_auto_tls_w_framing(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters):
     TEMPLATE = r'"${MESSAGE}\n"'
-    EXPECTED_MESSAGES = "message 0\n"
+    EXPECTED_MESSAGES = "message 0"
     NUMBER_OF_MESSAGES = 1
     INPUT_MESSAGES = "10 message 0\n"
     _test_pp(config, syslog_ng, syslog_ng_ctl, port_allocator, loggen, testcase_parameters, '"auto"', INPUT_MESSAGES, NUMBER_OF_MESSAGES, EXPECTED_MESSAGES, TEMPLATE, use_ssl=True)

--- a/tests/light/functional_tests/template_functions/graphite-output/test_graphite_output.py
+++ b/tests/light/functional_tests/template_functions/graphite-output/test_graphite_output.py
@@ -31,4 +31,4 @@ def test_graphite_output(config, syslog_ng):
     config.create_logpath(statements=[generator_source, file_destination])
     syslog_ng.start(config)
     log = file_destination.read_logs(2)
-    assert log == ["test.key1 value1 custom_timestamp\n", "test.key2 value2 custom_timestamp\n"]
+    assert log == ["test.key1 value1 custom_timestamp", "test.key2 value2 custom_timestamp"]

--- a/tests/light/functional_tests/templates/test_template_stmt.py
+++ b/tests/light/functional_tests/templates/test_template_stmt.py
@@ -32,7 +32,7 @@ def test_template_stmt_with_identifier_reference(config, syslog_ng):
     config.create_logpath(statements=[generator_source, file_destination])
     syslog_ng.start(config)
     log = file_destination.read_logs(1)
-    assert log == ["template with test.key1=value1 test.key2=value2\n"]
+    assert log == ["template with test.key1=value1 test.key2=value2"]
 
 
 def test_template_with_non_string_values(config, syslog_ng):
@@ -49,7 +49,7 @@ def test_template_with_non_string_values(config, syslog_ng):
     config.create_logpath(statements=[generator_source, *rewrites, file_destination])
     syslog_ng.start(config)
     log = file_destination.read_logs(1)
-    assert log == ["""{"values_int_literal":10,"values_int_hint":10,"values_float_literal":4.5,"values_float_hint":4.5}\n"""]
+    assert log == ['{"values_int_literal":10,"values_int_hint":10,"values_float_literal":4.5,"values_float_hint":4.5}']
 
 
 def test_template_stmt_with_indirect_invocation(config, syslog_ng):
@@ -62,7 +62,7 @@ def test_template_stmt_with_indirect_invocation(config, syslog_ng):
     config.create_logpath(statements=[generator_source, file_destination])
     syslog_ng.start(config)
     log = file_destination.read_logs(1)
-    assert log == ["template with test.key1=value1 test.key2=value2\n"]
+    assert log == ["template with test.key1=value1 test.key2=value2"]
 
 
 def test_simple_template_stmt_with_identifier_reference(config, syslog_ng):
@@ -75,7 +75,7 @@ def test_simple_template_stmt_with_identifier_reference(config, syslog_ng):
     config.create_logpath(statements=[generator_source, file_destination])
     syslog_ng.start(config)
     log = file_destination.read_logs(1)
-    assert log == ["template with test.key1=value1 test.key2=value2\n"]
+    assert log == ["template with test.key1=value1 test.key2=value2"]
 
 
 def test_template_stmt_with_string_reference(config, syslog_ng):
@@ -88,7 +88,7 @@ def test_template_stmt_with_string_reference(config, syslog_ng):
     config.create_logpath(statements=[generator_source, file_destination])
     syslog_ng.start(config)
     log = file_destination.read_logs(1)
-    assert log == ["template with test.key1=value1 test.key2=value2\n"]
+    assert log == ["template with test.key1=value1 test.key2=value2"]
 
 
 def test_inline_template(config, syslog_ng):
@@ -98,7 +98,7 @@ def test_inline_template(config, syslog_ng):
     config.create_logpath(statements=[generator_source, file_destination])
     syslog_ng.start(config)
     log = file_destination.read_logs(1)
-    assert log == ["template with test.key1=value1 test.key2=value2\n"]
+    assert log == ["template with test.key1=value1 test.key2=value2"]
 
 
 def test_inline_template_hints(config, syslog_ng):
@@ -109,7 +109,7 @@ def test_inline_template_hints(config, syslog_ng):
     syslog_ng.start(config)
     log = file_destination.read_logs(1)
     # NOTE: both key1 and key2 are formatted as integers
-    assert log == ['''template with {"test":{"key2":6,"key1":5}}\n''']
+    assert log == ['template with {"test":{"key2":6,"key1":5}}']
 
 
 def test_value_pair_type_hints(config, syslog_ng):
@@ -120,7 +120,7 @@ def test_value_pair_type_hints(config, syslog_ng):
     syslog_ng.start(config)
     log = file_destination.read_logs(1)
     # NOTE: v1 is formatted as an integer due to the type hint in the format-json option list
-    assert log == ['''template with {"v1":5}\n''']
+    assert log == ['template with {"v1":5}']
 
 
 def test_template_function(config, syslog_ng):
@@ -133,4 +133,4 @@ def test_template_function(config, syslog_ng):
     config.create_logpath(statements=[generator_source, file_destination])
     syslog_ng.start(config)
     log = file_destination.read_logs(1)
-    assert log == ["template with test.key1=value1 test.key2=value2\n"]
+    assert log == ["template with test.key1=value1 test.key2=value2"]

--- a/tests/light/functional_tests/value-pairs/test_value_pairs.py
+++ b/tests/light/functional_tests/value-pairs/test_value_pairs.py
@@ -24,14 +24,14 @@ import pytest
 
 
 test_parameters = [
-    ("$(format-json test.*)\n", """{"test":{"key2":"value2","key1":"value1"}}\n"""),
+    ("$(format-json test.*)\n", r'{"test":{"key2":"value2","key1":"value1"}}'),
     # transformations
-    ("$(format-json test.* --add-prefix foo.)\n", """{"foo":{"test":{"key2":"value2","key1":"value1"}}}\n"""),
-    ("$(format-json test.* --replace-prefix test=foobar)\n", """{"foobar":{"key2":"value2","key1":"value1"}}\n"""),
-    ("$(format-json test.* --shift-levels 1)\n", """{"key2":"value2","key1":"value1"}\n"""),
-    ("$(format-json test.* --shift 2)\n", """{"st":{"key2":"value2","key1":"value1"}}\n"""),
-    ("$(format-json test.* --upper)\n", """{"TEST":{"KEY2":"value2","KEY1":"value1"}}\n"""),
-    ("$(format-json MESSAGE --lower)\n", """{"message":"-- Generated message. --"}\n"""),
+    ("$(format-json test.* --add-prefix foo.)\n", r'{"foo":{"test":{"key2":"value2","key1":"value1"}}}'),
+    ("$(format-json test.* --replace-prefix test=foobar)\n", r'{"foobar":{"key2":"value2","key1":"value1"}}'),
+    ("$(format-json test.* --shift-levels 1)\n", r'{"key2":"value2","key1":"value1"}'),
+    ("$(format-json test.* --shift 2)\n", r'{"st":{"key2":"value2","key1":"value1"}}'),
+    ("$(format-json test.* --upper)\n", r'{"TEST":{"KEY2":"value2","KEY1":"value1"}}'),
+    ("$(format-json MESSAGE --lower)\n", r'{"message":"-- Generated message. --"}'),
 ]
 
 

--- a/tests/light/src/axosyslog_light/driver_io/file/file_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/file/file_io.py
@@ -34,7 +34,7 @@ class FileIO():
                 raise Exception("{} was not created in time.".format(self.__readable_file.path))
             self.__readable_file.open("r")
 
-        return self.__readable_file.wait_for_number_of_lines(counter)
+        return [line.rstrip("\n") for line in self.__readable_file.wait_for_number_of_lines(counter)]
 
     def read_until_messages(self, lines):
         if not self.__readable_file.is_opened():
@@ -42,7 +42,7 @@ class FileIO():
                 raise Exception("{} was not created in time.".format(self.__readable_file.path))
             self.__readable_file.open("r")
 
-        return self.__readable_file.wait_for_lines(lines)
+        return [line.rstrip("\n") for line in self.__readable_file.wait_for_lines(lines)]
 
     def write_raw(self, raw_content):
         if not self.__writeable_file.is_opened():

--- a/tests/light/src/axosyslog_light/driver_io/file/file_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/file/file_io.py
@@ -44,11 +44,17 @@ class FileIO():
 
         return self.__readable_file.wait_for_lines(lines)
 
-    def write(self, content):
+    def write_raw(self, raw_content):
         if not self.__writeable_file.is_opened():
             self.__writeable_file.open("a+")
 
-        self.__writeable_file.write(content)
+        self.__writeable_file.write_content_and_close(raw_content)
+
+    def write_message(self, message):
+        self.write_raw(message + "\n")
+
+    def write_messages(self, messages):
+        self.write_raw("".join([message + "\n" for message in messages]))
 
     def close_readable_file(self):
         self.__readable_file.close()

--- a/tests/light/src/axosyslog_light/driver_io/file/tests/test_file_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/file/tests/test_file_io.py
@@ -28,14 +28,14 @@ from axosyslog_light.self_test_fixtures import test_message
 
 def test_file_io_write_read(temp_file, test_message):
     fileio = FileIO(temp_file)
-    fileio.write(test_message)
+    fileio.write_message(test_message)
     output = fileio.read_number_of_messages(1)
     assert [test_message] == output
 
 
 def test_file_io_multiple_write_read(temp_file, test_message):
     fileio = FileIO(temp_file)
-    fileio.write(test_message)
-    fileio.write(test_message)
+    fileio.write_message(test_message)
+    fileio.write_message(test_message)
     output = fileio.read_number_of_messages(2)
     assert [test_message, test_message] == output

--- a/tests/light/src/axosyslog_light/driver_io/network/network_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/network/network_io.py
@@ -70,17 +70,19 @@ class NetworkIO():
             **extra_loggen_args,
         )
 
-    def __format_messages(self, messages):
-        if self.__framed:
+    def __format_messages(self, messages, framed=None):
+        if framed is None:
+            framed = self.__framed
+        if framed:
             return "".join([str(len(message)) + " " + message for message in messages])
         return "".join([message + "\n" for message in messages])
 
-    def write_messages(self, messages, rate=None, transport=None):
-        self.write_raw(self.__format_messages(messages), rate=rate, transport=transport)
+    def write_messages(self, messages, rate=None, transport=None, framed=None):
+        self.write_raw(self.__format_messages(messages, framed=framed), rate=rate, transport=transport)
 
-    def write_messages_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None):
+    def write_messages_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None, framed=None):
         self.write_raw(
-            self.__format_messages(messages),
+            self.__format_messages(messages, framed=framed),
             rate=rate,
             transport=transport,
             extra_loggen_args={

--- a/tests/light/src/axosyslog_light/message_builder/bsd_format.py
+++ b/tests/light/src/axosyslog_light/message_builder/bsd_format.py
@@ -25,7 +25,7 @@
 
 class BSDFormat(object):
     @staticmethod
-    def format_message(message, add_new_line=True):
+    def format_message(message):
         formatted_message = ""
         if message.priority_value:
             formatted_message += "<{}>".format(message.priority_value)
@@ -39,6 +39,4 @@ class BSDFormat(object):
             formatted_message += "[{}]:".format(message.pid_value)
         if message.message_value:
             formatted_message += " {}".format(message.message_value)
-        if add_new_line:
-            formatted_message += "\n"
         return formatted_message

--- a/tests/light/src/axosyslog_light/self_test_fixtures.py
+++ b/tests/light/src/axosyslog_light/self_test_fixtures.py
@@ -27,7 +27,7 @@ from axosyslog_light.testcase_parameters.testcase_parameters import TestcasePara
 
 @pytest.fixture
 def test_message():
-    return "test message - öüóőúéáű\n"
+    return "test message - öüóőúéáű"
 
 
 @pytest.fixture

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/network_destination.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/network_destination.py
@@ -40,7 +40,7 @@ def map_transport(transport):
 def create_io(ip, options):
     transport = options["transport"] if "transport" in options else "tcp"
 
-    return NetworkIO(ip, options["port"], map_transport(transport))
+    return NetworkIO(ip, options["port"], map_transport(transport), False)
 
 
 class NetworkDestination(DestinationDriver):

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/file_source.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/file_source.py
@@ -42,13 +42,22 @@ class FileSource(SourceDriver):
     def set_path(self, pathname):
         self.path = Path(pathname)
 
-    def write_log(self, formatted_log, counter=1):
+    def write_log(self, log, counter=1):
         for _ in range(counter):
-            self.io.write(formatted_log)
+            self.io.write_message(log)
         logger.info(
             "Content has been written to\nresource: {}\n"
             "number of times: {}\n"
-            "content: {}\n".format(self.get_path(), counter, formatted_log),
+            "content: {}\n".format(self.get_path(), counter, log),
+        )
+
+    def write_logs(self, logs, counter=1):
+        for _ in range(counter):
+            self.io.write_messages(logs)
+        logger.info(
+            "Content has been written to\nresource: {}\n"
+            "number of times: {}\n"
+            "content: {}\n".format(self.get_path(), counter, logs),
         )
 
     def close_file(self):

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/network_source.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/network_source.py
@@ -54,14 +54,14 @@ class NetworkSource(SourceDriver):
         self.driver_name = "network"
         super(NetworkSource, self).__init__(options=options)
 
-    def write_log(self, message, rate=None, transport=None):
-        self.io.write_messages([message], rate=rate, transport=transport)
+    def write_log(self, message, rate=None, transport=None, framed=None):
+        self.io.write_messages([message], rate=rate, transport=transport, framed=framed)
 
-    def write_logs(self, messages, rate=None, transport=None):
-        self.io.write_messages(messages, rate=rate, transport=transport)
+    def write_logs(self, messages, rate=None, transport=None, framed=None):
+        self.io.write_messages(messages, rate=rate, transport=transport, framed=framed)
 
-    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None):
-        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate, transport=transport)
+    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None, framed=None):
+        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate, transport=transport, framed=framed)
 
     def write_raw(self, raw_content, rate=None):
         self.io.write_raw(raw_content, rate=rate)

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/network_source.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/network_source.py
@@ -54,5 +54,14 @@ class NetworkSource(SourceDriver):
         self.driver_name = "network"
         super(NetworkSource, self).__init__(options=options)
 
-    def write_log(self, formatted_content, rate=None):
-        self.io.write(formatted_content, rate=rate)
+    def write_log(self, message, rate=None):
+        self.io.write_messages([message], rate=rate)
+
+    def write_logs(self, messages, rate=None):
+        self.io.write_messages(messages, rate=rate)
+
+    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None):
+        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate)
+
+    def write_raw(self, raw_content, rate=None):
+        self.io.write_raw(raw_content, rate=rate)

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/network_source.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/network_source.py
@@ -62,6 +62,3 @@ class NetworkSource(SourceDriver):
 
     def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None, framed=None):
         self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate, transport=transport, framed=framed)
-
-    def write_raw(self, raw_content, rate=None):
-        self.io.write_raw(raw_content, rate=rate)

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/network_source.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/network_source.py
@@ -44,7 +44,7 @@ def create_io(options):
     ip = options["ip"] if "ip" in options else "localhost"
     transport = options["transport"] if "transport" in options else "tcp"
 
-    return NetworkIO(ip, options["port"], map_transport(transport))
+    return NetworkIO(ip, options["port"], map_transport(transport), False)
 
 
 class NetworkSource(SourceDriver):

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/network_source.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/network_source.py
@@ -26,7 +26,7 @@ from axosyslog_light.syslog_ng_config.statements.sources.source_driver import So
 
 def map_transport(transport):
     mapping = {
-        "auto": NetworkIO.Transport.TCP,
+        "auto": NetworkIO.Transport.AUTO,
         "tcp": NetworkIO.Transport.TCP,
         "text-with-nuls": NetworkIO.Transport.TCP,
         "udp": NetworkIO.Transport.UDP,
@@ -54,14 +54,14 @@ class NetworkSource(SourceDriver):
         self.driver_name = "network"
         super(NetworkSource, self).__init__(options=options)
 
-    def write_log(self, message, rate=None):
-        self.io.write_messages([message], rate=rate)
+    def write_log(self, message, rate=None, transport=None):
+        self.io.write_messages([message], rate=rate, transport=transport)
 
-    def write_logs(self, messages, rate=None):
-        self.io.write_messages(messages, rate=rate)
+    def write_logs(self, messages, rate=None, transport=None):
+        self.io.write_messages(messages, rate=rate, transport=transport)
 
-    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None):
-        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate)
+    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None):
+        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate, transport=transport)
 
     def write_raw(self, raw_content, rate=None):
         self.io.write_raw(raw_content, rate=rate)

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/syslog_source.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/syslog_source.py
@@ -26,7 +26,7 @@ from axosyslog_light.syslog_ng_config.statements.sources.source_driver import So
 
 def map_transport(transport):
     mapping = {
-        "auto": NetworkIO.Transport.TCP,
+        "auto": NetworkIO.Transport.AUTO,
         "tcp": NetworkIO.Transport.TCP,
         "udp": NetworkIO.Transport.UDP,
         "tls": NetworkIO.Transport.TLS,
@@ -53,11 +53,11 @@ class SyslogSource(SourceDriver):
         self.driver_name = "syslog"
         super(SyslogSource, self).__init__(options=options)
 
-    def write_log(self, message, rate=None):
-        self.io.write_messages([message], rate=rate)
+    def write_log(self, message, rate=None, transport=None):
+        self.io.write_messages([message], rate=rate, transport=transport)
 
-    def write_logs(self, messages, rate=None):
-        self.io.write_messages(messages, rate=rate)
+    def write_logs(self, messages, rate=None, transport=None):
+        self.io.write_messages(messages, rate=rate, transport=transport)
 
-    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None):
-        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate)
+    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None):
+        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate, transport=transport)

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/syslog_source.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/syslog_source.py
@@ -43,7 +43,7 @@ def create_io(options):
     ip = options["ip"] if "ip" in options else "localhost"
     transport = options["transport"] if "transport" in options else "tcp"
 
-    return NetworkIO(ip, options["port"], map_transport(transport))
+    return NetworkIO(ip, options["port"], map_transport(transport), True)
 
 
 class SyslogSource(SourceDriver):
@@ -53,5 +53,11 @@ class SyslogSource(SourceDriver):
         self.driver_name = "syslog"
         super(SyslogSource, self).__init__(options=options)
 
-    def write_log(self, formatted_content, rate=None):
-        self.io.write_messages(formatted_content, rate=rate)
+    def write_log(self, message, rate=None):
+        self.io.write_messages([message], rate=rate)
+
+    def write_logs(self, messages, rate=None):
+        self.io.write_messages(messages, rate=rate)
+
+    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None):
+        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate)

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/syslog_source.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/syslog_source.py
@@ -54,4 +54,4 @@ class SyslogSource(SourceDriver):
         super(SyslogSource, self).__init__(options=options)
 
     def write_log(self, formatted_content, rate=None):
-        self.io.write(formatted_content, rate=rate)
+        self.io.write_messages(formatted_content, rate=rate)

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/syslog_source.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/syslog_source.py
@@ -53,11 +53,11 @@ class SyslogSource(SourceDriver):
         self.driver_name = "syslog"
         super(SyslogSource, self).__init__(options=options)
 
-    def write_log(self, message, rate=None, transport=None):
-        self.io.write_messages([message], rate=rate, transport=transport)
+    def write_log(self, message, rate=None, transport=None, framed=None):
+        self.io.write_messages([message], rate=rate, transport=transport, framed=framed)
 
-    def write_logs(self, messages, rate=None, transport=None):
-        self.io.write_messages(messages, rate=rate, transport=transport)
+    def write_logs(self, messages, rate=None, transport=None, framed=None):
+        self.io.write_messages(messages, rate=rate, transport=transport, framed=framed)
 
-    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None):
-        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate, transport=transport)
+    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None, framed=None):
+        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate, transport=transport, framed=framed)


### PR DESCRIPTION
We already had a `SyslogSource`, but it did not send the logs with framing, so this PR fixes that.

I also observed that the "log" entity all throughout Light is not separated well from some transport specific details, like `\n` delimiting in case of network and file drivers (`\n` was considered part of the log, but it is in reality a delimiter in case of network and file sources), I also fixed these.