### PR TITLE
ci: fix apt-packages test

### DIFF
--- a/.github/workflows/test-apt-packages.yml
+++ b/.github/workflows/test-apt-packages.yml
@@ -65,9 +65,9 @@ jobs:
       - name: Check revision
         run: |
           if [ "${{ inputs.pkg-type }}" = "nightly" ]; then
-            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}(\.[0-9]{1,3}\.[a-z0-9]{8})?-snapshot\+[0-9]{8}T[0-9]{6}$"
+            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep '^[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}[a-zA-Z0-9.]*-snapshot\+[0-9]{8}T[0-9]{6}$'
           elif [ "${{ inputs.pkg-type }}" = "stable" ]; then
-            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}-[0-9]{1,2}$"
+            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep '^[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}-[0-9]{1,2}$'
           fi
 
       - name: Check if installed package version matches with install revision


### PR DESCRIPTION
We now have revisions like this:
`4.11.0.new.dict.34.g0443ae7-snapshot+20250423T230904`