### PR TITLE
`log-flow-control(yes/no)` global option

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -269,6 +269,8 @@ main_location_print (FILE *yyo, YYLTYPE const * const yylocp)
 %token KW_HEALTHCHECK_FREQ            10406
 %token KW_WORKER_PARTITION_KEY        10407
 
+%token KW_LOG_FLOW_CONTROL            10408
+
 %token KW_CHAIN_HOSTNAMES             10090
 %token KW_NORMALIZE_HOSTNAMES         10091
 %token KW_KEEP_HOSTNAME               10092
@@ -1121,6 +1123,7 @@ options_item
 	| KW_LOG_IW_SIZE '(' positive_integer ')'	{ msg_warning("WARNING: Support for the global log-iw-size() option was removed, please use a per-source log-iw-size()", cfg_lexer_format_location_tag(lexer, &@1)); }
 	| KW_LOG_FETCH_LIMIT '(' positive_integer ')'	{ msg_warning("WARNING: Support for the global log-fetch-limit() option was removed, please use a per-source log-fetch-limit()", cfg_lexer_format_location_tag(lexer, &@1)); }
 	| KW_LOG_MSG_SIZE '(' positive_integer ')'	{ configuration->log_msg_size = $3; }
+	| KW_LOG_FLOW_CONTROL '(' yesno ')' { configuration->flow_control = $3; }
 	| KW_TRIM_LARGE_MESSAGES '(' yesno ')'	{ configuration->trim_large_messages = $3; }
 	| KW_KEEP_TIMESTAMP '(' yesno ')'	{ configuration->keep_timestamp = $3; }
 	| KW_CREATE_DIRS '(' yesno ')'		{ configuration->create_dirs = $3; }

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -913,7 +913,7 @@ log_content
         ;
 
 log_flags
-	: KW_FLAGS '(' log_flags_items ')' semicolons	{ $$ = $3; }
+	: KW_FLAGS '(' log_flags_items ')' semicolons	{ CHECK_ERROR(log_expr_node_validate_flags($3), @3, "incompatible flags were specified"); $$ = $3; }
 	|					{ $$ = 0; }
 	;
 

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -150,6 +150,7 @@ static CfgLexerKeyword main_keywords[] =
   { "log_fetch_limit",    KW_LOG_FETCH_LIMIT },
   { "log_iw_size",        KW_LOG_IW_SIZE },
   { "log_msg_size",       KW_LOG_MSG_SIZE },
+  { "log_flow_control",   KW_LOG_FLOW_CONTROL },
   { "trim_large_messages", KW_TRIM_LARGE_MESSAGES },
   { "idle_timeout",       KW_IDLE_TIMEOUT },
   { "log_prefix",         KW_LOG_PREFIX, KWS_OBSOLETE, "program_override" },

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -387,12 +387,6 @@ log_expr_node_new_log(LogExprNode *children, guint32 flags, CFG_LTYPE *yylloc)
 }
 
 LogExprNode *
-log_expr_node_new_sequence(LogExprNode *children, CFG_LTYPE *yylloc)
-{
-  return log_expr_node_new(ENL_SEQUENCE, ENC_PIPE, NULL, children, 0, yylloc);
-}
-
-LogExprNode *
 log_expr_node_new_junction(LogExprNode *children, CFG_LTYPE *yylloc)
 {
   return log_expr_node_new(ENL_JUNCTION, ENC_PIPE, NULL, children, 0, yylloc);

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -618,6 +618,12 @@ log_expr_node_new_compound_conditional(LogExprNode *block, CFG_LTYPE *yylloc)
 
 /****************************************************************************/
 
+static inline gboolean
+_is_log_path(LogExprNode *node)
+{
+  return node->layout == ENL_SEQUENCE && node->content == ENC_PIPE;
+}
+
 gint
 log_expr_node_lookup_flag(const gchar *flag)
 {
@@ -913,8 +919,11 @@ cfg_tree_propagate_expr_node_properties_to_pipe(LogExprNode *node, LogPipe *pipe
   if (node->flags & LC_FINAL)
     pipe->flags |= PIF_BRANCH_FINAL;
 
-  if (node->flags & LC_FLOW_CONTROL)
-    pipe->flags |= PIF_HARD_FLOW_CONTROL;
+  if (_is_log_path(node))
+    {
+      if (node->flags & LC_FLOW_CONTROL)
+        pipe->flags |= PIF_HARD_FLOW_CONTROL;
+    }
 
   if (!pipe->expr_node)
     pipe->expr_node = node;

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -931,6 +931,9 @@ cfg_tree_propagate_expr_node_properties_to_pipe(LogExprNode *node, LogPipe *pipe
     {
       if (node->flags & LC_FLOW_CONTROL)
         pipe->flags |= PIF_HARD_FLOW_CONTROL;
+
+      if (node->flags & LC_NO_FLOW_CONTROL)
+        pipe->flags |= PIF_NO_HARD_FLOW_CONTROL;
     }
 
   if (!pipe->expr_node)

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -635,6 +635,8 @@ log_expr_node_lookup_flag(const gchar *flag)
     return LC_FINAL;
   else if (strcmp(flag, "flow-control") == 0)
     return LC_FLOW_CONTROL;
+  else if (strcmp(flag, "no-flow-control") == 0)
+    return LC_NO_FLOW_CONTROL;
   else if (strcmp(flag, "drop-unmatched") == 0)
     {
       msg_warning_once("WARNING: The drop-unmatched flag has been removed starting with " VERSION_4_1 ". "
@@ -643,6 +645,12 @@ log_expr_node_lookup_flag(const gchar *flag)
     }
   msg_error("Unknown log statement flag", evt_tag_str("flag", flag));
   return 0;
+}
+
+gboolean
+log_expr_node_validate_flags(gint flags)
+{
+  return !(flags & LC_FLOW_CONTROL && flags & LC_NO_FLOW_CONTROL);
 }
 
 static LogPipe *

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -37,6 +37,7 @@ const gchar *log_expr_node_get_content_name(gint content);
 #define LC_FALLBACK       2
 #define LC_FINAL          4
 #define LC_FLOW_CONTROL   8
+#define LC_NO_FLOW_CONTROL 16
 
 enum
 {
@@ -127,6 +128,7 @@ struct _LogExprNode
 };
 
 gint log_expr_node_lookup_flag(const gchar *flag);
+gboolean log_expr_node_validate_flags(gint flags);
 
 LogExprNode *log_expr_node_append_tail(LogExprNode *a, LogExprNode *b);
 void log_expr_node_set_object(LogExprNode *self, gpointer object, GDestroyNotify destroy);

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -152,7 +152,6 @@ LogExprNode *log_expr_node_new_parser_reference(const gchar *name, CFG_LTYPE *yy
 LogExprNode *log_expr_node_new_rewrite(const gchar *name, LogExprNode *children, CFG_LTYPE *yylloc);
 LogExprNode *log_expr_node_new_rewrite_reference(const gchar *name, CFG_LTYPE *yylloc);
 LogExprNode *log_expr_node_new_log(LogExprNode *children, guint32 flags, CFG_LTYPE *yylloc);
-LogExprNode *log_expr_node_new_sequence(LogExprNode *children, CFG_LTYPE *yylloc);
 LogExprNode *log_expr_node_new_junction(LogExprNode *children, CFG_LTYPE *yylloc);
 LogExprNode *log_expr_node_new_source_junction(LogExprNode *children, CFG_LTYPE *yylloc);
 LogExprNode *log_expr_node_new_destination_junction(LogExprNode *children, CFG_LTYPE *yylloc);

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -95,6 +95,7 @@ struct _GlobalConfig
 
   gint log_fifo_size;
   gint log_msg_size;
+  gboolean flow_control;
   gboolean trim_large_messages;
   gint log_level;
 

--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -52,13 +52,19 @@ log_pipe_queue_slow_path(LogPipe *self, LogMessage *msg, const LogPathOptions *p
   if ((self->flags & PIF_SYNC_FILTERX_TO_MSG))
     filterx_eval_sync_message(path_options->filterx_context, &msg, path_options);
 
-  if (G_UNLIKELY(self->flags & (PIF_HARD_FLOW_CONTROL | PIF_JUNCTION_END | PIF_CONDITIONAL_MIDPOINT)))
+  if (G_UNLIKELY(self->flags &
+                 (PIF_HARD_FLOW_CONTROL | PIF_NO_HARD_FLOW_CONTROL | PIF_JUNCTION_END | PIF_CONDITIONAL_MIDPOINT)))
     {
       path_options = log_path_options_chain(&local_path_options, path_options);
       if (self->flags & PIF_HARD_FLOW_CONTROL)
         {
-          local_path_options.flow_control_requested = 1;
-          msg_trace("Requesting flow control", log_pipe_location_tag(self));
+          local_path_options.flow_control_requested = TRUE;
+          msg_trace("Enabling flow control", log_pipe_location_tag(self));
+        }
+      if (self->flags & PIF_NO_HARD_FLOW_CONTROL)
+        {
+          local_path_options.flow_control_requested = FALSE;
+          msg_trace("Disabling flow control", log_pipe_location_tag(self));
         }
       if (self->flags & PIF_JUNCTION_END)
         {
@@ -78,7 +84,7 @@ _is_fastpath(LogPipe *self)
   if (self->flags & PIF_SYNC_FILTERX_TO_MSG)
     return FALSE;
 
-  if (self->flags & (PIF_HARD_FLOW_CONTROL | PIF_JUNCTION_END | PIF_CONDITIONAL_MIDPOINT))
+  if (self->flags & (PIF_HARD_FLOW_CONTROL | PIF_NO_HARD_FLOW_CONTROL | PIF_JUNCTION_END | PIF_CONDITIONAL_MIDPOINT))
     return FALSE;
 
   return TRUE;

--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -59,12 +59,12 @@ log_pipe_queue_slow_path(LogPipe *self, LogMessage *msg, const LogPathOptions *p
       if (self->flags & PIF_HARD_FLOW_CONTROL)
         {
           local_path_options.flow_control_requested = TRUE;
-          msg_trace("Enabling flow control", log_pipe_location_tag(self));
+          msg_trace("Enabling flow control", log_pipe_location_tag(self), evt_tag_msg_reference(msg));
         }
       if (self->flags & PIF_NO_HARD_FLOW_CONTROL)
         {
           local_path_options.flow_control_requested = FALSE;
-          msg_trace("Disabling flow control", log_pipe_location_tag(self));
+          msg_trace("Disabling flow control", log_pipe_location_tag(self), evt_tag_msg_reference(msg));
         }
       if (self->flags & PIF_JUNCTION_END)
         {

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -59,20 +59,21 @@
 #define PIF_BRANCH_FALLBACK   0x0010
 #define PIF_BRANCH_PROPERTIES (PIF_BRANCH_FINAL + PIF_BRANCH_FALLBACK)
 
-/* branch starting with this pipe wants hard flow control */
+/* branch starting with this pipe wants to enable/disable hard flow control */
 #define PIF_HARD_FLOW_CONTROL 0x0020
+#define PIF_NO_HARD_FLOW_CONTROL 0x0040
 
 /* LogPipe right after the filter in an "if (filter)" expression */
-#define PIF_CONDITIONAL_MIDPOINT  0x0040
+#define PIF_CONDITIONAL_MIDPOINT  0x0080
 
 /* LogPipe as the joining element of a junction */
-#define PIF_JUNCTION_END          0x0080
+#define PIF_JUNCTION_END          0x0100
 
 /* node created directly by the user */
-#define PIF_CONFIG_RELATED    0x0100
+#define PIF_CONFIG_RELATED    0x0200
 
 /* sync filterx state to message in right before calling queue() */
-#define PIF_SYNC_FILTERX_TO_MSG      0x0200
+#define PIF_SYNC_FILTERX_TO_MSG      0x0400
 
 /* private flags range, to be used by other LogPipe instances for their own purposes */
 
@@ -209,9 +210,9 @@ struct _LogPathOptions
    * supports that). If flow-control is not requested, destinations
    * are permitted to call log_msg_ack() early (e.g. at queue time).
    *
-   * This is initially FALSE and can be set to TRUE anywhere _before_
-   * the destination driver, which will actually carry out the
-   * required action.
+   * This is initially set to the value of the global log-flow-control
+   * option and can be set to TRUE/FALSE anywhere _before_ the destination
+   * driver, which will actually carry out the required action.
    */
 
   gboolean flow_control_requested;

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -557,7 +557,7 @@ log_source_post(LogSource *self, LogMessage *msg)
   path_options.flow_control_requested = cfg->flow_control;
 
   if (path_options.flow_control_requested)
-    msg_trace("Enabling flow control", log_pipe_location_tag(&self->super));
+    msg_trace("Enabling flow control", log_pipe_location_tag(&self->super), evt_tag_msg_reference(msg));
 
   ack_tracker_track_msg(self->ack_tracker, msg);
 

--- a/news/feature-606.md
+++ b/news/feature-606.md
@@ -1,0 +1,27 @@
+`log-flow-control(yes/no)` global option
+
+This option allows enabling flow control for all log paths. When set to yes,
+flow control is globally enabled, but it can still be selectively disabled
+within individual log paths using the `no-flow-control` flag.
+
+WARNING: Enabling global flow control can cause the `system()` source to block.
+As a result, if messages accumulate at the destination, applications that log
+through the system may become completely stalled, potentially halting their
+operation. We don't recommend enabling flow control in log paths that
+include the `system()` source.
+
+For example,
+
+```
+options {
+  log-flow-control(yes);
+};
+
+log {
+  source { system(); };
+  destination { network("server" port(5555)); };
+  flags(no-flow-control);
+};
+
+log { ... };
+```


### PR DESCRIPTION
`log-flow-control(yes/no)` global option

This option allows enabling flow control for all log paths. When set to yes,
flow control is globally enabled, but it can still be selectively disabled
within individual log paths using the `no-flow-control` flag.

WARNING: Enabling global flow control can cause the `system()` source to block.
As a result, if messages accumulate at the destination, applications that log
through the system may become completely stalled, potentially halting their
operation. We don't recommend enabling flow control in log paths that
include the `system()` source.

For example,

```
options {
  log-flow-control(yes);
};

log {
  source { system(); };
  destination { network("server" port(5555)); };
  flags(no-flow-control);
};

log { ... };
```