### PR TITLE
light: work with leftover session file

### DIFF
--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "axosyslog-light"
-version = "0.6.0"
+version = "1.0.0"
 description = "Lightweight End-to-End Test Framework for AxoSyslog."
 authors = ["Andras Mitzki <andras.mitzki@axoflow.com>", "Attila Szakacs <attila.szakacs@axoflow.com>"]
 readme = "README.md"

--- a/tests/light/src/axosyslog_light/common/session_data.py
+++ b/tests/light/src/axosyslog_light/common/session_data.py
@@ -96,6 +96,10 @@ class SessionData:
         self.__ensure_with()
         return self.__data.get(key, default)
 
+    def clear(self) -> None:
+        self.__ensure_with()
+        self.__data.clear()
+
 
 def get_session_data() -> SessionData:
     return SessionData.get_singleton()

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -234,9 +234,9 @@ def pytest_runtest_setup(item):
 
 def pytest_sessionstart(session):
     if xdist.is_xdist_controller(session):
-        base_number_of_open_fds = 0  # with xdist, the current shell's open fds are not inherited
-    else:
-        base_number_of_open_fds = len(psutil.Process().open_files())
+        return
+
+    base_number_of_open_fds = len(psutil.Process().open_files())
 
     with get_session_data() as session_data:
         session_data["active_workers"] = session_data.get("active_workers", 0) + 1
@@ -261,6 +261,9 @@ def pytest_sessionstart(session):
 
 
 def pytest_sessionfinish(session, exitstatus):
+    if xdist.is_xdist_controller(session):
+        return
+
     with get_session_data() as session_data:
         active_workers = session_data["active_workers"] = session_data["active_workers"] - 1
 

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -26,6 +26,7 @@ import argparse
 import logging
 import os
 import re
+import uuid
 from datetime import datetime
 from pathlib import Path
 
@@ -239,6 +240,11 @@ def pytest_sessionstart(session):
     base_number_of_open_fds = len(psutil.Process().open_files())
 
     with get_session_data() as session_data:
+        testrunuid = os.environ.get("PYTEST_XDIST_TESTRUNUID", uuid.uuid4().hex)  # generate one if not running in xdist
+        if session_data.get("testrunuid") != testrunuid:
+            session_data.clear()
+            session_data["testrunuid"] = testrunuid
+
         session_data["active_workers"] = session_data.get("active_workers", 0) + 1
 
         if session_data.get("session_started", False):


### PR DESCRIPTION
Sometimes with unexpected process stops (e.g. aggressively Ctrl+C'ing the test run) the `SessionData` file can stay on the file system with initialized values in it.

This commit uses the `PYTEST_XDIST_TESTRUNUID` env var, which is provided by `xdist` for workers, and is guaranteed to be unique for each run, and be the same for all workers for that run.

We store this value to the `SessionData` file, and during start if we find a file that has a different uid, we clear its contents, and start a new one.

With this we also restart the active worker count, and will be able to delete the file after the run.

---

Tested with:
* `-n12`
* `-n1`
* `-n0`
* ` `