### PR TITLE
Filterx: handle macros in expr variable

### DIFF
--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -52,10 +52,7 @@ _eval_macro(FilterXVariableExpr *self, FilterXEvalContext *context)
       filterx_eval_push_error("Variable is unset", &self->super, self->variable_name);
       return NULL;
     }
-
-  FilterXObject *res = filterx_message_value_new(value, value_len, t);
-  filterx_object_make_readonly(res);
-  return res;
+  return filterx_unmarshal_repr(value, value_len, t);
 }
 
 static FilterXObject *

--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -215,14 +215,7 @@ _pull_variable_from_message(FilterXScope *self, NVHandle handle)
   if (!value)
     return NULL;
 
-  if (log_msg_is_handle_macro(handle))
-    {
-      FilterXObject *res = filterx_message_value_new(value, value_len, t);
-      filterx_object_make_readonly(res);
-      return res;
-    }
-  else
-    return filterx_message_value_new_borrowed(value, value_len, t);
+  return filterx_message_value_new_borrowed(value, value_len, t);
 }
 
 

--- a/lib/filterx/object-message-value.c
+++ b/lib/filterx/object-message-value.c
@@ -173,7 +173,7 @@ _is_value_type_pair_truthy(const gchar  *repr, gssize repr_len, LogMessageValueT
 }
 
 FilterXObject *
-_unmarshal_repr(const gchar *repr, gssize repr_len, LogMessageValueType t)
+filterx_unmarshal_repr(const gchar *repr, gssize repr_len, LogMessageValueType t)
 {
   gdouble dbl;
   gint64 i64;
@@ -368,7 +368,7 @@ static FilterXObject *
 _unmarshal(FilterXObject *s)
 {
   FilterXMessageValue *self = (FilterXMessageValue *) s;
-  return _unmarshal_repr(self->repr, self->repr_len, self->type);
+  return filterx_unmarshal_repr(self->repr, self->repr_len, self->type);
 }
 
 static gboolean

--- a/lib/filterx/object-message-value.h
+++ b/lib/filterx/object-message-value.h
@@ -44,4 +44,7 @@ gboolean filterx_message_value_get_datetime(FilterXObject *s, UnixTime *value);
 gboolean filterx_message_value_get_null(FilterXObject *s);
 gboolean filterx_message_value_get_json(FilterXObject *s, struct json_object **value);
 
+/* unmarshal a message representation into a FilterXObject */
+FilterXObject *filterx_unmarshal_repr(const gchar *repr, gssize repr_len, LogMessageValueType t);
+
 #endif


### PR DESCRIPTION
Instead of adding resolved macro values into our variable cache, just resolve them in place without even registering them.

This has two side effects: 
* macros are always resolved and never cached (I think this is a good thing)
* macro values are not bounced into FilterXMessageValue instances but get directly unmarshalled into a typed FilterXObject
