### PR TITLE
Filterx deduplicate frozen strings

### DIFF
--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -114,8 +114,8 @@ filterx_eval_prepare_for_fork(FilterXEvalContext *context, LogMessage **pmsg, co
 static inline void
 filterx_eval_store_weak_ref(FilterXObject *object)
 {
-  /* Frozen objects do not need weak refs. */
-  if (object && filterx_object_is_frozen(object))
+  /* Preserved objects do not need weak refs. */
+  if (object && filterx_object_is_preserved(object))
     return;
 
   if (object && !object->weak_referenced)

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -66,13 +66,13 @@ void
 filterx_cache_object(FilterXObject **cache_slot, FilterXObject *object)
 {
   *cache_slot = object;
-  filterx_object_freeze(cache_slot);
+  filterx_object_hybernate(cache_slot);
 }
 
 void
 filterx_uncache_object(FilterXObject **cache_slot)
 {
-  filterx_object_unfreeze_and_free(*cache_slot);
+  filterx_object_unhybernate_and_free(*cache_slot);
   *cache_slot = NULL;
 }
 

--- a/lib/filterx/filterx-globals.h
+++ b/lib/filterx/filterx-globals.h
@@ -52,6 +52,7 @@ typedef struct _FilterXGlobalCache
   FilterXObject *bool_cache[FILTERX_BOOL_CACHE_LIMIT];
   FilterXObject *integer_cache[FILTERX_INTEGER_CACHE_LIMIT];
   FilterXObject *string_cache[FILTERX_STRING_CACHE_LIMIT];
+  GHashTable *string_frozen_cache;
   FilterXObject *datetime_cache[FILTERX_DATETIME_CACHE_LIMIT];
 } FilterXGlobalCache;
 

--- a/lib/filterx/object-dict.c
+++ b/lib/filterx/object-dict.c
@@ -762,8 +762,9 @@ _filterx_dict_freeze(FilterXObject **s)
 static gboolean
 _unfreeze_dict_item(FilterXObject **key, FilterXObject **value, gpointer user_data)
 {
-  filterx_object_unfreeze(*key);
-  filterx_object_unfreeze(*value);
+  filterx_object_unfreeze_and_free(*key);
+  filterx_object_unfreeze_and_free(*value);
+  *key = *value = NULL;
   return TRUE;
 }
 

--- a/lib/filterx/object-list.c
+++ b/lib/filterx/object-list.c
@@ -329,7 +329,8 @@ _filterx_list_freeze(FilterXObject **s)
 static gboolean
 _unfreeze_list_item(gsize index, FilterXObject **value, gpointer user_data)
 {
-  filterx_object_unfreeze(*value);
+  filterx_object_unfreeze_and_free(*value);
+  *value = NULL;
   return TRUE;
 }
 

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -187,6 +187,7 @@ _string_freeze(FilterXObject **pself)
       *pself = frozen_string;
       return;
     }
+  self->hash = _filterx_string_hash(self);
   g_hash_table_insert(global_cache.string_frozen_cache, (gchar *) self->str, self);
 }
 

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -187,7 +187,7 @@ _string_freeze(FilterXObject **pself)
       *pself = frozen_string;
       return;
     }
-  self->hash = _filterx_string_hash(self);
+  _filterx_string_hash(self);
   g_hash_table_insert(global_cache.string_frozen_cache, (gchar *) self->str, self);
 }
 

--- a/lib/filterx/tests/test_object_string.c
+++ b/lib/filterx/tests/test_object_string.c
@@ -141,6 +141,14 @@ Test(filterx_string, test_filterx_string_typecast_from_protobuf)
   filterx_object_unref(obj);
 }
 
+Test(filterx_string, test_filterx_string_freeze_and_unfreeze)
+{
+  FilterXObject *o = filterx_string_new("foobar", 6);
+
+  filterx_object_freeze(&o);
+  filterx_object_unfreeze_and_free(o);
+}
+
 static void
 setup(void)
 {


### PR DESCRIPTION
This PR changes frozen FilterXString instances so they use the same instance throughout the execution of a configuration. This deduplicates strings such as common attribute name ("meta", "name", etc), it improves memory, cache use and thereby performance.

It rounds up the allocation strategies for FilterXObject instances to 4:
* normal heap allocated/refcounted
* stack allocated
* hybernated (e.g. created at syslog-ng startup, reloads not affecting them)
* frozen (associated with configurations)

Due to setting the hash value at freeze time, this depends on #583, so I am rebasing this on top of that.
