### PR TITLE
light: loggen from docker

### DIFF
--- a/tests/light/functional_tests/filterx/test_filterx_update_metric.py
+++ b/tests/light/functional_tests/filterx/test_filterx_update_metric.py
@@ -150,7 +150,7 @@ def test_filterx_update_metric_level(config, port_allocator, syslog_ng):
 
     syslog_ng.start(config)
     network_source.write_log("foo")
-    file_destination.read_log()
+    file_destination.read_logs(1)
 
     samples = config.get_prometheus_samples([MetricFilter("syslogng_metric", {})])
     assert len(samples) == 0
@@ -168,7 +168,7 @@ def test_filterx_update_metric_level(config, port_allocator, syslog_ng):
 
     syslog_ng.reload(config)
     network_source.write_log("foo")
-    file_destination.read_log()
+    file_destination.read_logs(2)
 
     # stats(level(2));
 
@@ -183,7 +183,7 @@ def test_filterx_update_metric_level(config, port_allocator, syslog_ng):
 
     syslog_ng.reload(config)
     network_source.write_log("foo")
-    file_destination.read_log()
+    file_destination.read_logs(3)
 
     assert wait_until_true(lambda: config.get_prometheus_samples([MetricFilter("syslogng_metric", {})]) != [])
     samples = config.get_prometheus_samples([MetricFilter("syslogng_metric", {})])

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_simple_tcp_connection.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_simple_tcp_connection.py
@@ -21,6 +21,7 @@
 #
 #############################################################################
 from axosyslog_light.common.blocking import wait_until_true
+from axosyslog_light.helpers.loggen.loggen import LoggenStartParams
 
 NUMBER_OF_MESSAGES = 10
 
@@ -32,7 +33,15 @@ def test_pp_with_simple_tcp_connection(config, port_allocator, syslog_ng, loggen
 
     syslog_ng.start(config)
 
-    loggen.start(network_source.options["ip"], network_source.options["port"], inet=True, stream=True, number=NUMBER_OF_MESSAGES)
+    loggen.start(
+        LoggenStartParams(
+            target=network_source.options["ip"],
+            port=network_source.options["port"],
+            inet=True,
+            stream=True,
+            number=NUMBER_OF_MESSAGES,
+        ),
+    )
     wait_until_true(lambda: loggen.get_sent_message_count() == NUMBER_OF_MESSAGES)
 
     # We could check the source side stats, too, but it is not yet implemented

--- a/tests/light/functional_tests/tools/loggen/test_loggen_with_reconnect.py
+++ b/tests/light/functional_tests/tools/loggen/test_loggen_with_reconnect.py
@@ -20,6 +20,7 @@
 # COPYING for details.
 #
 #############################################################################
+from axosyslog_light.helpers.loggen.loggen import LoggenStartParams
 
 NUMBER_OF_MESSAGES = 3
 
@@ -32,8 +33,16 @@ def test_loggen_with_reconnect(config, port_allocator, syslog_ng, loggen):
     syslog_ng.start(config)
 
     loggen.start(
-        network_source.options["ip"], network_source.options["port"], inet=True,
-        rate=1, active_connections=1, reconnect=True, interval=30, number=NUMBER_OF_MESSAGES,
+        LoggenStartParams(
+            target=network_source.options["ip"],
+            port=network_source.options["port"],
+            inet=True,
+            rate=1,
+            active_connections=1,
+            reconnect=True,
+            interval=30,
+            number=NUMBER_OF_MESSAGES,
+        ),
     )
 
     syslog_ng.stop()

--- a/tests/light/src/axosyslog_light/Makefile.am
+++ b/tests/light/src/axosyslog_light/Makefile.am
@@ -29,6 +29,9 @@ EXTRA_DIST += \
 	tests/light/src/axosyslog_light/fixtures.py \
 	tests/light/src/axosyslog_light/helpers/__init__.py \
 	tests/light/src/axosyslog_light/helpers/loggen/__init__.py \
+	tests/light/src/axosyslog_light/helpers/loggen/loggen_docker_executor.py \
+	tests/light/src/axosyslog_light/helpers/loggen/loggen_executor.py \
+	tests/light/src/axosyslog_light/helpers/loggen/loggen_local_executor.py \
 	tests/light/src/axosyslog_light/helpers/loggen/loggen.py \
 	tests/light/src/axosyslog_light/helpers/secure_logging/conftest.py \
 	tests/light/src/axosyslog_light/helpers/secure_logging/__init__.py \

--- a/tests/light/src/axosyslog_light/driver_io/file/file_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/file/file_io.py
@@ -44,6 +44,14 @@ class FileIO():
 
         return [line.rstrip("\n") for line in self.__readable_file.wait_for_lines(lines)]
 
+    def read_all(self):
+        if not self.__readable_file.is_opened():
+            if not self.__readable_file.wait_for_creation():
+                raise Exception("{} was not created in time.".format(self.__readable_file.path))
+            self.__readable_file.open("r")
+
+        return self.__readable_file.read().splitlines()
+
     def write_raw(self, raw_content):
         if not self.__writeable_file.is_opened():
             self.__writeable_file.open("a+")

--- a/tests/light/src/axosyslog_light/driver_io/network/network_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/network/network_io.py
@@ -35,6 +35,7 @@ from axosyslog_light.common.network import UDPServer
 from axosyslog_light.common.random_id import get_unique_id
 from axosyslog_light.driver_io import message_readers
 from axosyslog_light.helpers.loggen.loggen import Loggen
+from axosyslog_light.helpers.loggen.loggen import LoggenStartParams
 
 
 class NetworkIO():
@@ -60,14 +61,16 @@ class NetworkIO():
         loggen_input_file.write_content_and_close(raw_content)
 
         Loggen().start(
-            self.__ip,
-            self.__port,
-            read_file=str(loggen_input_file_path),
-            dont_parse=True,
-            permanent=True,
-            rate=rate,
-            **transport.value,
-            **extra_loggen_args,
+            LoggenStartParams(
+                target=self.__ip,
+                port=self.__port,
+                read_file=str(loggen_input_file_path),
+                dont_parse=True,
+                permanent=True,
+                rate=rate,
+                **transport.value,
+                **extra_loggen_args,
+            ),
         )
 
     def __format_messages(self, messages, framed=None):

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -36,6 +36,9 @@ import pytest
 from axosyslog_light.common.file import copy_file
 from axosyslog_light.common.pytest_operations import calculate_testcase_name
 from axosyslog_light.helpers.loggen.loggen import Loggen
+from axosyslog_light.helpers.loggen.loggen_docker_executor import LoggenDockerExecutor
+from axosyslog_light.helpers.loggen.loggen_executor import LoggenExecutor
+from axosyslog_light.helpers.loggen.loggen_local_executor import LoggenLocalExecutor
 from axosyslog_light.message_builder.bsd_format import BSDFormat
 from axosyslog_light.message_builder.log_message import LogMessage
 from axosyslog_light.syslog_ng.syslog_ng import SyslogNg
@@ -266,6 +269,15 @@ def setup(request):
     copy_file(testcase_parameters.get_testcase_file(), Path.cwd())
     light_extra_files(Path.cwd())
     request.addfinalizer(lambda: logger.info("Report file path\n{}\n".format(calculate_report_file_path(Path.cwd()))))
+
+    if request.config.getoption("--runner") == "docker":
+        LoggenExecutor.set_default_executor(
+            LoggenDockerExecutor(request.config.getoption("--docker-image")),
+        )
+    elif request.config.getoption("--runner") == "local":
+        LoggenExecutor.set_default_executor(
+            LoggenLocalExecutor(Path(request.config.getoption("--installdir"), "bin", "loggen")),
+        )
 
 
 class PortAllocator():

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -26,7 +26,6 @@ import argparse
 import logging
 import os
 import re
-import subprocess
 from datetime import datetime
 from pathlib import Path
 
@@ -198,12 +197,9 @@ def log_message():
     return LogMessage()
 
 
-@pytest.fixture(scope="session")
-def version(request):
-    installdir = request.config.getoption("--installdir")
-    binary_path = str(Path(installdir, "sbin", "syslog-ng"))
-    version_output = subprocess.check_output([binary_path, "--version"]).decode()
-    return version_output.splitlines()[1].split()[2]
+@pytest.fixture
+def version(syslog_ng):
+    return syslog_ng.get_version()
 
 
 @pytest.fixture

--- a/tests/light/src/axosyslog_light/helpers/loggen/loggen.py
+++ b/tests/light/src/axosyslog_light/helpers/loggen/loggen.py
@@ -21,123 +21,14 @@
 #
 #############################################################################
 import typing
-from dataclasses import dataclass
 from pathlib import Path
 
-import axosyslog_light.testcase_parameters.testcase_parameters as tc_parameters
-from axosyslog_light.executors.process_executor import ProcessExecutor
+from axosyslog_light.helpers.loggen.loggen_executor import LoggenExecutor
+from axosyslog_light.helpers.loggen.loggen_executor import LoggenStartParams
 from psutil import Popen
-from psutil import TimeoutExpired
-
-
-@dataclass
-class LoggenStartParams:
-    target: str
-    port: int
-    inet: bool = False
-    unix: bool = False
-    stream: bool = False
-    dgram: bool = False
-    use_ssl: bool = False
-    dont_parse: bool = False
-    read_file: typing.Optional[Path] = None
-    skip_tokens: typing.Optional[str] = None
-    loop_reading: bool = False
-    rate: typing.Optional[int] = None
-    interval: typing.Optional[int] = None
-    permanent: bool = None
-    syslog_proto: bool = None
-    proxied: typing.Optional[int] = None
-    sdata: bool = False
-    no_framing: bool = False
-    active_connections: typing.Optional[int] = None
-    idle_connections: typing.Optional[int] = None
-    ipv6: bool = False
-    debug: bool = False
-    number: typing.Optional[int] = None
-    csv: bool = False
-    quiet: bool = False
-    size: typing.Optional[int] = None
-    reconnect: bool = False
-    proxied_tls_passthrough: bool = False
-    proxy_src_ip: typing.Optional[str] = None
-    proxy_dst_ip: typing.Optional[str] = None
-    proxy_src_port: typing.Optional[int] = None
-    proxy_dst_port: typing.Optional[int] = None
-
-    def format(self) -> typing.List[str]:
-        params = []
-        if self.inet is True:
-            params.append("--inet")
-        if self.unix is True:
-            params.append("--unix")
-        if self.stream is True:
-            params.append("--stream")
-        if self.dgram is True:
-            params.append("--dgram")
-        if self.use_ssl is True:
-            params.append("--use-ssl")
-        if self.dont_parse is True:
-            params.append("--dont-parse")
-        if self.read_file is not None:
-            params.append(f"--read-file={self.read_file}")
-        if self.skip_tokens is not None:
-            params.append(f"--skip-tokens={self.skip_tokens}")
-        if self.loop_reading is True:
-            params.append("--loop-reading")
-        if self.rate is not None:
-            params.append(f"--rate={self.rate}")
-        if self.interval is not None:
-            params.append(f"--interval={self.interval}")
-        if self.permanent is True:
-            params.append("--permanent")
-        if self.syslog_proto is True:
-            params.append("--syslog-proto")
-        if self.proxied is True:
-            params.append("--proxied")
-        if self.proxied is not None:
-            if self.proxied not in {1, 2}:
-                raise ValueError(f"Proxied version must be 1 or 2, got {self.proxied}")
-            params.append(f"--proxied={self.proxied}")
-        if self.proxy_src_ip is not None:
-            params.append(f"--proxy-src-ip={self.proxy_src_ip}")
-        if self.proxy_dst_ip is not None:
-            params.append(f"--proxy-dst-ip={self.proxy_dst_ip}")
-        if self.proxy_src_port is not None:
-            params.append(f"--proxy-src-port={self.proxy_src_port}")
-        if self.proxy_dst_port is not None:
-            params.append(f"--proxy-dst-port={self.proxy_dst_port}")
-        if self.proxied_tls_passthrough is True:
-            params.append("--proxied-tls-passthrough")
-        if self.sdata is True:
-            params.append("--sdata")
-        if self.no_framing is True:
-            params.append("--no-framing")
-        if self.active_connections is not None:
-            params.append(f"--active-connections={self.active_connections}")
-        if self.idle_connections is not None:
-            params.append(f"--idle-connections={self.idle_connections}")
-        if self.ipv6 is True:
-            params.append("--ipv6")
-        if self.debug is True:
-            params.append("--debug")
-        if self.number is not None:
-            params.append(f"--number={self.number}")
-        if self.csv is True:
-            params.append("--csv")
-        if self.quiet is True:
-            params.append("--quiet")
-        if self.size is not None:
-            params.append(f"--size={self.size}")
-        if self.reconnect is True:
-            params.append("--reconnect")
-        params.append(self.target)
-        params.append(str(self.port))
-        return params
 
 
 class Loggen(object):
-
     instanceIndex = -1
 
     @staticmethod
@@ -145,38 +36,25 @@ class Loggen(object):
         Loggen.instanceIndex += 1
         return Loggen.instanceIndex
 
-    def __init__(self):
-        self.loggen_proc = None
-        self.loggen_bin_path = tc_parameters.INSTANCE_PATH.get_loggen_bin()
+    def __init__(self, loggen_executor: typing.Optional[LoggenExecutor] = None):
+        if loggen_executor is None:
+            loggen_executor = LoggenExecutor.get_default_executor()
+
+        if not loggen_executor:
+            raise Exception("Loggen executor is not available")
+
+        self.executor = loggen_executor
 
     def start(self, start_params: LoggenStartParams) -> Popen:
-        if self.loggen_proc is not None and self.loggen_proc.is_running():
-            raise Exception("Loggen is already running, you shouldn't call start")
+        instance_index = Loggen.__get_new_instance_index()
+        self.loggen_stdout_path = Path("loggen_stdout_{}".format(instance_index))
+        self.loggen_stderr_path = Path("loggen_stderr_{}".format(instance_index))
+        return self.executor.start(start_params, self.loggen_stderr_path, self.loggen_stdout_path, instance_index)
 
-        instanceIndex = Loggen.__get_new_instance_index()
-        self.loggen_stdout_path = Path("loggen_stdout_{}".format(instanceIndex))
-        self.loggen_stderr_path = Path("loggen_stderr_{}".format(instanceIndex))
-        self.loggen_proc = ProcessExecutor().start(
-            [self.loggen_bin_path] + start_params.format(),
-            self.loggen_stdout_path,
-            self.loggen_stderr_path,
-        )
+    def stop(self) -> None:
+        self.executor.stop()
 
-        return self.loggen_proc
-
-    def stop(self):
-        if self.loggen_proc is None:
-            return
-
-        self.loggen_proc.terminate()
-        try:
-            self.loggen_proc.wait(4)
-        except TimeoutExpired:
-            self.loggen_proc.kill()
-
-        self.loggen_proc = None
-
-    def get_sent_message_count(self):
+    def get_sent_message_count(self) -> int:
         if not self.loggen_stderr_path.exists():
             return 0
 

--- a/tests/light/src/axosyslog_light/helpers/loggen/loggen_docker_executor.py
+++ b/tests/light/src/axosyslog_light/helpers/loggen/loggen_docker_executor.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2025 Axoflow
+# Copyright (c) 2025 Attila Szakacs <attila.szakacs@axoflow.com>
+# Copyright (c) 2020 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from __future__ import annotations
+
+import os
+import typing
+from pathlib import Path
+
+from axosyslog_light.executors.process_executor import ProcessExecutor
+from axosyslog_light.helpers.loggen.loggen_executor import LoggenExecutor
+from axosyslog_light.helpers.loggen.loggen_executor import LoggenStartParams
+from psutil import Popen
+
+
+class LoggenDockerExecutor(LoggenExecutor):
+    def __init__(self, image_name: str) -> None:
+        self.__image_name = image_name
+        super().__init__()
+
+    def _start(self, start_params: LoggenStartParams, stderr: Path, stdout: Path, instance_index: int) -> Popen:
+        paths: typing.Set[Path] = {
+            Path.cwd().absolute(),
+        }
+        if start_params.read_file:
+            paths.add(Path(start_params.read_file).parent.absolute())
+
+        command = ["docker", "run", "--rm", "-i"]
+        command += ["--entrypoint", "loggen"]
+        command += ["--name", f"loggen_{instance_index}"]
+        command += ["--workdir", str(Path.cwd().absolute())]
+        command += ["--user", f"{os.getuid()}:{os.getgid()}"]
+        command += ["-e", f"PUID={os.getuid()}", "-e", f"PGID={os.getgid()}"]
+        command += ["--network", "host"]
+
+        for path in paths:
+            command += ["-v", f"{path}:{path}"]
+
+        command += [self.__image_name]
+        command += start_params.format()
+
+        return ProcessExecutor().start(command, stdout, stderr)
+
+    def _copy(self) -> LoggenExecutor:
+        return LoggenDockerExecutor(self.__image_name)

--- a/tests/light/src/axosyslog_light/helpers/loggen/loggen_executor.py
+++ b/tests/light/src/axosyslog_light/helpers/loggen/loggen_executor.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2025 Axoflow
+# Copyright (c) 2025 Attila Szakacs <attila.szakacs@axoflow.com>
+# Copyright (c) 2020 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from __future__ import annotations
+
+import typing
+from abc import ABC
+from abc import abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+
+from psutil import Popen
+from psutil import TimeoutExpired
+
+
+@dataclass
+class LoggenStartParams:
+    target: str
+    port: int
+    inet: bool = False
+    unix: bool = False
+    stream: bool = False
+    dgram: bool = False
+    use_ssl: bool = False
+    dont_parse: bool = False
+    read_file: typing.Optional[Path] = None
+    skip_tokens: typing.Optional[str] = None
+    loop_reading: bool = False
+    rate: typing.Optional[int] = None
+    interval: typing.Optional[int] = None
+    permanent: bool = None
+    syslog_proto: bool = None
+    proxied: typing.Optional[int] = None
+    sdata: bool = False
+    no_framing: bool = False
+    active_connections: typing.Optional[int] = None
+    idle_connections: typing.Optional[int] = None
+    ipv6: bool = False
+    debug: bool = False
+    number: typing.Optional[int] = None
+    csv: bool = False
+    quiet: bool = False
+    size: typing.Optional[int] = None
+    reconnect: bool = False
+    proxied_tls_passthrough: bool = False
+    proxy_src_ip: typing.Optional[str] = None
+    proxy_dst_ip: typing.Optional[str] = None
+    proxy_src_port: typing.Optional[int] = None
+    proxy_dst_port: typing.Optional[int] = None
+
+    def format(self) -> typing.List[str]:
+        params = []
+        if self.inet is True:
+            params.append("--inet")
+        if self.unix is True:
+            params.append("--unix")
+        if self.stream is True:
+            params.append("--stream")
+        if self.dgram is True:
+            params.append("--dgram")
+        if self.use_ssl is True:
+            params.append("--use-ssl")
+        if self.dont_parse is True:
+            params.append("--dont-parse")
+        if self.read_file is not None:
+            params.append(f"--read-file={self.read_file}")
+        if self.skip_tokens is not None:
+            params.append(f"--skip-tokens={self.skip_tokens}")
+        if self.loop_reading is True:
+            params.append("--loop-reading")
+        if self.rate is not None:
+            params.append(f"--rate={self.rate}")
+        if self.interval is not None:
+            params.append(f"--interval={self.interval}")
+        if self.permanent is True:
+            params.append("--permanent")
+        if self.syslog_proto is True:
+            params.append("--syslog-proto")
+        if self.proxied is True:
+            params.append("--proxied")
+        if self.proxied is not None:
+            if self.proxied not in {1, 2}:
+                raise ValueError(f"Proxied version must be 1 or 2, got {self.proxied}")
+            params.append(f"--proxied={self.proxied}")
+        if self.proxy_src_ip is not None:
+            params.append(f"--proxy-src-ip={self.proxy_src_ip}")
+        if self.proxy_dst_ip is not None:
+            params.append(f"--proxy-dst-ip={self.proxy_dst_ip}")
+        if self.proxy_src_port is not None:
+            params.append(f"--proxy-src-port={self.proxy_src_port}")
+        if self.proxy_dst_port is not None:
+            params.append(f"--proxy-dst-port={self.proxy_dst_port}")
+        if self.proxied_tls_passthrough is True:
+            params.append("--proxied-tls-passthrough")
+        if self.sdata is True:
+            params.append("--sdata")
+        if self.no_framing is True:
+            params.append("--no-framing")
+        if self.active_connections is not None:
+            params.append(f"--active-connections={self.active_connections}")
+        if self.idle_connections is not None:
+            params.append(f"--idle-connections={self.idle_connections}")
+        if self.ipv6 is True:
+            params.append("--ipv6")
+        if self.debug is True:
+            params.append("--debug")
+        if self.number is not None:
+            params.append(f"--number={self.number}")
+        if self.csv is True:
+            params.append("--csv")
+        if self.quiet is True:
+            params.append("--quiet")
+        if self.size is not None:
+            params.append(f"--size={self.size}")
+        if self.reconnect is True:
+            params.append("--reconnect")
+        params.append(self.target)
+        params.append(str(self.port))
+        return params
+
+
+class LoggenExecutor(ABC):
+    DEFAULT_EXECUTOR: typing.Optional[LoggenExecutor] = None
+
+    def __init__(self) -> None:
+        self.proc: typing.Optional[Popen] = None
+
+    @staticmethod
+    def set_default_executor(loggen_executor: LoggenExecutor) -> None:
+        LoggenExecutor.DEFAULT_EXECUTOR = loggen_executor.copy()
+
+    @staticmethod
+    def get_default_executor() -> typing.Optional[LoggenExecutor]:
+        if LoggenExecutor.DEFAULT_EXECUTOR is None:
+            return None
+        return LoggenExecutor.DEFAULT_EXECUTOR.copy()
+
+    def copy(self) -> LoggenExecutor:
+        if self.proc is not None:
+            raise Exception("You shouldn't copy a running executor")
+        return self._copy()
+
+    def start(self, start_params: LoggenStartParams, stderr: Path, stdout: Path, instance_index: int) -> Popen:
+        if self.proc is not None and self.proc.is_running():
+            raise Exception("Loggen is already running, you shouldn't call start")
+        self.proc = self._start(start_params, stderr, stdout, instance_index)
+        return self.proc
+
+    def stop(self) -> None:
+        if self.proc is None:
+            return
+
+        self.proc.terminate()
+        try:
+            self.proc.wait(4)
+        except TimeoutExpired:
+            self.proc.kill()
+
+        self.proc = None
+
+    @abstractmethod
+    def _copy(self) -> LoggenExecutor:
+        pass
+
+    @abstractmethod
+    def _start(self, start_params: LoggenStartParams, stderr: Path, stdout: Path) -> Popen:
+        pass

--- a/tests/light/src/axosyslog_light/helpers/loggen/loggen_local_executor.py
+++ b/tests/light/src/axosyslog_light/helpers/loggen/loggen_local_executor.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2025 Axoflow
+# Copyright (c) 2025 Attila Szakacs <attila.szakacs@axoflow.com>
+# Copyright (c) 2020 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from __future__ import annotations
+
+from pathlib import Path
+
+from axosyslog_light.executors.process_executor import ProcessExecutor
+from axosyslog_light.helpers.loggen.loggen_executor import LoggenExecutor
+from axosyslog_light.helpers.loggen.loggen_executor import LoggenStartParams
+from psutil import Popen
+
+
+class LoggenLocalExecutor(LoggenExecutor):
+    def __init__(self, loggen_binary_path: Path) -> None:
+        self.__binary_path = loggen_binary_path
+        super().__init__()
+
+    def _start(self, start_params: LoggenStartParams, stderr: Path, stdout: Path, instance_index: int) -> Popen:
+        return ProcessExecutor().start([self.__binary_path] + start_params.format(), stdout, stderr)
+
+    def _copy(self) -> LoggenExecutor:
+        return LoggenLocalExecutor(self.__binary_path)

--- a/tests/light/src/axosyslog_light/syslog_ng/syslog_ng.py
+++ b/tests/light/src/axosyslog_light/syslog_ng/syslog_ng.py
@@ -146,6 +146,27 @@ class SyslogNg(object):
                 return version_output_line.split()[2]
         raise Exception("Can not parse 'Config version' from 'syslog-ng --version'")
 
+    def get_version(self) -> str:
+        stdout_path = Path(f"syslog_ng_{self.instance_paths.get_instance_name()}_version_stdout")
+        stderr_path = Path(f"syslog_ng_{self.instance_paths.get_instance_name()}_version_stderr")
+
+        start_params = copy(self.start_params)
+        start_params.version = True
+
+        process = self.__syslog_ng_executor.run_process(
+            start_params=start_params,
+            stderr_path=stderr_path,
+            stdout_path=stdout_path,
+        )
+        returncode = process.wait()
+        if returncode != 0:
+            raise Exception(f"Cannot get syslog-ng version. Process returned with {returncode}. See {stderr_path.absolute()} for details")
+
+        try:
+            return stdout_path.read_text().splitlines()[1].split()[2]
+        except IndexError:
+            raise Exception("Can not parse 'Config version' from 'syslog-ng --version'")
+
     def is_process_running(self) -> bool:
         return self.__process and self.__process.poll() is None
 

--- a/tests/light/src/axosyslog_light/syslog_ng/syslog_ng_docker_executor.py
+++ b/tests/light/src/axosyslog_light/syslog_ng/syslog_ng_docker_executor.py
@@ -33,10 +33,12 @@ from axosyslog_light.syslog_ng.syslog_ng_executor import SyslogNgStartParams
 
 
 class SyslogNgDockerExecutor(SyslogNgExecutor):
-    def __init__(self, container_name: str, image_name: str) -> None:
+    def __init__(self, container_name: str, image_name: str, extra_volume_mounts: typing.Set[typing.Tuple[str, str]] = None, extra_env_vars: typing.Optional[dict] = None) -> None:
         self.__process_executor = ProcessExecutor()
         self.__container_name = container_name
         self.__image_name = image_name
+        self.__extra_volume_mounts = extra_volume_mounts
+        self.__extra_env_vars = extra_env_vars
 
     def run_process(
         self,
@@ -63,6 +65,14 @@ class SyslogNgDockerExecutor(SyslogNgExecutor):
 
         for path in paths:
             command += ["-v", f"{path}:{path}"]
+
+        if self.__extra_env_vars:
+            for key, value in self.__extra_env_vars.items():
+                command += ["-e", f"{key}={value}"]
+
+        if self.__extra_volume_mounts:
+            for host_path, container_path in self.__extra_volume_mounts:
+                command += ["-v", f"{host_path}:{container_path}"]
 
         command += [self.__image_name]
         command += start_params.format()

--- a/tests/light/src/axosyslog_light/syslog_ng/syslog_ng_paths.py
+++ b/tests/light/src/axosyslog_light/syslog_ng/syslog_ng_paths.py
@@ -35,12 +35,7 @@ class SyslogNgPaths(object):
         if self.__instance_name is not None:
             raise Exception("Instance already configured")
         self.__instance_name = instance_name
-        install_dir = self.__testcase_parameters.get_install_dir()
-        if not install_dir:
-            raise ValueError("Missing --installdir start parameter")
-
         self.__syslog_ng_paths = {
-            "dirs": {"install_dir": Path(install_dir)},
             "file_paths": {
                 "config_path": Path("syslog_ng_{}.conf".format(instance_name)),
                 "persist_path": Path("syslog_ng_{}.persist".format(instance_name)),
@@ -49,14 +44,25 @@ class SyslogNgPaths(object):
                 "stderr": Path("syslog_ng_{}_stderr".format(instance_name)),
                 "stdout": Path("syslog_ng_{}_stdout".format(instance_name)),
             },
-            "binary_file_paths": {
-                "slogkey": Path(install_dir, "bin", "slogkey"),
-                "slogverify": Path(install_dir, "bin", "slogverify"),
-                "syslog_ng_binary": Path(install_dir, "sbin", "syslog-ng"),
-                "syslog_ng_ctl": Path(install_dir, "sbin", "syslog-ng-ctl"),
-                "loggen": Path(install_dir, "bin", "loggen"),
-            },
         }
+
+        try:
+            install_dir = self.__testcase_parameters.get_install_dir()
+            self.__syslog_ng_paths.update(
+                {
+                    "dirs": {"install_dir": install_dir},
+                    "binary_file_paths": {
+                        "slogkey": Path(install_dir, "bin", "slogkey"),
+                        "slogverify": Path(install_dir, "bin", "slogverify"),
+                        "syslog_ng_binary": Path(install_dir, "sbin", "syslog-ng"),
+                        "syslog_ng_ctl": Path(install_dir, "sbin", "syslog-ng-ctl"),
+                        "loggen": Path(install_dir, "bin", "loggen"),
+                    },
+                },
+            )
+        except KeyError:
+            pass
+
         return self
 
     def get_instance_name(self):

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/file_destination.py
@@ -54,5 +54,8 @@ class FileDestination(DestinationDriver):
     def read_until_logs(self, logs):
         return self.io.read_until_messages(logs)
 
+    def read_all(self):
+        return self.io.read_all()
+
     def close_file(self):
         self.io.close_readable_file()

--- a/tests/light/src/axosyslog_light/testcase_parameters/testcase_parameters.py
+++ b/tests/light/src/axosyslog_light/testcase_parameters/testcase_parameters.py
@@ -34,7 +34,6 @@ class TestcaseParameters(object):
         absolute_framework_dir = Path(__file__).parents[3]
         self.testcase_parameters = {
             "dirs": {
-                "install_dir": Path(pytest_request.config.getoption("installdir")),
                 "shared_dir": Path(absolute_framework_dir, "shared_files"),
             },
             "file_paths": {
@@ -43,6 +42,12 @@ class TestcaseParameters(object):
             "testcase_name": testcase_name,
             "external_tool": pytest_request.config.getoption("run_under"),
         }
+
+        try:
+            install_dir = pytest_request.config.getoption("installdir")
+            self.testcase_parameters["dirs"]["install_dir"] = Path(install_dir)
+        except TypeError:
+            pass
 
     def get_install_dir(self):
         return self.testcase_parameters["dirs"]["install_dir"]


### PR DESCRIPTION
Alternative to #556 

---

The `Loggen` instance can now be instantiated with any `LoggenExecutor`, should it be `LoggenLocalExecutor` or `LoggenDockerExecutor`.

As `Loggen` is not instance specific (we can assume all syslog-ng instances have the same loggen), during the setup of the test runs, we store a `LoggenExecutor` globally from the `server` instance, and it is used for all subsequent `Loggen` constructors, if it is not overridden.

---

This PR also fixes missing `--installdir`, which can occur if we are using `docker` runner.

---

This PR also fixes a flakyness in one E2E test.

---

I have executed the E2E tests without `--installdir` with `docker` runner, and the only failing testcase is a `slog` related one, which is expected, as we cannot execute `slog` from docker right now.

Full run:
<details>

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0 -- /home/alltilla/.cache/pypoetry/virtualenvs/axosyslog-light-9lXcjrrb-py3.12/bin/python
cachedir: .pytest_cache
rootdir: /home/alltilla/repos/axosyslog/tests/light
configfile: pytest.ini
plugins: mock-3.14.0
collecting ... collected 392 items

functional_tests/config_change/test_backtick_substitution.py::test_backtick_substitution PASSED [  0%]
functional_tests/config_change/test_manipulating_config_between_reload.py::test_manipulating_config_between_reload PASSED [  0%]
functional_tests/config_change/test_python_custom_options.py::test_python_custom_options PASSED [  0%]
functional_tests/destination_drivers/example_destination/test_example_destination.py::test_example_destination_parser PASSED [  1%]
functional_tests/destination_drivers/network_destination/test_kept_alive_tls_connection_doing_handshake_after_reload.py::test_kept_alive_tls_connection_doing_handshake_after_reload PASSED [  1%]
functional_tests/destination_drivers/network_destination/test_network_destination_transport.py::test_network_destination_transport[default] PASSED [  1%]
functional_tests/destination_drivers/network_destination/test_network_destination_transport.py::test_network_destination_transport[tcp] PASSED [  1%]
functional_tests/destination_drivers/network_destination/test_network_destination_transport.py::test_network_destination_transport[udp] PASSED [  2%]
functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_acceptance.py::test_snmp_dest_acceptance PASSED [  2%]
functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_missing_snmp_obj.py::test_snmp_dest_missing_snmp_obj PASSED [  2%]
functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_missing_trap_obj.py::test_snmp_dest_missing_trap_obj PASSED [  2%]
functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_reload_statistics.py::test_snmp_dest_reload_stat PASSED [  3%]
functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_wrong_version.py::test_snmp_dest_wrong_version PASSED [  3%]
functional_tests/destination_drivers/snmp_destination/v2c/test_snmp_destination_v2c_cisco_ios_traps.py::test_snmp_dest_v2c_cisco_ios_trap PASSED [  3%]
functional_tests/destination_drivers/snmp_destination/v2c/test_snmp_destination_v2c_custom_community.py::test_snmp_dest_v2c_custom_community PASSED [  3%]
functional_tests/destination_drivers/snmp_destination/v2c/test_snmp_destination_v2c_using_macro_snmp_obj.py::test_snmp_dest_v2c_using_macros_in_snmp_obj PASSED [  4%]
functional_tests/destination_drivers/unix_dgram_destination/test_unix_dgram_destination.py::test_unix_dgram_destination PASSED [  4%]
functional_tests/destination_drivers/unix_stream_destination/test_unix_stream_destination.py::test_unix_stream_destination PASSED [  4%]
functional_tests/filters/rate-limit/test_rate_limit_filter_acceptance.py::test_rate_limit_filter_acceptance[rate_limit_filter_1] PASSED [  4%]
functional_tests/filters/rate-limit/test_rate_limit_filter_acceptance.py::test_rate_limit_filter_acceptance[rate_limit_filter_2] PASSED [  5%]
functional_tests/filters/rate-limit/test_rate_limit_filter_acceptance.py::test_rate_limit_filter_acceptance[rate_limit_filter_3] PASSED [  5%]
functional_tests/filters/rate-limit/test_rate_limit_filter_acceptance.py::test_rate_limit_filter_acceptance[rate_limit_filter_4] PASSED [  5%]
functional_tests/filters/test_filter_reference.py::test_filter_multiple_reference PASSED [  5%]
functional_tests/filters/test_multiple_filters.py::test_multiple_filters_implicit_and PASSED [  6%]
functional_tests/filterx/test_filterx.py::test_otel_logrecord_int32_setter_getter PASSED [  6%]
functional_tests/filterx/test_filterx.py::test_otel_logrecord_string_setter_getter PASSED [  6%]
functional_tests/filterx/test_filterx.py::test_otel_logrecord_bytes_setter_getter PASSED [  6%]
functional_tests/filterx/test_filterx.py::test_otel_logrecord_datetime_setter_getter PASSED [  7%]
functional_tests/filterx/test_filterx.py::test_otel_logrecord_body_string_setter_getter PASSED [  7%]
functional_tests/filterx/test_filterx.py::test_otel_logrecord_body_bool_setter_getter PASSED [  7%]
functional_tests/filterx/test_filterx.py::test_otel_logrecord_body_int_setter_getter PASSED [  7%]
functional_tests/filterx/test_filterx.py::test_otel_logrecord_body_double_setter_getter PASSED [  8%]
functional_tests/filterx/test_filterx.py::test_otel_logrecord_body_datetime_setter_getter PASSED [  8%]
functional_tests/filterx/test_filterx.py::test_otel_logrecord_body_bytes_setter_getter PASSED [  8%]
functional_tests/filterx/test_filterx.py::test_otel_logrecord_body_protobuf_setter_getter PASSED [  8%]
functional_tests/filterx/test_filterx.py::test_otel_logrecord_body_json_setter_getter PASSED [  9%]
functional_tests/filterx/test_filterx.py::test_json_to_otel PASSED       [  9%]
functional_tests/filterx/test_filterx.py::test_otel_to_json PASSED       [  9%]
functional_tests/filterx/test_filterx.py::test_otel_resource_scope_log_to_json PASSED [  9%]
functional_tests/filterx/test_filterx.py::test_json_to_otel_resource_scope_log PASSED [ 10%]
functional_tests/filterx/test_filterx.py::test_simple_true_condition PASSED [ 10%]
functional_tests/filterx/test_filterx.py::test_empty_block PASSED        [ 10%]
functional_tests/filterx/test_filterx.py::test_simple_false_condition PASSED [ 10%]
functional_tests/filterx/test_filterx.py::test_simple_assignment PASSED  [ 11%]
functional_tests/filterx/test_filterx.py::test_json_assignment_from_template PASSED [ 11%]
functional_tests/filterx/test_filterx.py::test_json_assignment_from_another_name_value_pair PASSED [ 11%]
functional_tests/filterx/test_filterx.py::test_json_getattr_returns_the_embedded_json PASSED [ 11%]
functional_tests/filterx/test_filterx.py::test_json_setattr_sets_the_embedded_json PASSED [ 12%]
functional_tests/filterx/test_filterx.py::test_json_assign_performs_a_deep_copy PASSED [ 12%]
functional_tests/filterx/test_filterx.py::test_json_simple_literal_assignment PASSED [ 12%]
functional_tests/filterx/test_filterx.py::test_json_recursive_literal_assignment PASSED [ 13%]
functional_tests/filterx/test_filterx.py::test_json_change_recursive_literal PASSED [ 13%]
functional_tests/filterx/test_filterx.py::test_list_literal_becomes_syslogng_list_as_string PASSED [ 13%]
functional_tests/filterx/test_filterx.py::test_list_literal_becomes_json_list_as_a_part_of_json PASSED [ 13%]
functional_tests/filterx/test_filterx.py::test_list_is_cloned_upon_assignment PASSED [ 14%]
functional_tests/filterx/test_filterx.py::test_list_subscript_without_index_appends_an_element PASSED [ 14%]
functional_tests/filterx/test_filterx.py::test_list_set_subscript_with_tail_element_appends_an_element PASSED [ 14%]
functional_tests/filterx/test_filterx.py::test_literal_generator_assignment PASSED [ 14%]
functional_tests/filterx/test_filterx.py::test_literal_generator_casted_assignment PASSED [ 15%]
functional_tests/filterx/test_filterx.py::test_function_call PASSED      [ 15%]
functional_tests/filterx/test_filterx.py::test_ternary_operator_true PASSED [ 15%]
functional_tests/filterx/test_filterx.py::test_ternary_operator_false PASSED [ 15%]
functional_tests/filterx/test_filterx.py::test_ternary_operator_expression_true PASSED [ 16%]
functional_tests/filterx/test_filterx.py::test_ternary_operator_expression_false PASSED [ 16%]
functional_tests/filterx/test_filterx.py::test_ternary_operator_inline_ternary_expression_true PASSED [ 16%]
functional_tests/filterx/test_filterx.py::test_ternary_operator_inline_ternary_expression_false PASSED [ 16%]
functional_tests/filterx/test_filterx.py::test_ternary_return_condition_expression_value_without_true_branch PASSED [ 17%]
functional_tests/filterx/test_filterx.py::test_isset_existing_value_not_in_scope_yet PASSED [ 17%]
functional_tests/filterx/test_filterx.py::test_isset_existing_value_already_in_scope PASSED [ 17%]
functional_tests/filterx/test_filterx.py::test_isset_inexisting_value_not_in_scope_yet PASSED [ 17%]
functional_tests/filterx/test_filterx.py::test_isset_inexisting_value_already_in_scope PASSED [ 18%]
functional_tests/filterx/test_filterx.py::test_isset PASSED              [ 18%]
functional_tests/filterx/test_filterx.py::test_unset_value_not_in_scope_yet PASSED [ 18%]
functional_tests/filterx/test_filterx.py::test_unset_value_already_in_scope PASSED [ 18%]
functional_tests/filterx/test_filterx.py::test_unset_existing_key PASSED [ 19%]
functional_tests/filterx/test_filterx.py::test_unset_inexisting_key PASSED [ 19%]
functional_tests/filterx/test_filterx.py::test_setting_an_unset_key_will_contain_the_right_value PASSED [ 19%]
functional_tests/filterx/test_filterx.py::test_unset PASSED              [ 19%]
functional_tests/filterx/test_filterx.py::test_strptime_error_result PASSED [ 20%]
functional_tests/filterx/test_filterx.py::test_strftime_error_result PASSED [ 20%]
functional_tests/filterx/test_filterx.py::test_strptime_success_result PASSED [ 20%]
functional_tests/filterx/test_filterx.py::test_strftime_success_result PASSED [ 20%]
functional_tests/filterx/test_filterx.py::test_strptime_guess_missing_year PASSED [ 21%]
functional_tests/filterx/test_filterx.py::test_strptime_failure_result PASSED [ 21%]
functional_tests/filterx/test_filterx.py::test_set_timestamp_wrong_param_error_result PASSED [ 21%]
functional_tests/filterx/test_filterx.py::test_set_timestamp_invalid_stamp_value_error_result PASSED [ 21%]
functional_tests/filterx/test_filterx.py::test_set_timestamp_set_stamp PASSED [ 22%]
functional_tests/filterx/test_filterx.py::test_set_timestamp_set_stamp_default PASSED [ 22%]
functional_tests/filterx/test_filterx.py::test_set_timestamp_set_recvd PASSED [ 22%]
functional_tests/filterx/test_filterx.py::test_set_pri_no_arg_error_result PASSED [ 22%]
functional_tests/filterx/test_filterx.py::test_set_pri_wrong_arg_set_error_result PASSED [ 23%]
functional_tests/filterx/test_filterx.py::test_set_pri_wrong_value PASSED [ 23%]
functional_tests/filterx/test_filterx.py::test_set_pri_succes_result PASSED [ 23%]
functional_tests/filterx/test_filterx.py::test_len PASSED                [ 23%]
functional_tests/filterx/test_filterx.py::test_regexp_match PASSED       [ 24%]
functional_tests/filterx/test_filterx.py::test_regexp_nomatch PASSED     [ 24%]
functional_tests/filterx/test_filterx.py::test_regexp_match_error_in_pattern PASSED [ 24%]
functional_tests/filterx/test_filterx.py::test_regexp_search PASSED      [ 25%]
functional_tests/filterx/test_filterx.py::test_regexp_search_error_in_pattern PASSED [ 25%]
functional_tests/filterx/test_filterx.py::test_parse_kv_default_option_set_is_skippable PASSED [ 25%]
functional_tests/filterx/test_filterx.py::test_parse_kv_value_separator PASSED [ 25%]
functional_tests/filterx/test_filterx.py::test_parse_kv_value_separator_use_first_character PASSED [ 26%]
functional_tests/filterx/test_filterx.py::test_parse_kv_pair_separator PASSED [ 26%]
functional_tests/filterx/test_filterx.py::test_parse_kv_stray_words_value_name PASSED [ 26%]
functional_tests/filterx/test_filterx.py::test_parse_csv_default_arguments PASSED [ 26%]
functional_tests/filterx/test_filterx.py::test_parse_csv_optional_arg_columns PASSED [ 27%]
functional_tests/filterx/test_filterx.py::test_parse_csv_optional_arg_delimiters PASSED [ 27%]
functional_tests/filterx/test_filterx.py::test_parse_csv_optional_arg_non_greedy PASSED [ 27%]
functional_tests/filterx/test_filterx.py::test_parse_csv_optional_arg_greedy PASSED [ 27%]
functional_tests/filterx/test_filterx.py::test_parse_csv_optional_arg_strip_whitespace PASSED [ 28%]
functional_tests/filterx/test_filterx.py::test_parse_csv_dialect PASSED  [ 28%]
functional_tests/filterx/test_filterx.py::test_vars PASSED               [ 28%]
functional_tests/filterx/test_filterx.py::test_load_vars PASSED          [ 28%]
functional_tests/filterx/test_filterx.py::test_macro_caching PASSED      [ 29%]
functional_tests/filterx/test_filterx.py::test_unset_empties PASSED      [ 29%]
functional_tests/filterx/test_filterx.py::test_null_coalesce_use_default_on_null PASSED [ 29%]
functional_tests/filterx/test_filterx.py::test_nullv_coalesce_assignment PASSED [ 29%]
functional_tests/filterx/test_filterx.py::test_null_coalesce_use_default_on_error_and_supress_error PASSED [ 30%]
functional_tests/filterx/test_filterx.py::test_null_coalesce_get_happy_paths PASSED [ 30%]
functional_tests/filterx/test_filterx.py::test_null_coalesce_get_subscript_error PASSED [ 30%]
functional_tests/filterx/test_filterx.py::test_null_coalesce_use_nested_coalesce PASSED [ 30%]
functional_tests/filterx/test_filterx.py::test_null_coalesce_use_nested_coalesce_return_mid_match PASSED [ 31%]
functional_tests/filterx/test_filterx.py::test_null_coalesce_do_not_supress_last_error PASSED [ 31%]
functional_tests/filterx/test_filterx.py::test_null_coalesce_precedence_versus_ternary PASSED [ 31%]
functional_tests/filterx/test_filterx.py::test_slash_string_features PASSED [ 31%]
functional_tests/filterx/test_filterx.py::test_regexp_subst PASSED       [ 32%]
functional_tests/filterx/test_filterx.py::test_regexp_subst_all_args_are_mandatory PASSED [ 32%]
functional_tests/filterx/test_filterx.py::test_add_operator_for_base_types PASSED [ 32%]
functional_tests/filterx/test_filterx.py::test_flatten PASSED            [ 32%]
functional_tests/filterx/test_filterx.py::test_add_operator_for_generators PASSED [ 33%]
functional_tests/filterx/test_filterx.py::test_plus_equal_grammar_rules PASSED [ 33%]
functional_tests/filterx/test_filterx.py::test_get_sdata PASSED          [ 33%]
functional_tests/filterx/test_filterx.py::test_list_range_check_with_nulls PASSED [ 33%]
functional_tests/filterx/test_filterx.py::test_list_range_check_out_of_range PASSED [ 34%]
functional_tests/filterx/test_filterx.py::test_parse_xml PASSED          [ 34%]
functional_tests/filterx/test_filterx.py::test_parse_windows_eventlog_xml PASSED [ 34%]
functional_tests/filterx/test_filterx.py::test_parse_cef PASSED          [ 34%]
functional_tests/filterx/test_filterx.py::test_parse_leef PASSED         [ 35%]
functional_tests/filterx/test_filterx.py::test_proper_generation_counter PASSED [ 35%]
functional_tests/filterx/test_filterx.py::test_set_fields PASSED         [ 35%]
functional_tests/filterx/test_filterx.py::test_keys PASSED               [ 35%]
functional_tests/filterx/test_filterx.py::test_pubsub_message PASSED     [ 36%]
functional_tests/filterx/test_filterx.py::test_otel_repr PASSED          [ 36%]
functional_tests/filterx/test_filterx_control.py::test_if_condition_without_else_branch_match PASSED [ 36%]
functional_tests/filterx/test_filterx_control.py::test_if_condition_without_else_branch_nomatch PASSED [ 36%]
functional_tests/filterx/test_filterx_control.py::test_if_condition_no_matching_condition PASSED [ 37%]
functional_tests/filterx/test_filterx_control.py::test_if_condition_matching_main_condition PASSED [ 37%]
functional_tests/filterx/test_filterx_control.py::test_if_condition_matching_elif_condition PASSED [ 37%]
functional_tests/filterx/test_filterx_control.py::test_if_condition_matching_else_condition PASSED [ 38%]
functional_tests/filterx/test_filterx_control.py::test_if_condition_matching_expression PASSED [ 38%]
functional_tests/filterx/test_filterx_control.py::test_if_condition_non_matching_expression PASSED [ 38%]
functional_tests/filterx/test_filterx_control.py::test_drop PASSED       [ 38%]
functional_tests/filterx/test_filterx_control.py::test_done PASSED       [ 39%]
functional_tests/filterx/test_filterx_control.py::test_break PASSED      [ 39%]
functional_tests/filterx/test_filterx_control.py::test_switch_right_case_is_picked_from_the_middle PASSED [ 39%]
functional_tests/filterx/test_filterx_control.py::test_switch_fallthrough PASSED [ 39%]
functional_tests/filterx/test_filterx_control.py::test_switch_fallthrough_twice PASSED [ 40%]
functional_tests/filterx/test_filterx_control.py::test_switch_default_case PASSED [ 40%]
functional_tests/filterx/test_filterx_control.py::test_switch_no_match_case_no_default_case PASSED [ 40%]
functional_tests/filterx/test_filterx_control.py::test_switch_variable_in_case PASSED [ 40%]
functional_tests/filterx/test_filterx_control.py::test_switch_duplicate_literal_case PASSED [ 41%]
functional_tests/filterx/test_filterx_control.py::test_switch_duplicate_default_case PASSED [ 41%]
functional_tests/filterx/test_filterx_control.py::test_switch_invalid_selector PASSED [ 41%]
functional_tests/filterx/test_filterx_control.py::test_switch_invalid_case PASSED [ 41%]
functional_tests/filterx/test_filterx_funcs.py::test_upper PASSED        [ 42%]
functional_tests/filterx/test_filterx_funcs.py::test_lower PASSED        [ 42%]
functional_tests/filterx/test_filterx_funcs.py::test_repr PASSED         [ 42%]
functional_tests/filterx/test_filterx_funcs.py::test_startswith_with_various_arguments PASSED [ 42%]
functional_tests/filterx/test_filterx_funcs.py::test_endswith_with_various_arguments PASSED [ 43%]
functional_tests/filterx/test_filterx_funcs.py::test_includes_with_various_arguments PASSED [ 43%]
functional_tests/filterx/test_filterx_funcs.py::test_startswith_endswith_includes PASSED [ 43%]
functional_tests/filterx/test_filterx_scope.py::test_message_tied_variables_are_propagated_to_the_output PASSED [ 43%]
functional_tests/filterx/test_filterx_scope.py::test_message_tied_variables_in_braces_are_propagated_to_the_output PASSED [ 44%]
functional_tests/filterx/test_filterx_scope.py::test_message_tied_variables_are_propagated_to_the_output_in_junctions PASSED [ 44%]
functional_tests/filterx/test_filterx_scope.py::test_message_tied_variables_do_not_propagate_to_parallel_branches PASSED [ 44%]
functional_tests/filterx/test_filterx_scope.py::test_message_tied_variables_are_invalidated_if_message_is_changed PASSED [ 44%]
functional_tests/filterx/test_filterx_scope.py::test_message_tied_mutable_objects_are_synced_if_child_object_is_changed PASSED [ 45%]
functional_tests/filterx/test_filterx_scope.py::test_message_tied_variables_are_not_considered_changed_just_by_unmarshaling PASSED [ 45%]
functional_tests/filterx/test_filterx_scope.py::test_floating_variables_are_dropped_at_the_end_of_the_scope PASSED [ 45%]
functional_tests/filterx/test_filterx_scope.py::test_floating_variables_are_dropped_at_the_end_of_the_scope_but_can_be_recreated PASSED [ 45%]
functional_tests/filterx/test_filterx_scope.py::test_declared_variables_are_retained_across_scopes PASSED [ 46%]
functional_tests/filterx/test_filterx_scope.py::test_declared_variables_are_retained_across_scopes_and_junctions PASSED [ 46%]
functional_tests/filterx/test_filterx_scope.py::test_changes_in_abandoned_branches_are_ignored PASSED [ 46%]
functional_tests/filterx/test_filterx_update_metric.py::test_filterx_update_metric_labels PASSED [ 46%]
functional_tests/filterx/test_filterx_update_metric.py::test_filterx_update_metric_increment PASSED [ 47%]
functional_tests/filterx/test_filterx_update_metric.py::test_filterx_update_metric_level PASSED [ 47%]
functional_tests/logpath/test_conditionals.py::test_simple_if PASSED     [ 47%]
functional_tests/logpath/test_conditionals.py::test_simple_if_negated PASSED [ 47%]
functional_tests/logpath/test_conditionals.py::test_simple_if_that_drops_in_all_branches PASSED [ 48%]
functional_tests/logpath/test_conditionals.py::test_compound_if PASSED   [ 48%]
functional_tests/logpath/test_conditionals.py::test_compound_if_negated_continues_in_the_false_expr PASSED [ 48%]
functional_tests/logpath/test_conditionals.py::test_compound_if_that_drops_in_all_branches PASSED [ 48%]
functional_tests/logpath/test_conditionals.py::test_compound_if_with_messages_dropped_after_if PASSED [ 49%]
functional_tests/logpath/test_conditionals.py::test_three_levels_of_conditionals_drop_after_the_innermost_if PASSED [ 49%]
functional_tests/logpath/test_conditionals.py::test_three_levels_of_conditionals_drop_after_the_middle_if PASSED [ 49%]
functional_tests/logpath/test_conditionals.py::test_three_levels_of_simple_conditionals_drop_after_the_middle_if PASSED [ 50%]
functional_tests/logpath/test_conditionals.py::test_three_levels_of_conditionals_drop_after_the_innermost_junction PASSED [ 50%]
functional_tests/logpath/test_conditionals.py::test_three_levels_of_conditionals_drop_after_the_middle_junction PASSED [ 50%]
functional_tests/logpath/test_conditionals.py::test_consuming_messages_into_correlation_state_does_not_cause_else_branches_to_be_processed PASSED [ 50%]
functional_tests/logpath/test_flags_catch_all.py::test_flags_catch_all PASSED [ 51%]
functional_tests/logpath/test_flags_fallback.py::test_flags_fallback PASSED [ 51%]
functional_tests/logpath/test_flags_final.py::test_flags_final PASSED    [ 51%]
functional_tests/logpath/test_midpoint_destinations.py::test_midpoint_destination_that_drops_all_messages_does_not_cause_message_to_be_unmatched PASSED [ 51%]
functional_tests/logpath/test_midpoint_destinations.py::test_midpoint_inline_destination_that_drops_all_messages_does_not_cause_message_to_be_unmatched PASSED [ 52%]
functional_tests/logpath/test_midpoint_destinations.py::test_filter_between_destinations_that_drops_all_messages_causes_the_message_to_be_unmatched PASSED [ 52%]
functional_tests/logpath/test_midpoint_destinations.py::test_junction_that_drops_messages_in_all_branches_causes_the_message_to_be_unmatched PASSED [ 52%]
functional_tests/logpath/test_midpoint_destinations.py::test_junction_that_drops_messages_in_all_branches_causes_the_message_to_be_unmatched_even_if_they_reference_destinations PASSED [ 52%]
functional_tests/logpath/test_midpoint_destinations.py::test_junction_that_contains_message_dropping_destination_continues_to_deliver_messages_on_the_same_path PASSED [ 53%]
functional_tests/logpath/test_multiple_embedded_logpaths.py::test_multiple_embedded_logpaths PASSED [ 53%]
functional_tests/logpath/test_multiple_flags.py::test_multiple_flags PASSED [ 53%]
functional_tests/logpath/test_named_logpaths.py::test_named_logpaths PASSED [ 53%]
functional_tests/logpath/test_named_logpaths_with_catchall_flag.py::test_named_logpaths_with_catchall_flag PASSED [ 54%]
functional_tests/logpath/test_named_logpaths_with_fallback_flag.py::test_named_logpaths_with_fallback_flag PASSED [ 54%]
functional_tests/logpath/test_named_logpaths_with_final_flag.py::test_named_logpaths_with_final_flag PASSED [ 54%]
functional_tests/parsers/app-parser/test_app_parser.py::test_app_parser_first_match_without_overlaps_only_traverses_the_first_app[0] PASSED [ 54%]
functional_tests/parsers/app-parser/test_app_parser.py::test_app_parser_first_match_without_overlaps_only_traverses_the_first_app[1] PASSED [ 55%]
functional_tests/parsers/app-parser/test_app_parser.py::test_app_parser_first_match_without_overlaps_only_traverses_the_first_app[2] PASSED [ 55%]
functional_tests/parsers/app-parser/test_app_parser.py::test_app_parser_allow_overlaps_causes_all_apps_to_be_traversed[0] PASSED [ 55%]
functional_tests/parsers/app-parser/test_app_parser.py::test_app_parser_allow_overlaps_causes_all_apps_to_be_traversed[1] PASSED [ 55%]
functional_tests/parsers/app-parser/test_app_parser.py::test_app_parser_allow_overlaps_causes_all_apps_to_be_traversed[2] PASSED [ 56%]
functional_tests/parsers/app-parser/test_app_parser.py::test_app_parser_dont_match_causes_the_message_to_be_dropped PASSED [ 56%]
functional_tests/parsers/app-parser/test_app_parser.py::test_app_parser_auto_parse_disabled_causes_the_message_to_be_dropped PASSED [ 56%]
functional_tests/parsers/app-parser/test_app_parser.py::test_app_parser_auto_parse_disabled_plus_overlaps_causes_the_message_to_be_accepted PASSED [ 56%]
functional_tests/parsers/app-parser/test_topic_syslog.py::test_application_syslog[0] PASSED [ 57%]
functional_tests/parsers/app-parser/test_topic_syslog.py::test_application_syslog[1] PASSED [ 57%]
functional_tests/parsers/app-parser/test_topic_syslog.py::test_application_syslog[2] PASSED [ 57%]
functional_tests/parsers/app-parser/test_topic_syslog.py::test_application_syslog[3] PASSED [ 57%]
functional_tests/parsers/app-parser/test_topic_syslog.py::test_application_syslog[4] PASSED [ 58%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[0] PASSED [ 58%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[1] PASSED [ 58%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[2] PASSED [ 58%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[3] PASSED [ 59%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[4] PASSED [ 59%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[5] PASSED [ 59%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[6] PASSED [ 59%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[7] PASSED [ 60%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[8] PASSED [ 60%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[9] PASSED [ 60%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[10] PASSED [ 60%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[11] PASSED [ 61%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[12] PASSED [ 61%]
functional_tests/parsers/app-parser/test_topic_syslog_raw.py::test_application_raw[13] PASSED [ 61%]
functional_tests/parsers/app-transform/test_app_transform_filterx.py::test_app_transform_filterx[non_existing_app_] PASSED [ 61%]
functional_tests/parsers/app-transform/test_app_transform_filterx.py::test_app_transform_filterx[filterx_only_1_] PASSED [ 62%]
functional_tests/parsers/app-transform/test_app_transform_filterx.py::test_app_transform_filterx[filterx_only_1_include-transforms(filterx_1)] PASSED [ 62%]
functional_tests/parsers/app-transform/test_app_transform_filterx.py::test_app_transform_filterx[filterx_only_2_] PASSED [ 62%]
functional_tests/parsers/app-transform/test_app_transform_filterx.py::test_app_transform_filterx[filterx_only_2_include-transforms(filterx_1)] PASSED [ 63%]
functional_tests/parsers/app-transform/test_app_transform_parser.py::test_app_transform_parser[non_existing_app_] PASSED [ 63%]
functional_tests/parsers/app-transform/test_app_transform_parser.py::test_app_transform_parser[parser_only_1_] PASSED [ 63%]
functional_tests/parsers/app-transform/test_app_transform_parser.py::test_app_transform_parser[parser_only_1_include-transforms(parser_1)] PASSED [ 63%]
functional_tests/parsers/app-transform/test_app_transform_parser.py::test_app_transform_parser[parser_only_2_] PASSED [ 64%]
functional_tests/parsers/app-transform/test_app_transform_parser.py::test_app_transform_parser[parser_only_2_include-transforms(parser_1)] PASSED [ 64%]
functional_tests/parsers/app-transform/test_app_transform_parser_and_filterx.py::test_app_transform_parser_and_filterx[non_existing_app_] PASSED [ 64%]
functional_tests/parsers/app-transform/test_app_transform_parser_and_filterx.py::test_app_transform_parser_and_filterx[filterx_only_] PASSED [ 64%]
functional_tests/parsers/app-transform/test_app_transform_parser_and_filterx.py::test_app_transform_parser_and_filterx[filterx_only_include-transforms(filterx_1)] PASSED [ 65%]
functional_tests/parsers/app-transform/test_app_transform_parser_and_filterx.py::test_app_transform_parser_and_filterx[parser_only_] PASSED [ 65%]
functional_tests/parsers/app-transform/test_app_transform_parser_and_filterx.py::test_app_transform_parser_and_filterx[parser_only_include-transforms(parser_1)] PASSED [ 65%]
functional_tests/parsers/app-transform/test_app_transform_parser_and_filterx.py::test_app_transform_parser_and_filterx[mixed_] PASSED [ 65%]
functional_tests/parsers/app-transform/test_app_transform_parser_and_filterx.py::test_app_transform_parser_and_filterx[mixed_include-transforms(filterx_1)] PASSED [ 66%]
functional_tests/parsers/app-transform/test_app_transform_parser_and_filterx.py::test_app_transform_parser_and_filterx[mixed_include-transforms(parser_1)] PASSED [ 66%]
functional_tests/parsers/app-transform/test_app_transform_parser_and_filterx.py::test_app_transform_parser_and_filterx[mixed_include-transforms(mixed_1)] PASSED [ 66%]
functional_tests/parsers/app-transform/test_app_transform_parser_and_filterx.py::test_app_transform_mixed_filterx_optimization PASSED [ 66%]
functional_tests/parsers/checkpoint/test_checkpoint.py::test_checkpoint_parser[0] PASSED [ 67%]
functional_tests/parsers/checkpoint/test_checkpoint.py::test_checkpoint_parser[1] PASSED [ 67%]
functional_tests/parsers/checkpoint/test_checkpoint.py::test_checkpoint_parser[2] PASSED [ 67%]
functional_tests/parsers/checkpoint/test_checkpoint.py::test_checkpoint_parser[3] PASSED [ 67%]
functional_tests/parsers/cisco-parser/test_cisco_parser.py::test_cisco_parser[0] PASSED [ 68%]
functional_tests/parsers/cisco-parser/test_cisco_parser.py::test_cisco_parser[1] PASSED [ 68%]
functional_tests/parsers/cisco-parser/test_cisco_parser.py::test_cisco_parser[2] PASSED [ 68%]
functional_tests/parsers/cisco-parser/test_cisco_parser.py::test_cisco_parser[3] PASSED [ 68%]
functional_tests/parsers/cisco-parser/test_cisco_parser.py::test_cisco_parser[4] PASSED [ 69%]
functional_tests/parsers/cisco-parser/test_cisco_parser.py::test_cisco_parser[5] PASSED [ 69%]
functional_tests/parsers/cisco-parser/test_cisco_parser.py::test_cisco_parser[6] PASSED [ 69%]
functional_tests/parsers/cisco-parser/test_cisco_parser.py::test_cisco_parser[7] PASSED [ 69%]
functional_tests/parsers/cisco-parser/test_cisco_parser.py::test_cisco_parser[8] PASSED [ 70%]
functional_tests/parsers/cisco-parser/test_cisco_parser.py::test_cisco_parser[9] PASSED [ 70%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser[simple] PASSED [ 70%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser[quoted] PASSED [ 70%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser[simple-quotes] PASSED [ 71%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser[quote-pairs] PASSED [ 71%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser[escape-none] PASSED [ 71%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser[escape-double-char] PASSED [ 71%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser[escape-backslash] PASSED [ 72%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser[escape-backslash-with-sequences] PASSED [ 72%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser[null-value] PASSED [ 72%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser[delimiter-character] PASSED [ 72%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser[delimiter-character2] PASSED [ 73%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser[delimiter-string] PASSED [ 73%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser[delimiter-string2] PASSED [ 73%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser_into_matches PASSED [ 73%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser_drop_invalid[too_many_columns_in_input] PASSED [ 74%]
functional_tests/parsers/csv-parser/test_csv_parser.py::test_csv_parser_drop_invalid[type_does_not_match] PASSED [ 74%]
functional_tests/parsers/db_parser/test_db_parser.py::test_db_parser PASSED [ 74%]
functional_tests/parsers/group-lines-parser/test_group_lines_parser.py::test_group_lines_parser PASSED [ 75%]
functional_tests/parsers/mariadb-parser/test_mariadb_audit_parser.py::test_mariadb_audit_parser[0] PASSED [ 75%]
functional_tests/parsers/mariadb-parser/test_mariadb_audit_parser.py::test_mariadb_audit_parser[1] PASSED [ 75%]
functional_tests/parsers/mariadb-parser/test_mariadb_audit_parser.py::test_mariadb_audit_parser[2] PASSED [ 75%]
functional_tests/parsers/mariadb-parser/test_mariadb_audit_parser.py::test_mariadb_audit_parser[3] PASSED [ 76%]
functional_tests/parsers/metrics-probe/test_metrics_probe.py::test_metrics_probe PASSED [ 76%]
functional_tests/parsers/panos/test_panos_parser.py::test_panos_parser[0] PASSED [ 76%]
functional_tests/parsers/panos/test_panos_parser.py::test_panos_parser[1] PASSED [ 76%]
functional_tests/parsers/panos/test_panos_parser.py::test_panos_parser[2] PASSED [ 77%]
functional_tests/parsers/panos/test_panos_parser.py::test_panos_parser[3] PASSED [ 77%]
functional_tests/parsers/postgresql-csvlog-parser/test_postgresql_csvlog_parser.py::test_postgresql_csvlog_parser[0] PASSED [ 77%]
functional_tests/parsers/postgresql-csvlog-parser/test_postgresql_csvlog_parser.py::test_postgresql_csvlog_parser[1] PASSED [ 77%]
functional_tests/parsers/postgresql-csvlog-parser/test_postgresql_csvlog_parser.py::test_postgresql_csvlog_parser[2] PASSED [ 78%]
functional_tests/parsers/postgresql-csvlog-parser/test_postgresql_csvlog_parser.py::test_postgresql_csvlog_parser[3] PASSED [ 78%]
functional_tests/parsers/postgresql-csvlog-parser/test_postgresql_csvlog_parser.py::test_postgresql_csvlog_parser[4] PASSED [ 78%]
functional_tests/parsers/postgresql-csvlog-parser/test_postgresql_csvlog_parser.py::test_postgresql_csvlog_parser[5] PASSED [ 78%]
functional_tests/parsers/regexp-parser/test_regexp_parser.py::test_regexp_parser[match_literally] PASSED [ 79%]
functional_tests/parsers/regexp-parser/test_regexp_parser.py::test_regexp_parser[match_regular_expression] PASSED [ 79%]
functional_tests/parsers/regexp-parser/test_regexp_parser.py::test_regexp_parser[match_with_prefix] PASSED [ 79%]
functional_tests/parsers/regexp-parser/test_regexp_parser.py::test_regexp_parser[match_with_prefix_and_wrong_template] PASSED [ 79%]
functional_tests/parsers/regexp-parser/test_regexp_parser.py::test_regexp_parser[match_with_dupnames] PASSED [ 80%]
functional_tests/parsers/regexp-parser/test_regexp_parser.py::test_regexp_parser[unmatch_case] PASSED [ 80%]
functional_tests/parsers/regexp-parser/test_regexp_parser.py::test_regexp_parser[match_ignore_case_flag] PASSED [ 80%]
functional_tests/parsers/regexp-parser/test_regexp_parser.py::test_regexp_parser[match_multiple_regular_expressions] PASSED [ 80%]
functional_tests/parsers/regexp-parser/test_regexp_parser.py::test_regexp_parser[regular_expression_compile_error] PASSED [ 81%]
functional_tests/parsers/regexp-parser/test_regexp_parser.py::test_regexp_parser[check_MSG_macro] PASSED [ 81%]
functional_tests/parsers/sdata-parser/test_sdata_parser.py::test_sdata_parser PASSED [ 81%]
functional_tests/rewrites/cc-mask/test_cc_mask_and_cc_hash.py::test_cc_mask_and_cc_hash PASSED [ 81%]
functional_tests/rewrites/set-pri/test_set_pri.py::test_set_pri[min_value] PASSED [ 82%]
functional_tests/rewrites/set-pri/test_set_pri.py::test_set_pri[valid_value] PASSED [ 82%]
functional_tests/rewrites/set-pri/test_set_pri.py::test_set_pri[max_value] PASSED [ 82%]
functional_tests/rewrites/set-pri/test_set_pri.py::test_set_pri[invalid_big_number] PASSED [ 82%]
functional_tests/rewrites/set-pri/test_set_pri.py::test_set_pri[invalid_negative] PASSED [ 83%]
functional_tests/rewrites/set-pri/test_set_pri.py::test_set_pri[invalid_letters] PASSED [ 83%]
functional_tests/rewrites/set-pri/test_set_pri.py::test_set_pri[empty_value] PASSED [ 83%]
functional_tests/rewrites/set-tag/test_set_tag.py::test_set_tag PASSED   [ 83%]
functional_tests/rewrites/set-tag/test_set_tag.py::test_set_tag_with_template PASSED [ 84%]
functional_tests/source_drivers/file_source/test_acceptance.py::test_acceptance[with_one_log] PASSED [ 84%]
functional_tests/source_drivers/file_source/test_acceptance.py::test_acceptance[with_ten_logs] PASSED [ 84%]
functional_tests/source_drivers/file_source/test_follow_freq_value.py::test_follow_freq_value[1-True] PASSED [ 84%]
functional_tests/source_drivers/file_source/test_follow_freq_value.py::test_follow_freq_value[1.0-True] PASSED [ 85%]
functional_tests/source_drivers/file_source/test_follow_freq_value.py::test_follow_freq_value[0.1-True] PASSED [ 85%]
functional_tests/source_drivers/file_source/test_follow_freq_value.py::test_follow_freq_value[0-True] PASSED [ 85%]
functional_tests/source_drivers/file_source/test_follow_freq_value.py::test_follow_freq_value[0.0-True] PASSED [ 85%]
functional_tests/source_drivers/file_source/test_follow_freq_value.py::test_follow_freq_value[-1-False] PASSED [ 86%]
functional_tests/source_drivers/file_source/test_follow_freq_value.py::test_follow_freq_value[-1.0-False] PASSED [ 86%]
functional_tests/source_drivers/file_source/test_follow_freq_value.py::test_follow_freq_value[-0.1-False] PASSED [ 86%]
functional_tests/source_drivers/file_source/test_no_header_flag.py::test_no_header_flag PASSED [ 86%]
functional_tests/source_drivers/generator_source/test_generator_source.py::test_generator_source PASSED [ 87%]
functional_tests/source_drivers/internal_source/test_internal_acceptance.py::test_internal_source_with_threaded_destination PASSED [ 87%]
functional_tests/source_drivers/network_source/proxyprotocol/test_pp_acceptance.py::test_pp_acceptance PASSED [ 87%]
functional_tests/source_drivers/network_source/proxyprotocol/test_pp_reload.py::test_pp_reload PASSED [ 88%]
functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_multiple_clients.py::test_pp_with_multiple_clients PASSED [ 88%]
functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_simple_tcp_connection.py::test_pp_with_simple_tcp_connection PASSED [ 88%]
functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_syslog_proto.py::test_pp_with_syslog_proto PASSED [ 88%]
functional_tests/source_drivers/network_source/test_network_transports.py::test_pp_network_tcp PASSED [ 89%]
functional_tests/source_drivers/network_source/test_network_transports.py::test_pp_network_tls PASSED [ 89%]
functional_tests/source_drivers/network_source/test_network_transports.py::test_pp_network_tls_with_passphrase PASSED [ 89%]
functional_tests/source_drivers/network_source/test_network_transports.py::test_pp_network_tls_passthrough PASSED [ 89%]
functional_tests/source_drivers/network_source/test_network_transports.py::test_network_tcp PASSED [ 90%]
functional_tests/source_drivers/network_source/test_network_transports.py::test_network_tls PASSED [ 90%]
functional_tests/source_drivers/network_source/test_network_transports.py::test_network_auto_tcp_no_framing PASSED [ 90%]
functional_tests/source_drivers/network_source/test_network_transports.py::test_network_auto_tcp_w_framing PASSED [ 90%]
functional_tests/source_drivers/network_source/test_network_transports.py::test_network_auto_tls_no_framing PASSED [ 91%]
functional_tests/source_drivers/network_source/test_network_transports.py::test_network_auto_tls_w_framing PASSED [ 91%]
functional_tests/source_drivers/network_source/test_syslog_parser_timestamp_spinning.py::test_syslog_parser_timestamp_spinning PASSED [ 91%]
functional_tests/source_drivers/network_source/text_with_nuls/test_nul_acceptance.py::test_nul_acceptance PASSED [ 91%]
functional_tests/source_drivers/syslog_source/auto/test_auto_proto.py::test_auto_framing PASSED [ 92%]
functional_tests/source_drivers/syslog_source/auto/test_auto_proto.py::test_auto_no_framing PASSED [ 92%]
functional_tests/source_drivers/syslog_source/test_syslog_transports.py::test_pp_syslog_tcp PASSED [ 92%]
functional_tests/source_drivers/syslog_source/test_syslog_transports.py::test_pp_syslog_tls PASSED [ 92%]
functional_tests/source_drivers/syslog_source/test_syslog_transports.py::test_pp_syslog_tls_with_passphrase PASSED [ 93%]
functional_tests/source_drivers/syslog_source/test_syslog_transports.py::test_pp_syslog_tls_passthrough PASSED [ 93%]
functional_tests/source_drivers/syslog_source/test_syslog_transports.py::test_syslog_tcp PASSED [ 93%]
functional_tests/source_drivers/syslog_source/test_syslog_transports.py::test_syslog_tls PASSED [ 93%]
functional_tests/source_drivers/syslog_source/test_syslog_transports.py::test_syslog_auto_tcp_no_framing PASSED [ 94%]
functional_tests/source_drivers/syslog_source/test_syslog_transports.py::test_syslog_auto_tcp_w_framing PASSED [ 94%]
functional_tests/source_drivers/syslog_source/test_syslog_transports.py::test_syslog_auto_tls_no_framing PASSED [ 94%]
functional_tests/source_drivers/syslog_source/test_syslog_transports.py::test_syslog_auto_tls_w_framing PASSED [ 94%]
functional_tests/source_options/test_use_syslogng_pid.py::test_use_syslogng_pid[use_syslogng_pid0] PASSED [ 95%]
functional_tests/template_functions/graphite-output/test_graphite_output.py::test_graphite_output PASSED [ 95%]
functional_tests/template_functions/slog/test_secure_logging.py::test_secure_logging ERROR [ 95%]
functional_tests/templates/test_template_stmt.py::test_template_stmt_with_identifier_reference PASSED [ 95%]
functional_tests/templates/test_template_stmt.py::test_template_with_non_string_values PASSED [ 96%]
functional_tests/templates/test_template_stmt.py::test_template_stmt_with_indirect_invocation PASSED [ 96%]
functional_tests/templates/test_template_stmt.py::test_simple_template_stmt_with_identifier_reference PASSED [ 96%]
functional_tests/templates/test_template_stmt.py::test_template_stmt_with_string_reference PASSED [ 96%]
functional_tests/templates/test_template_stmt.py::test_inline_template PASSED [ 97%]
functional_tests/templates/test_template_stmt.py::test_inline_template_hints PASSED [ 97%]
functional_tests/templates/test_template_stmt.py::test_value_pair_type_hints PASSED [ 97%]
functional_tests/templates/test_template_stmt.py::test_template_function PASSED [ 97%]
functional_tests/tools/loggen/test_loggen_with_reconnect.py::test_loggen_with_reconnect PASSED [ 98%]
functional_tests/value-pairs/test_value_pairs.py::test_value_pairs[$(format-json test.*)\n] PASSED [ 98%]
functional_tests/value-pairs/test_value_pairs.py::test_value_pairs[$(format-json test.* --add-prefix foo.)\n] PASSED [ 98%]
functional_tests/value-pairs/test_value_pairs.py::test_value_pairs[$(format-json test.* --replace-prefix test=foobar)\n] PASSED [ 98%]
functional_tests/value-pairs/test_value_pairs.py::test_value_pairs[$(format-json test.* --shift-levels 1)\n] PASSED [ 99%]
functional_tests/value-pairs/test_value_pairs.py::test_value_pairs[$(format-json test.* --shift 2)\n] PASSED [ 99%]
functional_tests/value-pairs/test_value_pairs.py::test_value_pairs[$(format-json test.* --upper)\n] PASSED [ 99%]
functional_tests/value-pairs/test_value_pairs.py::test_value_pairs[$(format-json MESSAGE --lower)\n] PASSED [100%]

==================================== ERRORS ====================================
____________________ ERROR at setup of test_secure_logging _____________________

testcase_parameters = <axosyslog_light.testcase_parameters.testcase_parameters.TestcaseParameters object at 0x7395ebee7200>

    @pytest.fixture
    def slog(testcase_parameters):
>       yield SecureLogging(testcase_parameters)

testcase_parameters = <axosyslog_light.testcase_parameters.testcase_parameters.TestcaseParameters object at 0x7395ebee7200>

/home/alltilla/repos/axosyslog/tests/light/src/axosyslog_light/helpers/secure_logging/conftest.py:94: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/alltilla/repos/axosyslog/tests/light/src/axosyslog_light/helpers/secure_logging/conftest.py:37: in __init__
    self.slogkey = self.instance_paths.get_slogkey_bin()
        self       = <axosyslog_light.helpers.secure_logging.conftest.SecureLogging object at 0x7395ebd0c0e0>
        testcase_parameters = <axosyslog_light.testcase_parameters.testcase_parameters.TestcaseParameters object at 0x7395ebee7200>
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <axosyslog_light.syslog_ng.syslog_ng_paths.SyslogNgPaths object at 0x7395ebd0c260>

    def get_slogkey_bin(self):
>       return self.__syslog_ng_paths["binary_file_paths"]["slogkey"]
E       KeyError: 'binary_file_paths'

self       = <axosyslog_light.syslog_ng.syslog_ng_paths.SyslogNgPaths object at 0x7395ebd0c260>

/home/alltilla/repos/axosyslog/tests/light/src/axosyslog_light/syslog_ng/syslog_ng_paths.py:102: KeyError
=========================== short test summary info ============================
ERROR functional_tests/template_functions/slog/test_secure_logging.py::test_secure_logging - KeyError: 'binary_file_paths'
=================== 391 passed, 1 error in 560.34s (0:09:20) ===================

```

</details>