### PR TITLE
filterx-dict: use typed string keys

### DIFF
--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -42,7 +42,7 @@ _eval_get_subscript(FilterXExpr *s)
   if (!variable)
     return NULL;
 
-  FilterXObject *key = filterx_expr_eval(self->key);
+  FilterXObject *key = filterx_expr_eval_typed(self->key);
   if (!key)
     goto exit;
   result = filterx_object_get_subscript(variable, key);

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -99,6 +99,8 @@ _filterx_string_hash(FilterXString *self);
 static inline guint
 filterx_string_hash(FilterXObject *s)
 {
+  g_assert(filterx_object_is_type(s, &FILTERX_TYPE_NAME(string)));
+
   FilterXString *self = (FilterXString *) s;
   if (self->hash)
     return self->hash;

--- a/tests/light/functional_tests/filterx/test_filterx_dict.py
+++ b/tests/light/functional_tests/filterx/test_filterx_dict.py
@@ -2,6 +2,7 @@
 #############################################################################
 # Copyright (c) 2025 Axoflow
 # Copyright (c) 2025 Attila Szakacs <attila.szakacs@axoflow.com>
+# Copyright (c) 2025 László Várady
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published
@@ -36,3 +37,18 @@ def test_filterx_dict_unset_key_with_hash_collision(syslog_ng, config):
 
     syslog_ng.start(config)
     assert destination.read_log() == "b"
+
+
+def test_filterx_dict_message_value_key(syslog_ng, config):
+    source = config.create_example_msg_generator_source(num=1, template='test_key')
+    filterx = config.create_filterx(r"""
+        d = {};
+        d["test_key"] = "test_value";
+        $MSG = d[$MSG];
+""")
+    destination = config.create_file_destination(file_name="output.log", template='"$MSG\n"')
+
+    config.create_logpath(statements=[source, filterx, destination])
+
+    syslog_ng.start(config)
+    assert destination.read_log() == "test_value"


### PR DESCRIPTION
The dict implementation uses `filterx_string_hash()` for keys, so `FilterXMessageValue` is no longer accepted.