### PR TITLE
filterx: fix `metrics_labels` crash

### DIFF
--- a/lib/filterx/object-metrics-labels.c
+++ b/lib/filterx/object-metrics-labels.c
@@ -85,6 +85,9 @@ _get_subscript(FilterXDict *s, FilterXObject *key)
   if (!filterx_object_extract_string_ref(key, &key_str, NULL))
     return NULL;
 
+  if (!self->labels->len)
+    return NULL;
+
   for (guint i = self->labels->len - 1; i >= 0; i--)
     {
       StatsClusterLabel *label = &g_array_index(self->labels, StatsClusterLabel, i);

--- a/news/fx-bugfix-601.md
+++ b/news/fx-bugfix-601.md
@@ -1,0 +1,1 @@
+`metrics_labels`: Fixed a crash that occurred when trying to get a label from an empty object.


### PR DESCRIPTION
`guint i = self->labels->len - 1` becomes a large value, instead of being `-1` if `len == 0`.

Repro config:
```
log {
  source { example-msg-generator(num(1)); };
  filterx {
    declare labels = metrics_labels();
    labels["almafa"];
  };
  destination{stdout();};
};
```