### PR TITLE
Log transport shutdown fix

### DIFF
--- a/lib/logproto/logproto-client.c
+++ b/lib/logproto/logproto-client.c
@@ -38,6 +38,7 @@ log_proto_client_validate_options_method(LogProtoClient *s)
 void
 log_proto_client_free_method(LogProtoClient *s)
 {
+  log_transport_stack_shutdown(&s->transport_stack);
   log_transport_stack_deinit(&s->transport_stack);
 }
 

--- a/lib/logproto/logproto-server.c
+++ b/lib/logproto/logproto-server.c
@@ -124,6 +124,7 @@ log_proto_server_validate_options_method(LogProtoServer *s)
 void
 log_proto_server_free_method(LogProtoServer *self)
 {
+  log_transport_stack_shutdown(&self->transport_stack);
   log_transport_stack_deinit(&self->transport_stack);
 }
 

--- a/lib/transport/logtransport.h
+++ b/lib/transport/logtransport.h
@@ -55,6 +55,7 @@ struct _LogTransport
   gssize (*read)(LogTransport *self, gpointer buf, gsize count, LogTransportAuxData *aux);
   gssize (*write)(LogTransport *self, const gpointer buf, gsize count);
   gssize (*writev)(LogTransport *self, struct iovec *iov, gint iov_count);
+  void (*shutdown)(LogTransport *self);
   void (*free_fn)(LogTransport *self);
 
   /* read ahead */
@@ -93,6 +94,13 @@ static inline gssize
 log_transport_writev(LogTransport *self, struct iovec *iov, gint iov_count)
 {
   return self->writev(self, iov, iov_count);
+}
+
+static inline void
+log_transport_shutdown(LogTransport *self)
+{
+  if (self->shutdown)
+    return self->shutdown(self);
 }
 
 gssize _log_transport_combined_read_with_read_ahead(LogTransport *self,

--- a/lib/transport/tls-context.c
+++ b/lib/transport/tls-context.c
@@ -25,6 +25,7 @@
 #include "messages.h"
 #include "compat/openssl_support.h"
 #include "secret-storage/secret-storage.h"
+#include "string-list.h"
 
 #include <sys/socket.h>
 #include <arpa/inet.h>
@@ -749,7 +750,7 @@ tls_context_set_ssl_options_by_name(TLSContext *self, GList *options)
       else
         return FALSE;
     }
-
+  string_list_free(options);
   return TRUE;
 }
 

--- a/lib/transport/transport-adapter.c
+++ b/lib/transport/transport-adapter.c
@@ -51,6 +51,15 @@ log_transport_adapter_writev_method(LogTransport *s, struct iovec *iov, gint iov
 }
 
 void
+log_transport_adapter_shutdown_method(LogTransport *s)
+{
+  LogTransportAdapter *self = (LogTransportAdapter *) s;
+  LogTransport *transport = log_transport_stack_get_or_create_transport(s->stack, self->base_index);
+
+  log_transport_shutdown(transport);
+}
+
+void
 log_transport_adapter_init_instance(LogTransportAdapter *self, const gchar *name,
                                     LogTransportIndex base_index)
 {
@@ -58,6 +67,7 @@ log_transport_adapter_init_instance(LogTransportAdapter *self, const gchar *name
   self->super.read = log_transport_adapter_read_method;
   self->super.write = log_transport_adapter_write_method;
   self->super.writev = log_transport_adapter_writev_method;
+  self->super.shutdown = log_transport_adapter_shutdown_method;
 
   self->base_index = base_index;
 }

--- a/lib/transport/transport-adapter.h
+++ b/lib/transport/transport-adapter.h
@@ -36,6 +36,7 @@ struct _LogTransportAdapter
 gssize log_transport_adapter_read_method(LogTransport *s, gpointer buf, gsize buflen, LogTransportAuxData *aux);
 gssize log_transport_adapter_write_method(LogTransport *s, const gpointer buf, gsize count);
 gssize log_transport_adapter_writev_method(LogTransport *s, struct iovec *iov, gint iov_count);
+void log_transport_adapter_shutdown_method(LogTransport *s);
 
 void log_transport_adapter_init_instance(LogTransportAdapter *self, const gchar *name,
                                          LogTransportIndex base);

--- a/lib/transport/transport-file.c
+++ b/lib/transport/transport-file.c
@@ -87,7 +87,6 @@ log_transport_file_init_instance(LogTransportFile *self, gint fd)
   self->super.read = log_transport_file_read_method;
   self->super.write = log_transport_file_write_method;
   self->super.writev = log_transport_file_writev_method;
-  self->super.free_fn = log_transport_free_method;
 }
 
 LogTransport *

--- a/lib/transport/transport-socket.c
+++ b/lib/transport/transport-socket.c
@@ -270,19 +270,18 @@ log_transport_dgram_socket_new(gint fd)
   return &self->super;
 }
 
-void
-log_transport_stream_socket_free_method(LogTransport *s)
+static void
+log_transport_stream_socket_shutdown(LogTransport *s)
 {
   if (s->fd != -1)
     shutdown(s->fd, SHUT_RDWR);
-  log_transport_free_method(s);
 }
 
 void
 log_transport_stream_socket_init_instance(LogTransportSocket *self, gint fd)
 {
   log_transport_socket_init_instance(self, "stream-socket", fd);
-  self->super.free_fn = log_transport_stream_socket_free_method;
+  self->super.shutdown = log_transport_stream_socket_shutdown;
 }
 
 LogTransport *

--- a/lib/transport/transport-stack.c
+++ b/lib/transport/transport-stack.c
@@ -114,6 +114,14 @@ log_transport_stack_move(LogTransportStack *self, LogTransportStack *other)
 }
 
 void
+log_transport_stack_shutdown(LogTransportStack *self)
+{
+  LogTransport *active_transport = log_transport_stack_get_active(self);
+  if (active_transport)
+    log_transport_shutdown(active_transport);
+}
+
+void
 log_transport_stack_init(LogTransportStack *self, LogTransport *initial_transport)
 {
   memset(self, 0, sizeof(*self));

--- a/lib/transport/transport-stack.h
+++ b/lib/transport/transport-stack.h
@@ -179,6 +179,7 @@ void log_transport_stack_add_factory(LogTransportStack *self, LogTransportFactor
 void log_transport_stack_add_transport(LogTransportStack *self, gint index, LogTransport *);
 gboolean log_transport_stack_switch(LogTransportStack *self, gint index);
 void log_transport_stack_move(LogTransportStack *self, LogTransportStack *other);
+void log_transport_stack_shutdown(LogTransportStack *self);
 
 void log_transport_stack_init(LogTransportStack *self, LogTransport *initial_transport);
 void log_transport_stack_deinit(LogTransportStack *self);

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -348,6 +348,16 @@ log_tansport_tls_get_session(LogTransport *s)
   return self->tls_session;
 }
 
+static void
+log_transport_tls_shutdown_method(LogTransport *s)
+{
+  LogTransportTLS *self = (LogTransportTLS *) s;
+
+  /* TODO: should handle SSL_ERROR_WANT_* and retry */
+  if (!SSL_in_init(self->tls_session->ssl))
+    log_transport_tls_send_shutdown(self);
+  log_transport_adapter_shutdown_method(s);
+}
 
 static void log_transport_tls_free_method(LogTransport *s);
 
@@ -360,6 +370,7 @@ log_transport_tls_new(TLSSession *tls_session, LogTransportIndex base)
   self->super.super.cond = 0;
   self->super.super.read = log_transport_tls_read_method;
   self->super.super.write = log_transport_tls_write_method;
+  self->super.super.shutdown = log_transport_tls_shutdown_method;
   self->super.super.free_fn = log_transport_tls_free_method;
   self->tls_session = tls_session;
 
@@ -372,10 +383,6 @@ static void
 log_transport_tls_free_method(LogTransport *s)
 {
   LogTransportTLS *self = (LogTransportTLS *) s;
-
-  /* TODO: should handle SSL_ERROR_WANT_* and retry */
-  if (!SSL_in_init(self->tls_session->ssl))
-    log_transport_tls_send_shutdown(self);
 
   tls_session_free(self->tls_session);
   log_transport_adapter_free_method(s);

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -132,7 +132,7 @@ BIO_s_transport(void)
 static BIO *
 BIO_transport_new(LogTransportTLS *transport)
 {
-  BIO *bio = BIO_new(BIO_s_transport());
+  BIO *bio = BIO_new(meth_transport);
 
   g_assert(transport != NULL);
   BIO_set_data(bio, transport);

--- a/tests/light/src/axosyslog_light/syslog_ng/syslog_ng_local_executor.py
+++ b/tests/light/src/axosyslog_light/syslog_ng/syslog_ng_local_executor.py
@@ -91,7 +91,7 @@ class SyslogNgLocalExecutor(SyslogNgExecutor):
             "gdb",
             "-ex",
             f"r {shlex.join(start_params.format())} > {str(stdout_path)} 2> {str(stderr_path)}",
-            str(self.__syslog_ng_binary_path()),
+            str(self.__syslog_ng_binary_path),
         ]
         return self.__process_executor.start(
             command=["xterm", "-fa", "Monospace", "-fs", "18", "-e", shlex.join(gdb_command_args)],


### PR DESCRIPTION
This is an alternative to #632 

This is a more complete fix compared to #632 which is more like a workaround. It also fixes a few small memory leaks
in TLS connection handling.
