### PR TITLE
filterx: add filterx_string_new_take() and filterx_bytes_new_take() constructors

### DIFF
--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -151,8 +151,10 @@ struct _FilterXObject
    *
    *     is_dirty          -- marks that the object was changed (mutable objects only)
    *
+   *     flags             -- to be used by descendant types
+   *
    */
-  guint readonly:1, weak_referenced:1, is_dirty:1;
+  guint readonly:1, weak_referenced:1, is_dirty:1, flags:5;
   FilterXType *type;
 };
 

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -134,11 +134,13 @@ _string_add(FilterXObject *s, FilterXObject *object)
       return NULL;
     }
 
-  GString *buffer = scratch_buffers_alloc();
-  g_string_append_len(buffer, self->str, self->str_len);
-  g_string_append_len(buffer, other_str, other_str_len);
-  /* FIXME: support taking over the already allocated space */
-  return filterx_string_new(buffer->str, buffer->len);
+  gsize buffer_len = self->str_len + other_str_len;
+  gchar *buffer = g_malloc(buffer_len + 1);
+  memcpy(buffer, self->str, self->str_len);
+  memcpy(buffer + self->str_len, other_str, other_str_len);
+  buffer[buffer_len] = 0;
+  FilterXObject *result = filterx_string_new_take(buffer, buffer_len);
+  return result;
 }
 
 /* we support clone of stack allocated strings */
@@ -271,11 +273,12 @@ _bytes_add(FilterXObject *s, FilterXObject *object)
   if (!filterx_object_extract_bytes_ref(object, &other_str, &other_str_len))
     return NULL;
 
-  GString *buffer = scratch_buffers_alloc();
-  g_string_append_len(buffer, self->str, self->str_len);
-  g_string_append_len(buffer, other_str, other_str_len);
-  /* FIXME: support taking over the already allocated space */
-  return filterx_bytes_new(buffer->str, buffer->len);
+  gsize buffer_len = self->str_len + other_str_len;
+  gchar *buffer = g_malloc(buffer_len);
+  memcpy(buffer, self->str, self->str_len);
+  memcpy(buffer + self->str_len, other_str, other_str_len);
+  FilterXObject *result = filterx_bytes_new_take(buffer, buffer_len);
+  return result;
 }
 
 FilterXObject *

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -52,7 +52,9 @@ FilterXObject *filterx_typecast_protobuf(FilterXExpr *s, FilterXObject *args[], 
 
 FilterXObject *_filterx_string_new(const gchar *str, gssize str_len);
 FilterXObject *filterx_string_new_translated(const gchar *str, gssize str_len, FilterXStringTranslateFunc translate);
+FilterXObject *filterx_string_new_take(gchar *str, gssize str_len);
 FilterXObject *filterx_bytes_new(const gchar *str, gssize str_len);
+FilterXObject *filterx_bytes_new_take(gchar *str, gssize str_len);
 FilterXObject *filterx_protobuf_new(const gchar *str, gssize str_len);
 
 /* NOTE: Consider using filterx_object_extract_string_ref() to also support message_value.

--- a/lib/filterx/tests/test_expr_plus.c
+++ b/lib/filterx/tests/test_expr_plus.c
@@ -66,6 +66,7 @@ Test(expr_plus, test_string_success)
   const gchar *res = filterx_string_get_value_ref(obj, &size);
 
   cr_assert_str_eq(res, "foobar");
+  cr_assert_eq(size, 6);
 
   filterx_object_unref(obj);
   filterx_expr_unref(expr);


### PR DESCRIPTION
add filterx_string_new_take() and filterx_bytes_new_type() constructors that take an already allocated buffer for the
string to avoid having to copy those bytes.
