### PR TITLE
github-actions: create linux/arm/v7 builder image

### DIFF
--- a/.github/workflows/axosyslog-builder.yml
+++ b/.github/workflows/axosyslog-builder.yml
@@ -17,7 +17,7 @@ on:
       platforms:
         required: false
         type: string
-        default: linux/amd64,linux/arm64
+        default: linux/amd64,linux/arm64,linux/arm/v7
 
 jobs:
   prepare:
@@ -29,7 +29,7 @@ jobs:
       - id: platforms
         name: platform
         env:
-          PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
+          PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64,linux/arm/v7' }}
         run: |
           PLATFORM_MATRIX="$(echo "$PLATFORMS" | jq 'split(",")' -Rc)"
           echo "platform-matrix=$PLATFORM_MATRIX" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Needed for the nightly builds.

Fixes the nightly build: https://github.com/axoflow/axosyslog/actions/runs/15242868164/job/42865153654

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
