### PR TITLE
docker: don't build glib on armv7

### DIFF
--- a/.github/workflows/axosyslog-builder.yml
+++ b/.github/workflows/axosyslog-builder.yml
@@ -55,8 +55,15 @@ jobs:
       - name: Prepare
         env:
           PLATFORM: ${{ matrix.platform }}
+          REBUILD_DEPS: main/musl main/jemalloc main/json-c main/glib community/grpc main/python3
         run: |
           echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> $GITHUB_ENV
+          if [ $PLATFORM != "linux/arm/v7" ]; then
+              echo "rebuild-deps=${{ env.REBUILD_DEPS }}" >> $GITHUB_OUTPUT
+          else
+              # on armv7 we only do a minimal rebuild
+              echo "rebuild-deps=main/json-c" >> $GITHUB_OUTPUT
+          fi
 
       - name: Checkout source
         uses: actions/checkout@v4
@@ -81,6 +88,8 @@ jobs:
           file: docker/axosyslog-builder.dockerfile
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ needs.prepare.outputs.image-name }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            REBUILD_DEPS=${{ needs.prepare.output.rebuild-deps }}
 
       - name: Export digest
         env:


### PR DESCRIPTION
As of now the Glib build fails on armv7, which is not really needed for now
