### PR TITLE
Filterx: optimize dict cow

### DIFF
--- a/lib/filterx/filterx-ref.c
+++ b/lib/filterx/filterx-ref.c
@@ -46,25 +46,16 @@ _filterx_ref_clone_value_if_shared(FilterXRef *self, FilterXRef *child_of_intere
   g_atomic_counter_inc(&self->value->fx_ref_cnt);
 }
 
-static void
-_filterx_ref_cow_parents(FilterXRef *self, FilterXRef *child_of_interest)
+gboolean
+_filterx_ref_cow_parents(FilterXObject *s, gpointer user_data)
 {
-  FilterXRef *parent_container = (FilterXRef *) filterx_weakref_get(&self->parent_container);
+  FilterXRef *self = (FilterXRef *) s;
+  FilterXRef *child_of_interest = (FilterXRef *) user_data;
 
-  if (parent_container)
-    {
-      _filterx_ref_cow_parents(parent_container, self);
-      filterx_object_unref(&parent_container->super);
-
-    }
+  filterx_weakref_invoke(&self->parent_container, _filterx_ref_cow_parents, self);
   _filterx_ref_clone_value_if_shared(self, child_of_interest);
   filterx_object_set_dirty(&self->super, TRUE);
-}
-
-void
-_filterx_ref_cow(FilterXRef *self)
-{
-  _filterx_ref_cow_parents(self, NULL);
+  return TRUE;
 }
 
 /* mutator methods */

--- a/lib/filterx/filterx-ref.h
+++ b/lib/filterx/filterx-ref.h
@@ -56,7 +56,13 @@ filterx_object_is_ref(FilterXObject *self)
   return self->type == &FILTERX_TYPE_NAME(ref);
 }
 
-void _filterx_ref_cow(FilterXRef *self);
+gboolean _filterx_ref_cow_parents(FilterXObject *s, gpointer user_data);
+
+static inline void
+_filterx_ref_cow(FilterXRef *self)
+{
+  _filterx_ref_cow_parents(&self->super, NULL);
+}
 
 /* Call them only where downcasting to a specific type is needed, the returned object should only be used locally. */
 static inline FilterXObject *


### PR DESCRIPTION
This improves copy-on-write performance for dicts by avoiding the ref/unref of dicts in the copy-on-write iteration.