### PR TITLE
Filterx: change literal dicts not to be generators

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -12,7 +12,7 @@ set(FILTERX_HEADERS
     filterx/expr-get-subscript.h
     filterx/expr-getattr.h
     filterx/expr-isset.h
-    filterx/expr-literal-generator.h
+    filterx/expr-literal-container.h
     filterx/expr-literal.h
     filterx/expr-null-coalesce.h
     filterx/expr-plus-generator.h
@@ -86,7 +86,7 @@ set(FILTERX_SOURCES
     filterx/expr-get-subscript.c
     filterx/expr-getattr.c
     filterx/expr-isset.c
-    filterx/expr-literal-generator.c
+    filterx/expr-literal-container.c
     filterx/expr-literal.c
     filterx/expr-null-coalesce.c
     filterx/expr-plus-generator.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -14,7 +14,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/expr-get-subscript.h \
 	lib/filterx/expr-getattr.h \
 	lib/filterx/expr-isset.h \
-	lib/filterx/expr-literal-generator.h \
+	lib/filterx/expr-literal-container.h \
 	lib/filterx/expr-literal.h \
 	lib/filterx/expr-null-coalesce.h \
 	lib/filterx/expr-plus-generator.h \
@@ -87,7 +87,7 @@ filterx_sources = 				\
 	lib/filterx/expr-get-subscript.c \
 	lib/filterx/expr-getattr.c \
 	lib/filterx/expr-isset.c \
-	lib/filterx/expr-literal-generator.c \
+	lib/filterx/expr-literal-container.c \
 	lib/filterx/expr-literal.c \
 	lib/filterx/expr-null-coalesce.c \
 	lib/filterx/expr-plus-generator.c \

--- a/lib/filterx/expr-literal-container.c
+++ b/lib/filterx/expr-literal-container.c
@@ -33,7 +33,6 @@ struct FilterXLiteralElement_
 {
   FilterXExpr *key;
   FilterXExpr *value;
-  gboolean cloneable;
   gboolean literal;
 };
 
@@ -76,13 +75,12 @@ _literal_element_free(FilterXLiteralElement *self)
 }
 
 FilterXLiteralElement *
-filterx_literal_element_new(FilterXExpr *key, FilterXExpr *value, gboolean cloneable)
+filterx_literal_element_new(FilterXExpr *key, FilterXExpr *value)
 {
   FilterXLiteralElement *self = g_new0(FilterXLiteralElement, 1);
 
   self->key = key;
   self->value = value;
-  self->cloneable = cloneable;
 
   return self;
 }
@@ -131,14 +129,7 @@ _literal_container_eval(FilterXExpr *s)
           goto error;
         }
 
-      if (elem->cloneable)
-        {
-          /* FIXME: check this! */
-          FilterXObject *cloned_value = filterx_object_clone(value);
-          filterx_object_unref(value);
-          value = cloned_value;
-        }
-
+      value = filterx_object_cow_fork2(value, NULL);
       gboolean success = filterx_object_set_subscript(result, key, &value);
 
       filterx_object_unref(key);

--- a/lib/filterx/expr-literal-container.c
+++ b/lib/filterx/expr-literal-container.c
@@ -21,7 +21,7 @@
  *
  */
 
-#include "filterx/expr-literal-generator.h"
+#include "filterx/expr-literal-container.h"
 #include "filterx/object-primitive.h"
 #include "filterx/object-dict.h"
 #include "filterx/object-list.h"

--- a/lib/filterx/expr-literal-container.h
+++ b/lib/filterx/expr-literal-container.h
@@ -30,8 +30,7 @@
 typedef struct FilterXLiteralElement_ FilterXLiteralElement;
 typedef struct FilterXLiteralContainer_ FilterXLiteralContainer;
 
-FilterXLiteralElement *filterx_literal_element_new(FilterXExpr *key, FilterXExpr *value,
-    gboolean cloneable);
+FilterXLiteralElement *filterx_literal_element_new(FilterXExpr *key, FilterXExpr *value);
 
 /* Literal Object expressions */
 

--- a/lib/filterx/expr-literal-container.h
+++ b/lib/filterx/expr-literal-container.h
@@ -36,7 +36,7 @@ FilterXLiteralElement *filterx_literal_element_new(FilterXExpr *key, FilterXExpr
 /* Literal Object expressions */
 
 FILTERX_EXPR_DECLARE_TYPE(literal_container);
-   
+
 gsize filterx_literal_container_len(FilterXExpr *s);
 
 

--- a/lib/filterx/expr-literal-generator.c
+++ b/lib/filterx/expr-literal-generator.c
@@ -23,28 +23,20 @@
 
 #include "filterx/expr-literal-generator.h"
 #include "filterx/object-primitive.h"
+#include "filterx/object-dict.h"
+#include "filterx/object-list.h"
 
-struct FilterXLiteralGeneratorElem_
+/* Object Members (e.g. key-value) */
+
+struct FilterXLiteralElement_
 {
   FilterXExpr *key;
   FilterXExpr *value;
   gboolean cloneable;
 };
 
-FilterXLiteralGeneratorElem *
-filterx_literal_generator_elem_new(FilterXExpr *key, FilterXExpr *value, gboolean cloneable)
-{
-  FilterXLiteralGeneratorElem *self = g_new0(FilterXLiteralGeneratorElem, 1);
-
-  self->key = key;
-  self->value = value;
-  self->cloneable = cloneable;
-
-  return self;
-}
-
 static gboolean
-_literal_generator_elem_init(FilterXLiteralGeneratorElem *self, GlobalConfig *cfg)
+_literal_element_init(FilterXLiteralElement *self, GlobalConfig *cfg)
 {
   if (!filterx_expr_init(self->key, cfg))
     return FALSE;
@@ -59,317 +51,188 @@ _literal_generator_elem_init(FilterXLiteralGeneratorElem *self, GlobalConfig *cf
 }
 
 static void
-_literal_generator_elem_optimize(FilterXLiteralGeneratorElem *self)
+_literal_element_optimize(FilterXLiteralElement *self)
 {
   self->key = filterx_expr_optimize(self->key);
   self->value = filterx_expr_optimize(self->value);
 }
 
 static void
-_literal_generator_elem_deinit(FilterXLiteralGeneratorElem *self, GlobalConfig *cfg)
+_literal_element_deinit(FilterXLiteralElement *self, GlobalConfig *cfg)
 {
   filterx_expr_deinit(self->key, cfg);
   filterx_expr_deinit(self->value, cfg);
 }
 
 static void
-_literal_generator_elem_free(FilterXLiteralGeneratorElem *self)
+_literal_element_free(FilterXLiteralElement *self)
 {
   filterx_expr_unref(self->key);
   filterx_expr_unref(self->value);
   g_free(self);
 }
 
-
-struct FilterXExprLiteralGenerator_
+FilterXLiteralElement *
+filterx_literal_element_new(FilterXExpr *key, FilterXExpr *value, gboolean cloneable)
 {
-  FilterXExprGenerator super;
+  FilterXLiteralElement *self = g_new0(FilterXLiteralElement, 1);
+
+  self->key = key;
+  self->value = value;
+  self->cloneable = cloneable;
+
+  return self;
+}
+
+/* Literal Object */
+
+struct FilterXLiteralContainer_
+{
+  FilterXExpr super;
+  FilterXObject *(*create_container)(FilterXLiteralContainer *self);
   GList *elements;
 };
 
-/* Takes reference of elements */
-void
-filterx_literal_generator_set_elements(FilterXExpr *s, GList *elements)
+gsize
+filterx_literal_container_len(FilterXExpr *s)
 {
-  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
+  GList *elements = NULL;
 
-  g_assert(!self->elements);
-  self->elements = elements;
+  elements = ((FilterXLiteralContainer *) s)->elements;
+  return g_list_length(elements);
 }
 
-static gboolean
-_eval_elements(FilterXObject *fillable, GList *elements)
+static FilterXObject *
+_literal_container_eval(FilterXExpr *s)
 {
-  for (GList *link = elements; link; link = link->next)
+  FilterXLiteralContainer *self = (FilterXLiteralContainer *) s;
+
+  FilterXObject *result = self->create_container(self);
+  filterx_object_cow_wrap(&result);
+  for (GList *link = self->elements; link; link = link->next)
     {
-      FilterXLiteralGeneratorElem *elem = (FilterXLiteralGeneratorElem *) link->data;
+      FilterXLiteralElement *elem = (FilterXLiteralElement *) link->data;
 
       FilterXObject *key = NULL;
       if (elem->key)
         {
           key = filterx_expr_eval(elem->key);
           if (!key)
-            return FALSE;
+            goto error;
         }
 
       FilterXObject *value = filterx_expr_eval(elem->value);
       if (!value)
         {
           filterx_object_unref(key);
-          return FALSE;
+          goto error;
         }
 
       if (elem->cloneable)
         {
+          /* FIXME: check this! */
           FilterXObject *cloned_value = filterx_object_clone(value);
           filterx_object_unref(value);
           value = cloned_value;
         }
 
-      gboolean success = filterx_object_set_subscript(fillable, key, &value);
+      gboolean success = filterx_object_set_subscript(result, key, &value);
 
       filterx_object_unref(key);
       filterx_object_unref(value);
 
       if (!success)
-        return FALSE;
+        goto error;
     }
 
-  return TRUE;
-}
-
-static gboolean
-_literal_generator_generate(FilterXExprGenerator *s, FilterXObject *fillable)
-{
-  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
-
-  return _eval_elements(fillable, self->elements);
+  return result;
+error:
+  filterx_object_unref(result);
+  return NULL;
 }
 
 static FilterXExpr *
-_literal_generator_optimize(FilterXExpr *s)
+_literal_container_optimize(FilterXExpr *s)
 {
-  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
+  FilterXLiteralContainer *self = (FilterXLiteralContainer *) s;
 
   for (GList *link = self->elements; link; link = link->next)
     {
-      FilterXLiteralGeneratorElem *elem = (FilterXLiteralGeneratorElem *) link->data;
+      FilterXLiteralElement *elem = (FilterXLiteralElement *) link->data;
 
-      _literal_generator_elem_optimize(elem);
+      _literal_element_optimize(elem);
     }
 
-  return filterx_generator_optimize_method(s);
+  return NULL;
 }
 
 static gboolean
-_literal_generator_init(FilterXExpr *s, GlobalConfig *cfg)
+_literal_container_init(FilterXExpr *s, GlobalConfig *cfg)
 {
-  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
+  FilterXLiteralContainer *self = (FilterXLiteralContainer *) s;
 
   for (GList *link = self->elements; link; link = link->next)
     {
-      FilterXLiteralGeneratorElem *elem = (FilterXLiteralGeneratorElem *) link->data;
+      FilterXLiteralElement *elem = (FilterXLiteralElement *) link->data;
 
-      if (!_literal_generator_elem_init(elem, cfg))
+      if (!_literal_element_init(elem, cfg))
         {
           for (GList *deinit_link = self->elements; deinit_link != link; deinit_link = deinit_link->next)
             {
-              elem = (FilterXLiteralGeneratorElem *) deinit_link->data;
-              _literal_generator_elem_deinit(elem, cfg);
+              elem = (FilterXLiteralElement *) deinit_link->data;
+              _literal_element_deinit(elem, cfg);
             }
           return FALSE;
         }
     }
 
-  return filterx_generator_init_method(s, cfg);
+  return filterx_expr_init_method(s, cfg);
 }
 
 static void
-_literal_generator_deinit(FilterXExpr *s, GlobalConfig *cfg)
+_literal_container_deinit(FilterXExpr *s, GlobalConfig *cfg)
 {
-  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
+  FilterXLiteralContainer *self = (FilterXLiteralContainer *) s;
 
   for (GList *link = self->elements; link; link = link->next)
     {
-      FilterXLiteralGeneratorElem *elem = (FilterXLiteralGeneratorElem *) link->data;
-      _literal_generator_elem_deinit(elem, cfg);
+      FilterXLiteralElement *elem = (FilterXLiteralElement *) link->data;
+      _literal_element_deinit(elem, cfg);
     }
 
-  filterx_generator_deinit_method(s, cfg);
+  filterx_expr_deinit_method(s, cfg);
 }
 
 void
-_literal_generator_free(FilterXExpr *s)
+_literal_container_free(FilterXExpr *s)
 {
-  FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
+  FilterXLiteralContainer *self = (FilterXLiteralContainer *) s;
 
-  g_list_free_full(self->elements, (GDestroyNotify) _literal_generator_elem_free);
-  filterx_generator_free_method(s);
-}
-
-static void
-_literal_generator_init_instance(FilterXExprLiteralGenerator *self)
-{
-  filterx_generator_init_instance(&self->super.super);
-  self->super.generate = _literal_generator_generate;
-  self->super.super.optimize = _literal_generator_optimize;
-  self->super.super.init = _literal_generator_init;
-  self->super.super.deinit = _literal_generator_deinit;
-  self->super.super.free_fn = _literal_generator_free;
-}
-
-
-FilterXExpr *
-filterx_literal_dict_generator_new(void)
-{
-  FilterXExprLiteralGenerator *self = g_new0(FilterXExprLiteralGenerator, 1);
-
-  _literal_generator_init_instance(self);
-  self->super.create_container = filterx_generator_create_dict_container;
-
-  return &self->super.super;
-}
-
-FilterXExpr *
-filterx_literal_list_generator_new(void)
-{
-  FilterXExprLiteralGenerator *self = g_new0(FilterXExprLiteralGenerator, 1);
-
-  _literal_generator_init_instance(self);
-  self->super.create_container = filterx_generator_create_list_container;
-
-  return &self->super.super;
-}
-
-
-typedef struct FilterXLiteralInnerGenerator_
-{
-  FilterXExpr super;
-  FilterXExprLiteralGenerator *root_literal_generator;
-  GList *elements;
-} FilterXLiteralInnerGenerator;
-
-FILTERX_EXPR_DEFINE_TYPE(literal_inner_dict_generator);
-FILTERX_EXPR_DEFINE_TYPE(literal_inner_list_generator);
-
-void
-_literal_inner_generator_free(FilterXExpr *s)
-{
-  FilterXLiteralInnerGenerator *self = (FilterXLiteralInnerGenerator *) s;
-
-  g_list_free_full(self->elements, (GDestroyNotify) _literal_generator_elem_free);
+  g_list_free_full(self->elements, (GDestroyNotify) _literal_element_free);
   filterx_expr_free_method(s);
 }
 
 static void
-_literal_inner_generator_init_instance(FilterXLiteralInnerGenerator *self, FilterXExpr *root_literal_generator,
-                                       GList *elements, const gchar *type)
+_literal_container_init_instance(FilterXLiteralContainer *self, const gchar *type)
 {
   filterx_expr_init_instance(&self->super, type);
-  self->super.free_fn = _literal_inner_generator_free;
-
-  /*
-   * We do not ref or unref the root_literal_generator, as we are always accessed through that, so it is expected
-   * to be alive while we are alive.
-   */
-  self->root_literal_generator = (FilterXExprLiteralGenerator *) root_literal_generator;
-  self->elements = elements;
+  self->super.eval = _literal_container_eval;
+  self->super.optimize = _literal_container_optimize;
+  self->super.init = _literal_container_init;
+  self->super.deinit = _literal_container_deinit;
+  self->super.free_fn = _literal_container_free;
 }
 
-static FilterXObject *
-_inner_dict_generator_eval(FilterXExpr *s)
-{
-  FilterXLiteralInnerGenerator *self = (FilterXLiteralInnerGenerator *) s;
-
-  FilterXObject *root_fillable = filterx_expr_eval_typed(self->root_literal_generator->super.fillable);
-  if (!root_fillable)
-    return NULL;
-
-  FilterXObject *fillable = filterx_object_create_dict(root_fillable);
-  filterx_object_unref(root_fillable);
-  if (!fillable)
-    return NULL;
-
-  if (_eval_elements(fillable, self->elements))
-    return fillable;
-
-  filterx_object_unref(fillable);
-  return NULL;
-}
-
-static FilterXObject *
-_inner_list_generator_eval(FilterXExpr *s)
-{
-  FilterXLiteralInnerGenerator *self = (FilterXLiteralInnerGenerator *) s;
-
-  FilterXObject *root_fillable = filterx_expr_eval_typed(self->root_literal_generator->super.fillable);
-  if (!root_fillable)
-    return NULL;
-
-  FilterXObject *fillable = filterx_object_create_list(root_fillable);
-  filterx_object_unref(root_fillable);
-  if (!fillable)
-    return NULL;
-
-  if (_eval_elements(fillable, self->elements))
-    return fillable;
-
-  filterx_object_unref(fillable);
-  return NULL;
-}
-
-/* Takes reference of elements */
-FilterXExpr *
-filterx_literal_inner_dict_generator_new(FilterXExpr *root_literal_generator, GList *elements)
-{
-  FilterXLiteralInnerGenerator *self = g_new0(FilterXLiteralInnerGenerator, 1);
-
-  _literal_inner_generator_init_instance(self,
-                                         root_literal_generator, elements,
-                                         FILTERX_EXPR_TYPE_NAME(literal_inner_dict_generator));
-  self->super.eval = _inner_dict_generator_eval;
-
-  return &self->super;
-}
-
-/* Takes reference of elements */
-FilterXExpr *
-filterx_literal_inner_list_generator_new(FilterXExpr *root_literal_generator, GList *elements)
-{
-  FilterXLiteralInnerGenerator *self = g_new0(FilterXLiteralInnerGenerator, 1);
-
-  _literal_inner_generator_init_instance(self,
-                                         root_literal_generator, elements,
-                                         FILTERX_EXPR_TYPE_NAME(literal_inner_list_generator));
-  self->super.eval = _inner_list_generator_eval;
-
-  return &self->super;
-}
-
-guint
-filterx_expr_literal_generator_len(FilterXExpr *s)
-{
-  GList *elements = NULL;
-  if (filterx_expr_is_literal_inner_dict_generator(s))
-    elements = ((FilterXLiteralInnerGenerator *) s)->elements;
-  else
-    elements = ((FilterXExprLiteralGenerator *) s)->elements;
-
-  return g_list_length(elements);
-}
+/* Literal dict objects */
 
 gboolean
-filterx_literal_dict_generator_foreach(FilterXExpr *s, FilterXLiteralDictGeneratorForeachFunc func, gpointer user_data)
+filterx_literal_dict_foreach(FilterXExpr *s, FilterXLiteralDictForeachFunc func, gpointer user_data)
 {
-  GList *elements = NULL;
-  if (filterx_expr_is_literal_inner_dict_generator(s))
-    elements = ((FilterXLiteralInnerGenerator *) s)->elements;
-  else
-    elements = ((FilterXExprLiteralGenerator *) s)->elements;
+  GList *elements = ((FilterXLiteralContainer *) s)->elements;
 
   for (GList *link = elements; link; link = link->next)
     {
-      FilterXLiteralGeneratorElem *elem = (FilterXLiteralGeneratorElem *) link->data;
+      FilterXLiteralElement *elem = (FilterXLiteralElement *) link->data;
 
       if (!func(elem->key, elem->value, user_data))
         return FALSE;
@@ -378,19 +241,35 @@ filterx_literal_dict_generator_foreach(FilterXExpr *s, FilterXLiteralDictGenerat
   return TRUE;
 }
 
-gboolean
-filterx_literal_list_generator_foreach(FilterXExpr *s, FilterXLiteralListGeneratorForeachFunc func, gpointer user_data)
+static FilterXObject *
+_literal_dict_create(FilterXLiteralContainer *s)
 {
-  GList *elements = NULL;
-  if (filterx_expr_is_literal_inner_list_generator(s))
-    elements = ((FilterXLiteralInnerGenerator *) s)->elements;
-  else
-    elements = ((FilterXExprLiteralGenerator *) s)->elements;
+  return filterx_dict_new();
+}
+
+FilterXExpr *
+filterx_literal_dict_new(GList *elements)
+{
+  FilterXLiteralContainer *self = g_new0(FilterXLiteralContainer, 1);
+
+  _literal_container_init_instance(self, FILTERX_EXPR_TYPE_NAME(literal_dict));
+  self->create_container = _literal_dict_create;
+  self->elements = elements;
+
+  return &self->super;
+}
+
+/* Literal list objects */
+
+gboolean
+filterx_literal_list_foreach(FilterXExpr *s, FilterXLiteralListForeachFunc func, gpointer user_data)
+{
+  GList *elements = ((FilterXLiteralContainer *) s)->elements;
 
   gsize i = 0;
   for (GList *link = elements; link; link = link->next)
     {
-      FilterXLiteralGeneratorElem *elem = (FilterXLiteralGeneratorElem *) link->data;
+      FilterXLiteralElement *elem = (FilterXLiteralElement *) link->data;
 
       if (!func(i, elem->value, user_data))
         return FALSE;
@@ -400,3 +279,24 @@ filterx_literal_list_generator_foreach(FilterXExpr *s, FilterXLiteralListGenerat
 
   return TRUE;
 }
+
+static FilterXObject *
+_literal_list_create(FilterXLiteralContainer *s)
+{
+  return filterx_list_new();
+}
+
+FilterXExpr *
+filterx_literal_list_new(GList *elements)
+{
+  FilterXLiteralContainer *self = g_new0(FilterXLiteralContainer, 1);
+
+  _literal_container_init_instance(self, FILTERX_EXPR_TYPE_NAME(literal_list));
+  self->create_container = _literal_list_create;
+  self->elements = elements;
+
+  return &self->super;
+}
+
+FILTERX_EXPR_DEFINE_TYPE(literal_list);
+FILTERX_EXPR_DEFINE_TYPE(literal_dict);

--- a/lib/filterx/expr-literal-generator.h
+++ b/lib/filterx/expr-literal-generator.h
@@ -24,65 +24,58 @@
 #ifndef FILTERX_EXPR_LITERAL_GENERATOR_H_INCLUDED
 #define FILTERX_EXPR_LITERAL_GENERATOR_H_INCLUDED
 
-#include "filterx/expr-generator.h"
+#include "filterx/filterx-expr.h"
 
-typedef gboolean (*FilterXLiteralDictGeneratorForeachFunc)(FilterXExpr *, FilterXExpr *, gpointer);
-typedef gboolean (*FilterXLiteralListGeneratorForeachFunc)(gsize, FilterXExpr *, gpointer);
 
-typedef struct FilterXLiteralGeneratorElem_ FilterXLiteralGeneratorElem;
-typedef struct FilterXExprLiteralGenerator_ FilterXExprLiteralGenerator;
+typedef struct FilterXLiteralElement_ FilterXLiteralElement;
+typedef struct FilterXLiteralContainer_ FilterXLiteralContainer;
 
-FilterXLiteralGeneratorElem *filterx_literal_generator_elem_new(FilterXExpr *key, FilterXExpr *value,
+FilterXLiteralElement *filterx_literal_element_new(FilterXExpr *key, FilterXExpr *value,
     gboolean cloneable);
 
-FilterXExpr *filterx_literal_dict_generator_new(void);
-FilterXExpr *filterx_literal_list_generator_new(void);
-void filterx_literal_generator_set_elements(FilterXExpr *s, GList *elements);
-gboolean filterx_literal_dict_generator_foreach(FilterXExpr *s, FilterXLiteralDictGeneratorForeachFunc func,
-                                                gpointer user_data);
-gboolean filterx_literal_list_generator_foreach(FilterXExpr *s, FilterXLiteralListGeneratorForeachFunc func,
-                                                gpointer user_data);
+/* Literal Object expressions */
 
-FilterXExpr *filterx_literal_inner_dict_generator_new(FilterXExpr *root_literal_generator, GList *elements);
-FilterXExpr *filterx_literal_inner_list_generator_new(FilterXExpr *root_literal_generator, GList *elements);
+FILTERX_EXPR_DECLARE_TYPE(literal_container);
+   
+gsize filterx_literal_container_len(FilterXExpr *s);
 
-guint filterx_expr_literal_generator_len(FilterXExpr *s);
 
-FILTERX_EXPR_DECLARE_TYPE(literal_inner_dict_generator);
-FILTERX_EXPR_DECLARE_TYPE(literal_inner_list_generator);
+/* Literal Dict */
+
+FILTERX_EXPR_DECLARE_TYPE(literal_dict);
+
+typedef gboolean (*FilterXLiteralDictForeachFunc)(FilterXExpr *, FilterXExpr *, gpointer);
+gboolean filterx_literal_dict_foreach(FilterXExpr *s, FilterXLiteralDictForeachFunc func, gpointer user_data);
+FilterXExpr *filterx_literal_dict_new(GList *elements);
+
+/* Literal List */
+
+FILTERX_EXPR_DECLARE_TYPE(literal_list);
+
+typedef gboolean (*FilterXLiteralListForeachFunc)(gsize, FilterXExpr *, gpointer);
+
+gboolean filterx_literal_list_foreach(FilterXExpr *s, FilterXLiteralListForeachFunc func, gpointer user_data);
+
+FilterXExpr *filterx_literal_list_new(GList *elements);
+
+/* inline functions */
 
 static inline gboolean
-filterx_expr_is_literal_inner_dict_generator(FilterXExpr *expr)
+filterx_expr_is_literal_dict(FilterXExpr *expr)
 {
-  return expr && expr->type == FILTERX_EXPR_TYPE_NAME(literal_inner_dict_generator);
+  return expr && expr->type == FILTERX_EXPR_TYPE_NAME(literal_dict);
 }
 
 static inline gboolean
-filterx_expr_is_literal_inner_list_generator(FilterXExpr *expr)
+filterx_expr_is_literal_list(FilterXExpr *expr)
 {
-  return expr && expr->type == FILTERX_EXPR_TYPE_NAME(literal_inner_list_generator);
+  return expr && expr->type == FILTERX_EXPR_TYPE_NAME(literal_list);
 }
 
 static inline gboolean
-filterx_expr_is_literal_dict_generator(FilterXExpr *s)
+filterx_expr_is_literal_container(FilterXExpr *s)
 {
-  FilterXExprGenerator *generator = (FilterXExprGenerator *) s;
-  return (filterx_expr_is_generator(s) && generator->create_container == filterx_generator_create_dict_container)
-         || filterx_expr_is_literal_inner_dict_generator(s);
-}
-
-static inline gboolean
-filterx_expr_is_literal_list_generator(FilterXExpr *s)
-{
-  FilterXExprGenerator *generator = (FilterXExprGenerator *) s;
-  return (filterx_expr_is_generator(s) && generator->create_container == filterx_generator_create_list_container)
-         || filterx_expr_is_literal_inner_list_generator(s);
-}
-
-static inline gboolean
-filterx_expr_is_literal_generator(FilterXExpr *s)
-{
-  return filterx_expr_is_literal_list_generator(s) || filterx_expr_is_literal_dict_generator(s);
+  return filterx_expr_is_literal_list(s) || filterx_expr_is_literal_dict(s);
 }
 
 #endif

--- a/lib/filterx/expr-literal.c
+++ b/lib/filterx/expr-literal.c
@@ -44,15 +44,24 @@ _free(FilterXExpr *s)
 }
 
 /* NOTE: takes the object reference */
-FilterXExpr *
-filterx_literal_new(FilterXObject *object)
+void
+filterx_literal_init_instance(FilterXLiteral *s, FilterXObject *object)
 {
-  FilterXLiteral *self = g_new0(FilterXLiteral, 1);
+  FilterXLiteral *self = (FilterXLiteral *) s;
 
   filterx_expr_init_instance(&self->super, FILTERX_EXPR_TYPE_NAME(literal));
   self->super.eval = _eval_literal;
   self->super.free_fn = _free;
   self->object = object;
+}
+
+/* NOTE: takes the object reference */
+FilterXExpr *
+filterx_literal_new(FilterXObject *object)
+{
+  FilterXLiteral *self = g_new0(FilterXLiteral, 1);
+
+  filterx_literal_init_instance(self, object);
   return &self->super;
 }
 

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -63,8 +63,6 @@
 
 #include "template/templates.h"
 
-FilterXExpr *last_literal_generator;
-
 FilterXExpr *
 construct_template_expr(LogTemplate *template)
 {
@@ -152,19 +150,15 @@ _assign_location(FilterXExpr *expr, CfgLexer *lexer, CFG_LTYPE *lloc)
 %type <ptr> arguments
 %type <ptr> first_argument
 %type <ptr> rest_argument
-%type <ptr> list_argument
-%type <ptr> dict_argument
 %type <node> literal
 %type <ptr> literal_object
 %type <node> variable
 %type <node> filterx_variable
 %type <ptr> template
-%type <ptr> dict_generator
-%type <ptr> inner_dict_generator
+%type <ptr> dict_literal
 %type <ptr> dict_element
 %type <ptr> dict_elements
-%type <ptr> list_generator
-%type <ptr> inner_list_generator
+%type <ptr> list_literal
 %type <ptr> list_element
 %type <ptr> list_elements
 %type <ptr> regexp_match
@@ -474,9 +468,7 @@ expr_generator
         ;
 
 __expr_generator
-	: dict_generator
-	| list_generator
-	| generator_function_call
+	: generator_function_call
 	| expr_plus_generator
 	| '(' expr_generator ')'		{ $$ = $2; }
 	;
@@ -517,39 +509,17 @@ arguments
 first_argument
 	: expr					{ $$ = filterx_function_arg_new(NULL, $1); }
 	| string KW_ASSIGN expr			{ $$ = filterx_function_arg_new($1, $3); free($1); }
-	| string KW_ASSIGN list_argument	{ $$ = filterx_function_arg_new($1, $3); free($1); }
-	| string KW_ASSIGN dict_argument	{ $$ = filterx_function_arg_new($1, $3); free($1); }
 	;
 
 rest_argument
 	: first_argument
-	| dict_argument				{ $$ = filterx_function_arg_new(NULL, $1); }
-	| list_argument				{ $$ = filterx_function_arg_new(NULL, $1); }
 	;
 
-list_argument
-	: list_generator			{
-						  GError *error = NULL;
-						  FilterXExpr *func = filterx_function_lookup(configuration, "list", NULL, &error);
-						  CHECK_FUNCTION_ERROR(func, @1, "list", error);
-
-						  filterx_generator_set_fillable($1, func);
-						  $$ = $1;
-						}
+literal
+	: literal_object				{ $$ = filterx_literal_new(filterx_config_freeze_object(configuration, $1)); }
+	| dict_literal
+	| list_literal
 	;
-
-dict_argument
-	: dict_generator			{
-						  GError *error = NULL;
-						  FilterXExpr *func = filterx_function_lookup(configuration, "dict", NULL, &error);
-						  CHECK_FUNCTION_ERROR(func, @1, "dict", error);
-
-						  filterx_generator_set_fillable($1, func);
-						  $$ = $1;
-						}
-	;
-
-literal: literal_object				{ $$ = filterx_literal_new(filterx_config_freeze_object(configuration, $1)); }
 
 literal_object
 	: LL_NUMBER				{ $$ = filterx_integer_new($1); }
@@ -593,13 +563,11 @@ template
           }
 	;
 
-dict_generator
-	: '{' { last_literal_generator = filterx_literal_dict_generator_new(); } dict_elements '}'
-						{ filterx_literal_generator_set_elements(last_literal_generator, $3); $$ = last_literal_generator; }
-	;
-
-inner_dict_generator
-	: '{' dict_elements '}'			{ $$ = filterx_literal_inner_dict_generator_new(last_literal_generator, $2); }
+dict_literal
+	: '{' dict_elements '}'
+          {
+            $$ = filterx_literal_dict_new($2);
+          }
 	;
 
 dict_elements
@@ -609,18 +577,14 @@ dict_elements
 	;
 
 dict_element
-	: expr ':' expr				{ $$ = filterx_literal_generator_elem_new($1, $3, TRUE); }
-	| expr ':' inner_dict_generator		{ $$ = filterx_literal_generator_elem_new($1, $3, FALSE); }
-	| expr ':' inner_list_generator		{ $$ = filterx_literal_generator_elem_new($1, $3, FALSE); }
+	: expr ':' expr				{ $$ = filterx_literal_element_new($1, $3, TRUE); }
 	;
 
-list_generator
-	: '[' { last_literal_generator = filterx_literal_list_generator_new(); } list_elements ']'
-						{ filterx_literal_generator_set_elements(last_literal_generator, $3); $$ = last_literal_generator; }
-	;
-
-inner_list_generator
-	: '[' list_elements ']'			{ $$ = filterx_literal_inner_list_generator_new(last_literal_generator, $2); }
+list_literal
+	: '[' list_elements ']'
+          {
+            $$ = filterx_literal_list_new($2);
+          }
 	;
 
 list_elements
@@ -630,9 +594,7 @@ list_elements
 	;
 
 list_element
-	: expr					{ $$ = filterx_literal_generator_elem_new(NULL, $1, TRUE); }
-	| inner_dict_generator			{ $$ = filterx_literal_generator_elem_new(NULL, $1, FALSE); }
-	| inner_list_generator			{ $$ = filterx_literal_generator_elem_new(NULL, $1, FALSE); }
+	: expr					{ $$ = filterx_literal_element_new(NULL, $1, TRUE); }
 	;
 
 regexp_match

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -51,7 +51,7 @@
 #include "filterx/expr-switch.h"
 #include "filterx/expr-isset.h"
 #include "filterx/expr-unset.h"
-#include "filterx/expr-literal-generator.h"
+#include "filterx/expr-literal-container.h"
 #include "filterx/expr-compound.h"
 #include "filterx/expr-regexp.h"
 #include "filterx/expr-plus.h"

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -577,7 +577,7 @@ dict_elements
 	;
 
 dict_element
-	: expr ':' expr				{ $$ = filterx_literal_element_new($1, $3, TRUE); }
+	: expr ':' expr				{ $$ = filterx_literal_element_new($1, $3); }
 	;
 
 list_literal
@@ -594,7 +594,7 @@ list_elements
 	;
 
 list_element
-	: expr					{ $$ = filterx_literal_element_new(NULL, $1, TRUE); }
+	: expr					{ $$ = filterx_literal_element_new(NULL, $1); }
 	;
 
 regexp_match

--- a/lib/filterx/filterx-metrics-labels.c
+++ b/lib/filterx/filterx-metrics-labels.c
@@ -25,7 +25,7 @@
 #include "filterx-metrics-labels.h"
 #include "filterx-eval.h"
 #include "expr-literal.h"
-#include "expr-literal-generator.h"
+#include "expr-literal-container.h"
 #include "object-string.h"
 #include "object-dict-interface.h"
 #include "object-metrics-labels.h"

--- a/lib/filterx/filterx-metrics-labels.c
+++ b/lib/filterx/filterx-metrics-labels.c
@@ -413,7 +413,7 @@ _init_literal_labels(FilterXExpr *labels_expr)
 {
   GPtrArray *literal_labels = g_ptr_array_new_with_free_func((GDestroyNotify) _label_free);
 
-  if (!filterx_literal_dict_generator_foreach(labels_expr, _add_literal_label, literal_labels))
+  if (!filterx_literal_dict_foreach(labels_expr, _add_literal_label, literal_labels))
     {
       g_ptr_array_unref(literal_labels);
       literal_labels = NULL;
@@ -435,7 +435,7 @@ _init_labels(FilterXMetricsLabels *self, FilterXExpr *labels)
       return TRUE;
     }
 
-  if (filterx_expr_is_literal_dict_generator(labels))
+  if (filterx_expr_is_literal_dict(labels))
     {
       self->literal_labels = _init_literal_labels(labels);
       return !!self->literal_labels;

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -41,7 +41,11 @@ log_filterx_pipe_init(LogPipe *s)
   if (!self->name)
     self->name = cfg_tree_get_rule_name(&cfg->tree, ENC_FILTER, s->expr_node);
 
+  FilterXEvalContext compile_context;
+
+  filterx_eval_begin_compile(&compile_context, cfg);
   self->block = filterx_expr_optimize(self->block);
+  filterx_eval_end_compile(&compile_context);
 
   if (!filterx_expr_init(self->block, cfg))
     return FALSE;

--- a/lib/filterx/func-set-fields.c
+++ b/lib/filterx/func-set-fields.c
@@ -28,7 +28,7 @@
 #include "filterx/object-dict-interface.h"
 #include "filterx/object-extractor.h"
 #include "filterx/expr-literal.h"
-#include "filterx/expr-literal-generator.h"
+#include "filterx/expr-literal-container.h"
 #include "filterx/filterx-eval.h"
 #include "scratch-buffers.h"
 

--- a/lib/filterx/func-set-fields.c
+++ b/lib/filterx/func-set-fields.c
@@ -384,8 +384,8 @@ _load_override(FilterXExpr *key, FilterXExpr *value, gpointer user_data)
   if (!field.key)
     return FALSE;
 
-  if (filterx_expr_is_literal_list_generator(value))
-    g_assert(filterx_literal_list_generator_foreach(value, _add_override, &field));
+  if (filterx_expr_is_literal_list(value))
+    g_assert(filterx_literal_list_foreach(value, _add_override, &field));
   else
     _field_add_override(&field, value);
 
@@ -402,7 +402,7 @@ _extract_overrides_arg(FilterXFunctionSetFields *self, FilterXFunctionArgs *args
 
   gboolean success = FALSE;
 
-  if (!filterx_expr_is_literal_dict_generator(overrides))
+  if (!filterx_expr_is_literal_dict(overrides))
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
                   "overrides argument must a literal dict. " FILTERX_FUNC_SET_FIELDS_USAGE);
@@ -410,7 +410,7 @@ _extract_overrides_arg(FilterXFunctionSetFields *self, FilterXFunctionArgs *args
     }
 
   gpointer user_data[] = { self, error };
-  success = filterx_literal_dict_generator_foreach(overrides, _load_override, user_data);
+  success = filterx_literal_dict_foreach(overrides, _load_override, user_data);
 
 exit:
   filterx_expr_unref(overrides);
@@ -455,8 +455,8 @@ _load_default(FilterXExpr *key, FilterXExpr *value, gpointer user_data)
       field->key = filterx_object_ref(key_obj);
     }
 
-  if (filterx_expr_is_literal_list_generator(value))
-    g_assert(filterx_literal_list_generator_foreach(value, _add_default, field));
+  if (filterx_expr_is_literal_list(value))
+    g_assert(filterx_literal_list_foreach(value, _add_default, field));
   else
     _field_add_default(field, value);
 
@@ -473,7 +473,7 @@ _extract_defaults_arg(FilterXFunctionSetFields *self, FilterXFunctionArgs *args,
 
   gboolean success = FALSE;
 
-  if (!filterx_expr_is_literal_dict_generator(defaults))
+  if (!filterx_expr_is_literal_dict(defaults))
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
                   "defaults argument must be a literal dict. " FILTERX_FUNC_SET_FIELDS_USAGE);
@@ -481,7 +481,7 @@ _extract_defaults_arg(FilterXFunctionSetFields *self, FilterXFunctionArgs *args,
     }
 
   gpointer user_data[] = { self, error };
-  success = filterx_literal_dict_generator_foreach(defaults, _load_default, user_data);
+  success = filterx_literal_dict_foreach(defaults, _load_default, user_data);
 
 exit:
   filterx_expr_unref(defaults);

--- a/lib/filterx/func-str.c
+++ b/lib/filterx/func-str.c
@@ -227,10 +227,10 @@ _expr_affix_cache_needle(FilterXExprAffix *self)
         goto error;
       g_ptr_array_add(self->needle.cached_strings, obj_with_cache);
     }
-  else if (filterx_expr_is_literal_list_generator(self->needle.expr))
+  else if (filterx_expr_is_literal_list(self->needle.expr))
     {
       gpointer user_data[] = {&self->ignore_case, self->needle.cached_strings};
-      if (!filterx_literal_list_generator_foreach(self->needle.expr, _cache_needle, user_data))
+      if (!filterx_literal_list_foreach(self->needle.expr, _cache_needle, user_data))
         goto error;
     }
 

--- a/lib/filterx/func-str.c
+++ b/lib/filterx/func-str.c
@@ -25,7 +25,7 @@
 #include "filterx/func-str.h"
 #include "filterx/object-primitive.h"
 #include "filterx/expr-literal.h"
-#include "filterx/expr-literal-generator.h"
+#include "filterx/expr-literal-container.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/object-extractor.h"
 #include "filterx/object-string.h"

--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -422,12 +422,12 @@ _handle_target_object(FilterXFunctionUnsetEmpties *self, FilterXObject *target, 
 }
 
 static gboolean
-_target_iterator(FilterXExpr *key, FilterXExpr *value, gpointer user_data)
+_target_iterator(gsize index, FilterXExpr *value, gpointer user_data)
 {
   FilterXFunctionUnsetEmpties *self = ((gpointer *) user_data)[0];
   GError **error = ((gpointer *) user_data)[1];
 
-  if (!filterx_expr_is_literal(value) && !filterx_expr_is_literal_generator(value))
+  if (!filterx_expr_is_literal(value) && !filterx_expr_is_literal_container(value))
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
                   FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS" list members must be literals!" FILTERX_FUNC_UNSET_EMPTIES_USAGE);
@@ -453,14 +453,14 @@ _extract_target_objects(FilterXFunctionUnsetEmpties *self, FilterXFunctionArgs *
   if (!exists)
     return TRUE;
 
-  if (!filterx_expr_is_literal_list_generator(targets))
+  if (!filterx_expr_is_literal_list(targets))
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
                   FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS" argument must be literal list. " FILTERX_FUNC_UNSET_EMPTIES_USAGE);
       return FALSE;
     }
 
-  guint64 num_targets = filterx_expr_literal_generator_len(targets);
+  guint64 num_targets = filterx_literal_container_len(targets);
   if (num_targets > 0)
     reset_flags(&self->flags, self->flags & (FLAG_VAL(FILTERX_FUNC_UNSET_EMPTIES_FLAG_IGNORECASE) |
                                              FLAG_VAL(FILTERX_FUNC_UNSET_EMPTIES_FLAG_RECURSIVE)));
@@ -468,7 +468,7 @@ _extract_target_objects(FilterXFunctionUnsetEmpties *self, FilterXFunctionArgs *
 
   gpointer user_data[] = { self, error };
   gboolean result = TRUE;
-  if (!filterx_literal_dict_generator_foreach(targets, _target_iterator, user_data))
+  if (!filterx_literal_list_foreach(targets, _target_iterator, user_data))
     result = FALSE;
   filterx_expr_unref(targets);
   return result;

--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -33,7 +33,7 @@
 #include "filterx/filterx-eval.h"
 #include "filterx/filterx-globals.h"
 #include "filterx/func-flags.h"
-#include "filterx/expr-literal-generator.h"
+#include "filterx/expr-literal-container.h"
 #include "filterx/expr-literal.h"
 
 #define FILTERX_FUNC_UNSET_EMPTIES_USAGE "Usage: unset_empties(object, " \

--- a/lib/filterx/tests/test_expr_plus_generator.c
+++ b/lib/filterx/tests/test_expr_plus_generator.c
@@ -84,21 +84,19 @@ _assert_cmp_lists(FilterXObject *expected, FilterXObject *provided)
 
 Test(expr_plus_generator, test_list_add_two_generators_with_post_set_fillable)
 {
-  FilterXExpr *lhs = filterx_literal_list_generator_new();
   GList *lhs_vals = NULL;
   lhs_vals = g_list_append(lhs_vals,
-                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("foo", -1)), FALSE));
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("foo", -1)), FALSE));
   lhs_vals = g_list_append(lhs_vals,
-                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("bar", -1)), FALSE));
-  filterx_literal_generator_set_elements(lhs, lhs_vals);
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("bar", -1)), FALSE));
+  FilterXExpr *lhs = filterx_literal_list_new(lhs_vals);
 
-  FilterXExpr *rhs = filterx_literal_list_generator_new();
   GList *rhs_vals = NULL;
   rhs_vals = g_list_append(rhs_vals,
-                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("baz", -1)), FALSE));
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("baz", -1)), FALSE));
   rhs_vals = g_list_append(rhs_vals,
-                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("other", -1)), FALSE));
-  filterx_literal_generator_set_elements(rhs, rhs_vals);
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("other", -1)), FALSE));
+  FilterXExpr *rhs = filterx_literal_list_new(rhs_vals);
 
 
   FilterXExpr *expr = filterx_operator_plus_generator_new(lhs, rhs);
@@ -121,13 +119,12 @@ Test(expr_plus_generator, test_list_add_two_generators_with_post_set_fillable)
 
 Test(expr_plus_generator, test_list_add_variable_to_generator_with_post_set_fillable)
 {
-  FilterXExpr *lhs = filterx_literal_list_generator_new();
   GList *lhs_vals = NULL;
   lhs_vals = g_list_append(lhs_vals,
-                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("foo", -1)), FALSE));
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("foo", -1)), FALSE));
   lhs_vals = g_list_append(lhs_vals,
-                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("bar", -1)), FALSE));
-  filterx_literal_generator_set_elements(lhs, lhs_vals);
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("bar", -1)), FALSE));
+  FilterXExpr *lhs = filterx_literal_list_new(lhs_vals);
 
   FilterXExpr *rhs = filterx_non_literal_new(filterx_object_from_json("[\"baz\", \"other\"]", -1, NULL));
 
@@ -154,13 +151,12 @@ Test(expr_plus_generator, test_list_add_generator_to_variable_with_post_set_fill
 {
   FilterXExpr *lhs = filterx_non_literal_new(filterx_object_from_json("[\"foo\", \"bar\"]", -1, NULL));
 
-  FilterXExpr *rhs = filterx_literal_list_generator_new();
   GList *rhs_vals = NULL;
   rhs_vals = g_list_append(rhs_vals,
-                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("baz", -1)), FALSE));
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("baz", -1)), FALSE));
   rhs_vals = g_list_append(rhs_vals,
-                           filterx_literal_generator_elem_new(NULL, filterx_literal_new(filterx_string_new("other", -1)), FALSE));
-  filterx_literal_generator_set_elements(rhs, rhs_vals);
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("other", -1)), FALSE));
+  FilterXExpr *rhs = filterx_literal_list_new(rhs_vals);
 
   FilterXExpr *expr = filterx_operator_plus_generator_new(lhs, rhs);
   FilterXObject *list = filterx_list_new();
@@ -184,27 +180,25 @@ Test(expr_plus_generator, test_list_add_generator_to_variable_with_post_set_fill
 
 Test(expr_plus_generator, test_nested_dict_add_two_generators_with_post_set_fillable)
 {
-  FilterXExpr *lhs = filterx_literal_dict_generator_new();
   GList *lhs_vals = NULL;
   GList *lhs_inner = NULL;
   lhs_inner = g_list_append(lhs_inner,
-                            filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("bar", -1)),
+                            filterx_literal_element_new(filterx_literal_new(filterx_string_new("bar", -1)),
                                 filterx_literal_new(filterx_string_new("baz", -1)), TRUE));
   lhs_vals = g_list_append(lhs_vals,
-                           filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("foo", -1)),
-                                                              filterx_literal_inner_dict_generator_new(lhs, lhs_inner), FALSE));
-  filterx_literal_generator_set_elements(lhs, lhs_vals);
+                           filterx_literal_element_new(filterx_literal_new(filterx_string_new("foo", -1)),
+                                                              filterx_literal_dict_new(lhs_inner), FALSE));
+  FilterXExpr *lhs = filterx_literal_dict_new(lhs_vals);
 
-  FilterXExpr *rhs = filterx_literal_dict_generator_new();
   GList *rhs_vals = NULL;
   GList *rhs_inner = NULL;
   rhs_inner = g_list_append(rhs_inner,
-                            filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("tak", -1)),
+                            filterx_literal_element_new(filterx_literal_new(filterx_string_new("tak", -1)),
                                 filterx_literal_new(filterx_string_new("toe", -1)), TRUE));
   rhs_vals = g_list_append(rhs_vals,
-                           filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("tik", -1)),
-                                                              filterx_literal_inner_dict_generator_new(rhs, rhs_inner), FALSE));
-  filterx_literal_generator_set_elements(rhs, rhs_vals);
+                           filterx_literal_element_new(filterx_literal_new(filterx_string_new("tik", -1)),
+                                                              filterx_literal_dict_new(rhs_inner), FALSE));
+  FilterXExpr *rhs = filterx_literal_dict_new(rhs_vals);
 
   FilterXExpr *expr = filterx_operator_plus_generator_new(lhs, rhs);
   FilterXObject *dict = filterx_dict_new();
@@ -224,16 +218,15 @@ Test(expr_plus_generator, test_nested_dict_add_two_generators_with_post_set_fill
 
 Test(expr_plus_generator, test_nested_dict_add_variable_to_generator_with_post_set_fillable)
 {
-  FilterXExpr *lhs = filterx_literal_dict_generator_new();
   GList *lhs_vals = NULL;
   GList *lhs_inner = NULL;
   lhs_inner = g_list_append(lhs_inner,
-                            filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("bar", -1)),
+                            filterx_literal_element_new(filterx_literal_new(filterx_string_new("bar", -1)),
                                 filterx_literal_new(filterx_string_new("baz", -1)), TRUE));
   lhs_vals = g_list_append(lhs_vals,
-                           filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("foo", -1)),
-                                                              filterx_literal_inner_dict_generator_new(lhs, lhs_inner), FALSE));
-  filterx_literal_generator_set_elements(lhs, lhs_vals);
+                           filterx_literal_element_new(filterx_literal_new(filterx_string_new("foo", -1)),
+                                                              filterx_literal_dict_new(lhs_inner), FALSE));
+  FilterXExpr *lhs = filterx_literal_dict_new(lhs_vals);
 
   FilterXExpr *rhs = filterx_non_literal_new(filterx_object_from_json("{\"tik\":{\"tak\":\"toe\"}}", -1, NULL));
 
@@ -258,16 +251,15 @@ Test(expr_plus_generator, test_nested_dict_add_generator_to_variable_with_post_s
 
   FilterXExpr *lhs = filterx_non_literal_new(filterx_object_from_json("{\"foo\":{\"bar\":\"baz\"}}", -1, NULL));
 
-  FilterXExpr *rhs = filterx_literal_dict_generator_new();
   GList *rhs_vals = NULL;
   GList *rhs_inner = NULL;
   rhs_inner = g_list_append(rhs_inner,
-                            filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("tak", -1)),
+                            filterx_literal_element_new(filterx_literal_new(filterx_string_new("tak", -1)),
                                 filterx_literal_new(filterx_string_new("toe", -1)), TRUE));
   rhs_vals = g_list_append(rhs_vals,
-                           filterx_literal_generator_elem_new(filterx_literal_new(filterx_string_new("tik", -1)),
-                                                              filterx_literal_inner_dict_generator_new(rhs, rhs_inner), FALSE));
-  filterx_literal_generator_set_elements(rhs, rhs_vals);
+                           filterx_literal_element_new(filterx_literal_new(filterx_string_new("tik", -1)),
+                                                              filterx_literal_dict_new(rhs_inner), FALSE));
+  FilterXExpr *rhs = filterx_literal_dict_new(rhs_vals);
 
   FilterXExpr *expr = filterx_operator_plus_generator_new(lhs, rhs);
   FilterXObject *dict = filterx_dict_new();

--- a/lib/filterx/tests/test_expr_plus_generator.c
+++ b/lib/filterx/tests/test_expr_plus_generator.c
@@ -47,7 +47,7 @@
 #include "filterx/object-dict-interface.h"
 #include "filterx/json-repr.h"
 #include "filterx/expr-generator.h"
-#include "filterx/expr-literal-generator.h"
+#include "filterx/expr-literal-container.h"
 
 #include "apphook.h"
 #include "scratch-buffers.h"

--- a/lib/filterx/tests/test_expr_plus_generator.c
+++ b/lib/filterx/tests/test_expr_plus_generator.c
@@ -86,16 +86,16 @@ Test(expr_plus_generator, test_list_add_two_generators_with_post_set_fillable)
 {
   GList *lhs_vals = NULL;
   lhs_vals = g_list_append(lhs_vals,
-                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("foo", -1)), FALSE));
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("foo", -1))));
   lhs_vals = g_list_append(lhs_vals,
-                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("bar", -1)), FALSE));
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("bar", -1))));
   FilterXExpr *lhs = filterx_literal_list_new(lhs_vals);
 
   GList *rhs_vals = NULL;
   rhs_vals = g_list_append(rhs_vals,
-                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("baz", -1)), FALSE));
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("baz", -1))));
   rhs_vals = g_list_append(rhs_vals,
-                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("other", -1)), FALSE));
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("other", -1))));
   FilterXExpr *rhs = filterx_literal_list_new(rhs_vals);
 
 
@@ -121,9 +121,9 @@ Test(expr_plus_generator, test_list_add_variable_to_generator_with_post_set_fill
 {
   GList *lhs_vals = NULL;
   lhs_vals = g_list_append(lhs_vals,
-                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("foo", -1)), FALSE));
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("foo", -1))));
   lhs_vals = g_list_append(lhs_vals,
-                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("bar", -1)), FALSE));
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("bar", -1))));
   FilterXExpr *lhs = filterx_literal_list_new(lhs_vals);
 
   FilterXExpr *rhs = filterx_non_literal_new(filterx_object_from_json("[\"baz\", \"other\"]", -1, NULL));
@@ -153,9 +153,9 @@ Test(expr_plus_generator, test_list_add_generator_to_variable_with_post_set_fill
 
   GList *rhs_vals = NULL;
   rhs_vals = g_list_append(rhs_vals,
-                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("baz", -1)), FALSE));
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("baz", -1))));
   rhs_vals = g_list_append(rhs_vals,
-                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("other", -1)), FALSE));
+                           filterx_literal_element_new(NULL, filterx_literal_new(filterx_string_new("other", -1))));
   FilterXExpr *rhs = filterx_literal_list_new(rhs_vals);
 
   FilterXExpr *expr = filterx_operator_plus_generator_new(lhs, rhs);
@@ -184,20 +184,20 @@ Test(expr_plus_generator, test_nested_dict_add_two_generators_with_post_set_fill
   GList *lhs_inner = NULL;
   lhs_inner = g_list_append(lhs_inner,
                             filterx_literal_element_new(filterx_literal_new(filterx_string_new("bar", -1)),
-                                filterx_literal_new(filterx_string_new("baz", -1)), TRUE));
+                                                        filterx_literal_new(filterx_string_new("baz", -1))));
   lhs_vals = g_list_append(lhs_vals,
                            filterx_literal_element_new(filterx_literal_new(filterx_string_new("foo", -1)),
-                                                              filterx_literal_dict_new(lhs_inner), FALSE));
+                                                       filterx_literal_dict_new(lhs_inner)));
   FilterXExpr *lhs = filterx_literal_dict_new(lhs_vals);
 
   GList *rhs_vals = NULL;
   GList *rhs_inner = NULL;
   rhs_inner = g_list_append(rhs_inner,
                             filterx_literal_element_new(filterx_literal_new(filterx_string_new("tak", -1)),
-                                filterx_literal_new(filterx_string_new("toe", -1)), TRUE));
+                                                        filterx_literal_new(filterx_string_new("toe", -1))));
   rhs_vals = g_list_append(rhs_vals,
                            filterx_literal_element_new(filterx_literal_new(filterx_string_new("tik", -1)),
-                                                              filterx_literal_dict_new(rhs_inner), FALSE));
+                                                       filterx_literal_dict_new(rhs_inner)));
   FilterXExpr *rhs = filterx_literal_dict_new(rhs_vals);
 
   FilterXExpr *expr = filterx_operator_plus_generator_new(lhs, rhs);
@@ -222,10 +222,10 @@ Test(expr_plus_generator, test_nested_dict_add_variable_to_generator_with_post_s
   GList *lhs_inner = NULL;
   lhs_inner = g_list_append(lhs_inner,
                             filterx_literal_element_new(filterx_literal_new(filterx_string_new("bar", -1)),
-                                filterx_literal_new(filterx_string_new("baz", -1)), TRUE));
+                                                        filterx_literal_new(filterx_string_new("baz", -1))));
   lhs_vals = g_list_append(lhs_vals,
                            filterx_literal_element_new(filterx_literal_new(filterx_string_new("foo", -1)),
-                                                              filterx_literal_dict_new(lhs_inner), FALSE));
+                                                       filterx_literal_dict_new(lhs_inner)));
   FilterXExpr *lhs = filterx_literal_dict_new(lhs_vals);
 
   FilterXExpr *rhs = filterx_non_literal_new(filterx_object_from_json("{\"tik\":{\"tak\":\"toe\"}}", -1, NULL));
@@ -255,10 +255,10 @@ Test(expr_plus_generator, test_nested_dict_add_generator_to_variable_with_post_s
   GList *rhs_inner = NULL;
   rhs_inner = g_list_append(rhs_inner,
                             filterx_literal_element_new(filterx_literal_new(filterx_string_new("tak", -1)),
-                                filterx_literal_new(filterx_string_new("toe", -1)), TRUE));
+                                                        filterx_literal_new(filterx_string_new("toe", -1))));
   rhs_vals = g_list_append(rhs_vals,
                            filterx_literal_element_new(filterx_literal_new(filterx_string_new("tik", -1)),
-                                                              filterx_literal_dict_new(rhs_inner), FALSE));
+                                                       filterx_literal_dict_new(rhs_inner)));
   FilterXExpr *rhs = filterx_literal_dict_new(rhs_vals);
 
   FilterXExpr *expr = filterx_operator_plus_generator_new(lhs, rhs);

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -28,7 +28,7 @@
 #include "filterx/filterx-eval.h"
 #include "filterx/expr-literal.h"
 #include "filterx/expr-template.h"
-#include "filterx/expr-literal-generator.h"
+#include "filterx/expr-literal-container.h"
 #include "filterx/object-primitive.h"
 #include "filterx/object-string.h"
 #include "filterx/object-dict.h"

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -96,16 +96,13 @@ Test(filterx_expr, test_filterx_literal_list_with_inmutable_values)
   // [42];
   values = g_list_append(values,
                          filterx_literal_element_new(NULL,
-                                                     filterx_literal_new(filterx_integer_new(42)),
-                                                     TRUE));
+                                                     filterx_literal_new(filterx_integer_new(42))));
   values = g_list_append(values,
                          filterx_literal_element_new(NULL,
-                                                     filterx_literal_new(filterx_integer_new(43)),
-                                                     TRUE));
+                                                     filterx_literal_new(filterx_integer_new(43))));
   values = g_list_append(values,
                          filterx_literal_element_new(NULL,
-                                                     filterx_literal_new(filterx_integer_new(44)),
-                                                     TRUE));
+                                                     filterx_literal_new(filterx_integer_new(44))));
   list_expr = filterx_literal_list_new(values);
 
   // result = [42,43,44];
@@ -131,12 +128,10 @@ Test(filterx_expr, test_filterx_literal_list_with_embedded_list)
   // [[1337]];
   inner_values = g_list_append(NULL,
                                filterx_literal_element_new(NULL,
-                                                           filterx_literal_new(filterx_integer_new(1337)),
-                                                           TRUE));
+                                                           filterx_literal_new(filterx_integer_new(1337))));
   values = g_list_append(NULL,
                          filterx_literal_element_new(NULL,
-                                                     filterx_literal_list_new(inner_values),
-                                                     TRUE));
+                                                     filterx_literal_list_new(inner_values)));
   list_expr = filterx_literal_list_new(values);
 
   // result = [[1337]];
@@ -172,16 +167,13 @@ Test(filterx_expr, test_filterx_dict_immutable_values)
 
   values = g_list_append(values,
                          filterx_literal_element_new(filterx_literal_new(filterx_object_ref(foo)),
-                                                     filterx_literal_new(filterx_integer_new(42)),
-                                                     TRUE));
+                                                     filterx_literal_new(filterx_integer_new(42))));
   values = g_list_append(values,
                          filterx_literal_element_new(filterx_literal_new(filterx_object_ref(bar)),
-                                                     filterx_literal_new(filterx_integer_new(43)),
-                                                     TRUE));
+                                                     filterx_literal_new(filterx_integer_new(43))));
   values = g_list_append(values,
                          filterx_literal_element_new(filterx_literal_new(filterx_object_ref(baz)),
-                                                     filterx_literal_new(filterx_integer_new(44)),
-                                                     TRUE));
+                                                     filterx_literal_new(filterx_integer_new(44))));
   dict_expr = filterx_literal_dict_new(values);
 
   // result = {"foo": 42, "bar": 43, "baz": 44};
@@ -214,21 +206,17 @@ Test(filterx_expr, test_filterx_dict_with_embedded_dict)
   // {"foo": 1};
   inner_values = g_list_append(inner_values,
                                filterx_literal_element_new(filterx_literal_new(filterx_object_ref(foo)),
-                                                           filterx_literal_new(filterx_integer_new(1)),
-                                                           TRUE));
+                                                           filterx_literal_new(filterx_integer_new(1))));
   // result = {"foo": 420, "bar": 1337", "baz": {"foo":1}};
   values = g_list_append(values,
                          filterx_literal_element_new(filterx_literal_new(filterx_object_ref(foo)),
-                                                     filterx_literal_new(filterx_integer_new(420)),
-                                                     TRUE));
+                                                     filterx_literal_new(filterx_integer_new(420))));
   values = g_list_append(values,
                          filterx_literal_element_new(filterx_literal_new(filterx_object_ref(bar)),
-                                                     filterx_literal_new(filterx_integer_new(1337)),
-                                                     TRUE));
+                                                     filterx_literal_new(filterx_integer_new(1337))));
   values = g_list_append(values,
                          filterx_literal_element_new(filterx_literal_new(filterx_object_ref(baz)),
-                                                     filterx_literal_dict_new(inner_values),
-                                                     FALSE));
+                                                     filterx_literal_dict_new(inner_values)));
 
   dict_expr = filterx_literal_dict_new(values);
 

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -85,66 +85,68 @@ Test(filterx_expr, test_filterx_template_evaluates_to_the_expanded_value)
   filterx_object_unref(fobj);
 }
 
-Test(filterx_expr, test_filterx_list_merge)
+Test(filterx_expr, test_filterx_literal_list_with_inmutable_values)
 {
-  // $fillable = json_array();
-  FilterXObject *list = filterx_list_new();
-  FilterXExpr *fillable = filterx_literal_new(list);
+  FilterXExpr *list_expr = NULL;
+  FilterXObject *result = NULL;
+  GList *values = NULL;
+  guint64 len;
+
+
+  // [42];
+  values = g_list_append(values,
+                         filterx_literal_element_new(NULL,
+                                                     filterx_literal_new(filterx_integer_new(42)),
+                                                     TRUE));
+  values = g_list_append(values,
+                         filterx_literal_element_new(NULL,
+                                                     filterx_literal_new(filterx_integer_new(43)),
+                                                     TRUE));
+  values = g_list_append(values,
+                         filterx_literal_element_new(NULL,
+                                                     filterx_literal_new(filterx_integer_new(44)),
+                                                     TRUE));
+  list_expr = filterx_literal_list_new(values);
+
+  // result = [42,43,44];
+  result = filterx_expr_eval(list_expr);
+  cr_assert(result);
+  cr_assert(filterx_object_truthy(result));
+  cr_assert(filterx_object_len(result, &len));
+  cr_assert_eq(len, 3);
+  _assert_int_value_and_unref(filterx_list_get_subscript(result, 0), 42);
+  _assert_int_value_and_unref(filterx_list_get_subscript(result, 1), 43);
+  _assert_int_value_and_unref(filterx_list_get_subscript(result, 2), 44);
+  filterx_object_unref(result);
+  filterx_expr_unref(list_expr);
+}
+
+Test(filterx_expr, test_filterx_literal_list_with_embedded_list)
+{
   FilterXExpr *list_expr = NULL;
   FilterXObject *result = NULL;
   GList *values = NULL, *inner_values = NULL;
   guint64 len;
 
-
-  // [42];
-  values = g_list_append(NULL, filterx_literal_generator_elem_new(NULL,
-                         filterx_literal_new(filterx_integer_new(42)),
-                         TRUE));
-  list_expr = filterx_literal_list_generator_new();
-  filterx_generator_set_fillable(list_expr, filterx_expr_ref(fillable));
-  filterx_literal_generator_set_elements(list_expr, values);
-
-  // $fillable += [42];
-  result = filterx_expr_eval(list_expr);
-  cr_assert(result);
-  cr_assert(filterx_object_truthy(result));
-  cr_assert(filterx_object_len(list, &len));
-  cr_assert_eq(len, 1);
-  _assert_int_value_and_unref(filterx_list_get_subscript(list, 0), 42);
-  filterx_object_unref(result);
-
-  // $fillable += [42];
-  result = filterx_expr_eval(list_expr);
-  cr_assert(result);
-  cr_assert(filterx_object_truthy(result));
-  cr_assert(filterx_object_len(list, &len));
-  cr_assert_eq(len, 2);
-  _assert_int_value_and_unref(filterx_list_get_subscript(list, 0), 42);
-  _assert_int_value_and_unref(filterx_list_get_subscript(list, 1), 42);
-  filterx_object_unref(result);
-
-  filterx_expr_unref(list_expr);
-
-
   // [[1337]];
-  list_expr = filterx_literal_list_generator_new();
-  filterx_generator_set_fillable(list_expr, filterx_expr_ref(fillable));
-  inner_values = g_list_append(NULL, filterx_literal_generator_elem_new(NULL,
-                               filterx_literal_new(filterx_integer_new(1337)),
-                               TRUE));
-  values = g_list_append(NULL, filterx_literal_generator_elem_new(NULL,
-                         filterx_literal_inner_list_generator_new(list_expr, inner_values),
-                         FALSE));
-  filterx_literal_generator_set_elements(list_expr, values);
+  inner_values = g_list_append(NULL,
+                               filterx_literal_element_new(NULL,
+                                                           filterx_literal_new(filterx_integer_new(1337)),
+                                                           TRUE));
+  values = g_list_append(NULL,
+                         filterx_literal_element_new(NULL,
+                                                     filterx_literal_list_new(inner_values),
+                                                     TRUE));
+  list_expr = filterx_literal_list_new(values);
 
-  // $fillable += [[1337]];
+  // result = [[1337]];
   result = filterx_expr_eval(list_expr);
   cr_assert(result);
   cr_assert(filterx_object_truthy(result));
-  cr_assert(filterx_object_len(list, &len));
-  cr_assert_eq(len, 3);
+  cr_assert(filterx_object_len(result, &len));
+  cr_assert_eq(len, 1);
 
-  FilterXObject *stored_inner_list = filterx_list_get_subscript(list, 2);
+  FilterXObject *stored_inner_list = filterx_list_get_subscript(result, 0);
   cr_assert(stored_inner_list);
   cr_assert(filterx_object_is_type(filterx_ref_unwrap_ro(stored_inner_list), &FILTERX_TYPE_NAME(list)));
   cr_assert(filterx_object_len(stored_inner_list, &len));
@@ -154,16 +156,52 @@ Test(filterx_expr, test_filterx_list_merge)
 
   filterx_object_unref(result);
   filterx_expr_unref(list_expr);
-
-
-  filterx_expr_unref(fillable);
 }
 
-Test(filterx_expr, test_filterx_dict_merge)
+Test(filterx_expr, test_filterx_dict_immutable_values)
 {
-  // $fillable = json();
-  FilterXObject *dict = filterx_dict_new();
-  FilterXExpr *fillable = filterx_literal_new(dict);
+  FilterXExpr *dict_expr = NULL;
+  FilterXObject *result = NULL;
+  GList *values = NULL;
+  guint64 len;
+
+  FilterXObject *foo = filterx_string_new("foo", -1);
+  FilterXObject *bar = filterx_string_new("bar", -1);
+  FilterXObject *baz = filterx_string_new("baz", -1);
+
+
+  values = g_list_append(values,
+                         filterx_literal_element_new(filterx_literal_new(filterx_object_ref(foo)),
+                                                     filterx_literal_new(filterx_integer_new(42)),
+                                                     TRUE));
+  values = g_list_append(values,
+                         filterx_literal_element_new(filterx_literal_new(filterx_object_ref(bar)),
+                                                     filterx_literal_new(filterx_integer_new(43)),
+                                                     TRUE));
+  values = g_list_append(values,
+                         filterx_literal_element_new(filterx_literal_new(filterx_object_ref(baz)),
+                                                     filterx_literal_new(filterx_integer_new(44)),
+                                                     TRUE));
+  dict_expr = filterx_literal_dict_new(values);
+
+  // result = {"foo": 42, "bar": 43, "baz": 44};
+  result = filterx_expr_eval(dict_expr);
+  cr_assert(result);
+  cr_assert(filterx_object_truthy(result));
+  cr_assert(filterx_object_len(result, &len));
+  cr_assert_eq(len, 3);
+  _assert_int_value_and_unref(filterx_object_get_subscript(result, foo), 42);
+  _assert_int_value_and_unref(filterx_object_get_subscript(result, bar), 43);
+  _assert_int_value_and_unref(filterx_object_get_subscript(result, baz), 44);
+  filterx_object_unref(result);
+  filterx_object_unref(baz);
+  filterx_object_unref(bar);
+  filterx_object_unref(foo);
+  filterx_expr_unref(dict_expr);
+}
+
+Test(filterx_expr, test_filterx_dict_with_embedded_dict)
+{
   FilterXExpr *dict_expr = NULL;
   FilterXObject *result = NULL;
   GList *values = NULL, *inner_values = NULL;
@@ -173,96 +211,36 @@ Test(filterx_expr, test_filterx_dict_merge)
   FilterXObject *bar = filterx_string_new("bar", -1);
   FilterXObject *baz = filterx_string_new("baz", -1);
 
+  // {"foo": 1};
+  inner_values = g_list_append(inner_values,
+                               filterx_literal_element_new(filterx_literal_new(filterx_object_ref(foo)),
+                                                           filterx_literal_new(filterx_integer_new(1)),
+                                                           TRUE));
+  // result = {"foo": 420, "bar": 1337", "baz": {"foo":1}};
+  values = g_list_append(values,
+                         filterx_literal_element_new(filterx_literal_new(filterx_object_ref(foo)),
+                                                     filterx_literal_new(filterx_integer_new(420)),
+                                                     TRUE));
+  values = g_list_append(values,
+                         filterx_literal_element_new(filterx_literal_new(filterx_object_ref(bar)),
+                                                     filterx_literal_new(filterx_integer_new(1337)),
+                                                     TRUE));
+  values = g_list_append(values,
+                         filterx_literal_element_new(filterx_literal_new(filterx_object_ref(baz)),
+                                                     filterx_literal_dict_new(inner_values),
+                                                     FALSE));
 
-  // {"foo": 42};
-  values = g_list_append(NULL, filterx_literal_generator_elem_new(filterx_literal_new(filterx_object_ref(foo)),
-                         filterx_literal_new(filterx_integer_new(42)),
-                         TRUE));
-  dict_expr = filterx_literal_dict_generator_new();
-  filterx_generator_set_fillable(dict_expr, filterx_expr_ref(fillable));
-  filterx_literal_generator_set_elements(dict_expr, values);
+  dict_expr = filterx_literal_dict_new(values);
 
-  // $fillable += {"foo": 42};
   result = filterx_expr_eval(dict_expr);
   cr_assert(result);
   cr_assert(filterx_object_truthy(result));
-  cr_assert(filterx_object_len(dict, &len));
-  cr_assert_eq(len, 1);
-  _assert_int_value_and_unref(filterx_object_get_subscript(dict, foo), 42);
-  filterx_object_unref(result);
-
-  // $fillable += {"foo": 42};
-  result = filterx_expr_eval(dict_expr);
-  cr_assert(result);
-  cr_assert(filterx_object_truthy(result));
-  cr_assert(filterx_object_len(dict, &len));
-  cr_assert_eq(len, 1);
-  _assert_int_value_and_unref(filterx_object_get_subscript(dict, foo), 42);
-  filterx_object_unref(result);
-
-  filterx_expr_unref(dict_expr);
-
-
-  // {"foo": 420};
-  values = g_list_append(NULL, filterx_literal_generator_elem_new(filterx_literal_new(filterx_object_ref(foo)),
-                         filterx_literal_new(filterx_integer_new(420)),
-                         TRUE));
-  dict_expr = filterx_literal_dict_generator_new();
-  filterx_generator_set_fillable(dict_expr, filterx_expr_ref(fillable));
-  filterx_literal_generator_set_elements(dict_expr, values);
-
-  // $fillable += {"foo": 420};
-  result = filterx_expr_eval(dict_expr);
-  cr_assert(result);
-  cr_assert(filterx_object_truthy(result));
-  cr_assert(filterx_object_len(dict, &len));
-  cr_assert_eq(len, 1);
-  _assert_int_value_and_unref(filterx_object_get_subscript(dict, foo), 420);
-  filterx_object_unref(result);
-
-  filterx_expr_unref(dict_expr);
-
-
-  // {"bar": 1337};
-  values = g_list_append(NULL, filterx_literal_generator_elem_new(filterx_literal_new(filterx_object_ref(bar)),
-                         filterx_literal_new(filterx_integer_new(1337)),
-                         TRUE));
-  dict_expr = filterx_literal_dict_generator_new();
-  filterx_generator_set_fillable(dict_expr, filterx_expr_ref(fillable));
-  filterx_literal_generator_set_elements(dict_expr, values);
-
-  // $fillable += {"bar": 1337};
-  result = filterx_expr_eval(dict_expr);
-  cr_assert(result);
-  cr_assert(filterx_object_truthy(result));
-  cr_assert(filterx_object_len(dict, &len));
-  cr_assert_eq(len, 2);
-  _assert_int_value_and_unref(filterx_object_get_subscript(dict, foo), 420);
-  _assert_int_value_and_unref(filterx_object_get_subscript(dict, bar), 1337);
-  filterx_object_unref(result);
-
-  filterx_expr_unref(dict_expr);
-
-
-  // {"baz": {"foo": 1}};
-  dict_expr = filterx_literal_dict_generator_new();
-  filterx_generator_set_fillable(dict_expr, filterx_expr_ref(fillable));
-  inner_values = g_list_append(NULL, filterx_literal_generator_elem_new(filterx_literal_new(filterx_object_ref(foo)),
-                               filterx_literal_new(filterx_integer_new(1)),
-                               TRUE));
-  values = g_list_append(NULL, filterx_literal_generator_elem_new(filterx_literal_new(filterx_object_ref(baz)),
-                         filterx_literal_inner_dict_generator_new(dict_expr, inner_values),
-                         FALSE));
-  filterx_literal_generator_set_elements(dict_expr, values);
-
-  // $fillable += {"baz": {"foo": 1}};
-  result = filterx_expr_eval(dict_expr);
-  cr_assert(result);
-  cr_assert(filterx_object_truthy(result));
-  cr_assert(filterx_object_len(dict, &len));
+  cr_assert(filterx_object_len(result, &len));
   cr_assert_eq(len, 3);
+  _assert_int_value_and_unref(filterx_object_get_subscript(result, foo), 420);
+  _assert_int_value_and_unref(filterx_object_get_subscript(result, bar), 1337);
 
-  FilterXObject *stored_inner_dict = filterx_object_get_subscript(dict, baz);
+  FilterXObject *stored_inner_dict = filterx_object_get_subscript(result, baz);
   cr_assert(stored_inner_dict);
   cr_assert(filterx_object_is_type(filterx_ref_unwrap_ro(stored_inner_dict), &FILTERX_TYPE_NAME(dict)));
   cr_assert_eq(filterx_object_len(stored_inner_dict, &len), 1);
@@ -270,31 +248,11 @@ Test(filterx_expr, test_filterx_dict_merge)
   filterx_object_unref(stored_inner_dict);
 
   filterx_object_unref(result);
-
-  // $fillable += {"foo": 1}};
-  // Shallow merge.
-  result = filterx_expr_eval(dict_expr);
-  cr_assert(result);
-  cr_assert(filterx_object_truthy(result));
-  cr_assert(filterx_object_len(dict, &len));
-  cr_assert_eq(len, 3);
-
-  stored_inner_dict = filterx_object_get_subscript(dict, baz);
-  cr_assert(stored_inner_dict);
-  cr_assert(filterx_object_is_type(filterx_ref_unwrap_ro(stored_inner_dict), &FILTERX_TYPE_NAME(dict)));
-  cr_assert(filterx_object_len(stored_inner_dict, &len));
-  cr_assert_eq(len, 1);
-  _assert_int_value_and_unref(filterx_object_get_subscript(stored_inner_dict, foo), 1);
-  filterx_object_unref(stored_inner_dict);
-
-  filterx_object_unref(result);
   filterx_expr_unref(dict_expr);
-
 
   filterx_object_unref(baz);
   filterx_object_unref(bar);
   filterx_object_unref(foo);
-  filterx_expr_unref(fillable);
 }
 
 Test(filterx_expr, test_filterx_assign)

--- a/lib/filterx/tests/test_func_unset_empties.c
+++ b/lib/filterx/tests/test_func_unset_empties.c
@@ -78,7 +78,6 @@ _assert_unset_empties(GList *args, const gchar *expected_repr)
 FilterXExpr *
 _list_generator_helper(FilterXObject *first, ...)
 {
-  FilterXExpr *result = filterx_literal_list_generator_new();
   GList *target_vals = NULL;
   va_list va;
 
@@ -86,14 +85,12 @@ _list_generator_helper(FilterXObject *first, ...)
   FilterXObject *arg = first;
   while (arg)
     {
-      target_vals = g_list_append(target_vals, filterx_literal_generator_elem_new(NULL, filterx_literal_new(arg), FALSE));
+      target_vals = g_list_append(target_vals, filterx_literal_element_new(NULL, filterx_literal_new(arg), FALSE));
       arg = va_arg(va, FilterXObject *);
     }
   va_end(va);
 
-
-  filterx_literal_generator_set_elements(result, target_vals);
-  return result;
+  return filterx_literal_list_new(target_vals);
 }
 
 Test(filterx_func_unset_empties, invalid_args)

--- a/lib/filterx/tests/test_func_unset_empties.c
+++ b/lib/filterx/tests/test_func_unset_empties.c
@@ -85,7 +85,7 @@ _list_generator_helper(FilterXObject *first, ...)
   FilterXObject *arg = first;
   while (arg)
     {
-      target_vals = g_list_append(target_vals, filterx_literal_element_new(NULL, filterx_literal_new(arg), FALSE));
+      target_vals = g_list_append(target_vals, filterx_literal_element_new(NULL, filterx_literal_new(arg)));
       arg = va_arg(va, FilterXObject *);
     }
   va_end(va);

--- a/lib/filterx/tests/test_func_unset_empties.c
+++ b/lib/filterx/tests/test_func_unset_empties.c
@@ -31,7 +31,7 @@
 #include "filterx/object-list.h"
 #include "filterx/json-repr.h"
 #include "filterx/expr-literal.h"
-#include "filterx/expr-literal-generator.h"
+#include "filterx/expr-literal-container.h"
 #include "filterx/object-null.h"
 
 #include "apphook.h"

--- a/lib/filterx/tests/test_metrics_labels.c
+++ b/lib/filterx/tests/test_metrics_labels.c
@@ -37,7 +37,7 @@
 static GList *
 _add_label_expr(GList *label_exprs, FilterXExpr *key, FilterXExpr *value)
 {
-  return g_list_append(label_exprs, filterx_literal_generator_elem_new(key, value, TRUE));
+  return g_list_append(label_exprs, filterx_literal_element_new(key, value, TRUE));
 }
 
 Test(filterx_metrics_labels, null_labels)
@@ -61,7 +61,7 @@ Test(filterx_metrics_labels, null_labels)
 
 Test(filterx_metrics_labels, const_literal_generator_empty_labels)
 {
-  FilterXExpr *labels_expr = filterx_literal_dict_generator_new();
+  FilterXExpr *labels_expr = filterx_literal_dict_new(NULL);
   FilterXMetricsLabels *metrics_labels = filterx_metrics_labels_new(labels_expr);
   filterx_expr_unref(labels_expr);
   cr_assert(metrics_labels);
@@ -111,8 +111,7 @@ Test(filterx_metrics_labels, const_literal_generator_labels)
                                 filterx_literal_new(filterx_string_new("bar", -1)),
                                 filterx_literal_new(filterx_string_new("barvalue", -1)));
 
-  FilterXExpr *labels_expr = filterx_literal_dict_generator_new();
-  filterx_literal_generator_set_elements(labels_expr, label_exprs);
+  FilterXExpr *labels_expr = filterx_literal_dict_new(label_exprs);
 
   FilterXMetricsLabels *metrics_labels = filterx_metrics_labels_new(labels_expr);
   filterx_expr_unref(labels_expr);
@@ -147,8 +146,7 @@ Test(filterx_metrics_labels, non_const_literal_generator_labels)
                                 filterx_literal_new(filterx_string_new("bar", -1)),
                                 filterx_literal_new(filterx_string_new("barvalue", -1)));
 
-  FilterXExpr *labels_expr = filterx_literal_dict_generator_new();
-  filterx_literal_generator_set_elements(labels_expr, label_exprs);
+  FilterXExpr *labels_expr = filterx_literal_dict_new(label_exprs);
 
   FilterXMetricsLabels *metrics_labels = filterx_metrics_labels_new(labels_expr);
   filterx_expr_unref(labels_expr);
@@ -180,8 +178,7 @@ Test(filterx_metrics_labels, non_literal_key_in_literal_generator_labels)
                                 filterx_non_literal_new(filterx_string_new("foo", -1)),
                                 filterx_literal_new(filterx_string_new("foovalue", -1)));
 
-  FilterXExpr *labels_expr = filterx_literal_dict_generator_new();
-  filterx_literal_generator_set_elements(labels_expr, label_exprs);
+  FilterXExpr *labels_expr = filterx_literal_dict_new(label_exprs);
 
   FilterXMetricsLabels *metrics_labels = filterx_metrics_labels_new(labels_expr);
   filterx_expr_unref(labels_expr);

--- a/lib/filterx/tests/test_metrics_labels.c
+++ b/lib/filterx/tests/test_metrics_labels.c
@@ -27,7 +27,7 @@
 
 #include "filterx/filterx-metrics-labels.h"
 #include "filterx/expr-literal.h"
-#include "filterx/expr-literal-generator.h"
+#include "filterx/expr-literal-container.h"
 #include "filterx/object-string.h"
 #include "stats/stats-cluster.h"
 #include "metrics/dyn-metrics-cache.h"

--- a/lib/filterx/tests/test_metrics_labels.c
+++ b/lib/filterx/tests/test_metrics_labels.c
@@ -37,7 +37,7 @@
 static GList *
 _add_label_expr(GList *label_exprs, FilterXExpr *key, FilterXExpr *value)
 {
-  return g_list_append(label_exprs, filterx_literal_element_new(key, value, TRUE));
+  return g_list_append(label_exprs, filterx_literal_element_new(key, value));
 }
 
 Test(filterx_metrics_labels, null_labels)

--- a/modules/cef/event-format-parser.c
+++ b/modules/cef/event-format-parser.c
@@ -27,7 +27,7 @@
 #include "filterx/object-string.h"
 #include "filterx/object-primitive.h"
 #include "filterx/expr-literal.h"
-#include "filterx/expr-literal-generator.h"
+#include "filterx/expr-literal-container.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/filterx-globals.h"
 #include "filterx/object-extractor.h"

--- a/modules/csvparser/filterx-func-parse-csv.c
+++ b/modules/csvparser/filterx-func-parse-csv.c
@@ -26,7 +26,7 @@
 #include "filterx/object-string.h"
 #include "filterx/object-primitive.h"
 #include "filterx/expr-literal.h"
-#include "filterx/expr-literal-generator.h"
+#include "filterx/expr-literal-container.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/filterx-globals.h"
 #include "filterx/object-extractor.h"

--- a/modules/csvparser/filterx-func-parse-csv.c
+++ b/modules/csvparser/filterx-func-parse-csv.c
@@ -488,7 +488,7 @@ _extract_literal_columns(FilterXFunctionParseCSV *self, FilterXExpr *columns)
 {
   GPtrArray *literal_columns = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
 
-  if (!filterx_literal_list_generator_foreach(columns, _add_literal_column, literal_columns))
+  if (!filterx_literal_list_foreach(columns, _add_literal_column, literal_columns))
     {
       g_ptr_array_unref(literal_columns);
       return FALSE;
@@ -514,7 +514,7 @@ _extract_args(FilterXFunctionParseCSV *self, FilterXFunctionArgs *args, GError *
     return FALSE;
 
   FilterXExpr *columns = _extract_columns_expr(args, error);
-  if (filterx_expr_is_literal_list_generator(columns) && _extract_literal_columns(self, columns))
+  if (filterx_expr_is_literal_list(columns) && _extract_literal_columns(self, columns))
     filterx_expr_unref(columns);
   else
     self->columns.expr = columns;


### PR DESCRIPTION
This branch changes the handling of literal dict and list instances encountered in the source code.

Without this PRs, these were generators, e.g. we generated the values in the literal in the target fillable. With this patch, this is changed, literal dict/list instances become simple expressions that result in dict/list instances as appropriate.

This makes it possible to cache the literal dicts if all they contain are literal values.
