### PR TITLE
light: parallel run

### DIFF
--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -117,7 +117,7 @@ jobs:
         id: prepare-light-reports
         if: always() && steps.light.outcome == 'failure'
         run: |
-          REPORTS_DIR=tests/light/reports
+          REPORTS_DIR=${{ github.workspace }}/build/reports
           cp -r ${REPORTS_DIR} /tmp/light-reports
           find /tmp/light-reports -type p,s -print0 | xargs -0 rm -f
           tar -cz -f /tmp/light-reports.tar.gz /tmp/light-reports

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -293,6 +293,7 @@ tests/light/functional_tests/parsers/metrics-probe/test_metrics_probe\.py
 tests/light/functional_tests/source_drivers/opentelemetry_source/test_opentelemetry_source_acceptance\.py
 tests/light/functional_tests/source_drivers/unix_dgram_source/test_unix_dgram_source_acceptance\.py
 tests/light/functional_tests/source_drivers/syslog_source/auto/test_auto_proto\.py
+tests/light/src/axosyslog_light/common/session_data\.py
 tests/light/src/axosyslog_light/driver_io/opentelemetry/opentelemetry_io\.py
 tests/light/src/axosyslog_light/driver_io/unix_dgram/unix_dgram_io\.py
 tests/light/src/axosyslog_light/syslog_ng/syslog_ng_docker_executor.py

--- a/tests/light/CMakeLists.txt
+++ b/tests/light/CMakeLists.txt
@@ -11,7 +11,7 @@ add_custom_target(light-self-check
 
 add_custom_target(light-check
    COMMAND ${LIGHT_POETRY_CMD} install
-   COMMAND ${LIGHT_PYTEST_CMD} ${LIGHT_SOURCE_DIR}/functional_tests --installdir=${CMAKE_INSTALL_PREFIX} $$EXTRA_ARGS)
+   COMMAND ${LIGHT_PYTEST_CMD} ${LIGHT_SOURCE_DIR}/functional_tests -n auto --installdir=${CMAKE_INSTALL_PREFIX} $$EXTRA_ARGS)
 
 add_custom_target(light-linters
    COMMAND ${LIGHT_POETRY_CMD} install

--- a/tests/light/Makefile.am
+++ b/tests/light/Makefile.am
@@ -29,7 +29,7 @@ light-self-check pytest-self-check: light-venv
 	@$(LIGHT_PYTEST_CMD) $(LIGHT_SRC_DIR)/src/axosyslog_light
 
 light-check pytest-check: light-venv
-	$(LIGHT_PYTEST_CMD) -o log_cli=$(PYTEST_VERBOSE) $(LIGHT_SRC_DIR)/functional_tests/$(PYTEST_SUBDIR) $(PYTEST_OPTS) --installdir=${prefix} --show-capture=no
+	$(LIGHT_PYTEST_CMD) -o log_cli=$(PYTEST_VERBOSE) $(LIGHT_SRC_DIR)/functional_tests/$(PYTEST_SUBDIR) -n auto $(PYTEST_OPTS) --installdir=${prefix} --show-capture=no
 
 light-linters pytest-linters: light-venv
 	find $(abs_top_srcdir)/tests/light/ -name "*.py" \

--- a/tests/light/poetry.lock
+++ b/tests/light/poetry.lock
@@ -123,7 +123,7 @@ version = "3.18.0"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de"},
     {file = "filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2"},
@@ -976,4 +976,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "df092c355db52dbeed824030c6c7b80afd61cc85581f3bfb8e7a80fe2ac3b89a"
+content-hash = "f8a908508481773ef868512c76e01aae7761e97de0c720276360c2426c7c9286"

--- a/tests/light/poetry.lock
+++ b/tests/light/poetry.lock
@@ -103,6 +103,21 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc"},
+    {file = "execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "filelock"
 version = "3.18.0"
 description = "A platform independent file lock."
@@ -656,6 +671,27 @@ pytest = ">=6.2.5"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7"},
+    {file = "pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 description = "YAML parser and emitter for Python"
@@ -940,4 +976,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "cf804d21cde7fbf8a00ba3d14455015d0401bc23648adc75e55dba1c11bef9d1"
+content-hash = "df092c355db52dbeed824030c6c7b80afd61cc85581f3bfb8e7a80fe2ac3b89a"

--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -24,6 +24,7 @@ pytest-mock = "^3.14.0"
 opentelemetry-sdk = "^1.31.1"
 opentelemetry-exporter-otlp-proto-grpc = "^1.31.1"
 pytest-xdist = "^3.6.1"
+filelock = "^3.18.0"
 
 [tool.poetry.group.dev.dependencies]
 pycodestyle = "^2.12.1"

--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "axosyslog-light"
-version = "0.3.0"
+version = "0.4.0"
 description = "Lightweight End-to-End Test Framework for AxoSyslog."
 authors = ["Andras Mitzki <andras.mitzki@axoflow.com>", "Attila Szakacs <attila.szakacs@axoflow.com>"]
 readme = "README.md"

--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -23,6 +23,7 @@ pytest = "^8.3.5"
 pytest-mock = "^3.14.0"
 opentelemetry-sdk = "^1.31.1"
 opentelemetry-exporter-otlp-proto-grpc = "^1.31.1"
+pytest-xdist = "^3.6.1"
 
 [tool.poetry.group.dev.dependencies]
 pycodestyle = "^2.12.1"

--- a/tests/light/src/axosyslog_light/Makefile.am
+++ b/tests/light/src/axosyslog_light/Makefile.am
@@ -10,6 +10,7 @@ EXTRA_DIST += \
 	tests/light/src/axosyslog_light/common/operations.py \
 	tests/light/src/axosyslog_light/common/pytest_operations.py \
 	tests/light/src/axosyslog_light/common/random_id.py \
+	tests/light/src/axosyslog_light/common/session_data.py \
 	tests/light/src/axosyslog_light/common/tests/__init__.py \
 	tests/light/src/axosyslog_light/common/tests/test_blocking.py \
 	tests/light/src/axosyslog_light/driver_io/file/file_io.py \

--- a/tests/light/src/axosyslog_light/common/pytest_operations.py
+++ b/tests/light/src/axosyslog_light/common/pytest_operations.py
@@ -25,4 +25,4 @@
 def calculate_testcase_name(item_name):
     # In case of parametrized tests we need to replace "[" and "]" because
     # testcase name will appear in directory name
-    return item_name.replace("[", "_").replace("]", "_")
+    return item_name.replace("[", "_").replace("]", "_").replace("/", "_")

--- a/tests/light/src/axosyslog_light/common/session_data.py
+++ b/tests/light/src/axosyslog_light/common/session_data.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2025 Axoflow
+# Copyright (c) 2025 Attila Szakacs <attila.szakacs@axoflow.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from __future__ import annotations
+
+import pickle
+import typing
+from pathlib import Path
+
+from filelock import FileLock
+
+
+class SessionData:
+    SINGLETON: typing.Optional[SessionData] = None
+    SESSION_FILE = Path("axosyslog-light.session.pickle").resolve().absolute()
+    SESSION_LOCK_FILE = Path("axosyslog-light.lock").resolve().absolute()
+
+    def __init__(self) -> None:
+        if SessionData.SINGLETON is not None:
+            raise ValueError("SessionData is a singleton, cannot create more than one instance")
+        SessionData.SINGLETON = self
+
+        self.__data: typing.Dict[str, typing.Any] = dict()
+        self.__lock = FileLock(SessionData.SESSION_LOCK_FILE)
+
+        with self.__lock:
+            self.__sync_from_file()
+
+    @staticmethod
+    def get_singleton() -> None:
+        if SessionData.SINGLETON is None:
+            SessionData.SINGLETON = SessionData()
+        return SessionData.SINGLETON
+
+    @staticmethod
+    def cleanup() -> None:
+        if get_session_data().__lock.is_locked:
+            raise Exception("SessionData.cleanup() must be used without the 'with' statement")
+
+        SessionData.SESSION_FILE.unlink(missing_ok=True)
+        SessionData.SESSION_LOCK_FILE.unlink(missing_ok=True)
+
+    def __sync_from_file(self) -> None:
+        if not SessionData.SESSION_FILE.exists():
+            return
+
+        with SessionData.SESSION_FILE.open("rb") as f:
+            self.__data.update(pickle.load(f))
+
+    def __sync_to_file(self) -> None:
+        with SessionData.SESSION_FILE.open("wb") as f:
+            pickle.dump(self.__data, f)
+
+    def __enter__(self) -> SessionData:
+        self.__lock.acquire()
+        self.__sync_from_file()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.__sync_to_file()
+        self.__lock.release()
+
+    def __ensure_with(self) -> None:
+        if not self.__lock.is_locked:
+            raise ValueError("SessionData must be used with the 'with' statement")
+
+    def __getitem__(self, key: str) -> typing.Any:
+        self.__ensure_with()
+        return self.__data[key]
+
+    def __setitem__(self, key: str, value: typing.Any) -> None:
+        self.__ensure_with()
+        self.__data[key] = value
+
+    def get(self, key: str, default: typing.Any = None) -> typing.Any:
+        self.__ensure_with()
+        return self.__data.get(key, default)
+
+
+def get_session_data() -> SessionData:
+    return SessionData.get_singleton()

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -215,12 +215,21 @@ def chdir_to_light_base_dir():
     os.chdir(absolute_light_base_dir)
 
 
+def __calculate_testcase_dir(name):
+    with get_session_data() as session_data:
+        return Path(session_data["reports_dir"], calculate_testcase_name(name))
+
+
+@pytest.fixture
+def testcase_dir(request):
+    return __calculate_testcase_dir(request.node.name)
+
+
 def pytest_runtest_setup(item):
     logging_plugin = item.config.pluginmanager.get_plugin("logging-plugin")
-    with get_session_data() as session_data:
-        working_dir = Path(session_data["reports_dir"], calculate_testcase_name(item.name))
-    logging_plugin.set_log_path(calculate_report_file_path(working_dir))
-    os.chdir(working_dir)
+    testcase_dir = __calculate_testcase_dir(item.name)
+    logging_plugin.set_log_path(calculate_report_file_path(testcase_dir))
+    os.chdir(testcase_dir)
 
 
 def pytest_sessionstart(session):

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -284,14 +284,13 @@ def setup(request):
         )
 
 
-class PortAllocator():
-    CURRENT_DYNAMIC_PORT = 30000
-
-
-@pytest.fixture(scope="session")
+@pytest.fixture
 def port_allocator():
-    def get_next_port():
-        PortAllocator.CURRENT_DYNAMIC_PORT += 1
-        return PortAllocator.CURRENT_DYNAMIC_PORT
+    def get_next_port() -> int:
+        with get_session_data() as session_data:
+            last_port = session_data.get("port_allocator_last_port", 30000)
+            port = last_port + 1
+            session_data["port_allocator_last_port"] = port
+        return port
 
     return get_next_port

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -245,7 +245,6 @@ def pytest_sessionstart(session):
         try:
             reports_dir = Path(session.config.getoption("--reports")).resolve().absolute()
         except TypeError:
-            chdir_to_light_base_dir()
             reports_dir = Path("reports", get_current_date()).resolve().absolute()
 
         reports_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -32,8 +32,11 @@ from pathlib import Path
 import axosyslog_light.testcase_parameters.testcase_parameters as tc_parameters
 import psutil
 import pytest
+import xdist
 from axosyslog_light.common.file import copy_file
 from axosyslog_light.common.pytest_operations import calculate_testcase_name
+from axosyslog_light.common.session_data import get_session_data
+from axosyslog_light.common.session_data import SessionData
 from axosyslog_light.helpers.loggen.loggen import Loggen
 from axosyslog_light.helpers.loggen.loggen_docker_executor import LoggenDockerExecutor
 from axosyslog_light.helpers.loggen.loggen_executor import LoggenExecutor
@@ -51,7 +54,6 @@ from axosyslog_light.syslog_ng_ctl.syslog_ng_ctl_local_executor import SyslogNgC
 from axosyslog_light.testcase_parameters.testcase_parameters import TestcaseParameters
 
 logger = logging.getLogger(__name__)
-base_number_of_open_fds = 0
 
 
 class InstallDirAction(argparse.Action):
@@ -93,13 +95,8 @@ def pytest_addoption(parser):
     parser.addoption(
         "--reports",
         action="store",
-        default=get_relative_report_dir(),
         help="Path for report files folder. Default form: 'reports/<current_date>'",
     )
-
-
-def get_relative_report_dir():
-    return str(Path("reports/", get_current_date()))
 
 
 def get_current_date():
@@ -218,33 +215,43 @@ def chdir_to_light_base_dir():
     os.chdir(absolute_light_base_dir)
 
 
-def get_report_dir(pytest_config_object):
-    chdir_to_light_base_dir()
-    return Path(pytest_config_object.getoption("--reports")).resolve().absolute()
-
-
-def calculate_working_dir(pytest_config_object, testcase_name):
-    report_dir = get_report_dir(pytest_config_object)
-    return Path(report_dir, calculate_testcase_name(testcase_name))
-
-
 def pytest_runtest_setup(item):
     logging_plugin = item.config.pluginmanager.get_plugin("logging-plugin")
-    working_dir = calculate_working_dir(item.config, item.name)
+    with get_session_data() as session_data:
+        working_dir = Path(session_data["reports_dir"], calculate_testcase_name(item.name))
     logging_plugin.set_log_path(calculate_report_file_path(working_dir))
     os.chdir(working_dir)
 
 
 def pytest_sessionstart(session):
-    global base_number_of_open_fds
-    base_number_of_open_fds = len(psutil.Process().open_files())
+    if xdist.is_xdist_controller(session):
+        base_number_of_open_fds = 0  # with xdist, the current shell's open fds are not inherited
+    else:
+        base_number_of_open_fds = len(psutil.Process().open_files())
 
-    report_dir = get_report_dir(session.config)
-    report_dir.mkdir(parents=True, exist_ok=True)
-    if report_dir.parent.name == "reports":
-        last_report_dir = Path(report_dir.parent, "last")
-        last_report_dir.unlink(True)
-        last_report_dir.symlink_to(report_dir)
+    with get_session_data() as session_data:
+        if session_data.get("session_started", False):
+            return
+
+        try:
+            reports_dir = Path(session.config.getoption("--reports")).resolve().absolute()
+        except TypeError:
+            chdir_to_light_base_dir()
+            reports_dir = Path("reports", get_current_date()).resolve().absolute()
+
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        if reports_dir.parent.name == "reports":
+            last_reports_dir = Path(reports_dir.parent, "last")
+            last_reports_dir.unlink(True)
+            last_reports_dir.symlink_to(reports_dir)
+
+        session_data["session_started"] = True
+        session_data["reports_dir"] = reports_dir
+        session_data["base_number_of_open_fds"] = base_number_of_open_fds
+
+
+def pytest_sessionfinish(session, exitstatus):
+    SessionData.cleanup()
 
 
 def light_extra_files(target_dir):
@@ -256,7 +263,8 @@ def light_extra_files(target_dir):
 
 @pytest.fixture(autouse=True)
 def setup(request):
-    global base_number_of_open_fds
+    with get_session_data() as session_data:
+        base_number_of_open_fds = session_data["base_number_of_open_fds"]
     number_of_open_fds = len(psutil.Process().open_files())
     assert base_number_of_open_fds + 1 == number_of_open_fds, "Previous testcase has unclosed opened fds"
     assert len(psutil.Process().net_connections(kind="inet")) == 0, "Previous testcase has unclosed opened sockets"

--- a/tests/light/src/axosyslog_light/helpers/loggen/loggen.py
+++ b/tests/light/src/axosyslog_light/helpers/loggen/loggen.py
@@ -23,18 +23,20 @@
 import typing
 from pathlib import Path
 
+from axosyslog_light.common.session_data import get_session_data
 from axosyslog_light.helpers.loggen.loggen_executor import LoggenExecutor
 from axosyslog_light.helpers.loggen.loggen_executor import LoggenStartParams
 from psutil import Popen
 
 
 class Loggen(object):
-    instanceIndex = -1
-
     @staticmethod
     def __get_new_instance_index():
-        Loggen.instanceIndex += 1
-        return Loggen.instanceIndex
+        with get_session_data() as session_data:
+            last_index = session_data.get("loggen_instance_index", 0)
+            index = last_index + 1
+            session_data["loggen_instance_index"] = index
+        return index
 
     def __init__(self, loggen_executor: typing.Optional[LoggenExecutor] = None):
         if loggen_executor is None:


### PR DESCRIPTION
Builds upon #562 

---

pytest-xdist does not work well with session scoped fixtures. Each runner has its own session, and no data is shared
between runners' sessions.

The introduced `SessionData` class intends to bridge this issue, by managing a session specific data storage on the disk.