### PR TITLE
filterx/metrics_labels: fix crash when getting non-existent label

### DIFF
--- a/lib/filterx/object-metrics-labels.c
+++ b/lib/filterx/object-metrics-labels.c
@@ -85,10 +85,7 @@ _get_subscript(FilterXDict *s, FilterXObject *key)
   if (!filterx_object_extract_string_ref(key, &key_str, NULL))
     return NULL;
 
-  if (!self->labels->len)
-    return NULL;
-
-  for (guint i = self->labels->len - 1; i >= 0; i--)
+  for (gssize i = (gssize)(self->labels->len) - 1; i >= 0; i--)
     {
       StatsClusterLabel *label = &g_array_index(self->labels, StatsClusterLabel, i);
       if (strcmp(label->name, key_str) == 0)


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
