### PR TITLE
Filterx: turn parse_csv() into a function

### DIFF
--- a/lib/filterx/object-dict.c
+++ b/lib/filterx/object-dict.c
@@ -670,6 +670,14 @@ filterx_dict_new(void)
   return filterx_dict_new_with_table(_table_new(32));
 }
 
+FilterXObject *
+filterx_dict_sized_new(gsize init_size)
+{
+  if (init_size < 16)
+    init_size = 16;
+  return filterx_dict_new_with_table(_table_new(init_size));
+}
+
 static void
 _filterx_dict_free(FilterXObject *s)
 {

--- a/lib/filterx/object-dict.h
+++ b/lib/filterx/object-dict.h
@@ -30,6 +30,7 @@
 FILTERX_DECLARE_TYPE(dict_object);
 
 FilterXObject *filterx_dict_new(void);
+FilterXObject *filterx_dict_sized_new(gsize init_size);
 FilterXObject *filterx_dict_new_from_args(FilterXExpr *s, FilterXObject *args[], gsize args_len);
 
 #endif

--- a/modules/csvparser/csvparser-plugin.c
+++ b/modules/csvparser/csvparser-plugin.c
@@ -38,7 +38,7 @@ static Plugin csvparser_plugins[] =
     .name = "csv-parser",
     .parser = &csvparser_parser,
   },
-  FILTERX_GENERATOR_FUNCTION_PLUGIN(parse_csv),
+  FILTERX_FUNCTION_PLUGIN(parse_csv),
   FILTERX_FUNCTION_PLUGIN(format_csv),
 };
 

--- a/modules/csvparser/filterx-func-parse-csv.c
+++ b/modules/csvparser/filterx-func-parse-csv.c
@@ -218,11 +218,11 @@ _eval_parse_csv(FilterXExpr *s)
                             FILTERX_FUNC_PARSE_CSV_ARG_NAME_STRING_DELIMITERS))
     goto exit;
 
-  if(!_maybe_init_columns(self, &cols, &num_of_columns))
+  if (!_maybe_init_columns(self, &cols, &num_of_columns))
     goto exit;
 
   if (_are_column_names_set(self))
-    result = filterx_dict_new();
+    result = filterx_dict_sized_new(num_of_columns);
   else
     result = filterx_list_new();
 

--- a/modules/csvparser/filterx-func-parse-csv.h
+++ b/modules/csvparser/filterx-func-parse-csv.h
@@ -46,7 +46,7 @@
     FILTERX_FUNC_PARSE_CSV_ARG_NAME_DELIMITER"' cannot be empty if '" \
     FILTERX_FUNC_PARSE_CSV_ARG_NAME_STRING_DELIMITERS"' is unset"
 
-FILTERX_GENERATOR_FUNCTION_DECLARE(parse_csv);
+FILTERX_FUNCTION_DECLARE(parse_csv);
 
 FilterXExpr *filterx_function_parse_csv_new(FilterXFunctionArgs *args, GError **error);
 

--- a/modules/csvparser/tests/test_filterx_func_parse_csv.c
+++ b/modules/csvparser/tests/test_filterx_func_parse_csv.c
@@ -58,20 +58,6 @@ _generate_string_list(const gchar *elts, ...)
   return result;
 }
 
-FilterXExpr *
-_csv_new(FilterXFunctionArgs *args, GError **error, FilterXObject *fillable)
-{
-  FilterXExpr *func = filterx_function_parse_csv_new(args, error);
-
-  if (!func)
-    return NULL;
-
-  FilterXExpr *fillable_expr = filterx_non_literal_new(fillable);
-  filterx_generator_set_fillable(func, fillable_expr);
-
-  return func;
-}
-
 Test(filterx_func_parse_csv, test_helper_generate_string_list_empty)
 {
   FilterXObject *col_names = _generate_string_list(NULL);
@@ -115,7 +101,7 @@ Test(filterx_func_parse_csv, test_empty_args_error)
 {
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(NULL, &args_err), &err, filterx_list_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(NULL, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_null(func);
   cr_assert_not_null(err);
@@ -132,7 +118,7 @@ Test(filterx_func_parse_csv, test_skipped_opts_causes_default_behaviour)
 
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(args, &args_err), &err, filterx_list_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_null(err);
 
@@ -162,7 +148,7 @@ Test(filterx_func_parse_csv, test_set_optional_first_argument_column_names)
 
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(args, &args_err), &err, filterx_dict_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_null(err);
 
@@ -193,7 +179,7 @@ Test(filterx_func_parse_csv, test_column_names_sets_expected_column_size_additio
 
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(args, &args_err), &err, filterx_dict_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_null(err);
 
@@ -223,7 +209,7 @@ Test(filterx_func_parse_csv, test_optional_argument_delimiters)
 
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(args, &args_err), &err, filterx_list_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_null(err);
 
@@ -253,7 +239,7 @@ Test(filterx_func_parse_csv, test_optional_argument_dialect)
 
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(args, &args_err), &err, filterx_list_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_null(err);
 
@@ -286,7 +272,7 @@ Test(filterx_func_parse_csv, test_optional_argument_flag_greedy)
 
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(args, &args_err), &err, filterx_dict_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_null(err);
 
@@ -319,7 +305,7 @@ Test(filterx_func_parse_csv, test_optional_argument_flag_non_greedy)
 
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(args, &args_err), &err, filterx_dict_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_null(err);
 
@@ -352,7 +338,7 @@ Test(filterx_func_parse_csv, test_optional_argument_flag_strip_whitespace)
 
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(args, &args_err), &err, filterx_list_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_null(err);
 
@@ -385,7 +371,7 @@ Test(filterx_func_parse_csv, test_optional_argument_flag_not_to_strip_whitespace
 
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(args, &args_err), &err, filterx_list_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_null(err);
 
@@ -416,7 +402,7 @@ Test(filterx_func_parse_csv, test_optional_argument_string_delimiters)
 
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(args, &args_err), &err, filterx_list_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_null(err);
 
@@ -449,7 +435,7 @@ Test(filterx_func_parse_csv, test_optional_argument_string_delimiters_and_delimi
 
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(args, &args_err), &err, filterx_list_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_null(err);
 
@@ -482,7 +468,7 @@ Test(filterx_func_parse_csv, test_optional_argument_delimiter_default_unset_when
 
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(args, &args_err), &err, filterx_list_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_null(err);
 
@@ -513,7 +499,7 @@ Test(filterx_func_parse_csv, test_optional_argument_delimiter_unable_to_set_with
 
   GError *err = NULL;
   GError *args_err = NULL;
-  FilterXExpr *func = _csv_new(filterx_function_args_new(args, &args_err), &err, filterx_list_new());
+  FilterXExpr *func = filterx_function_parse_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert_null(args_err);
   cr_assert_not_null(err);
   cr_assert(strcmp(err->message, FILTERX_FUNC_PARSE_ERR_EMPTY_DELIMITER));


### PR DESCRIPTION
This turns parse_csv() from a generator to a function, returning a dict instance. It also optimizes dict allocation when
the number of columns are known.
