### PR TITLE
wallclocktime: strptime and strftime fixes

### DIFF
--- a/lib/timeutils/tests/test_wallclocktime.c
+++ b/lib/timeutils/tests/test_wallclocktime.c
@@ -556,7 +556,7 @@ Test(wallclocktime, test_strftime_all_format_spec)
                            "%a %A %b %B '%c' %C %d '%D' '%e' %f '%F' %g %G %h %H %I %j %m %M %n %p %r %R %s %S %t '%T' %u %U %W %V %w %x %X %y %Y %z %Z");
   cr_assert_str_eq(buf,
                    "Sat Saturday Aug August 'Sat Aug  7 09:29:12 2021' 20 07 '08/07/21' ' 7' 123456 '2021-08-07' 21 2021 Aug 09 09 219 08 29 \n"
-                   " AM 09:29:12 AM 09:29 1628324952 12 \t '10:29:12' 6 31 31 31 6 08/07/21 10:29:12 21 2021 +0200 +02:00");
+                   " AM 09:29:12 AM 09:29 1628324952 12 \t '09:29:12' 6 31 31 31 6 08/07/21 09:29:12 21 2021 +0200 +02:00");
 }
 
 static void

--- a/lib/timeutils/tests/test_wallclocktime.c
+++ b/lib/timeutils/tests/test_wallclocktime.c
@@ -551,12 +551,20 @@ Test(wallclocktime, test_strftime_all_format_spec)
   WallClockTime wct = WALL_CLOCK_TIME_INIT;
   gchar buf[256];
 
+  const gchar *format =
+    "%a %A %b %B '%c' %C %d '%D' '%e' %f '%F' %g %G %h %H %I %j %m %M %n"
+    " %p %r %R %s %S %t '%T' %u %U %W %V %w %x %X %y %Y %z %Z";
+  const gchar *expected =
+    "Sat Saturday Aug August 'Sat Aug  7 09:29:12 2021' 20 07 '08/07/21' ' 7' 123456 '2021-08-07' 21 2021 Aug 09 09 219 08 29 \n"
+    " AM 09:29:12 AM 09:29 1628324952 12 \t '09:29:12' 6 31 31 31 6 08/07/21 09:29:12 21 2021 -0700 -07:00";
+
   wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S.%f %z", "Aug  7 2021 09:29:12.123456-07:00");
-  wall_clock_time_strftime(&wct, buf, sizeof(buf),
-                           "%a %A %b %B '%c' %C %d '%D' '%e' %f '%F' %g %G %h %H %I %j %m %M %n %p %r %R %s %S %t '%T' %u %U %W %V %w %x %X %y %Y %z %Z");
-  cr_assert_str_eq(buf,
-                   "Sat Saturday Aug August 'Sat Aug  7 09:29:12 2021' 20 07 '08/07/21' ' 7' 123456 '2021-08-07' 21 2021 Aug 09 09 219 08 29 \n"
-                   " AM 09:29:12 AM 09:29 1628324952 12 \t '09:29:12' 6 31 31 31 6 08/07/21 09:29:12 21 2021 -0700 -07:00");
+
+  // Test it twice, so we see if a format has a side effect that would modify the timestamp
+  wall_clock_time_strftime(&wct, buf, sizeof(buf), format);
+  cr_assert_str_eq(buf, expected);
+  wall_clock_time_strftime(&wct, buf, sizeof(buf), format);
+  cr_assert_str_eq(buf, expected);
 }
 
 static void

--- a/lib/timeutils/tests/test_wallclocktime.c
+++ b/lib/timeutils/tests/test_wallclocktime.c
@@ -551,12 +551,12 @@ Test(wallclocktime, test_strftime_all_format_spec)
   WallClockTime wct = WALL_CLOCK_TIME_INIT;
   gchar buf[256];
 
-  wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S.%f %z", "Aug  7 2021 09:29:12.123456+02:00");
+  wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S.%f %z", "Aug  7 2021 09:29:12.123456-07:00");
   wall_clock_time_strftime(&wct, buf, sizeof(buf),
                            "%a %A %b %B '%c' %C %d '%D' '%e' %f '%F' %g %G %h %H %I %j %m %M %n %p %r %R %s %S %t '%T' %u %U %W %V %w %x %X %y %Y %z %Z");
   cr_assert_str_eq(buf,
                    "Sat Saturday Aug August 'Sat Aug  7 09:29:12 2021' 20 07 '08/07/21' ' 7' 123456 '2021-08-07' 21 2021 Aug 09 09 219 08 29 \n"
-                   " AM 09:29:12 AM 09:29 1628324952 12 \t '09:29:12' 6 31 31 31 6 08/07/21 09:29:12 21 2021 +0200 +02:00");
+                   " AM 09:29:12 AM 09:29 1628324952 12 \t '09:29:12' 6 31 31 31 6 08/07/21 09:29:12 21 2021 -0700 -07:00");
 }
 
 static void

--- a/lib/timeutils/tests/test_wallclocktime.c
+++ b/lib/timeutils/tests/test_wallclocktime.c
@@ -555,7 +555,7 @@ Test(wallclocktime, test_strftime_all_format_spec)
   wall_clock_time_strftime(&wct, buf, sizeof(buf),
                            "%a %A %b %B '%c' %C %d '%D' '%e' %f '%F' %g %G %h %H %I %j %m %M %n %p %r %R %s %S %t '%T' %u %U %W %V %w %x %X %y %Y %z %Z");
   cr_assert_str_eq(buf,
-                   "Fri Friday Aug August 'Fri Aug  7 09:29:12 2021' 20 07 '08/07/21' ' 7' 123456 '2021-08-07' 21 2021 Aug 09 09 219 08 29 \n"
+                   "Sat Saturday Aug August 'Sat Aug  7 09:29:12 2021' 20 07 '08/07/21' ' 7' 123456 '2021-08-07' 21 2021 Aug 09 09 219 08 29 \n"
                    " AM 09:29:12 AM 09:29 1628324952 12 \t '10:29:12' 6 31 31 31 6 08/07/21 10:29:12 21 2021 +0200 +02:00");
 }
 

--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -862,8 +862,8 @@ out:
         {
           /* calculate day of week */
           i = 0;
-          week_offset = first_wday_of(wct->tm.tm_year);
-          while (i++ <= wct->tm.tm_yday)
+          week_offset = first_wday_of(wct->tm.tm_year + TM_YEAR_BASE);
+          while (i++ < wct->tm.tm_yday)
             {
               if (week_offset++ >= 6)
                 week_offset = 0;

--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -1201,7 +1201,7 @@ __strftime_fmt_1(WallClockTime *wct, char (*s)[100], size_t *l, int f, int pad)
         }
       *l = snprintf(*s, sizeof *s, "%c%02ld:%02ld",
                     wct->wct_gmtoff < 0 ? '-' : '+',
-                    wct->wct_gmtoff/3600, wct->wct_gmtoff%3600/60);
+                    (wct->wct_gmtoff > 0 ? wct->wct_gmtoff : -wct->wct_gmtoff)/3600, wct->wct_gmtoff%3600/60);
       return *s;
     case '%':
       *l = 1;

--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -1133,9 +1133,12 @@ __strftime_fmt_1(WallClockTime *wct, char (*s)[100], size_t *l, int f, int pad)
       fmt = "%H:%M";
       goto recu_strftime;
     case 's':
-      val = cached_mktime(&wct->tm);
+    {
+      WallClockTime wct_copy = *wct;
+      val = cached_mktime(&wct_copy.tm);
       width = 1;
       goto number;
+    }
     case 'S':
       val = wct->wct_sec;
       goto number;

--- a/news/bugfix-626.md
+++ b/news/bugfix-626.md
@@ -1,0 +1,1 @@
+Fixed some time parsing and time formatting issues.


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
