### PR TITLE
light: do not call create_statement_group unnecessarily

### DIFF
--- a/tests/light/src/axosyslog_light/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/syslog_ng_config.py
@@ -284,7 +284,11 @@ class SyslogNgConfig(object):
         if isinstance(item, (StatementGroup, LogPath, FilterX, LogContextSclBlock)):
             return item
         else:
-            return self.__implicit_statement_groups.setdefault(id(item), self.create_statement_group(item))
+            item_id = id(item)
+            group = self.__implicit_statement_groups.get(item_id)
+            if group is None:
+                group = self.__implicit_statement_groups[item_id] = self.create_statement_group(item)
+            return group
 
     def __create_logpath_with_conversion(self, name, items, flags):
         return self.__create_logpath_group(


### PR DESCRIPTION
It has a side effect of adding a new statement
group to the config, although it is not getting
used by anything, because the cached one is
returned.

No need to release this commit on its own, as it
is a non-functional change regarding AxoSyslog's
execution from Light.

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
