### PR TITLE
filterx/expr-null-coalesce: add more details to the null coalesce operator

### DIFF
--- a/lib/filterx/expr-null-coalesce.c
+++ b/lib/filterx/expr-null-coalesce.c
@@ -47,7 +47,8 @@ _eval_null_coalesce(FilterXExpr *s)
     {
       if (!lhs_object)
         {
-          msg_debug("FILTERX null coalesce supressing error:",
+          msg_debug("FILTERX null coalesce supressing error",
+                    filterx_expr_format_location_tag(s),
                     filterx_eval_format_last_error_tag());
           filterx_eval_clear_errors();
         }


### PR DESCRIPTION
This just extends the debug message, for a lack of a better diagnostics.
