### PR TITLE
persist: fix typo for "persist" in user visible messages

### DIFF
--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1545,7 +1545,7 @@ _verify_unique_persist_names_among_pipes(const GPtrArray *initialized_pipes)
               msg_error("Automatic assignment of persist names failed, as "
                         "conflicting persist-names were found. Please override "
                         "the automatically assigned identifier using an "
-                        "explicit perist-name() option or remove the duplicated "
+                        "explicit persist-name() option or remove the duplicated "
                         "configuration elements",
                         evt_tag_str("persist_name", current_pipe_name),
                         log_pipe_location_tag(current_pipe),

--- a/persist-tool/persist-tool.c
+++ b/persist-tool/persist-tool.c
@@ -66,7 +66,7 @@ persist_tool_start_state(PersistTool *self)
       break;
 
     default:
-      fprintf(stderr, "Invalid perist mode: %d\n", self->mode);
+      fprintf(stderr, "Invalid persist mode: %d\n", self->mode);
       start_result = FALSE;
       break;
     }


### PR DESCRIPTION
This PR fixes a typo in messages related to "persist"
