### PR TITLE
Filterx cache string hash values

### DIFF
--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -146,6 +146,8 @@ _string_new(const gchar *str, gssize str_len, FilterXStringTranslateFunc transla
   if (str_len == -1)
     str_len = strlen(str);
 
+  g_assert(str_len < G_MAXUINT);
+
   FilterXString *self = g_malloc(sizeof(FilterXString) + str_len + 1);
   memset(self, 0, sizeof(FilterXString));
   filterx_object_init_instance(&self->super, &FILTERX_TYPE_NAME(string));

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -31,7 +31,7 @@ struct _FilterXString
 {
   FilterXObject super;
   const gchar *str;
-  gsize str_len;
+  guint32 str_len;
   gchar storage[];
 };
 
@@ -97,7 +97,7 @@ void filterx_string_global_deinit(void);
   { \
     FILTERX_OBJECT_STACK_INIT(string), \
     .str = (cstr), \
-    .str_len = (((gssize) cstr_len) == -1 ? strlen(cstr) : (cstr_len)), \
+    .str_len = (((gssize) cstr_len) == -1 ? (guint32) strlen(cstr) : (guint32) (cstr_len)), \
   }
 
 #define FILTERX_STRING_DECLARE_ON_STACK(_name, cstr, cstr_len) \


### PR DESCRIPTION
This branch adds a "hash" value to FilterXString instances, which is calculated either:

1) when the string is frozen, as that happens during compile phase, so it's cheap
2) at runtime at the first invocation (potentially racy, but should resolve itself, review required!)

This way, a hash lookup with a frozen string will avoid having to do a g_str_hash() call

