### PR TITLE
light: Add various improvements to NetworkIO() and SyslogNg()

### DIFF
--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "axosyslog-light"
-version = "1.2.0"
+version = "1.3.0"
 description = "Lightweight End-to-End Test Framework for AxoSyslog."
 authors = ["Andras Mitzki <andras.mitzki@axoflow.com>", "Attila Szakacs <attila.szakacs@axoflow.com>"]
 readme = "README.md"

--- a/tests/light/src/axosyslog_light/driver_io/network/network_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/network/network_io.py
@@ -81,8 +81,8 @@ class NetworkIO():
             return "".join([str(len(message)) + " " + message for message in messages])
         return "".join([message + "\n" for message in messages])
 
-    def write_messages(self, messages, rate=None, transport=None, framed=None):
-        return self.write_raw(self.__format_messages(messages, framed=framed), rate=rate, transport=transport)
+    def write_messages(self, messages, rate=None, transport=None, framed=None, extra_loggen_args=None):
+        return self.write_raw(self.__format_messages(messages, framed=framed), rate=rate, transport=transport, extra_loggen_args=extra_loggen_args)
 
     def write_messages_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None, framed=None):
         return self.write_raw(

--- a/tests/light/src/axosyslog_light/driver_io/network/network_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/network/network_io.py
@@ -60,7 +60,7 @@ class NetworkIO():
         loggen_input_file = File(loggen_input_file_path)
         loggen_input_file.write_content_and_close(raw_content)
 
-        Loggen().start(
+        loggen_process = Loggen().start(
             LoggenStartParams(
                 target=self.__ip,
                 port=self.__port,
@@ -72,6 +72,7 @@ class NetworkIO():
                 **extra_loggen_args,
             ),
         )
+        return loggen_process
 
     def __format_messages(self, messages, framed=None):
         if framed is None:
@@ -81,10 +82,10 @@ class NetworkIO():
         return "".join([message + "\n" for message in messages])
 
     def write_messages(self, messages, rate=None, transport=None, framed=None):
-        self.write_raw(self.__format_messages(messages, framed=framed), rate=rate, transport=transport)
+        return self.write_raw(self.__format_messages(messages, framed=framed), rate=rate, transport=transport)
 
     def write_messages_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None, framed=None):
-        self.write_raw(
+        return self.write_raw(
             self.__format_messages(messages, framed=framed),
             rate=rate,
             transport=transport,

--- a/tests/light/src/axosyslog_light/syslog_ng/syslog_ng.py
+++ b/tests/light/src/axosyslog_light/syslog_ng/syslog_ng.py
@@ -125,7 +125,7 @@ class SyslogNg(object):
         self.stop()
         self.start(config)
 
-    def get_config_version(self) -> str:
+    def _get_version_info(self, parse_line: typing.Callable[[str], str], error_message: str) -> str:
         stdout_path = Path(f"syslog_ng_{self.instance_paths.get_instance_name()}_version_stdout")
         stderr_path = Path(f"syslog_ng_{self.instance_paths.get_instance_name()}_version_stderr")
 
@@ -139,33 +139,26 @@ class SyslogNg(object):
         )
         returncode = process.wait()
         if returncode != 0:
-            raise Exception(f"Cannot get syslog-ng config version. Process returned with {returncode}. See {stderr_path.absolute()} for details")
+            raise Exception(f"{error_message}. Process returned with {returncode}. See {stderr_path.absolute()} for details")
 
-        for version_output_line in stdout_path.read_text().splitlines():
-            if "Config version:" in version_output_line:
-                return version_output_line.split()[2]
-        raise Exception("Can not parse 'Config version' from 'syslog-ng --version'")
+        for line in stdout_path.read_text().splitlines():
+            try:
+                return parse_line(line)
+            except (IndexError, ValueError):
+                continue
+        raise Exception(f"Cannot parse version information from 'syslog-ng --version'")
+
+    def get_config_version(self) -> str:
+        def parse_line(line: str) -> str:
+            if "Config version:" in line:
+                return line.split()[2]
+            raise ValueError
+        return self._get_version_info(parse_line, "Cannot get syslog-ng config version")
 
     def get_version(self) -> str:
-        stdout_path = Path(f"syslog_ng_{self.instance_paths.get_instance_name()}_version_stdout")
-        stderr_path = Path(f"syslog_ng_{self.instance_paths.get_instance_name()}_version_stderr")
-
-        start_params = copy(self.start_params)
-        start_params.version = True
-
-        process = self._syslog_ng_executor.run_process(
-            start_params=start_params,
-            stderr_path=stderr_path,
-            stdout_path=stdout_path,
-        )
-        returncode = process.wait()
-        if returncode != 0:
-            raise Exception(f"Cannot get syslog-ng version. Process returned with {returncode}. See {stderr_path.absolute()} for details")
-
-        try:
-            return stdout_path.read_text().splitlines()[1].split()[2]
-        except IndexError:
-            raise Exception("Can not parse 'Config version' from 'syslog-ng --version'")
+        def parse_line(line: str) -> str:
+            return line.split()[2]
+        return self._get_version_info(parse_line, "Cannot get syslog-ng version")
 
     def is_process_running(self) -> bool:
         return self._process and self._process.poll() is None


### PR DESCRIPTION
NetworkIO() improvement:
 - return object of loggen process from NetworkIO.write_messages() functions, after this we will able to wait for process finish on caller side
 - pass "extra_loggen_args" to NetworkIO.write_messages() function, after this we can specify other loggen params on caller side as well

SyslogNg() improvement:
 - eliminate duplicate code of SyslogNg.get_config_version() and SyslogNg.get_version(), also fixes a bug in one of the  returned value.