### PR TITLE
filterx/object-primitive: add caching for small negative integers

### DIFF
--- a/lib/filterx/filterx-globals.h
+++ b/lib/filterx/filterx-globals.h
@@ -27,7 +27,8 @@
 #include "filterx/expr-function.h"
 
 #define FILTERX_BOOL_CACHE_LIMIT 2
-#define FILTERX_INTEGER_CACHE_LIMIT 100
+#define FILTERX_INTEGER_CACHE_LIMIT 256
+#define FILTERX_INTEGER_CACHE_OFFSET 128
 #define FILTERX_DATETIME_CACHE_LIMIT 1
 
 /* cache indices */

--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -417,7 +417,7 @@ filterx_primitive_global_init(void)
   filterx_cache_object(&global_cache.bool_cache[FALSE], _bool_wrap(FALSE));
   filterx_cache_object(&global_cache.bool_cache[TRUE], _bool_wrap(TRUE));
   for (guint64 i = 0; i < FILTERX_INTEGER_CACHE_LIMIT; i++)
-    filterx_cache_object(&global_cache.integer_cache[i], _integer_wrap(i - 1));
+    filterx_cache_object(&global_cache.integer_cache[i], _integer_wrap(i - FILTERX_INTEGER_CACHE_OFFSET));
 }
 
 void

--- a/lib/filterx/object-primitive.h
+++ b/lib/filterx/object-primitive.h
@@ -111,8 +111,8 @@ filterx_boolean_new(gboolean value)
 static inline FilterXObject *
 filterx_integer_new(gint64 value)
 {
-  if (value >= -1 && value < FILTERX_INTEGER_CACHE_LIMIT - 1)
-    return filterx_object_ref(global_cache.integer_cache[value + 1]);
+  if (value >= -FILTERX_INTEGER_CACHE_OFFSET && value < FILTERX_INTEGER_CACHE_LIMIT - FILTERX_INTEGER_CACHE_OFFSET)
+    return filterx_object_ref(global_cache.integer_cache[value + FILTERX_INTEGER_CACHE_OFFSET]);
   return _filterx_integer_new(value);
 }
 

--- a/lib/filterx/tests/test_object_integer.c
+++ b/lib/filterx/tests/test_object_integer.c
@@ -47,6 +47,39 @@ Test(filterx_integer, test_filterx_primitive_int_is_mapped_to_a_json_int)
   filterx_object_unref(fobj);
 }
 
+Test(filterx_integer, test_filterx_primitive_small_int_is_cached)
+{
+  FilterXObject *fobj = filterx_integer_new(127);
+  FilterXObject *fobj2 = filterx_integer_new(127);
+  assert_object_json_equals(fobj, "127");
+  assert_object_json_equals(fobj2, "127");
+  cr_assert(fobj == fobj2);
+  filterx_object_unref(fobj);
+  filterx_object_unref(fobj2);
+}
+
+Test(filterx_integer, test_filterx_primitive_small_negative_int_is_cached)
+{
+  FilterXObject *fobj = filterx_integer_new(-128);
+  FilterXObject *fobj2 = filterx_integer_new(-128);
+  assert_object_json_equals(fobj, "-128");
+  assert_object_json_equals(fobj2, "-128");
+  cr_assert(fobj == fobj2);
+  filterx_object_unref(fobj);
+  filterx_object_unref(fobj2);
+}
+
+Test(filterx_integer, test_filterx_primitive_larger_int_is_not_cached)
+{
+  FilterXObject *fobj = filterx_integer_new(128);
+  FilterXObject *fobj2 = filterx_integer_new(128);
+  assert_object_json_equals(fobj, "128");
+  assert_object_json_equals(fobj2, "128");
+  cr_assert(fobj != fobj2);
+  filterx_object_unref(fobj);
+  filterx_object_unref(fobj2);
+}
+
 Test(filterx_integer, test_filterx_primitive_int_is_truthy_if_nonzero)
 {
   FilterXObject *fobj = filterx_integer_new(36);


### PR DESCRIPTION
This should avoid allocation integers in the range of [-128,127)
