### PR TITLE
filterx: fix precedence and associativity of "not"

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -211,12 +211,13 @@ main_location_print (FILE *yyo, YYLTYPE const * const yylocp)
 %right KW_NULL_COALESCING
 %left  KW_OR 9010
 %left  KW_AND 9020
+%right KW_NOT 9025
 %left  KW_STR_EQ 9030 KW_STR_NE 9031, KW_TA_EQ 9032, KW_TA_NE 9033, KW_TAV_EQ 9034, KW_TAV_NE 9035, KW_REGEXP_MATCH 9036, KW_REGEXP_NOMATCH 9037, KW_IN 9038
 %left  KW_STR_LT 9040, KW_STR_LE 9041, KW_STR_GE, 9042 KW_STR_GT, 9043, KW_TA_LT 9044, KW_TA_LE 9045, KW_TA_GE 9046, KW_TA_GT 9047
 
 %left  '+' '-'
 %left  '*'
-%left '.' '[' ']' KW_NOT 9049
+%left '.' '[' ']'
 
 /* statements */
 %token KW_SOURCE                      10000


### PR DESCRIPTION
For example:
https://docs.python.org/3/reference/expressions.html#operator-precedence