### PR TITLE
light: fix multiple implicit source groups

### DIFF
--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "axosyslog-light"
-version = "1.1.0"
+version = "1.2.0"
 description = "Lightweight End-to-End Test Framework for AxoSyslog."
 authors = ["Andras Mitzki <andras.mitzki@axoflow.com>", "Attila Szakacs <attila.szakacs@axoflow.com>"]
 readme = "README.md"

--- a/tests/light/src/axosyslog_light/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/syslog_ng_config.py
@@ -88,6 +88,7 @@ class SyslogNgConfig(object):
         }
         self._stats_handler = stats_handler
         self._prometheus_stats_handler = prometheus_stats_handler
+        self.__implicit_statement_groups: typing.Dict[int, StatementGroup] = {}
         self.teardown = teardown
 
     stringify = staticmethod(stringify)
@@ -283,7 +284,7 @@ class SyslogNgConfig(object):
         if isinstance(item, (StatementGroup, LogPath, FilterX, LogContextSclBlock)):
             return item
         else:
-            return self.create_statement_group(item)
+            return self.__implicit_statement_groups.setdefault(id(item), self.create_statement_group(item))
 
     def __create_logpath_with_conversion(self, name, items, flags):
         return self.__create_logpath_group(


### PR DESCRIPTION
The bug happened when we added the same source driver to multiple logpaths, like:
```py
source = config.create_xy_source()
config.create_logpath(statements=[source, dest_1])
config.create_logpath(statements=[source, dest_2])
```

This implicitly generated two separate source groups for `source`, which failed to start AxoSyslog.

The fix uses the `id()` function in python, which returns a unique id (pointer) to the python object, in this case the `SourceDriver`. This is not doing a real equivalence check on the object level, so if we create two separate, but identically configured sources with `config.create_xy_source()`, they will both have their respective implicitly generated source groups, but I don't think we need to optimize for this use case.