### PR TITLE
filterx/filterx-scope: delay making the message writable in filterx_scope_sync()

### DIFF
--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -88,8 +88,7 @@ filterx_eval_sync_message(FilterXEvalContext *context, LogMessage **pmsg, const 
   if (!filterx_scope_is_dirty(context->scope))
     return;
 
-  log_msg_make_writable(pmsg, path_options);
-  filterx_scope_sync(context->scope, *pmsg);
+  filterx_scope_sync(context->scope, pmsg, path_options);
 }
 
 static inline void

--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -62,7 +62,7 @@ struct _FilterXScope
 
 typedef gboolean (*FilterXScopeForeachFunc)(FilterXVariable *variable, gpointer user_data);
 
-void filterx_scope_sync(FilterXScope *self, LogMessage *msg);
+void filterx_scope_sync(FilterXScope *self, LogMessage **pmsg, const LogPathOptions *path_options);
 
 FilterXVariable *filterx_scope_lookup_variable(FilterXScope *self, FilterXVariableHandle handle);
 FilterXVariable *filterx_scope_register_variable(FilterXScope *self,

--- a/lib/filterx/tests/test_scope.c
+++ b/lib/filterx/tests/test_scope.c
@@ -29,6 +29,7 @@
 #include "libtest/filterx-lib.h"
 #include "apphook.h"
 #include "logmsg/logmsg.h"
+#include "logpipe.h"
 
 #include "filterx/filterx-scope.h"
 #include "filterx/filterx-variable.h"
@@ -62,6 +63,8 @@ Test(filterx_scope, test_scope_stacking)
 
 Test(filterx_scope, test_scope_sync)
 {
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+
   gsize alloc_size = filterx_scope_get_alloc_size();
   FilterXScope *s = g_alloca(alloc_size);
   filterx_scope_init_instance(s, alloc_size, NULL);
@@ -76,7 +79,7 @@ Test(filterx_scope, test_scope_sync)
   filterx_object_unref(o);
 
   filterx_scope_set_dirty(s);
-  filterx_scope_sync(s, msg);
+  filterx_scope_sync(s, &msg, &path_options);
 
   LogMessageValueType type;
   const gchar *value = log_msg_get_value_with_type(msg, filterx_variable_get_nv_handle(v), NULL, &type);


### PR DESCRIPTION
Instead of immediately allocating a scratch buffer and making the message writable, delay these operations until we have
an actual value to sync back into the message.
