### PR TITLE
docker: extract ALPINE_VERSION

### DIFF
--- a/docker/axosyslog-builder.dockerfile
+++ b/docker/axosyslog-builder.dockerfile
@@ -21,7 +21,10 @@
 #
 #############################################################################
 
-FROM alpine:3.21
+ARG ALPINE_VERSION=3.21
+
+FROM alpine:$ALPINE_VERSION
+ARG ALPINE_VERSION
 
 RUN apk add --update-cache \
       alpine-conf \
@@ -39,7 +42,7 @@ WORKDIR /home/builder
 
 RUN mkdir packages || true \
     && USER=builder abuild-keygen -n -a -i \
-    && git clone --depth 1 --branch 3.21-stable git://git.alpinelinux.org/aports
+    && git clone --depth 1 --branch "$ALPINE_VERSION-stable" git://git.alpinelinux.org/aports
 
 
 ADD --chown=builder:builder apkbuild .

--- a/docker/axosyslog.dockerfile
+++ b/docker/axosyslog.dockerfile
@@ -21,6 +21,8 @@
 #
 #############################################################################
 
+# must be in sync with axosyslog-builder
+ARG ALPINE_VERSION=3.21
 ARG DEBUG=false
 
 FROM ghcr.io/axoflow/axosyslog-builder:latest AS apkbuilder
@@ -51,7 +53,7 @@ RUN mkdir packages || true \
     && abuild -r
 
 
-FROM alpine:3.21
+FROM alpine:$ALPINE_VERSION
 
 ARG DEBUG
 


### PR DESCRIPTION
We should also make version tags for the builder, they could easily go out of sync due to how these jobs are scheduled.