### PR TITLE
FilterX failure info

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -59,6 +59,7 @@ set(FILTERX_HEADERS
     filterx/func-unset-empties.h
     filterx/func-vars.h
     filterx/func-repr.h
+    filterx/func-failure-info.h
     filterx/object-datetime.h
     filterx/object-dict-interface.h
     filterx/object-dict.h
@@ -134,6 +135,7 @@ set(FILTERX_SOURCES
     filterx/func-unset-empties.c
     filterx/func-vars.c
     filterx/func-repr.c
+    filterx/func-failure-info.c
     filterx/object-datetime.c
     filterx/object-dict-interface.c
     filterx/object-dict.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -62,6 +62,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/func-unset-empties.h \
 	lib/filterx/func-repr.h \
 	lib/filterx/func-vars.h \
+	lib/filterx/func-failure-info.h \
 	lib/filterx/object-datetime.h \
 	lib/filterx/object-dict-interface.h \
 	lib/filterx/object-dict.h \
@@ -137,6 +138,7 @@ filterx_sources = 				\
 	lib/filterx/func-unset-empties.c \
 	lib/filterx/func-vars.c \
 	lib/filterx/func-repr.c \
+	lib/filterx/func-failure-info.c \
 	lib/filterx/object-datetime.c \
 	lib/filterx/object-dict-interface.c \
 	lib/filterx/object-dict.c \

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -131,7 +131,7 @@ _eval_compound_start(FilterXCompoundExpr *self, gsize start_index)
     {
       if (result)
         {
-          filterx_eval_push_error("bailing out due to a falsy expr", &self->super, result);
+          filterx_eval_push_falsy_error("bailing out due to a falsy expr", &self->super, result);
           filterx_object_unref(result);
           result = NULL;
         }

--- a/lib/filterx/filterx-error.c
+++ b/lib/filterx/filterx-error.c
@@ -93,6 +93,15 @@ filterx_error_set_values(FilterXError *error, const gchar *message, FilterXExpr 
 }
 
 void
+filterx_falsy_error_set_values(FilterXError *error, const gchar *message, FilterXExpr *expr, FilterXObject *object)
+{
+  error->message = message;
+  error->expr = expr;
+  error->object = filterx_object_ref(object);
+  error->falsy = TRUE;
+}
+
+void
 filterx_error_set_info(FilterXError *error, gchar *info, gboolean free_info)
 {
   error->info = info;

--- a/lib/filterx/filterx-error.c
+++ b/lib/filterx/filterx-error.c
@@ -98,3 +98,15 @@ filterx_error_set_info(FilterXError *error, gchar *info, gboolean free_info)
   error->info = info;
   error->free_info = free_info;
 }
+
+void
+filterx_error_copy(FilterXError *src, FilterXError *dst)
+{
+  g_assert(!dst->message);
+
+  dst->message = src->message;
+  dst->expr = src->expr;
+  dst->object = filterx_object_ref(src->object);
+  dst->info = g_strdup(src->info);
+  dst->free_info = TRUE;
+}

--- a/lib/filterx/filterx-error.h
+++ b/lib/filterx/filterx-error.h
@@ -35,7 +35,7 @@ typedef struct _FilterXError
   FilterXExpr *expr;
   FilterXObject *object;
   gchar *info;
-  gboolean free_info;
+  guint8 free_info:1, falsy:1;
 } FilterXError;
 
 void filterx_error_clear(FilterXError *error);
@@ -45,6 +45,8 @@ EVTTAG *filterx_error_format_tag(FilterXError *error);
 EVTTAG *filterx_error_format_location_tag(FilterXError *error);
 void filterx_error_set_info(FilterXError *error, gchar *info, gboolean free_info);
 void filterx_error_set_values(FilterXError *error, const gchar *message, FilterXExpr *expr, FilterXObject *object);
+void filterx_falsy_error_set_values(FilterXError *error, const gchar *message, FilterXExpr *expr,
+                                    FilterXObject *object);
 
 
 #endif

--- a/lib/filterx/filterx-error.h
+++ b/lib/filterx/filterx-error.h
@@ -39,6 +39,7 @@ typedef struct _FilterXError
 } FilterXError;
 
 void filterx_error_clear(FilterXError *error);
+void filterx_error_copy(FilterXError *src, FilterXError *dst);
 const gchar *filterx_error_format(FilterXError *error);
 EVTTAG *filterx_error_format_tag(FilterXError *error);
 EVTTAG *filterx_error_format_location_tag(FilterXError *error);

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -36,6 +36,8 @@ TLS_BLOCK_END;
 
 #define eval_context __tls_deref(eval_context)
 
+#define FAILURE_INFO_PREALLOC_SIZE 16
+
 FilterXEvalContext *
 filterx_eval_get_context(void)
 {
@@ -131,6 +133,38 @@ filterx_eval_format_last_error_location_tag(void)
   return filterx_error_format_location_tag(&context->error);
 }
 
+static inline FilterXFailureInfo *
+_new_failure_info_entry(FilterXEvalContext *context)
+{
+  GArray *finfo = context->failure_info;
+  g_assert(finfo);
+
+  g_array_set_size(finfo, finfo->len + 1);
+
+  return &g_array_index(finfo, FilterXFailureInfo, finfo->len - 1);
+}
+
+static void
+_fill_failure_info(FilterXEvalContext *context, FilterXExpr *block, FilterXObject *block_res)
+{
+  if (!context->failure_info)
+    return;
+
+  if (context->error.falsy && !context->failure_info_collect_falsy)
+    return;
+
+  FilterXFailureInfo *failure_info = _new_failure_info_entry(context);
+  failure_info->meta = filterx_object_ref(context->current_frame_meta);
+
+  if (!context->error.message && context->failure_info_collect_falsy)
+    {
+      filterx_falsy_error_set_values(&failure_info->error, "Falsy expression", block, block_res);
+      return;
+    }
+
+  filterx_error_copy(&context->error, &failure_info->error);
+}
+
 FilterXEvalResult
 filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr)
 {
@@ -142,17 +176,21 @@ filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr)
       msg_debug("FILTERX ERROR",
                 filterx_eval_format_last_error_location_tag(),
                 filterx_eval_format_last_error_tag());
-      filterx_eval_clear_errors();
-      goto fail;
+      goto exit;
     }
 
   if (G_UNLIKELY(context->eval_control_modifier == FXC_DROP))
     result = FXE_DROP;
   else if (filterx_object_truthy(res))
     result = FXE_SUCCESS;
-  filterx_object_unref(res);
   /* NOTE: we only store the results into the message if the entire evaluation was successful */
-fail:
+
+exit:
+  if (result == FXE_FAILURE)
+    _fill_failure_info(context, expr, res);
+
+  filterx_error_clear(&context->error);
+  filterx_object_unref(res);
   filterx_scope_set_dirty(context->scope);
   return result;
 }
@@ -171,7 +209,11 @@ filterx_eval_begin_context(FilterXEvalContext *context,
   context->scope = scope;
 
   if (previous_context)
-    context->weak_refs = previous_context->weak_refs;
+    {
+      context->weak_refs = previous_context->weak_refs;
+      context->failure_info = previous_context->failure_info;
+      context->failure_info_collect_falsy = previous_context->failure_info_collect_falsy;
+    }
   else
     context->weak_refs = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
   context->previous_context = previous_context;
@@ -180,11 +222,41 @@ filterx_eval_begin_context(FilterXEvalContext *context,
   filterx_eval_set_context(context);
 }
 
+static void
+_failure_info_clear_entry(FilterXFailureInfo *failure_info)
+{
+  filterx_error_clear(&failure_info->error);
+  filterx_object_unref(failure_info->meta);
+}
+
+static void
+_clear_failure_info(GArray *failure_info)
+{
+  for (guint i = 0; i < failure_info->len; ++i)
+    {
+      FilterXFailureInfo *fi = &g_array_index(failure_info, FilterXFailureInfo, i);
+      _failure_info_clear_entry(fi);
+    }
+
+  g_array_set_size(failure_info, 0);
+}
+
 void
 filterx_eval_end_context(FilterXEvalContext *context)
 {
   if (!context->previous_context)
-    g_ptr_array_free(context->weak_refs, TRUE);
+    {
+      g_ptr_array_free(context->weak_refs, TRUE);
+
+      if (context->failure_info)
+        {
+          _clear_failure_info(context->failure_info);
+          g_array_free(context->failure_info, TRUE);
+        }
+    }
+
+  context->failure_info = NULL;
+  filterx_object_unref(context->current_frame_meta);
   filterx_eval_set_context(context->previous_context);
 }
 
@@ -205,6 +277,37 @@ void
 filterx_eval_end_compile(FilterXEvalContext *context)
 {
   filterx_eval_set_context(NULL);
+}
+
+void
+filterx_eval_enable_failure_info(FilterXEvalContext *context, gboolean collect_falsy)
+{
+  if (context->failure_info)
+    return;
+
+  context->failure_info = g_array_sized_new(FALSE, TRUE, sizeof(FilterXFailureInfo), FAILURE_INFO_PREALLOC_SIZE);
+  context->failure_info_collect_falsy = collect_falsy;
+
+  while (context->previous_context)
+    {
+      context->previous_context->failure_info = context->failure_info;
+      context->previous_context->failure_info_collect_falsy = context->failure_info_collect_falsy;
+
+      context = context->previous_context;
+    }
+}
+
+void
+filterx_eval_clear_failure_info(FilterXEvalContext *context)
+{
+  if (context->failure_info)
+    _clear_failure_info(context->failure_info);
+}
+
+GArray *
+filterx_eval_get_failure_info(FilterXEvalContext *context)
+{
+  return context->failure_info;
 }
 
 EVTTAG *

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -68,6 +68,18 @@ filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObject *
     }
 }
 
+void
+filterx_eval_push_falsy_error(const gchar *message, FilterXExpr *expr, FilterXObject *object)
+{
+  FilterXEvalContext *context = filterx_eval_get_context();
+
+  if (!context)
+    return;
+
+  filterx_error_clear(&context->error);
+  filterx_falsy_error_set_values(&context->error, message, expr, object);
+}
+
 /* takes ownership of info */
 void
 filterx_eval_push_error_info(const gchar *message, FilterXExpr *expr, gchar *info, gboolean free_info)

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -26,6 +26,7 @@
 #include "filterx/filterx-scope.h"
 #include "filterx/filterx-expr.h"
 #include "filterx/filterx-error.h"
+#include "filterx/filterx-object.h"
 #include "template/eval.h"
 
 
@@ -49,16 +50,26 @@ typedef enum _FilterXEvalControl
   FXC_BREAK,
 } FilterXEvalControl;
 
+typedef struct _FilterXFailureInfo
+{
+  FilterXObject *meta;
+  FilterXError error;
+} FilterXFailureInfo;
+
 typedef struct _FilterXEvalContext FilterXEvalContext;
 struct _FilterXEvalContext
 {
   LogMessage *msg;
   FilterXScope *scope;
   FilterXError error;
+  FilterXObject *current_frame_meta;
   LogTemplateEvalOptions template_eval_options;
   GPtrArray *weak_refs;
   FilterXEvalControl eval_control_modifier;
   FilterXEvalContext *previous_context;
+
+  guint8 failure_info_collect_falsy:1;
+  GArray *failure_info;
 };
 
 FilterXEvalContext *filterx_eval_get_context(void);
@@ -79,6 +90,17 @@ void filterx_eval_begin_context(FilterXEvalContext *context, FilterXEvalContext 
 void filterx_eval_end_context(FilterXEvalContext *context);
 void filterx_eval_begin_compile(FilterXEvalContext *context, GlobalConfig *cfg);
 void filterx_eval_end_compile(FilterXEvalContext *context);
+
+void filterx_eval_enable_failure_info(FilterXEvalContext *context, gboolean collect_falsy);
+void filterx_eval_clear_failure_info(FilterXEvalContext *context);
+GArray *filterx_eval_get_failure_info(FilterXEvalContext *context);
+
+static inline void
+filterx_eval_set_current_frame_meta(FilterXEvalContext *context, FilterXObject *meta)
+{
+  filterx_object_unref(context->current_frame_meta);
+  context->current_frame_meta = filterx_object_ref(meta);
+}
 
 static inline void
 filterx_eval_sync_message(FilterXEvalContext *context, LogMessage **pmsg, const LogPathOptions *path_options)

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -64,6 +64,7 @@ struct _FilterXEvalContext
 FilterXEvalContext *filterx_eval_get_context(void);
 FilterXScope *filterx_eval_get_scope(void);
 void filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObject *object);
+void filterx_eval_push_falsy_error(const gchar *message, FilterXExpr *expr, FilterXObject *object);
 void filterx_eval_push_error_info(const gchar *message, FilterXExpr *expr, gchar *info, gboolean free_info);
 void filterx_eval_set_context(FilterXEvalContext *context);
 FilterXEvalResult filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr);

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -31,12 +31,6 @@
 #include "scratch-buffers.h"
 #include "perf/perf.h"
 
-static inline gboolean
-_extract_source_text(void)
-{
-  return debug_flag || perf_is_enabled();
-}
-
 void
 filterx_expr_set_location_with_text(FilterXExpr *self, CFG_LTYPE *lloc, const gchar *text)
 {
@@ -44,7 +38,7 @@ filterx_expr_set_location_with_text(FilterXExpr *self, CFG_LTYPE *lloc, const gc
     self->lloc = g_new0(CFG_LTYPE, 1);
   *self->lloc = *lloc;
 
-  if (_extract_source_text() && text && text != self->expr_text)
+  if (text && text != self->expr_text)
     {
       g_free(self->expr_text);
       self->expr_text = g_strdup(text);
@@ -57,13 +51,11 @@ filterx_expr_set_location(FilterXExpr *self, CfgLexer *lexer, CFG_LTYPE *lloc)
   if (!self->lloc)
     self->lloc = g_new0(CFG_LTYPE, 1);
   *self->lloc = *lloc;
-  if (_extract_source_text())
-    {
-      g_free(self->expr_text);
-      GString *res = g_string_sized_new(0);
-      cfg_source_extract_source_text(lexer, lloc, res);
-      self->expr_text = g_string_free(res, FALSE);
-    }
+
+  g_free(self->expr_text);
+  GString *res = g_string_sized_new(0);
+  cfg_source_extract_source_text(lexer, lloc, res);
+  self->expr_text = g_string_free(res, FALSE);
 }
 
 EVTTAG *

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -28,6 +28,7 @@
 #include "mainloop.h"
 #include "stats/stats-registry.h"
 #include "stats/stats-cluster-single.h"
+#include "scratch-buffers.h"
 #include "perf/perf.h"
 
 static inline gboolean
@@ -74,6 +75,28 @@ filterx_expr_format_location_tag(FilterXExpr *self)
                           self->expr_text ? : "n/a");
   else
     return evt_tag_str("expr", "n/a");
+}
+
+GString *
+filterx_expr_format_location(FilterXExpr *self)
+{
+  GString *location = scratch_buffers_alloc();
+
+  if (self && self->lloc)
+    g_string_printf(location, "%s:%d:%d", self->lloc->name, self->lloc->first_line, self->lloc->first_column);
+  else
+    g_string_assign(location, "n/a");
+
+  return location;
+}
+
+const gchar *
+filterx_expr_get_text(FilterXExpr *self)
+{
+  if (self && self->expr_text)
+    return self->expr_text;
+
+  return "n/a";
 }
 
 FilterXExpr *

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -165,6 +165,8 @@ filterx_expr_unset_available(FilterXExpr *self)
 void filterx_expr_set_location(FilterXExpr *self, CfgLexer *lexer, CFG_LTYPE *lloc);
 void filterx_expr_set_location_with_text(FilterXExpr *self, CFG_LTYPE *lloc, const gchar *text);
 EVTTAG *filterx_expr_format_location_tag(FilterXExpr *self);
+GString *filterx_expr_format_location(FilterXExpr *self);
+const gchar *filterx_expr_get_text(FilterXExpr *self);
 FilterXExpr *filterx_expr_optimize(FilterXExpr *self);
 void filterx_expr_init_instance(FilterXExpr *self, const gchar *type);
 FilterXExpr *filterx_expr_new(void);

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -47,6 +47,7 @@
 #include "filterx/func-sdata.h"
 #include "filterx/func-repr.h"
 #include "filterx/func-cache-json-file.h"
+#include "filterx/func-failure-info.h"
 #include "filterx/expr-regexp-search.h"
 #include "filterx/expr-regexp-subst.h"
 #include "filterx/expr-regexp.h"
@@ -173,6 +174,10 @@ _ctors_init(void)
   g_assert(filterx_builtin_function_ctor_register("set_pri", filterx_function_set_pri_new));
   g_assert(filterx_builtin_function_ctor_register("cache_json_file", filterx_function_cache_json_file_new));
   g_assert(filterx_builtin_function_ctor_register("regexp_search", filterx_function_regexp_search_new));
+  g_assert(filterx_builtin_function_ctor_register("failure_info_enable", filterx_fn_failure_info_enable_new));
+  g_assert(filterx_builtin_function_ctor_register("failure_info_clear", filterx_fn_failure_info_clear_new));
+  g_assert(filterx_builtin_function_ctor_register("failure_info", filterx_fn_failure_info_new));
+  g_assert(filterx_builtin_function_ctor_register("failure_info_meta", filterx_fn_failure_info_meta_new));
 }
 
 static void

--- a/lib/filterx/func-failure-info.c
+++ b/lib/filterx/func-failure-info.c
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2025 Axoflow
+ * Copyright (c) 2025 László Várady
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/func-failure-info.h"
+#include "filterx/filterx-eval.h"
+#include "filterx/filterx-expr.h"
+#include "filterx/filterx-error.h"
+#include "filterx/expr-literal.h"
+#include "filterx/expr-literal-container.h"
+#include "filterx/object-primitive.h"
+#include "filterx/object-string.h"
+#include "filterx/object-dict.h"
+#include "filterx/object-list.h"
+#include "filterx/object-list-interface.h"
+
+#include "scratch-buffers.h"
+
+#define FILTERX_FUNC_FAILURE_INFO_ENABLE_USAGE "Usage: failure_info_enable(collect_falsy=false/true);"
+#define FILTERX_FUNC_FAILURE_INFO_META_USAGE "Usage: failure_info_meta({});"
+
+typedef struct FilterXFunctionFailureInfoEnable_
+{
+  FilterXFunction super;
+  gboolean collect_falsy;
+} FilterXFunctionFailureInfoEnable;
+
+typedef struct FilterXFunctionFailureInfoMeta_
+{
+  FilterXFunction super;
+  FilterXObject *metadata;
+} FilterXFunctionFailureInfoMeta;
+
+static inline void
+_set_subscript_cstr(FilterXObject *dict, const gchar *key, const gchar *value)
+{
+  FILTERX_STRING_DECLARE_ON_STACK(fx_key, key, -1);
+  FILTERX_STRING_DECLARE_ON_STACK(fx_value, value, -1);
+
+  filterx_object_set_subscript(dict, fx_key, &fx_value);
+
+  filterx_object_unref(fx_value);
+  filterx_object_unref(fx_key);
+}
+
+static FilterXObject *
+_create_dict_from_failure_info_entry(FilterXFailureInfo *fi)
+{
+  FilterXObject *fx_finfo_entry = filterx_dict_new();
+  filterx_object_cow_prepare(&fx_finfo_entry);
+
+  if (fi->meta)
+    {
+      FILTERX_STRING_DECLARE_ON_STACK(meta_key, "meta", -1);
+      filterx_object_set_subscript(fx_finfo_entry, meta_key, &fi->meta);
+      filterx_object_unref(meta_key);
+    }
+
+  _set_subscript_cstr(fx_finfo_entry, "location", filterx_expr_format_location(fi->error.expr)->str);
+  _set_subscript_cstr(fx_finfo_entry, "line", filterx_expr_get_text(fi->error.expr));
+  _set_subscript_cstr(fx_finfo_entry, "error", filterx_error_format(&fi->error));
+
+  return fx_finfo_entry;
+}
+
+static FilterXObject *
+_failure_info_eval(FilterXExpr *s)
+{
+  GArray *failure_info = filterx_eval_get_failure_info(filterx_eval_get_context());
+  FilterXObject *fx_finfo = filterx_list_new();
+
+  if (!failure_info)
+    return fx_finfo;
+
+  ScratchBuffersMarker mark;
+  scratch_buffers_mark(&mark);
+
+  for (guint i = 0; i < failure_info->len; ++i)
+    {
+      FilterXFailureInfo *failure_info_entry = &g_array_index(failure_info, FilterXFailureInfo, i);
+
+      FilterXObject *finfo_entry = _create_dict_from_failure_info_entry(failure_info_entry);
+      filterx_list_set_subscript(fx_finfo, i, &finfo_entry);
+      filterx_object_unref(finfo_entry);
+    }
+
+  scratch_buffers_reclaim_marked(mark);
+
+  return fx_finfo;
+}
+
+static FilterXObject *
+_failure_info_clear_eval(FilterXExpr *s)
+{
+  filterx_eval_clear_failure_info(filterx_eval_get_context());
+
+  return filterx_boolean_new(TRUE);
+}
+
+static FilterXObject *
+_failure_info_meta_eval(FilterXExpr *s)
+{
+  FilterXFunctionFailureInfoMeta *self = (FilterXFunctionFailureInfoMeta *) s;
+
+  FilterXEvalContext *context = filterx_eval_get_context();
+  if (!filterx_eval_get_failure_info(context))
+    goto exit;
+
+  filterx_eval_set_current_frame_meta(context, self->metadata);
+
+exit:
+  return filterx_boolean_new(TRUE);
+}
+
+static FilterXObject *
+_failure_info_enable_eval(FilterXExpr *s)
+{
+  FilterXFunctionFailureInfoEnable *self = (FilterXFunctionFailureInfoEnable *) s;
+
+  filterx_eval_enable_failure_info(filterx_eval_get_context(), self->collect_falsy);
+
+  return filterx_boolean_new(TRUE);
+}
+
+static gboolean
+_extract_failure_info_enable_args(FilterXFunctionFailureInfoEnable *self, FilterXFunctionArgs *args, GError **error)
+{
+  if (filterx_function_args_len(args) != 0)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "invalid number of arguments. " FILTERX_FUNC_FAILURE_INFO_ENABLE_USAGE);
+      return FALSE;
+    }
+
+  gboolean exists, eval_error;
+  gboolean collect_falsy = filterx_function_args_get_named_literal_boolean(args, "collect_falsy", &exists, &eval_error);
+
+  if (eval_error)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "collect_falsy argument must be boolean literal. %s", FILTERX_FUNC_FAILURE_INFO_ENABLE_USAGE);
+      return FALSE;
+    }
+
+  if (!exists)
+    return TRUE;
+
+  self->collect_falsy = collect_falsy;
+  return TRUE;
+}
+
+static gboolean
+_extract_failure_info_meta_args(FilterXFunctionFailureInfoMeta *self, FilterXFunctionArgs *args, GError **error)
+{
+  if (filterx_function_args_len(args) != 1)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "invalid number of arguments. " FILTERX_FUNC_FAILURE_INFO_META_USAGE);
+      return FALSE;
+    }
+
+  FilterXExpr *meta_expr = filterx_function_args_get_expr(args, 0);
+  if (!filterx_expr_is_literal(meta_expr) && !filterx_expr_is_literal_container(meta_expr))
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "argument must be literal. %s", FILTERX_FUNC_FAILURE_INFO_META_USAGE);
+      filterx_expr_unref(meta_expr);
+      return FALSE;
+    }
+
+  FilterXObject *metadata = filterx_expr_eval(meta_expr);
+  self->metadata = metadata;
+
+  filterx_expr_unref(meta_expr);
+  return TRUE;
+}
+
+static gboolean
+_check_zero_args(FilterXFunctionArgs *args, GError **error)
+{
+  if (filterx_function_args_len(args) != 0)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "requires 0 arguments");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+FilterXExpr *
+filterx_fn_failure_info_enable_new(FilterXFunctionArgs *args, GError **error)
+{
+  FilterXFunctionFailureInfoEnable *self = g_new0(FilterXFunctionFailureInfoEnable, 1);
+  filterx_function_init_instance(&self->super, "failure_info_enable");
+  self->super.super.eval = _failure_info_enable_eval;
+
+  if (!_extract_failure_info_enable_args(self, args, error) || !filterx_function_args_check(args, error))
+    goto error;
+
+  filterx_function_args_free(args);
+  return &self->super.super;
+
+error:
+  filterx_function_args_free(args);
+  filterx_expr_unref(&self->super.super);
+  return NULL;
+}
+
+FilterXExpr *
+filterx_fn_failure_info_clear_new(FilterXFunctionArgs *args, GError **error)
+{
+  FilterXFunction *self = g_new0(FilterXFunction, 1);
+  filterx_function_init_instance(self, "failure_info_clear");
+  self->super.eval = _failure_info_clear_eval;
+
+  if (!_check_zero_args(args, error) || !filterx_function_args_check(args, error))
+    {
+      filterx_function_args_free(args);
+      filterx_expr_unref(&self->super);
+      return NULL;
+    }
+
+  filterx_function_args_free(args);
+  return &self->super;
+}
+
+FilterXExpr *
+filterx_fn_failure_info_new(FilterXFunctionArgs *args, GError **error)
+{
+  FilterXFunction *self = g_new0(FilterXFunction, 1);
+  filterx_function_init_instance(self, "failure_info");
+  self->super.eval = _failure_info_eval;
+
+  if (!_check_zero_args(args, error) || !filterx_function_args_check(args, error))
+    {
+      filterx_function_args_free(args);
+      filterx_expr_unref(&self->super);
+      return NULL;
+    }
+
+  filterx_function_args_free(args);
+  return &self->super;
+}
+
+static void
+_failure_info_meta_free(FilterXExpr *s)
+{
+  FilterXFunctionFailureInfoMeta *self = (FilterXFunctionFailureInfoMeta *) s;
+
+  filterx_object_unref(self->metadata);
+  filterx_function_free_method(&self->super);
+}
+
+FilterXExpr *
+filterx_fn_failure_info_meta_new(FilterXFunctionArgs *args, GError **error)
+{
+  FilterXFunctionFailureInfoMeta *self = g_new0(FilterXFunctionFailureInfoMeta, 1);
+  filterx_function_init_instance(&self->super, "failure_info_meta");
+  self->super.super.eval = _failure_info_meta_eval;
+  self->super.super.free_fn = _failure_info_meta_free;
+
+  if (!_extract_failure_info_meta_args(self, args, error) || !filterx_function_args_check(args, error))
+    {
+      filterx_function_args_free(args);
+      filterx_expr_unref(&self->super.super);
+      return NULL;
+    }
+
+  filterx_function_args_free(args);
+  return &self->super.super;
+}

--- a/lib/filterx/func-failure-info.h
+++ b/lib/filterx/func-failure-info.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Axoflow
+ * Copyright (c) 2025 László Várady
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_FUNC_FAILURE_INFO_H
+#define FILTERX_FUNC_FAILURE_INFO_H
+
+#include "filterx/expr-function.h"
+
+FilterXExpr *filterx_fn_failure_info_enable_new(FilterXFunctionArgs *args, GError **error);
+FilterXExpr *filterx_fn_failure_info_clear_new(FilterXFunctionArgs *args, GError **error);
+FilterXExpr *filterx_fn_failure_info_new(FilterXFunctionArgs *args, GError **error);
+FilterXExpr *filterx_fn_failure_info_meta_new(FilterXFunctionArgs *args, GError **error);
+
+#endif

--- a/lib/filterx/func-flatten.c
+++ b/lib/filterx/func-flatten.c
@@ -302,7 +302,7 @@ filterx_function_flatten_new(FilterXFunctionArgs *args, GError **error)
   self->super.super.deinit = _deinit;
   self->super.super.free_fn = _free;
 
-  if (!_extract_args(self, args, error))
+  if (!_extract_args(self, args, error) || !filterx_function_args_check(args, error))
     goto error;
 
   filterx_function_args_free(args);

--- a/news/fx-feature-629.md
+++ b/news/fx-feature-629.md
@@ -1,0 +1,31 @@
+Failure information tracking
+
+The following functions have been added to allow tracking failures in FilterX code:
+
+- `failure_info_enable()`, optional parameter: `collect_falsy=true/false`, defaults to `false`:
+  Enable failure information collection from this point downwards through all branches of the pipeline.
+
+- `failure_info_clear()`:
+  Clear accumulated failure information
+
+- `failure_info_meta({})`:
+  Attach metadata to the given section of FilterX code. The metadata remains in effect until the next call
+  or until the end of the enclosing FilterX block, whichever comes first.
+
+- `failure_info()`:
+  Return failure information as a FilterX dictionary. This should ideally be called as late as possible, for example, in the last log path of your configuration or within a fallback path.
+
+Example output:
+
+```
+[
+  {
+    "meta": {
+      "step": "Setting common fields"
+    },
+    "location": "/etc/syslog-ng/syslog-ng.conf:33:7",
+    "line": "nonexisting.key = 13;",
+    "error": "No such variable: nonexisting"
+  }
+]
+```

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -286,14 +286,7 @@ tests/light/functional_tests/logpath/test_midpoint_destinations\.py
 tests/light/functional_tests/value-pairs/test_value_pairs\.py
 tests/light/functional_tests/templates/test_template_stmt\.py
 tests/light/functional_tests/filters/test_multiple_filters\.py
-tests/light/functional_tests/filterx/test_filterx\.py
-tests/light/functional_tests/filterx/test_filterx_cow\.py
-tests/light/functional_tests/filterx/test_filterx_dict\.py
-tests/light/functional_tests/filterx/test_filterx_scope\.py
-tests/light/functional_tests/filterx/test_filterx_control\.py
-tests/light/functional_tests/filterx/test_filterx_funcs\.py
-tests/light/functional_tests/filterx/test_filterx_update_metric\.py
-tests/light/functional_tests/filterx/test_filterx_cache_json_file\.py
+tests/light/functional_tests/filterx/test_filterx.*\.py
 tests/light/functional_tests/parsers/metrics-probe/test_metrics_probe\.py
 tests/light/functional_tests/source_drivers/opentelemetry_source/test_opentelemetry_source_acceptance\.py
 tests/light/functional_tests/source_drivers/unix_dgram_source/test_unix_dgram_source_acceptance\.py

--- a/tests/light/functional_tests/Makefile.am
+++ b/tests/light/functional_tests/Makefile.am
@@ -25,6 +25,7 @@ EXTRA_DIST += \
 	tests/light/functional_tests/filterx/test_filterx_control.py \
 	tests/light/functional_tests/filterx/test_filterx_cow.py \
 	tests/light/functional_tests/filterx/test_filterx_dict.py \
+	tests/light/functional_tests/filterx/test_filterx_failure_info.py \
 	tests/light/functional_tests/filterx/test_filterx_funcs.py \
 	tests/light/functional_tests/filterx/test_filterx_scope.py \
 	tests/light/functional_tests/filterx/test_filterx_update_metric.py \

--- a/tests/light/functional_tests/filterx/test_filterx_failure_info.py
+++ b/tests/light/functional_tests/filterx/test_filterx_failure_info.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2025 Axoflow
+# Copyright (c) 2025 László Várady
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import json
+
+
+def test_filterx_failure_info(syslog_ng, config):
+    source = config.create_example_msg_generator_source(num=1, template='"test message"')
+    fx_failure_info_enable = config.create_filterx("failure_info_enable(collect_falsy=true);")
+
+    fx_error = config.create_filterx(r"""
+        failure_info_meta({"step": "step_1"});
+        a = 3;
+
+        failure_info_meta({"step": "step_2"});
+        nonexisting.key = a;
+    """)
+    error_path = config.create_inner_logpath(statements=[fx_error])
+
+    fx_falsy = config.create_filterx(r"""
+        failure_info_meta({"step": "falsy_block"});
+        a = 4;
+        a == 3;
+    """)
+    falsy_path = config.create_inner_logpath(statements=[fx_falsy])
+
+    fx_failure_info_collect = config.create_filterx("$failure_info = failure_info();")
+    destination = config.create_file_destination(file_name="output.log", template='"${failure_info}\n"')
+    last_path = config.create_inner_logpath(statements=[fx_failure_info_collect, destination])
+
+    config.create_logpath(statements=[source, fx_failure_info_enable, error_path, falsy_path, last_path])
+
+    syslog_ng.start(config)
+
+    actual_failure_info = json.loads(destination.read_log())
+    assert len(actual_failure_info) == 2
+
+    actual_error = actual_failure_info[0]
+    assert "No such variable" in actual_error["error"]
+    assert actual_error["meta"]["step"] == "step_2"
+    assert "line" in actual_error and "location" in actual_error
+
+    actual_falsy = actual_failure_info[1]
+    assert "falsy expr" in actual_falsy["error"]
+    assert actual_falsy["meta"]["step"] == "falsy_block"
+    assert "line" in actual_falsy and "location" in actual_falsy


### PR DESCRIPTION
The following functions have been added to allow tracking failures in FilterX code:

- `failure_info_enable()`, optional parameter: `collect_falsy=true/false`, defaults to `false`:
  Enable failure information collection from this point downwards through all branches of the pipeline.

- `failure_info_clear()`:
  Clear accumulated failure information

- `failure_info_meta({})`:
  Attach metadata to the given section of FilterX code. The metadata remains in effect until the next call
  or until the end of the enclosing FilterX block, whichever comes first.

- `failure_info()`:
  Return failure information as a FilterX dictionary. This should ideally be called as late as possible, for example, in the last log path of your configuration or within a fallback path.

Example output:

```
[
  {
    "meta": {
      "step": "Setting common fields"
    },
    "location": "/etc/syslog-ng/syslog-ng.conf:33:7",
    "line": "nonexisting.key = 13;",
    "error": "No such variable: nonexisting"
  }
]
```

```
destination oucs {
  stdout(template("$a\n"));
};

source incs {
  channel {
    source { stdin(); network(port(4444)); };

    filterx {
      # it can be enabled for a subset of messages
      failure_info_enable(collect_falsy=true);
    };
  };
};

log {
  source(incs);

  log "somethinginternal" {
    filterx {
      # "somethinginternal" was successful, clear accumulated errors
      failure_info_clear();
    };
  };

  log "path1" {
    filterx {

      # Step #1: abc
      failure_info_meta({"step": "#1 abc"});
      a = 1;
      b = 3;
      1 == 1;
      true;

      # Step #2: cba
      failure_info_meta({"step": "#2 cba"});
      declare g = 33;
      nonexisting.key = g;
    };
  };

  log "path2" {
    filterx {
      failure_info_meta({"step": "falsystep"});
      1 == 0;
      true;
    };
  };
};

# WARNING: must be the last logpath in the config file, or a real fallback path
log "fallback" {
  source(incs);

  filterx {
    $a = failure_info();
  };

  destination(oucs);
};
```