### PR TITLE
Move EOF detection and close-on-input to the proto

### DIFF
--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -67,6 +67,7 @@ struct _LogProtoClient
   LogProtoStatus status;
   const LogProtoClientOptions *options;
   LogTransportStack transport_stack;
+  gboolean transport_reversed_io_direction;
   gboolean (*poll_prepare)(LogProtoClient *s, GIOCondition *cond, GIOCondition *idle_cond, gint *timeout);
   LogProtoStatus (*post)(LogProtoClient *s, LogMessage *logmsg, guchar *msg, gsize msg_len, gboolean *consumed);
   LogProtoStatus (*process_in)(LogProtoClient *s);
@@ -123,39 +124,47 @@ log_proto_client_handshake(LogProtoClient *s, gboolean *handshake_finished)
 }
 
 static inline gboolean
-log_proto_client_poll_prepare(LogProtoClient *s, GIOCondition *cond, GIOCondition *idle_cond, gint *timeout)
+log_proto_client_poll_prepare(LogProtoClient *self, GIOCondition *cond, GIOCondition *idle_cond, gint *timeout)
 {
-  gboolean result = s->poll_prepare(s, cond, idle_cond, timeout);
+  GIOCondition transport_cond = 0;
+  gboolean result = TRUE;
+
+  if (log_transport_stack_poll_prepare(&self->transport_stack, &transport_cond))
+    goto exit;
+
+  result = self->poll_prepare(self, cond, idle_cond, timeout);
 
   if (!result && *timeout < 0)
-    *timeout = s->options->idle_timeout;
+    *timeout = self->options->idle_timeout;
+
+exit:
+  self->transport_reversed_io_direction = transport_cond != 0;
+
+  /* transport I/O needs take precedence */
+  if (transport_cond != 0)
+    *cond = transport_cond;
+
   return result;
 }
 
+static inline LogProtoStatus log_proto_client_process_in(LogProtoClient *s);
+
 static inline LogProtoStatus
-log_proto_client_flush(LogProtoClient *s)
+log_proto_client_flush(LogProtoClient *self)
 {
-  if (s->flush)
-    return s->flush(s);
-  else
-    return LPS_SUCCESS;
+  if (self->transport_reversed_io_direction)
+    return self->process_in(self);
+
+  return self->flush(self);
 }
 
 static inline LogProtoStatus
-log_proto_client_process_in(LogProtoClient *s)
+log_proto_client_process_in(LogProtoClient *self)
 {
-  if (s->process_in)
-    return s->process_in(s);
-  else if (s->flush)
-    /*
-     * In some clients, flush is used for input processing, but it should not be.
-     * Fix these clients, than remove the flush call here.
-     *
-     * SSL_ERROR_WANT_READ in the TLS transport is also built upon this.
-     */
-    return s->flush(s);
-  else
-    return LPS_SUCCESS;
+  if (self->transport_reversed_io_direction)
+    return self->flush(self);
+
+  return self->process_in(self);
 }
 
 static inline LogProtoStatus

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -67,7 +67,7 @@ struct _LogProtoClient
   LogProtoStatus status;
   const LogProtoClientOptions *options;
   LogTransportStack transport_stack;
-  gboolean (*poll_prepare)(LogProtoClient *s, gint *fd, GIOCondition *cond, gint *timeout);
+  gboolean (*poll_prepare)(LogProtoClient *s, GIOCondition *cond, GIOCondition *idle_cond, gint *timeout);
   LogProtoStatus (*post)(LogProtoClient *s, LogMessage *logmsg, guchar *msg, gsize msg_len, gboolean *consumed);
   LogProtoStatus (*process_in)(LogProtoClient *s);
   LogProtoStatus (*flush)(LogProtoClient *s);
@@ -123,9 +123,9 @@ log_proto_client_handshake(LogProtoClient *s, gboolean *handshake_finished)
 }
 
 static inline gboolean
-log_proto_client_poll_prepare(LogProtoClient *s, gint *fd, GIOCondition *cond, gint *timeout)
+log_proto_client_poll_prepare(LogProtoClient *s, GIOCondition *cond, GIOCondition *idle_cond, gint *timeout)
 {
-  gboolean result = s->poll_prepare(s, fd, cond, timeout);
+  gboolean result = s->poll_prepare(s, cond, idle_cond, timeout);
 
   if (!result && *timeout < 0)
     *timeout = s->options->idle_timeout;

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -29,18 +29,18 @@
 static LogProtoStatus log_proto_text_client_flush(LogProtoClient *s);
 
 static gboolean
-log_proto_text_client_poll_prepare(LogProtoClient *s, gint *fd, GIOCondition *cond, gint *timeout)
+log_proto_text_client_poll_prepare(LogProtoClient *s, GIOCondition *cond, GIOCondition *idle_cond, gint *timeout)
 {
   LogProtoTextClient *self = (LogProtoTextClient *) s;
 
   if (log_transport_stack_poll_prepare(&self->super.transport_stack, cond))
     return TRUE;
 
-  *fd = self->super.transport_stack.fd;
-
   /* if there's no pending I/O in the transport layer, then we want to do a write and allow reads as well*/
   if (*cond == 0)
     *cond = G_IO_OUT | G_IO_IN;
+
+  *idle_cond = G_IO_IN;
 
   return self->partial != NULL;
 }

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -38,27 +38,37 @@ log_proto_text_client_poll_prepare(LogProtoClient *s, gint *fd, GIOCondition *co
 
   /* if there's no pending I/O in the transport layer, then we want to do a write and allow reads as well*/
   if (*cond == 0)
-    *cond = G_IO_OUT | (self->super.options->drop_input ? G_IO_IN : 0);
+    *cond = G_IO_OUT | G_IO_IN;
 
   return self->partial != NULL;
 }
 
 static LogProtoStatus
-log_proto_text_client_drop_input(LogProtoClient *s)
+log_proto_text_client_process_input(LogProtoClient *s)
 {
   LogProtoTextClient *self = (LogProtoTextClient *) s;
   guchar buf[1024];
   gssize rc = -1;
   gsize read_limit = 0;
+  gsize read = 0;
 
   do
     {
       rc = log_transport_stack_read(&self->super.transport_stack, buf, sizeof(buf), NULL);
       read_limit++;
+
+      if (rc > 0)
+        read += rc;
     }
   while (rc > 0 && read_limit < 100);
 
-  if (rc == -1 && errno != EAGAIN)
+  if (read > 0 && !self->super.options->drop_input)
+    {
+      msg_error("Unexpected input, closing", evt_tag_int("fd", self->super.transport_stack.fd));
+      return LPS_ERROR;
+    }
+
+  if (rc < 0 && errno != EAGAIN)
     {
       msg_error("Error reading data",
                 evt_tag_int("fd", self->super.transport_stack.fd),
@@ -67,9 +77,8 @@ log_proto_text_client_drop_input(LogProtoClient *s)
     }
   else if (rc == 0)
     {
-      msg_error("EOF occurred while idle",
-                evt_tag_int("fd", self->super.transport_stack.fd));
-      return LPS_ERROR;
+      msg_notice("EOF occurred", evt_tag_int("fd", self->super.transport_stack.fd));
+      return LPS_EOF;
     }
 
   return LPS_SUCCESS;
@@ -200,8 +209,7 @@ log_proto_text_client_init(LogProtoTextClient *self, LogTransport *transport, co
   log_proto_client_init(&self->super, transport, options);
   self->super.poll_prepare = log_proto_text_client_poll_prepare;
   self->super.flush = log_proto_text_client_flush;
-  if (options->drop_input)
-    self->super.process_in = log_proto_text_client_drop_input;
+  self->super.process_in = log_proto_text_client_process_input;
   self->super.post = log_proto_text_client_post;
   self->super.free_fn = log_proto_text_client_free;
   self->next_state = -1;

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -36,9 +36,9 @@ log_proto_text_client_poll_prepare(LogProtoClient *s, gint *fd, GIOCondition *co
 
   *fd = self->super.transport_stack.fd;
 
-  /* if there's no pending I/O in the transport layer, then we want to do a write */
+  /* if there's no pending I/O in the transport layer, then we want to do a write and allow reads as well*/
   if (*cond == 0)
-    *cond = G_IO_OUT;
+    *cond = G_IO_OUT | (self->super.options->drop_input ? G_IO_IN : 0);
 
   return self->partial != NULL;
 }

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -48,13 +48,15 @@ log_proto_text_client_drop_input(LogProtoClient *s)
 {
   LogProtoTextClient *self = (LogProtoTextClient *) s;
   guchar buf[1024];
-  gint rc = -1;
+  gssize rc = -1;
+  gsize read_limit = 0;
 
   do
     {
       rc = log_transport_stack_read(&self->super.transport_stack, buf, sizeof(buf), NULL);
+      read_limit++;
     }
-  while (rc > 0);
+  while (rc > 0 && read_limit < 100);
 
   if (rc == -1 && errno != EAGAIN)
     {

--- a/lib/logproto/logproto-text-client.h
+++ b/lib/logproto/logproto-text-client.h
@@ -33,6 +33,7 @@ typedef struct _LogProtoTextClient
   guchar *partial;
   GDestroyNotify partial_free;
   gsize partial_len, partial_pos;
+  guint8 pending_flush:1, pending_in:1;
 } LogProtoTextClient;
 
 LogProtoStatus log_proto_text_client_submit_write(LogProtoClient *s, guchar *msg, gsize msg_len,

--- a/lib/logproto/logproto-text-client.h
+++ b/lib/logproto/logproto-text-client.h
@@ -33,7 +33,6 @@ typedef struct _LogProtoTextClient
   guchar *partial;
   GDestroyNotify partial_free;
   gsize partial_len, partial_pos;
-  guint8 pending_flush:1, pending_in:1;
 } LogProtoTextClient;
 
 LogProtoStatus log_proto_text_client_submit_write(LogProtoClient *s, guchar *msg, gsize msg_len,

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -527,20 +527,13 @@ is_file_regular(gint fd)
 static void
 log_writer_start_watches(LogWriter *self)
 {
-  gint fd;
-  GIOCondition cond;
-  gint idle_timeout = -1;
-
   if (self->watches_running)
     return;
 
-  log_proto_client_poll_prepare(self->proto, &fd, &cond, &idle_timeout);
-
-  self->fd_watch.fd = fd;
-
+  self->fd_watch.fd = log_proto_client_get_fd(self->proto);;
   if (self->pollable_state < 0)
     {
-      if (is_file_regular(fd))
+      if (is_file_regular(self->fd_watch.fd))
         self->pollable_state = 0;
       else
         self->pollable_state = !iv_fd_register_try(&self->fd_watch);

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -340,7 +340,7 @@ log_writer_io_error(gpointer s)
 }
 
 static void
-log_writer_io_check_eof(gpointer s)
+log_writer_io_close_on_input(gpointer s)
 {
   LogWriter *self = (LogWriter *) s;
 
@@ -368,8 +368,8 @@ log_writer_update_fd_callbacks(LogWriter *self, GIOCondition cond)
     {
       if (cond & G_IO_IN)
         iv_fd_set_handler_in(&self->fd_watch, log_writer_io_handle_in);
-      else if (self->flags & LW_DETECT_EOF)
-        iv_fd_set_handler_in(&self->fd_watch, log_writer_io_check_eof);
+      else if (self->flags & LW_CLOSE_ON_INPUT)
+        iv_fd_set_handler_in(&self->fd_watch, log_writer_io_close_on_input);
       else
         iv_fd_set_handler_in(&self->fd_watch, NULL);
 

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -490,7 +490,7 @@ log_writer_update_watches(LogWriter *self)
     {
       /* few elements are available, but less than flush_lines, we need to start a timer to initiate a flush */
 
-      log_writer_update_fd_callbacks(self, 0);
+      log_writer_update_fd_callbacks(self, cond & ~G_IO_OUT);
       self->waiting_for_throttle = TRUE;
       log_writer_arm_suspend_timer(self, (void (*)(void *)) log_writer_update_watches, (glong)timeout_msec);
     }
@@ -500,7 +500,7 @@ log_writer_update_watches(LogWriter *self)
        * when the required number of items are added.  see the
        * log_queue_check_items and its parallel_push argument above
        */
-      log_writer_update_fd_callbacks(self, 0);
+      log_writer_update_fd_callbacks(self, cond & ~G_IO_OUT);
     }
 
   if (idle_timeout > 0)

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -32,7 +32,7 @@
 #include "stats/stats-cluster-key-builder.h"
 
 /* writer constructor flags */
-#define LW_DETECT_EOF        0x0001
+#define LW_CLOSE_ON_INPUT    0x0001
 #define LW_FORMAT_FILE       0x0002
 #define LW_FORMAT_PROTO      0x0004
 #define LW_SYSLOG_PROTOCOL   0x0008

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -32,11 +32,10 @@
 #include "stats/stats-cluster-key-builder.h"
 
 /* writer constructor flags */
-#define LW_CLOSE_ON_INPUT    0x0001
-#define LW_FORMAT_FILE       0x0002
-#define LW_FORMAT_PROTO      0x0004
-#define LW_SYSLOG_PROTOCOL   0x0008
-#define LW_SOFT_FLOW_CONTROL 0x0010
+#define LW_FORMAT_FILE       0x0001
+#define LW_FORMAT_PROTO      0x0002
+#define LW_SYSLOG_PROTOCOL   0x0004
+#define LW_SOFT_FLOW_CONTROL 0x0008
 
 /* writer options (set by the user) */
 #define LWO_SYSLOG_PROTOCOL   0x0001

--- a/lib/transport/logtransport.c
+++ b/lib/transport/logtransport.c
@@ -130,7 +130,7 @@ log_transport_init_instance(LogTransport *self, const gchar *name, gint fd)
 {
   self->name = name;
   self->fd = fd;
-  self->cond = 0;
+  self->cond = LTIO_NOTHING;
   self->free_fn = log_transport_free_method;
 }
 

--- a/lib/transport/logtransport.h
+++ b/lib/transport/logtransport.h
@@ -50,6 +50,7 @@ typedef struct _LogTransportStack LogTransportStack;
 struct _LogTransport
 {
   gint fd;
+  /* should only be used to reverse the original I/O direction */
   GIOCondition cond;
 
   gssize (*read)(LogTransport *self, gpointer buf, gsize count, LogTransportAuxData *aux);
@@ -71,9 +72,11 @@ struct _LogTransport
 static inline gboolean
 log_transport_poll_prepare(LogTransport *self, GIOCondition *cond)
 {
+  *cond = self->cond;
+
   if (self->ra.buf_len != self->ra.pos)
     return TRUE;
-  *cond = self->cond;
+
   return FALSE;
 }
 

--- a/lib/transport/transport-stack.h
+++ b/lib/transport/transport-stack.h
@@ -146,6 +146,13 @@ log_transport_stack_poll_prepare(LogTransportStack *self, GIOCondition *cond)
   return log_transport_poll_prepare(transport, cond);
 }
 
+static inline LogTransportIOCond
+log_transport_stack_get_io_requirement(LogTransportStack *self)
+{
+  LogTransport *transport = log_transport_stack_get_active(self);
+  return log_transport_get_io_requirement(transport);
+}
+
 static inline gssize
 log_transport_stack_write(LogTransportStack *self, const gpointer buf, gsize count)
 {

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -151,11 +151,11 @@ _handle_shutdown_error(LogTransportTLS *self, gint ssl_error)
   switch (ssl_error)
     {
     case SSL_ERROR_WANT_READ:
-      self->super.super.cond = G_IO_IN;
+      self->super.super.cond = LTIO_READ_WANTS_READ;
       errno = EAGAIN;
       break;
     case SSL_ERROR_WANT_WRITE:
-      self->super.super.cond = G_IO_OUT;
+      self->super.super.cond = LTIO_READ_WANTS_WRITE;
       errno = EAGAIN;
       break;
     case SSL_ERROR_SYSCALL:
@@ -198,10 +198,10 @@ log_transport_tls_read_method(LogTransport *s, gpointer buf, gsize buflen, LogTr
   gint ssl_error;
   gint rc;
 
+  self->super.super.cond = LTIO_NOTHING;
+
   if (G_UNLIKELY(self->sending_shutdown))
     return (log_transport_tls_send_shutdown(self) >= 0) ? 0 : -1;
-
-  self->super.super.cond = 0;
 
   if (aux)
     {
@@ -231,13 +231,14 @@ log_transport_tls_read_method(LogTransport *s, gpointer buf, gsize buflen, LogTr
           switch (ssl_error)
             {
             case SSL_ERROR_WANT_READ:
+              /* SSL_ERROR_WANT_READ is not a must, LTIO_READ_WANTS_READ should NOT be set */
               rc = -1;
               errno = EAGAIN;
               break;
             case SSL_ERROR_WANT_WRITE:
               /* although we are reading this fd, libssl wants to write. This
                * happens during renegotiation for example */
-              self->super.super.cond = G_IO_OUT;
+              self->super.super.cond = LTIO_READ_WANTS_WRITE;
               rc = -1;
               errno = EAGAIN;
               break;
@@ -278,7 +279,7 @@ log_transport_tls_write_method(LogTransport *s, const gpointer buf, gsize buflen
   gint ssl_error;
   gint rc;
 
-  self->super.super.cond = 0;
+  self->super.super.cond = LTIO_NOTHING;
 
   rc = SSL_write(self->tls_session->ssl, buf, buflen);
 
@@ -290,10 +291,16 @@ log_transport_tls_write_method(LogTransport *s, const gpointer buf, gsize buflen
         case SSL_ERROR_WANT_READ:
           /* although we are writing this fd, libssl wants to read. This
            * happens during renegotiation for example */
-          self->super.super.cond = G_IO_IN;
+          self->super.super.cond = LTIO_WRITE_WANTS_READ;
           errno = EAGAIN;
           break;
         case SSL_ERROR_WANT_WRITE:
+          /*
+           * If you get SSL_ERROR_WANT_WRITE from SSL_write() then you should
+           * not do any other operation that could trigger IO other than to
+           * repeat the previous SSL_write() call.
+           */
+          self->super.super.cond = LTIO_WRITE_WANTS_WRITE;
           errno = EAGAIN;
           break;
         case SSL_ERROR_SYSCALL:
@@ -345,7 +352,7 @@ log_transport_tls_new(TLSSession *tls_session, LogTransportIndex base)
   LogTransportTLS *self = g_new0(LogTransportTLS, 1);
 
   log_transport_adapter_init_instance(&self->super, TLS_TRANSPORT_NAME, base);
-  self->super.super.cond = 0;
+  self->super.super.cond = LTIO_NOTHING;
   self->super.super.read = log_transport_tls_read_method;
   self->super.super.write = log_transport_tls_write_method;
   self->super.super.free_fn = log_transport_tls_free_method;

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -294,7 +294,6 @@ log_transport_tls_write_method(LogTransport *s, const gpointer buf, gsize buflen
           errno = EAGAIN;
           break;
         case SSL_ERROR_WANT_WRITE:
-          self->super.super.cond = G_IO_OUT;
           errno = EAGAIN;
           break;
         case SSL_ERROR_SYSCALL:

--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -230,14 +230,12 @@ log_proto_file_writer_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg, g
 }
 
 static gboolean
-log_proto_file_writer_poll_prepare(LogProtoClient *s, gint *fd, GIOCondition *cond, gint *timeout)
+log_proto_file_writer_poll_prepare(LogProtoClient *s, GIOCondition *cond, GIOCondition *idle_cond, gint *timeout)
 {
   LogProtoFileWriter *self = (LogProtoFileWriter *) s;
 
   if (log_transport_stack_poll_prepare(&self->super.transport_stack, cond))
     return TRUE;
-
-  *fd = self->super.transport_stack.fd;
 
   /* if there's no pending I/O in the transport layer, then we want to do a write */
   if (*cond == 0)

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -295,33 +295,6 @@ afinet_dd_set_failback_successful_probes_required(LogDriver *s, gint successful_
   afinet_dd_failover_set_successful_probes_required(self->failover, successful_probes_required);
 }
 
-static void
-_disable_connection_closure_on_input(LogWriter *writer)
-{
-  /* SSL is duplex, so we can certainly expect input from the server, which
-   * would cause the LogWriter to close this connection.  In a better world
-   * LW_CLOSE_ON_INPUT would be implemented by the LogProto class and would
-   * inherently work w/o mockery in LogWriter.  Defer that change for now
-   * (and possibly for all eternity :)
-   */
-
-  log_writer_set_flags(writer, log_writer_get_flags(writer) & ~LW_CLOSE_ON_INPUT);
-}
-
-static LogWriter *
-afinet_dd_construct_writer(AFSocketDestDriver *s)
-{
-  AFInetDestDriver *self = (AFInetDestDriver *) s;
-  TransportMapperInet *transport_mapper_inet = ((TransportMapperInet *) (self->super.transport_mapper));
-
-  LogWriter *writer = afsocket_dd_construct_writer_method(s);
-
-  if (((self->super.transport_mapper->sock_type == SOCK_STREAM) && transport_mapper_inet->tls_context))
-    _disable_connection_closure_on_input(writer);
-
-  return writer;
-}
-
 static gint
 _determine_port(const AFInetDestDriver *self)
 {
@@ -801,7 +774,6 @@ afinet_dd_new_instance(TransportMapper *transport_mapper, gchar *hostname, Globa
   self->super.super.super.super.deinit = afinet_dd_deinit;
   self->super.super.super.super.queue = afinet_dd_queue;
   self->super.super.super.super.free_fn = afinet_dd_free;
-  self->super.construct_writer = afinet_dd_construct_writer;
   self->super.setup_addresses = afinet_dd_setup_addresses;
   self->super.get_dest_name = afinet_dd_get_dest_name;
   self->super.should_restore_connection = afinet_dd_should_restore_connection;
@@ -844,13 +816,7 @@ afinet_dd_new_udp6(gchar *host, GlobalConfig *cfg)
 static LogWriter *
 afinet_dd_syslog_construct_writer(AFSocketDestDriver *s)
 {
-  AFInetDestDriver *self = (AFInetDestDriver *) s;
-  TransportMapperInet *transport_mapper_inet = ((TransportMapperInet *) (self->super.transport_mapper));
-
   LogWriter *writer = afsocket_dd_construct_writer_method(s);
-
-  if (((self->super.transport_mapper->sock_type == SOCK_STREAM) && transport_mapper_inet->tls_context))
-    _disable_connection_closure_on_input(writer);
 
   log_writer_set_flags(writer, log_writer_get_flags(writer) | LW_SYSLOG_PROTOCOL);
   return writer;

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -300,12 +300,12 @@ _disable_connection_closure_on_input(LogWriter *writer)
 {
   /* SSL is duplex, so we can certainly expect input from the server, which
    * would cause the LogWriter to close this connection.  In a better world
-   * LW_DETECT_EOF would be implemented by the LogProto class and would
+   * LW_CLOSE_ON_INPUT would be implemented by the LogProto class and would
    * inherently work w/o mockery in LogWriter.  Defer that change for now
    * (and possibly for all eternity :)
    */
 
-  log_writer_set_flags(writer, log_writer_get_flags(writer) & ~LW_DETECT_EOF);
+  log_writer_set_flags(writer, log_writer_get_flags(writer) & ~LW_CLOSE_ON_INPUT);
 }
 
 static LogWriter *

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -96,14 +96,6 @@ afsocket_dd_set_keep_alive(LogDriver *s, gboolean enable)
   self->connections_kept_alive_across_reloads = enable;
 }
 
-void
-afsocket_dd_set_close_on_input(LogDriver *s, gboolean close_on_input)
-{
-  AFSocketDestDriver *self = (AFSocketDestDriver *) s;
-
-  self->close_on_input = close_on_input;
-}
-
 static const gchar *_module_name = "afsocket_dd";
 
 static const gchar *
@@ -498,8 +490,6 @@ afsocket_dd_construct_writer_method(AFSocketDestDriver *self)
   guint32 writer_flags = 0;
 
   writer_flags |= LW_FORMAT_PROTO;
-  if (self->transport_mapper->sock_type == SOCK_STREAM && self->close_on_input)
-    writer_flags |= LW_CLOSE_ON_INPUT;
 
   LogWriter *writer = log_writer_new(writer_flags, self->super.super.super.cfg);
   log_pipe_set_options((LogPipe *) writer, &self->super.super.super.options);
@@ -815,7 +805,6 @@ afsocket_dd_init_instance(AFSocketDestDriver *self,
   self->transport_mapper = transport_mapper;
   self->socket_options = socket_options;
   self->connections_kept_alive_across_reloads = TRUE;
-  self->close_on_input = TRUE;
   self->connection_initialized = FALSE;
 
 

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -499,7 +499,7 @@ afsocket_dd_construct_writer_method(AFSocketDestDriver *self)
 
   writer_flags |= LW_FORMAT_PROTO;
   if (self->transport_mapper->sock_type == SOCK_STREAM && self->close_on_input)
-    writer_flags |= LW_DETECT_EOF;
+    writer_flags |= LW_CLOSE_ON_INPUT;
 
   LogWriter *writer = log_writer_new(writer_flags, self->super.super.super.cfg);
   log_pipe_set_options((LogPipe *) writer, &self->super.super.super.options);

--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -41,7 +41,6 @@ struct _AFSocketDestDriver
 
   guint
   connections_kept_alive_across_reloads:1;
-  gboolean close_on_input;
   gint fd;
   LogWriter *writer;
   LogWriterOptions writer_options;
@@ -102,7 +101,6 @@ afsocket_dd_get_dest_name(const AFSocketDestDriver *s)
 LogWriter *afsocket_dd_construct_writer_method(AFSocketDestDriver *self);
 gboolean afsocket_dd_setup_addresses_method(AFSocketDestDriver *self);
 void afsocket_dd_set_keep_alive(LogDriver *self, gint enable);
-void afsocket_dd_set_close_on_input(LogDriver *self, gboolean close_on_input);
 void afsocket_dd_init_instance(AFSocketDestDriver *self, SocketOptions *socket_options,
                                TransportMapper *transport_mapper, GlobalConfig *cfg);
 void afsocket_dd_reconnect(AFSocketDestDriver *self);

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -681,7 +681,6 @@ dest_afsocket_option
         : KW_KEEP_ALIVE '(' yesno ')'        { afsocket_dd_set_keep_alive(last_driver, $3); }
         | KW_CLOSE_ON_INPUT '(' yesno ')'
           {
-            afsocket_dd_set_close_on_input(last_driver, $3);
             log_proto_client_options_set_drop_input(last_proto_client_options, !$3);
           }
         ;

--- a/news/bugfix-609-2.md
+++ b/news/bugfix-609-2.md
@@ -1,0 +1,1 @@
+`collectd()`: fix not reading server responses

--- a/news/bugfix-609.md
+++ b/news/bugfix-609.md
@@ -1,0 +1,1 @@
+`network()`, `syslog()` destinations: handle async TLS messages (KeyUpdate, etc.)


### PR DESCRIPTION
Fixes the `collectd()` destination (we never read the server's response).
Fixes possible starvation issue on the destination side when reading server responses
Fixes and workarounds TLS-related state handling issues
Fixes #604