### PR TITLE
Filterx: expr comparison cleanups and perf improvements

### DIFF
--- a/lib/filterx/expr-comparison.c
+++ b/lib/filterx/expr-comparison.c
@@ -142,7 +142,10 @@ _evaluate_as_num(FilterXObject *lhs, FilterXObject *rhs, gint operator)
 static gboolean
 _evaluate_type_aware(FilterXObject *lhs, FilterXObject *rhs, gint operator)
 {
+#if SYSLOG_NG_ENABLE_DEBUG
+  /* we already unwrapped the ref in filterx_compare_objects() by the time we got here */
   g_assert(!(filterx_object_is_ref(lhs) || filterx_object_is_ref(rhs)));
+#endif
 
   if (lhs->type == rhs->type &&
       (filterx_object_is_type(lhs, &FILTERX_TYPE_NAME(string)) ||
@@ -168,7 +171,10 @@ _evaluate_type_aware(FilterXObject *lhs, FilterXObject *rhs, gint operator)
 static gboolean
 _evaluate_type_and_value_based(FilterXObject *lhs, FilterXObject *rhs, gint operator)
 {
+#if SYSLOG_NG_ENABLE_DEBUG
+  /* we already unwrapped the ref in filterx_compare_objects() by the time we got here */
   g_assert(!(filterx_object_is_ref(lhs) || filterx_object_is_ref(rhs)));
+#endif
 
   switch (operator)
     {


### PR DESCRIPTION
These are small improvements both in readability and performance.

The performance changes are not huge if measurable at all, these are:
* we don't take an extra ref to literal objects, that was what I've noticed taking most of the time of a comparison
* use switch instead of if-elif-else (2x)
* make internal helper functions inline
* make some extra safety checks to DEBUG only (should not be needed)

I think the readability patches did improve the code as well.
