### PR TITLE
filterx-dict: fix crash in filterx_dict_new_from_args

### DIFF
--- a/lib/filterx/object-dict.c
+++ b/lib/filterx/object-dict.c
@@ -728,6 +728,7 @@ filterx_dict_new_from_args(FilterXExpr *s, FilterXObject *args[], gsize args_len
           filterx_eval_push_error_info("Argument must be a valid JSON string", s,
                                        g_strdup(error->message), TRUE);
           g_clear_error(&error);
+          return NULL;
         }
       if (!filterx_object_is_type_or_ref(self, &FILTERX_TYPE_NAME(dict)))
         {


### PR DESCRIPTION
Fixing case, when json, or dict creation crashed, if parameter was not a valid json string.

Example:
`$MSG = json("ASD");`