### PR TITLE
Filterx: add filterx_object_cow_fork2() function

### DIFF
--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -28,10 +28,9 @@
 #include "scratch-buffers.h"
 
 static inline FilterXObject *
-_assign(FilterXBinaryOp *self, FilterXObject **value)
+_assign(FilterXBinaryOp *self, FilterXObject *value)
 {
-  FilterXObject *cloned = filterx_object_cow_fork(value);
-
+  FilterXObject *cloned = filterx_object_cow_fork2(filterx_object_ref(value), NULL);
   if (!filterx_expr_assign(self->lhs, &cloned))
     {
       filterx_object_unref(cloned);
@@ -67,7 +66,7 @@ _nullv_assign_eval(FilterXExpr *s)
       return value;
     }
 
-  FilterXObject *result = _assign(self, &value);
+  FilterXObject *result = _assign(self, value);
   filterx_object_unref(value);
   return result;
 }
@@ -82,7 +81,7 @@ _assign_eval(FilterXExpr *s)
   if (!value)
     return NULL;
 
-  FilterXObject *result = _assign(self, &value);
+  FilterXObject *result = _assign(self, value);
   filterx_object_unref(value);
   return result;
 }

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -38,7 +38,7 @@ typedef struct _FilterXSetSubscript
 } FilterXSetSubscript;
 
 static inline FilterXObject *
-_set_subscript(FilterXSetSubscript *self, FilterXObject *object, FilterXObject *key, FilterXObject **new_value)
+_set_subscript(FilterXSetSubscript *self, FilterXObject *object, FilterXObject *key, FilterXObject *new_value)
 {
   if (object->readonly)
     {
@@ -46,7 +46,7 @@ _set_subscript(FilterXSetSubscript *self, FilterXObject *object, FilterXObject *
       return NULL;
     }
 
-  FilterXObject *cloned = filterx_object_cow_fork(new_value);
+  FilterXObject *cloned = filterx_object_cow_fork2(filterx_object_ref(new_value), NULL);
   if (!filterx_object_set_subscript(object, key, &cloned))
     {
       filterx_eval_push_error("Object set-subscript failed", &self->super, key);
@@ -95,7 +95,7 @@ _nullv_set_subscript_eval(FilterXExpr *s)
         goto exit;
     }
 
-  result = _set_subscript(self, object, key, &new_value);
+  result = _set_subscript(self, object, key, new_value);
 
 exit:
   filterx_object_unref(new_value);
@@ -126,7 +126,7 @@ _set_subscript_eval(FilterXExpr *s)
         goto exit;
     }
 
-  result = _set_subscript(self, object, key, &new_value);
+  result = _set_subscript(self, object, key, new_value);
 
 exit:
   filterx_object_unref(new_value);

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -39,7 +39,7 @@ typedef struct _FilterXSetAttr
 } FilterXSetAttr;
 
 static inline FilterXObject *
-_setattr(FilterXSetAttr *self, FilterXObject *object, FilterXObject **new_value)
+_setattr(FilterXSetAttr *self, FilterXObject *object, FilterXObject *new_value)
 {
   if (object->readonly)
     {
@@ -47,7 +47,7 @@ _setattr(FilterXSetAttr *self, FilterXObject *object, FilterXObject **new_value)
       return NULL;
     }
 
-  FilterXObject *cloned = filterx_object_cow_fork(new_value);
+  FilterXObject *cloned = filterx_object_cow_fork2(filterx_object_ref(new_value), NULL);
   if (!filterx_object_setattr(object, self->attr, &cloned))
     {
       filterx_eval_push_error("Attribute set failed", &self->super, self->attr);
@@ -88,7 +88,7 @@ _nullv_setattr_eval(FilterXExpr *s)
   if (!object)
     goto exit;
 
-  result = _setattr(self, object, &new_value);
+  result = _setattr(self, object, new_value);
 
 exit:
   filterx_object_unref(new_value);
@@ -110,7 +110,7 @@ _setattr_eval(FilterXExpr *s)
   if (!object)
     goto exit;
 
-  result = _setattr(self, object, &new_value);
+  result = _setattr(self, object, new_value);
 
 exit:
   filterx_object_unref(new_value);

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -552,30 +552,30 @@ filterx_object_is_type_or_ref(FilterXObject *object, FilterXType *type)
  * reference, returning a FilterXRef instead.
  */
 static inline void
-filterx_object_cow_wrap(FilterXObject **o)
+filterx_object_cow_wrap(FilterXObject **pself)
 {
-  FilterXObject *value = *o;
+  FilterXObject *value = *pself;
   if (!value || value->readonly || !_filterx_type_is_referenceable(value->type))
     return;
-  *o = _filterx_ref_new(value);
+  *pself = _filterx_ref_new(value);
 }
 
 
 /* NOTE: potentially replaces *value with a FilterXRef, sinking the passed
  * reference.  It replaces the copied object as a return value */
 static inline FilterXObject *
-filterx_object_cow_fork(FilterXObject **o)
+filterx_object_cow_fork(FilterXObject **pself)
 {
-  filterx_object_cow_wrap(o);
-  return filterx_object_clone(*o);
+  filterx_object_cow_wrap(pself);
+  return filterx_object_clone(*pself);
 }
 
 /* */
 static inline FilterXObject *
-filterx_object_cow_store(FilterXObject **o)
+filterx_object_cow_store(FilterXObject **pself)
 {
-  filterx_object_cow_wrap(o);
-  return filterx_object_ref(*o);
+  filterx_object_cow_wrap(pself);
+  return filterx_object_ref(*pself);
 }
 
 #endif

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -561,13 +561,47 @@ filterx_object_cow_wrap(FilterXObject **pself)
 }
 
 
-/* NOTE: potentially replaces *value with a FilterXRef, sinking the passed
- * reference.  It replaces the copied object as a return value */
+/* Perform a lazy copy (e.g.  copy-on-write) of @self and return the new
+ * copy. This function does nothing for inmutable data types.
+ *
+ * For copy-on-write to work, all references to @self need to be done
+ * through refs, but our @self argument may still point to a bare, but
+ * mutable object.
+ *
+ * In this case, @self is automatically wrapped into a ref here.  This ref
+ * is returned using the @pself output argument.  In case @pself is NULL, we
+ * assume the caller is not interested, and we either never create a ref to
+ * the old copy or we destroy it.
+ *
+ * The return value is the ref to the new copy.
+ */
+static inline FilterXObject *
+filterx_object_cow_fork2(FilterXObject *self, FilterXObject **pself)
+{
+  FilterXObject *saved_self = self;
+  filterx_object_cow_wrap(&self);
+
+  if (pself)
+    {
+      *pself = self;
+      return filterx_object_clone(self);
+    }
+  else
+    {
+      if (self != saved_self)
+        return self;
+
+      FilterXObject *result = filterx_object_clone(self);
+      filterx_object_unref(self);
+      return result;
+    }
+}
+
+/* Same as filterx_object_cow_fork2() with an input/output argument */
 static inline FilterXObject *
 filterx_object_cow_fork(FilterXObject **pself)
 {
-  filterx_object_cow_wrap(pself);
-  return filterx_object_clone(*pself);
+  return filterx_object_cow_fork2(*pself, pself);
 }
 
 /* */


### PR DESCRIPTION
This branch adds filterx_object_cow_fork2() function that allows us decrease the number of FilterXRef allocations (when set_subscript/setattr/assignment sees a bare, unwrapped FilterXDict or a FilterXList instance.
