### PR TITLE
light: `SessionData` refcount and `LogContextSclBlocks`

### DIFF
--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -301,6 +301,7 @@ tests/light/src/axosyslog_light/syslog_ng_ctl/prometheus_stats_handler.py
 tests/light/src/axosyslog_light/syslog_ng_config/statements/template/template\.py
 tests/light/src/axosyslog_light/syslog_ng_config/statements/__init__\.py
 tests/light/src/axosyslog_light/syslog_ng_config/statements/filterx/filterx\.py
+tests/light/src/axosyslog_light/syslog_ng_config/statements/logpath/log_context_scl_block\.py
 tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/opentelemetry_source\.py
 tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/unix_dgram_source\.py
 tests/light/functional_tests/destination_drivers/network_destination/test_kept_alive_tls_connection_doing_handshake_after_reload\.py

--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "axosyslog-light"
-version = "0.5.0"
+version = "0.6.0"
 description = "Lightweight End-to-End Test Framework for AxoSyslog."
 authors = ["Andras Mitzki <andras.mitzki@axoflow.com>", "Attila Szakacs <attila.szakacs@axoflow.com>"]
 readme = "README.md"

--- a/tests/light/src/axosyslog_light/common/session_data.py
+++ b/tests/light/src/axosyslog_light/common/session_data.py
@@ -47,7 +47,7 @@ class SessionData:
             self.__sync_from_file()
 
     @staticmethod
-    def get_singleton() -> None:
+    def get_singleton() -> SessionData:
         if SessionData.SINGLETON is None:
             SessionData.SINGLETON = SessionData()
         return SessionData.SINGLETON

--- a/tests/light/src/axosyslog_light/common/session_data.py
+++ b/tests/light/src/axosyslog_light/common/session_data.py
@@ -57,8 +57,8 @@ class SessionData:
         if get_session_data().__lock.is_locked:
             raise Exception("SessionData.cleanup() must be used without the 'with' statement")
 
-        SessionData.SESSION_FILE.unlink(missing_ok=True)
-        SessionData.SESSION_LOCK_FILE.unlink(missing_ok=True)
+        SessionData.SESSION_FILE.unlink()
+        SessionData.SESSION_LOCK_FILE.unlink()
 
     def __sync_from_file(self) -> None:
         if not SessionData.SESSION_FILE.exists():

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -239,6 +239,8 @@ def pytest_sessionstart(session):
         base_number_of_open_fds = len(psutil.Process().open_files())
 
     with get_session_data() as session_data:
+        session_data["active_workers"] = session_data.get("active_workers", 0) + 1
+
         if session_data.get("session_started", False):
             return
 
@@ -259,7 +261,11 @@ def pytest_sessionstart(session):
 
 
 def pytest_sessionfinish(session, exitstatus):
-    SessionData.cleanup()
+    with get_session_data() as session_data:
+        active_workers = session_data["active_workers"] = session_data["active_workers"] - 1
+
+    if active_workers == 0:
+        SessionData.cleanup()
 
 
 def light_extra_files(target_dir):

--- a/tests/light/src/axosyslog_light/syslog_ng_config/renderer.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/renderer.py
@@ -191,6 +191,11 @@ def render_logpath_groups(logpath_groups, depth=0):
                 for line in statement_group.code.split("\n"):
                     config_snippet += _indent(line + "\n", depth + 2)
                 config_snippet += _indent("};\n", depth + 1)
+            elif statement_group.group_type == "log_context_scl_block":
+                config_snippet += _indent(statement_group.name + "(\n", depth + 1)
+                for line in render_driver_options(statement_group.options).split("\n"):
+                    config_snippet += _indent(line + "\n", depth + 2)
+                config_snippet += _indent(");\n", depth + 1)
             else:
                 config_snippet += _indent("{}({});\n".format(statement_group.group_type, statement_group.group_id), depth + 1)
         if logpath_group.flags:

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/logpath/log_context_scl_block.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/logpath/log_context_scl_block.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2025 Axoflow
+# Copyright (c) 2025 Attila Szakacs <attila.szakacs@axoflow.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import typing
+
+
+class LogContextSclBlock:
+    group_type = "log_context_scl_block"
+
+    def __init__(self, name: str, **options: typing.Dict[str, typing.Any]) -> None:
+        self.__name = name
+        self.__options = options
+
+    @property
+    def name(self):
+        return self.__name
+
+    @property
+    def options(self):
+        return self.__options

--- a/tests/light/src/axosyslog_light/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/syslog_ng_config.py
@@ -39,6 +39,7 @@ from axosyslog_light.syslog_ng_config.statements.filters.filter import Filter
 from axosyslog_light.syslog_ng_config.statements.filters.filter import Match
 from axosyslog_light.syslog_ng_config.statements.filters.filter import RateLimit
 from axosyslog_light.syslog_ng_config.statements.filterx.filterx import FilterX
+from axosyslog_light.syslog_ng_config.statements.logpath.log_context_scl_block import LogContextSclBlock
 from axosyslog_light.syslog_ng_config.statements.logpath.logpath import LogPath
 from axosyslog_light.syslog_ng_config.statements.parsers.db_parser import DBParser
 from axosyslog_light.syslog_ng_config.statements.parsers.parser import Parser
@@ -271,7 +272,7 @@ class SyslogNgConfig(object):
         return statement_group
 
     def __create_statement_group_if_needed(self, item):
-        if isinstance(item, (StatementGroup, LogPath, FilterX)):
+        if isinstance(item, (StatementGroup, LogPath, FilterX, LogContextSclBlock)):
             return item
         else:
             return self.create_statement_group(item)


### PR DESCRIPTION
Previously, the first worker to finish could remove the file while others were still running, causing race conditions.

After this commit, an active worker counter is maintained, and the file is deleted only when the counter reaches zero.

---

`LogContextSclBlocks` is useful to use things like this in the config:

```
block log foobar() {
   ....
};

log {
  foobar(); # generating this line is now possible
};