### PR TITLE
filterx/object-dict: fix unset in case of a hash collision

### DIFF
--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -287,6 +287,7 @@ tests/light/functional_tests/templates/test_template_stmt\.py
 tests/light/functional_tests/filters/test_multiple_filters\.py
 tests/light/functional_tests/filterx/test_filterx\.py
 tests/light/functional_tests/filterx/test_filterx_cow\.py
+tests/light/functional_tests/filterx/test_filterx_dict\.py
 tests/light/functional_tests/filterx/test_filterx_scope\.py
 tests/light/functional_tests/filterx/test_filterx_control\.py
 tests/light/functional_tests/filterx/test_filterx_funcs\.py

--- a/tests/light/functional_tests/Makefile.am
+++ b/tests/light/functional_tests/Makefile.am
@@ -22,6 +22,7 @@ EXTRA_DIST += \
 	tests/light/functional_tests/filters/test_filter_reference.py \
 	tests/light/functional_tests/filters/test_multiple_filters.py \
 	tests/light/functional_tests/filterx/test_filterx_control.py \
+	tests/light/functional_tests/filterx/test_filterx_dict.py \
 	tests/light/functional_tests/filterx/test_filterx_funcs.py \
 	tests/light/functional_tests/filterx/test_filterx.py \
 	tests/light/functional_tests/filterx/test_filterx_scope.py \

--- a/tests/light/functional_tests/filterx/test_filterx_dict.py
+++ b/tests/light/functional_tests/filterx/test_filterx_dict.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2025 Axoflow
+# Copyright (c) 2025 Attila Szakacs <attila.szakacs@axoflow.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+def test_filterx_dict_unset_key_with_hash_collision(syslog_ng, config):
+    source = config.create_example_msg_generator_source(num=1, template='"id=a m=b"')
+    filterx = config.create_filterx(r"""
+        log = {"id": "a", "m": "b"};
+        unset(log.id);
+        $MSG = log.m;
+""")
+    destination = config.create_file_destination(file_name="output.log", template='"$MSG\n"')
+
+    config.create_logpath(statements=[source, filterx, destination])
+
+    syslog_ng.start(config)
+    assert destination.read_log() == "b"


### PR DESCRIPTION
In case an item was unset() while another item with the same hash is in the dict, we erroneously reported the other item as missing as well.

The problem is that we can only break out of the lookup loop in case the index is its initial value (FXD_IX_EMPTY) and not when it is cleared (e.g. FXD_IX_DUMMY). In the latter case, we need to continue the lookup loop.

However, we should try to reuse the cleared slot for the new item. We do this by storing the first found dummy slot and returning it if we did not find any valid values in the lookup loop.