### PR TITLE
loggen: show standard deviation

### DIFF
--- a/tests/functional/test_performance.py
+++ b/tests/functional/test_performance.py
@@ -43,10 +43,10 @@ def test_performance():
       'bzorp': 10000
     }
     print_user("Starting loggen for 10 seconds")
-    out = os.popen("../loggen/loggen --quiet --stream --inet --rate 1000000 --size 160 --interval 10 --active-connections 1 127.0.0.1 %d 2>&1 |tail -n +1" % port_number, 'r').read()
+    out = os.popen("../loggen/loggen --quiet --stream --inet --rate 1000000 --size 160 --interval 10 --active-connections 1 127.0.0.1 %d 2>&1 |tail -n 1" % port_number, 'r').read()
 
     print_user("performance: %s" % out)
-    rate = float(re.sub('^.*rate=([0-9.]+).*$', '\\1', out))
+    rate = float(re.sub('^.*avg_rate=([0-9.]+).*$', '\\1', out))
 
     hostname = os.uname()[1]
     if hostname in expected_rate:

--- a/tests/loggen/CMakeLists.txt
+++ b/tests/loggen/CMakeLists.txt
@@ -65,7 +65,8 @@ target_compile_definitions(loggen PUBLIC
 
 target_link_libraries(
   loggen
-  loggen_helper)
+  loggen_helper
+  m)
 
 install(TARGETS loggen RUNTIME DESTINATION bin)
 

--- a/tests/loggen/Makefile.am
+++ b/tests/loggen/Makefile.am
@@ -65,6 +65,7 @@ tests_loggen_loggen_LDADD	= \
 	@GLIB_LIBS@ \
 	@OPENSSL_LIBS@ \
 	@BASE_LIBS@ \
+	-lm \
 	tests/loggen/libloggen_helper.la
 
 include tests/loggen/socket_plugin/Makefile.am

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -387,7 +387,7 @@ get_welford_variance(WelfordVariance *variance)
 }
 
 static inline void
-update_stats(struct timeval start_time, WelfordVariance *variance, gboolean final, gboolean print)
+update_stats(struct timeval start_time, WelfordVariance *variance, gboolean print)
 {
   static gsize last_count = 0;
   static struct timeval last_ts_format = {0};
@@ -395,8 +395,6 @@ update_stats(struct timeval start_time, WelfordVariance *variance, gboolean fina
   struct timeval now;
   gettimeofday(&now, NULL);
   gsize count = atomic_gssize_get_unsigned(&global_plugin_option.global_sent_messages);
-  if (final && last_count == count)
-    return;
 
   gboolean first = FALSE;
   if (!last_ts_format.tv_sec)
@@ -445,15 +443,13 @@ periodic_stats(GPtrArray *plugin_array)
 
       do
         {
-          update_stats(start_time, &variance, FALSE, !quiet);
+          update_stats(start_time, &variance, !quiet);
         }
       while (!plugin->wait_with_timeout(&global_plugin_option, PERIODIC_STAT_USEC));
     }
 
   struct timeval now;
   gettimeofday(&now, NULL);
-
-  update_stats(start_time, &variance, TRUE, !quiet);
 
   gsize count = atomic_gssize_get_unsigned(&global_plugin_option.global_sent_messages);
   double total_runtime_sec = time_val_diff_in_sec(&now, &start_time);

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -508,6 +508,33 @@ setup_rate_change_signals(void)
   sigaction(SIGUSR2, &sa, NULL);
 }
 
+static void
+show_options_summary(void)
+{
+  GString *summary = g_string_new("options: ");
+
+  if (global_plugin_option.perf)
+    g_string_append(summary, "rate=max, ");
+  else
+    g_string_append_printf(summary, "rate=%"G_GINT64_FORMAT", ", global_plugin_option.rate);
+
+  if (global_plugin_option.permanent || global_plugin_option.number_of_messages)
+    g_string_append(summary, "interval=disabled, ");
+  else
+    g_string_append_printf(summary, "interval=%d, ", global_plugin_option.interval);
+
+
+  if (global_plugin_option.number_of_messages)
+    g_string_append_printf(summary, "number=%d, ", global_plugin_option.number_of_messages);
+
+  g_string_append_printf(summary, "active_connections=%d, idle_connections=%d\n",
+                         global_plugin_option.active_connections, global_plugin_option.idle_connections);
+
+  printf("%s", summary->str);
+  fflush(stdout);
+  g_string_free(summary, TRUE);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -536,6 +563,11 @@ main(int argc, char *argv[])
         g_error_free(error);
       return 1;
     }
+
+  if (global_plugin_option.rate == 0)
+    global_plugin_option.perf = TRUE;
+
+  show_options_summary();
 
   /* debug option defined by --debug command line option */
   set_debug_level(debug);

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -406,6 +406,10 @@ update_stats(struct timeval start_time, WelfordVariance *variance, gboolean prin
   gint64 diff_msec = time_val_diff_in_msec(&now, &last_ts_format);
   gdouble current_runtime_sec = time_val_diff_in_sec(&now, &start_time);
 
+  /* skip samples that would produce inaccurate rate/variance (last one) */
+  if (diff_msec < 100 && !first)
+    return;
+
   gdouble rate = 0;
   if (diff_msec)
     rate = (count - last_count) * (1000.0 / diff_msec);

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -394,7 +394,8 @@ print_statistic(struct timeval start_time, gboolean final)
   last_ts_format = now;
 }
 
-void wait_all_plugin_to_finish(GPtrArray *plugin_array)
+void
+periodic_stats(GPtrArray *plugin_array)
 {
   if (!plugin_array)
     return;
@@ -542,7 +543,7 @@ main(int argc, char *argv[])
 
   if (start_plugins(plugin_array) > 0)
     {
-      wait_all_plugin_to_finish(plugin_array);
+      periodic_stats(plugin_array);
       stop_plugins(plugin_array);
     }
 


### PR DESCRIPTION
```
avg_rate=99998.15 msg/s, stdev_rate=0.10%, count=1000000, time=10.0002, avg_msg_size=256, bandwidth=24999.54 KiB/s
```
Depends on #598