### PR TITLE
webhook: fix shutdown with older Python versions

### DIFF
--- a/modules/python-modules/syslogng/modules/webhook/source.py
+++ b/modules/python-modules/syslogng/modules/webhook/source.py
@@ -1,4 +1,5 @@
 #############################################################################
+# Copyright (c) 2024-2025 Axoflow
 # Copyright (c) 2024 László Várady
 # Copyright (c) 2025 One Identity LLC.
 #

--- a/modules/python-modules/syslogng/modules/webhook/source.py
+++ b/modules/python-modules/syslogng/modules/webhook/source.py
@@ -1,5 +1,6 @@
 #############################################################################
 # Copyright (c) 2024 László Várady
+# Copyright (c) 2025 One Identity LLC.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published
@@ -133,7 +134,11 @@ class HTTPSource(LogSource):
 
         self.suspended = threading.Event()
         self.event_loop = asyncio.new_event_loop()
-        self.request_exit = asyncio.Event()
+        self.request_exit = None
+
+        async def init_request_exit():
+            self.request_exit = asyncio.Event()
+        self.event_loop.run_until_complete(init_request_exit())
 
         handlers = list(map(lambda p: (p, Handler, {"source": self}), self.paths))
         if len(handlers) == 0:

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -264,7 +264,8 @@ modules/ebpf/.*
 modules/python-modules/syslogng/modules/hypr/.*
 modules/python-modules/syslogng/modules/example/.*
 modules/python-modules/syslogng/modules/s3/.*
-modules/python-modules/syslogng/modules/webhook/.*
+modules/python-modules/syslogng/modules/webhook/scl/.*
+modules/python-modules/syslogng/modules/webhook/__init__.py
 modules/python-modules/setup\.py
 scripts/build-python-venv\.sh
 modules/syslogformat/sdata-parser\.[ch]
@@ -329,8 +330,6 @@ modules/kvformat/tests/test_filterx_func_format_kv.c
 modules/appmodel/app-transform-generator\.[ch]$
 modules/appmodel/tests/test_app_transform_generator.c
 modules/appmodel/transformation\.[ch]$
-docker/python-modules/webhook/scl/webhook.conf
-docker/python-modules/webhook/source.py
 packaging/package-indexer/remote_storage_synchronizer/s3_bucket_synchronizer.py
 packaging/package-indexer/cdn/cloudflare_cdn.py
 packaging/package-indexer/indexer/rpm_indexer.py
@@ -380,3 +379,4 @@ modules/http/http\.[ch]
 modules/http/http-parser.c
 modules/http/http-grammar.ym
 modules/correlation/group-lines.c
+modules/python-modules/syslogng/modules/webhook/source.py


### PR DESCRIPTION
> In python 3.9 the event must be created inside the eventloop that will await on it

Cherry-picked from syslog-ng/syslog-ng#5372

The author is @kovgeri01, it is not visible on GitHub (probably because of the unregistered email address).