### PR TITLE
FilterX ref count type clarification and multiple bugfixes

### DIFF
--- a/lib/filterx/filterx-config.c
+++ b/lib/filterx/filterx-config.c
@@ -63,8 +63,13 @@ FilterXObject *
 filterx_config_freeze_object(GlobalConfig *cfg, FilterXObject *object)
 {
   FilterXConfig *fxc = filterx_config_get(cfg);
+
+  FilterXObject *orig = object;
   filterx_object_freeze(&object);
-  g_ptr_array_add(fxc->frozen_objects, object);
+
+  if (orig == object)
+    g_ptr_array_add(fxc->frozen_objects, object);
+
   return object;
 }
 

--- a/lib/filterx/filterx-config.c
+++ b/lib/filterx/filterx-config.c
@@ -32,6 +32,7 @@ filterx_config_free(ModuleConfig *s)
 
   g_ptr_array_unref(self->weak_refs);
   g_ptr_array_unref(self->frozen_objects);
+  g_hash_table_unref(self->frozen_deduplicated_objects);
   module_config_free_method(s);
 }
 
@@ -42,6 +43,8 @@ filterx_config_new(GlobalConfig *cfg)
 
   self->super.free_fn = filterx_config_free;
   self->frozen_objects = g_ptr_array_new_with_free_func((GDestroyNotify) _filterx_object_unfreeze_and_free);
+  self->frozen_deduplicated_objects = g_hash_table_new_full(g_str_hash, g_str_equal, g_free,
+                                                            (GDestroyNotify)_filterx_object_unfreeze_and_free);
   self->weak_refs = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
   return self;
 }

--- a/lib/filterx/filterx-config.c
+++ b/lib/filterx/filterx-config.c
@@ -41,7 +41,7 @@ filterx_config_new(GlobalConfig *cfg)
   FilterXConfig *self = g_new0(FilterXConfig, 1);
 
   self->super.free_fn = filterx_config_free;
-  self->frozen_objects = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unfreeze_and_free);
+  self->frozen_objects = g_ptr_array_new_with_free_func((GDestroyNotify) _filterx_object_unfreeze_and_free);
   self->weak_refs = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
   return self;
 }
@@ -56,25 +56,4 @@ filterx_config_get(GlobalConfig *cfg)
       g_hash_table_insert(cfg->module_config, g_strdup(MODULE_CONFIG_KEY), fxc);
     }
   return fxc;
-}
-
-/* NOTE: consumes object reference */
-FilterXObject *
-filterx_config_freeze_object(GlobalConfig *cfg, FilterXObject *object)
-{
-  FilterXConfig *fxc = filterx_config_get(cfg);
-
-  FilterXObject *orig = object;
-  filterx_object_freeze(&object);
-
-  if (orig == object)
-    g_ptr_array_add(fxc->frozen_objects, object);
-
-  return object;
-}
-
-FilterXObject *
-filterx_config_frozen_string(GlobalConfig *cfg, const gchar *str)
-{
-  return filterx_config_freeze_object(cfg, filterx_string_new(str, -1));
 }

--- a/lib/filterx/filterx-config.h
+++ b/lib/filterx/filterx-config.h
@@ -31,6 +31,7 @@ typedef struct _FilterXConfig
 {
   ModuleConfig super;
   GPtrArray *frozen_objects;
+  GHashTable *frozen_deduplicated_objects;
   GPtrArray *weak_refs;
 } FilterXConfig;
 

--- a/lib/filterx/filterx-config.h
+++ b/lib/filterx/filterx-config.h
@@ -35,7 +35,5 @@ typedef struct _FilterXConfig
 } FilterXConfig;
 
 FilterXConfig *filterx_config_get(GlobalConfig *cfg);
-FilterXObject *filterx_config_freeze_object(GlobalConfig *cfg, FilterXObject *object);
-FilterXObject *filterx_config_frozen_string(GlobalConfig *cfg, const gchar *str);
 
 #endif

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -138,7 +138,7 @@ static inline void
 filterx_eval_store_weak_ref(FilterXObject *object)
 {
   /* Preserved objects do not need weak refs. */
-  if (object && filterx_object_is_preserved(object))
+  if (object && (filterx_object_is_preserved(object) || filterx_object_is_readonly(object)))
     return;
 
   if (object && !object->weak_referenced)

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -67,13 +67,13 @@ void
 filterx_cache_object(FilterXObject **cache_slot, FilterXObject *object)
 {
   *cache_slot = object;
-  filterx_object_hybernate(cache_slot);
+  filterx_object_hibernate(cache_slot);
 }
 
 void
 filterx_uncache_object(FilterXObject **cache_slot)
 {
-  filterx_object_unhybernate_and_free(*cache_slot);
+  filterx_object_unhibernate_and_free(*cache_slot);
   *cache_slot = NULL;
 }
 

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -56,29 +56,11 @@
 #include "filterx/func-keys.h"
 #include "filterx/json-repr.h"
 
-FilterXGlobalCache global_cache;
-
 static GHashTable *filterx_builtin_simple_functions = NULL;
 static GHashTable *filterx_builtin_function_ctors = NULL;
 static GHashTable *filterx_builtin_generator_function_ctors = NULL;
 static GHashTable *filterx_types = NULL;
 
-void
-filterx_cache_object(FilterXObject **cache_slot, FilterXObject *object)
-{
-  *cache_slot = object;
-  filterx_object_hibernate(cache_slot);
-}
-
-void
-filterx_uncache_object(FilterXObject **cache_slot)
-{
-  filterx_object_unhibernate_and_free(*cache_slot);
-  *cache_slot = NULL;
-}
-
-
-// Builtin functions
 
 gboolean
 filterx_builtin_simple_function_register(const gchar *fn_name, FilterXSimpleFunctionProto func)

--- a/lib/filterx/filterx-globals.h
+++ b/lib/filterx/filterx-globals.h
@@ -26,42 +26,6 @@
 #include "filterx-object.h"
 #include "filterx/expr-function.h"
 
-#define FILTERX_BOOL_CACHE_LIMIT 2
-#define FILTERX_INTEGER_CACHE_LIMIT 256
-#define FILTERX_INTEGER_CACHE_OFFSET 128
-#define FILTERX_DATETIME_CACHE_LIMIT 1
-
-/* cache indices */
-enum
-{
-  FILTERX_STRING_ZERO_LENGTH,
-  FILTERX_STRING_NUMBER0,
-  FILTERX_STRING_NUMBER1,
-  FILTERX_STRING_NUMBER2,
-  FILTERX_STRING_NUMBER3,
-  FILTERX_STRING_NUMBER4,
-  FILTERX_STRING_NUMBER5,
-  FILTERX_STRING_NUMBER6,
-  FILTERX_STRING_NUMBER7,
-  FILTERX_STRING_NUMBER8,
-  FILTERX_STRING_NUMBER9,
-  FILTERX_STRING_CACHE_LIMIT,
-};
-
-typedef struct _FilterXGlobalCache
-{
-  FilterXObject *bool_cache[FILTERX_BOOL_CACHE_LIMIT];
-  FilterXObject *integer_cache[FILTERX_INTEGER_CACHE_LIMIT];
-  FilterXObject *string_cache[FILTERX_STRING_CACHE_LIMIT];
-  GHashTable *string_frozen_cache;
-  FilterXObject *datetime_cache[FILTERX_DATETIME_CACHE_LIMIT];
-} FilterXGlobalCache;
-
-extern FilterXGlobalCache global_cache;
-
-void filterx_cache_object(FilterXObject **cache_slot, FilterXObject *object);
-void filterx_uncache_object(FilterXObject **cache_slot);
-
 void filterx_global_init(void);
 void filterx_global_deinit(void);
 

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -71,7 +71,11 @@ construct_template_expr(LogTemplate *template)
   FilterXExpr *result;
 
   if (log_template_is_literal_string(template))
-    result = filterx_literal_new(filterx_config_freeze_object(configuration, filterx_string_new(log_template_get_literal_value(template, NULL), -1)));
+    {
+      FilterXObject *obj = filterx_string_new(log_template_get_literal_value(template, NULL), -1);
+      filterx_object_freeze(&obj, configuration);
+      result = filterx_literal_new(obj);
+    }
   else if (log_template_is_trivial(template))
     result = filterx_msg_variable_expr_new(log_msg_get_value_name(log_template_get_trivial_value_handle(template), NULL));
   else
@@ -229,8 +233,8 @@ plus_assignment
 	| expr '.' identifier KW_PLUS_ASSIGN expr
 						{
 						  $$ = filterx_setattr_new(filterx_expr_ref($1),
-						                           filterx_config_frozen_string(configuration, $3),
-						                           filterx_operator_plus_new(filterx_getattr_new($1, filterx_config_frozen_string(configuration, $3)),
+						                           filterx_string_new_frozen($3, configuration),
+						                           filterx_operator_plus_new(filterx_getattr_new($1, filterx_string_new_frozen($3, configuration)),
 						                           $5));
 						  free($3);
 						}
@@ -240,7 +244,7 @@ plus_assignment
 assignment
 	/* TODO extract lvalues */
 	: variable KW_ASSIGN expr		{ $$ = filterx_assign_new($1, $3); }
-	| expr '.' identifier KW_ASSIGN expr	{ $$ = filterx_setattr_new($1, filterx_config_frozen_string(configuration, $3), $5); free($3); }
+	| expr '.' identifier KW_ASSIGN expr	{ $$ = filterx_setattr_new($1, filterx_string_new_frozen($3, configuration), $5); free($3); }
 	| expr '[' expr ']' KW_ASSIGN expr	{ $$ = filterx_set_subscript_new($1, $3, $6); }
 	| expr '[' ']' KW_ASSIGN expr  		{ $$ = filterx_set_subscript_new($1, NULL, $5); }
 	| generator_assignment
@@ -250,7 +254,7 @@ assignment
 
 nullv_assignment
 	: variable KW_NULLV_ASSIGN expr			{ $$ = filterx_nullv_assign_new($1, $3); }
-	| expr '.' identifier KW_NULLV_ASSIGN expr	{ $$ = filterx_nullv_setattr_new($1, filterx_config_frozen_string(configuration, $3), $5); free($3); }
+	| expr '.' identifier KW_NULLV_ASSIGN expr	{ $$ = filterx_nullv_setattr_new($1, filterx_string_new_frozen($3, configuration), $5); free($3); }
 	| expr '[' expr ']' KW_NULLV_ASSIGN expr	{ $$ = filterx_nullv_set_subscript_new($1, $3, $6); }
 	| expr '[' ']' KW_NULLV_ASSIGN expr  		{ $$ = filterx_nullv_set_subscript_new($1, NULL, $5); }
 	;
@@ -259,12 +263,12 @@ generator_assignment
 	/* TODO extract lvalues */
 	: expr '.' identifier KW_ASSIGN expr_generator
 						{
-						  filterx_generator_set_fillable($5, filterx_getattr_new(filterx_expr_ref($1), filterx_config_frozen_string(configuration, $3)));
+						  filterx_generator_set_fillable($5, filterx_getattr_new(filterx_expr_ref($1), filterx_string_new_frozen($3, configuration)));
 
 						  $$ = filterx_compound_expr_new_va(TRUE,
 						    _assign_location(
 						      filterx_setattr_new(filterx_expr_ref($1),
-						                          filterx_config_frozen_string(configuration, $3),
+						                          filterx_string_new_frozen($3, configuration),
 						                          filterx_generator_create_container_new(filterx_expr_ref($5), $1)),
 						      lexer, &@$),
 						    $5,
@@ -288,7 +292,7 @@ generator_assignment
 						}
 	| expr '[' ']' KW_ASSIGN expr_generator
 						{
-						  FilterXExpr *minus_one = filterx_literal_new(filterx_config_freeze_object(configuration, filterx_integer_new(-1)));
+						  FilterXExpr *minus_one = filterx_literal_new(filterx_integer_new(-1));
 						  filterx_generator_set_fillable($5, filterx_get_subscript_new(filterx_expr_ref($1), minus_one));
 
 						  $$ = filterx_compound_expr_new_va(TRUE,
@@ -323,7 +327,7 @@ generator_assignment
 generator_plus_assignment
 	: variable KW_PLUS_ASSIGN expr_generator		{ $$ = $3; filterx_generator_set_fillable($3, $1); }
 	| expr '[' expr ']' KW_PLUS_ASSIGN expr_generator	{ $$ = $6; filterx_generator_set_fillable($6, filterx_get_subscript_new($1, $3)); }
-	| expr '.' identifier KW_PLUS_ASSIGN expr_generator	{ $$ = $5; filterx_generator_set_fillable($5, filterx_getattr_new($1, filterx_config_frozen_string(configuration, $3))); free($3);}
+	| expr '.' identifier KW_PLUS_ASSIGN expr_generator	{ $$ = $5; filterx_generator_set_fillable($5, filterx_getattr_new($1, filterx_string_new_frozen($3, configuration))); free($3);}
 
 generator_casted_assignment
 	/* TODO extract lvalues */
@@ -348,10 +352,10 @@ generator_casted_assignment
 						  FilterXExpr *func = filterx_function_lookup(configuration, $5, NULL, &error);
 						  CHECK_FUNCTION_ERROR(func, @5, $5, error);
 
-						  filterx_generator_set_fillable($7, filterx_getattr_new(filterx_expr_ref($1), filterx_config_frozen_string(configuration, $3)));
+						  filterx_generator_set_fillable($7, filterx_getattr_new(filterx_expr_ref($1), filterx_string_new_frozen($3, configuration)));
 
 						  $$ = filterx_compound_expr_new_va(TRUE,
-						    filterx_setattr_new($1, filterx_config_frozen_string(configuration, $3), func),
+						    filterx_setattr_new($1, filterx_string_new_frozen($3, configuration), func),
 						    $7,
 						    NULL
 						  );
@@ -379,7 +383,7 @@ generator_casted_assignment
 						  FilterXExpr *func = filterx_function_lookup(configuration, $5, NULL, &error);
 						  CHECK_FUNCTION_ERROR(func, @5, $5, error);
 
-						  FilterXExpr *minus_one = filterx_literal_new(filterx_config_freeze_object(configuration, filterx_integer_new(-1)));
+						  FilterXExpr *minus_one = filterx_literal_new(filterx_integer_new(-1));
 						  filterx_generator_set_fillable($7, filterx_get_subscript_new(filterx_expr_ref($1), minus_one));
 
 						  $$ = filterx_compound_expr_new_va(TRUE,
@@ -431,7 +435,7 @@ expr_operator
 	| ternary
 	| default
 	/* TODO extract lvalues */
-	| expr '.' identifier		{ $$ = filterx_getattr_new($1, filterx_config_frozen_string(configuration, $3)); free($3); }
+	| expr '.' identifier		{ $$ = filterx_getattr_new($1, filterx_string_new_frozen($3, configuration)); free($3); }
 	| expr '[' expr ']'		{ $$ = filterx_get_subscript_new($1, $3); }
 	;
 
@@ -534,7 +538,7 @@ rest_argument
 	;
 
 literal
-	: literal_object				{ $$ = filterx_literal_new(filterx_config_freeze_object(configuration, $1)); }
+	: literal_object				{ FilterXObject *literal = $1; filterx_object_freeze(&literal, configuration); $$ = filterx_literal_new(literal); }
 	| dict_literal
 	| list_literal
 	;

--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -131,17 +131,18 @@ filterx_object_freeze(FilterXObject **pself, GlobalConfig *cfg)
   if (filterx_object_is_preserved(self))
     return;
 
-  if (self->type->freeze)
-    self->type->freeze(pself);
-
-  /* NOTE: type->freeze may change self to replace with an already frozen version (deduplication) */
-  if (self != *pself)
-    return;
+  if (filterx_object_dedup(pself, fx_cfg->frozen_deduplicated_objects))
+    {
+      /* NOTE: filterx_object_dedup() may change self to replace with an already frozen version */
+      if (self != *pself)
+        return;
+    }
+  else
+    g_ptr_array_add(fx_cfg->frozen_objects, self);
 
   /* no change in the object, so we are freezing self */
   filterx_object_make_readonly(self);
   g_atomic_counter_set(&self->ref_cnt, FILTERX_OBJECT_REFCOUNT_FROZEN);
-  g_ptr_array_add(fx_cfg->frozen_objects, self);
 }
 
 void

--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -26,6 +26,7 @@
 #include "filterx/object-primitive.h"
 #include "filterx/object-string.h"
 #include "filterx/filterx-globals.h"
+#include "filterx/filterx-config.h"
 
 FilterXObject *
 filterx_object_getattr_string(FilterXObject *self, const gchar *attr_name)
@@ -117,9 +118,10 @@ filterx_object_new(FilterXType *type)
 /* NOTE: we expect an exclusive reference, as it is not thread safe to be
  * called on the same object from multiple threads */
 void
-filterx_object_freeze(FilterXObject **pself)
+filterx_object_freeze(FilterXObject **pself, GlobalConfig *cfg)
 {
   FilterXObject *self = *pself;
+  FilterXConfig *fx_cfg = filterx_config_get(cfg);
 
   if (filterx_object_is_preserved(self))
     return;
@@ -135,10 +137,11 @@ filterx_object_freeze(FilterXObject **pself)
   /* no change in the object, so we are freezing self */
   filterx_object_make_readonly(self);
   g_atomic_counter_set(&self->ref_cnt, FILTERX_OBJECT_REFCOUNT_FROZEN);
+  g_ptr_array_add(fx_cfg->frozen_objects, self);
 }
 
 void
-filterx_object_unfreeze_and_free(FilterXObject *self)
+_filterx_object_unfreeze_and_free(FilterXObject *self)
 {
   if (!self)
     return;

--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -135,7 +135,7 @@ _filterx_object_preserve(FilterXObject **pself, guint32 new_ref)
   if (self->type->freeze)
     self->type->freeze(pself);
 
-  /* NOTE: type->freeze may change self to replace with a frozen/hybernated
+  /* NOTE: type->freeze may change self to replace with a frozen/hibernated
    * version */
 
   if (self == *pself)
@@ -149,7 +149,7 @@ _filterx_object_preserve(FilterXObject **pself, guint32 new_ref)
   self = *pself;
   if (g_atomic_counter_get(&self->ref_cnt) >= FILTERX_OBJECT_REFCOUNT_FROZEN)
     {
-      /* we get replaced by another frozen (but not hybernated) object */
+      /* we get replaced by another frozen (but not hibernated) object */
       g_atomic_counter_inc(&self->ref_cnt);
     }
 }
@@ -175,7 +175,7 @@ filterx_object_freeze(FilterXObject **pself)
   FilterXObject *self = *pself;
 
   gint r = g_atomic_counter_get(&self->ref_cnt);
-  if (r == FILTERX_OBJECT_REFCOUNT_HYBERNATED)
+  if (r == FILTERX_OBJECT_REFCOUNT_HIBERNATED)
     return;
 
   if (r >= FILTERX_OBJECT_REFCOUNT_FROZEN)
@@ -192,7 +192,7 @@ filterx_object_unfreeze_and_free(FilterXObject *self)
   if (!self)
     return;
   gint r = g_atomic_counter_get(&self->ref_cnt);
-  if (r == FILTERX_OBJECT_REFCOUNT_HYBERNATED)
+  if (r == FILTERX_OBJECT_REFCOUNT_HIBERNATED)
     return;
 
   g_assert(r >= FILTERX_OBJECT_REFCOUNT_FROZEN);
@@ -205,23 +205,23 @@ filterx_object_unfreeze_and_free(FilterXObject *self)
 }
 
 void
-filterx_object_hybernate(FilterXObject **pself)
+filterx_object_hibernate(FilterXObject **pself)
 {
   FilterXObject *self = *pself;
 
   gint r = g_atomic_counter_get(&self->ref_cnt);
   g_assert(r < FILTERX_OBJECT_REFCOUNT_BARRIER);
 
-  _filterx_object_preserve(pself, FILTERX_OBJECT_REFCOUNT_HYBERNATED);
+  _filterx_object_preserve(pself, FILTERX_OBJECT_REFCOUNT_HIBERNATED);
 }
 
 void
-filterx_object_unhybernate_and_free(FilterXObject *self)
+filterx_object_unhibernate_and_free(FilterXObject *self)
 {
   if (!self)
     return;
   gint r = g_atomic_counter_get(&self->ref_cnt);
-  g_assert(r == FILTERX_OBJECT_REFCOUNT_HYBERNATED);
+  g_assert(r == FILTERX_OBJECT_REFCOUNT_HIBERNATED);
 
   _filterx_object_thaw(self);
   filterx_object_unref(self);

--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -115,7 +115,7 @@ filterx_object_new(FilterXType *type)
 }
 
 static void
-_filterx_object_preserve(FilterXObject **pself, guint32 new_ref)
+_filterx_object_preserve(FilterXObject **pself, FilterXObjectRefcountRange ref_type)
 {
   FilterXObject *self = *pself;
 
@@ -142,7 +142,7 @@ _filterx_object_preserve(FilterXObject **pself, guint32 new_ref)
     {
       /* no change in the object, so we are freezing self */
       filterx_object_make_readonly(self);
-      g_atomic_counter_set(&self->ref_cnt, new_ref);
+      g_atomic_counter_set(&self->ref_cnt, ref_type);
       return;
     }
 

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -118,7 +118,7 @@ filterx_type_is_cowable(FilterXType *type)
  *
  *    The ref_cnt is always equal to FILTERX_OBJECT_REFCOUNT_STACK
  *
- * 3) hybernated objects
+ * 3) hibernated objects
  *
  *    Hybernated objects are preserved for the entire lifecycle of a
  *    filterx-based configuration.  They are allocated at startup or when
@@ -131,9 +131,9 @@ filterx_type_is_cowable(FilterXType *type)
  *    these objects can be replace the unfrozen version of the same object by
  *    filterx_object_freeze() (e.g. when they represent the same string).
  *
- *    The ref_cnt will always be: FILTERX_OBJECT_REFCOUNT_HYBERNATED
+ *    The ref_cnt will always be: FILTERX_OBJECT_REFCOUNT_HIBERNATED
  *
- *    NOTE: hybernated objects are considered "preserved"
+ *    NOTE: hibernated objects are considered "preserved"
  *
  * 4) frozen objects
  *
@@ -165,13 +165,13 @@ enum
   FILTERX_OBJECT_REFCOUNT_BARRIER_MAX=FILTERX_OBJECT_REFCOUNT_BARRIER + 1023,
   /* stack based allocation */
   FILTERX_OBJECT_REFCOUNT_STACK,
-  /* anything above this point is preserved: either hybernated or frozen */
+  /* anything above this point is preserved: either hibernated or frozen */
   FILTERX_OBJECT_REFCOUNT_PRESERVED,
 
-  /* hybernated object (considered preserved) */
-  FILTERX_OBJECT_REFCOUNT_HYBERNATED=FILTERX_OBJECT_REFCOUNT_PRESERVED,
+  /* hibernated object (considered preserved) */
+  FILTERX_OBJECT_REFCOUNT_HIBERNATED=FILTERX_OBJECT_REFCOUNT_PRESERVED,
 
-  /* hybernated object (considered preserved) */
+  /* hibernated object (considered preserved) */
   FILTERX_OBJECT_REFCOUNT_FROZEN,
 };
 
@@ -237,8 +237,8 @@ gboolean filterx_object_setattr_string(FilterXObject *self, const gchar *attr_na
 FilterXObject *filterx_object_new(FilterXType *type);
 void filterx_object_freeze(FilterXObject **pself);
 void filterx_object_unfreeze_and_free(FilterXObject *self);
-void filterx_object_hybernate(FilterXObject **pself);
-void filterx_object_unhybernate_and_free(FilterXObject *self);
+void filterx_object_hibernate(FilterXObject **pself);
+void filterx_object_unhibernate_and_free(FilterXObject *self);
 void filterx_object_init_instance(FilterXObject *self, FilterXType *type);
 void filterx_object_free_method(FilterXObject *self);
 

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -247,7 +247,7 @@ void filterx_json_associate_cached_object(struct json_object *jso, FilterXObject
 static inline gboolean
 filterx_object_is_preserved(FilterXObject *self)
 {
-  return g_atomic_counter_get(&self->ref_cnt) >= FILTERX_OBJECT_REFCOUNT_HYBERNATED;
+  return g_atomic_counter_get(&self->ref_cnt) >= FILTERX_OBJECT_REFCOUNT_PRESERVED;
 }
 
 static inline FilterXObject *

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -156,7 +156,7 @@ filterx_type_is_cowable(FilterXType *type)
  *
  *    NOTE: frozen objects are considered "preserved"
  */
-enum
+typedef enum _FilterXObjectRefcountRange
 {
   FILTERX_OBJECT_REFCOUNT_BARRIER=G_MAXINT32/2,
 
@@ -173,7 +173,7 @@ enum
 
   /* hibernated object (considered preserved) */
   FILTERX_OBJECT_REFCOUNT_FROZEN,
-};
+} FilterXObjectRefcountRange;
 
 struct _FilterXObject
 {

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -59,7 +59,6 @@ struct _FilterXType
   FilterXObject *(*add)(FilterXObject *self, FilterXObject *object);
   void (*make_readonly)(FilterXObject *self);
   void (*freeze)(FilterXObject **self);
-  void (*unfreeze)(FilterXObject *self);
   void (*free_fn)(FilterXObject *self);
 };
 
@@ -118,6 +117,8 @@ filterx_type_is_cowable(FilterXType *type)
  *    The caller is responsible for providing efficient storage and deallocation
  *    before shutdown.
  *
+ *    Only immutable, non-recursive objects can be hibernated.
+ *
  *    Both the normal ref/unref and the freeze operations are noops.
  *
  *    The ref_cnt will always be: FILTERX_OBJECT_REFCOUNT_HIBERNATED
@@ -132,6 +133,8 @@ filterx_type_is_cowable(FilterXType *type)
  *
  *    The storage and deallocation is taken care of by the freeze() call.
  *    Frozen objects may be deduplicated if they support such operation.
+ *
+ *    Only immutable, non-recursive objects can be frozen.
  *
  *    The ref/unref operations are noops.
  *

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -217,8 +217,8 @@ FilterXObject *filterx_object_getattr_string(FilterXObject *self, const gchar *a
 gboolean filterx_object_setattr_string(FilterXObject *self, const gchar *attr_name, FilterXObject **new_value);
 
 FilterXObject *filterx_object_new(FilterXType *type);
-void filterx_object_freeze(FilterXObject **pself);
-void filterx_object_unfreeze_and_free(FilterXObject *self);
+void filterx_object_freeze(FilterXObject **pself, GlobalConfig *cfg);
+void _filterx_object_unfreeze_and_free(FilterXObject *self);
 void filterx_object_hibernate(FilterXObject *self);
 void filterx_object_unhibernate_and_free(FilterXObject *self);
 void filterx_object_init_instance(FilterXObject *self, FilterXType *type);

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -101,13 +101,7 @@ filterx_type_is_cowable(FilterXType *type)
  *    Most objects will be in this category, ref_cnt starts with 1,
  *    ref/unref increments and decrements the refcount respectively.
  *
- *    The ref_cnt will be in this range: (0, FILTERX_OBJECT_REFCOUNT_OFLOW_MARK)
- *
- *    The ref_cnt overflow is detected by leaving a gap between the overflow
- *    mark and the first special value, which is large enough to avoid races
- *    stepping through the range
- *
- * 2) read-only, local values (allocated on stack, no refcounting)
+ * 2) local values (allocated on stack, no refcounting)
  *
  *    Local values can be stored on the stack, to avoid a heap allocation,
  *    these values are only used by a single thread.
@@ -120,16 +114,11 @@ filterx_type_is_cowable(FilterXType *type)
  *
  * 3) hibernated objects
  *
- *    Hybernated objects are preserved for the entire lifecycle of a
- *    filterx-based configuration.  They are allocated at startup or when
- *    the config is initialized and freed once the configuration finishes or syslog-ng exits.
+ *    Hibernated objects are preserved for the entire lifecycle of the process.
+ *    The caller is responsible for providing efficient storage and deallocation
+ *    before shutdown.
  *
- *    Both the normal ref/unref and the freeze/unfreeze operations are
- *    noops. Hybernated objects simply exist as long as necessary.
- *
- *    Hybernated objects can be used in place of any normal objects, e.g.
- *    these objects can be replace the unfrozen version of the same object by
- *    filterx_object_freeze() (e.g. when they represent the same string).
+ *    Both the normal ref/unref and the freeze operations are noops.
  *
  *    The ref_cnt will always be: FILTERX_OBJECT_REFCOUNT_HIBERNATED
  *
@@ -137,43 +126,36 @@ filterx_type_is_cowable(FilterXType *type)
  *
  * 4) frozen objects
  *
- *    Frozen objects are also preserved and have their own lifecycle.  But
- *    instead of being tracked by the configuration or by the syslog-ng
- *    startup/teardown mechanism, they get allocated and freed during the
- *    runtime of a configuration.
+ *    Frozen objects are preserved for the entire lifecycle of a
+ *    filterx-based configuration.  They are allocated when
+ *    the config is initialized and freed once the configuration finishes.
  *
- *    An example is cache_json_file(), which allocates the representation of
- *    the JSON data structure at configuration compilation and can reload it
- *    if the file changes, even if the configuration itself remains the
- *    same.  We want to be able to free a previous version of the JSON, even
- *    without a complete configuration reload.
+ *    The storage and deallocation is taken care of by the freeze() call.
+ *    Frozen objects may be deduplicated if they support such operation.
  *
- *    The ref/unref operations are noops.  The freeze/unfreeze operations
- *    have a reference counting nature, and the object will be freed at the
- *    last unfreeze.
+ *    The ref/unref operations are noops.
  *
- *    The ref_cnt will be in this range: [FILTERX_OBJECT_REFCOUNT_FROZEN, G_MAXINT32]
+ *    The ref_cnt will always be: FILTERX_OBJECT_REFCOUNT_FROZEN
  *
  *    NOTE: frozen objects are considered "preserved"
  */
 typedef enum _FilterXObjectRefcountRange
 {
-  FILTERX_OBJECT_REFCOUNT_BARRIER=G_MAXINT32/2,
+  FILTERX_OBJECT_REFCOUNT_BARRIER = G_MAXINT32-3,
 
-  /* the distance between BARRIER and BARRIER_MAX protects against a race
-   * condition and a resulting overflow, see the comment in filterx_object_ref() */
-  FILTERX_OBJECT_REFCOUNT_BARRIER_MAX=FILTERX_OBJECT_REFCOUNT_BARRIER + 1023,
   /* stack based allocation */
-  FILTERX_OBJECT_REFCOUNT_STACK,
+  FILTERX_OBJECT_REFCOUNT_STACK = FILTERX_OBJECT_REFCOUNT_BARRIER,
+
   /* anything above this point is preserved: either hibernated or frozen */
   FILTERX_OBJECT_REFCOUNT_PRESERVED,
 
-  /* hibernated object (considered preserved) */
   FILTERX_OBJECT_REFCOUNT_HIBERNATED=FILTERX_OBJECT_REFCOUNT_PRESERVED,
-
-  /* hibernated object (considered preserved) */
   FILTERX_OBJECT_REFCOUNT_FROZEN,
+
+  __FILTERX_OBJECT_REFCOUNT_MAX
 } FilterXObjectRefcountRange;
+
+G_STATIC_ASSERT(__FILTERX_OBJECT_REFCOUNT_MAX == G_MAXINT32);
 
 struct _FilterXObject
 {
@@ -237,7 +219,7 @@ gboolean filterx_object_setattr_string(FilterXObject *self, const gchar *attr_na
 FilterXObject *filterx_object_new(FilterXType *type);
 void filterx_object_freeze(FilterXObject **pself);
 void filterx_object_unfreeze_and_free(FilterXObject *self);
-void filterx_object_hibernate(FilterXObject **pself);
+void filterx_object_hibernate(FilterXObject *self);
 void filterx_object_unhibernate_and_free(FilterXObject *self);
 void filterx_object_init_instance(FilterXObject *self, FilterXType *type);
 void filterx_object_free_method(FilterXObject *self);
@@ -257,41 +239,8 @@ filterx_object_ref(FilterXObject *self)
     return NULL;
 
   gint r = g_atomic_counter_get(&self->ref_cnt);
-  if (r < FILTERX_OBJECT_REFCOUNT_BARRIER && r > 0)
-    {
-      /* NOTE: getting into this path is racy, as two threads might be
-       * checking the overflow mark in parallel and then decide we need to
-       * run this (normal) path.  In this case, the race could cause ref_cnt
-       * to reach FILTERX_OBJECT_REFCOUNT_OFLOW_MARK, without triggering the
-       * overflow assert below.
-       *
-       * To mitigate this, FILTERX_OBJECT_REFCOUNT_OFLOW_MARK is set to 1024
-       * less than the first value that we handle specially.  This means
-       * that even if the race is lost, we would need 1024 competing CPUs
-       * concurrently losing the race and incrementing ref_cnt here.  And
-       * even in this case the only issue is that we don't detect an actual
-       * overflow at runtime that should never occur in the first place.
-       *
-       * This is _really_ unlikely, and we will detect ref_cnt overflows in
-       * non-doom scenarios first, so we can address the actual issue (which
-       * might be a reference counting bug somewhere).
-       *
-       * If less than 1024 CPUs lose the race, then the refcount would end
-       * up in the range between FILTERX_OBJECT_REFCOUNT_OFLOW_MARK and
-       * FILTERX_OBJECT_REFCOUNT_STACK, causing the assertion at the end of
-       * this function to trigger an abort.
-       *
-       * The non-racy solution would be to use a
-       * g_atomic_int_exchange_and_add() call and checking the old_value
-       * against FILTERX_OBJECT_REFCOUNT_OFLOW_MARK another time, but that's
-       * an extra conditional in a hot-path.
-       */
 
-      g_atomic_counter_inc(&self->ref_cnt);
-      return self;
-    }
-
-  if (r == FILTERX_OBJECT_REFCOUNT_STACK)
+  if (G_UNLIKELY(r == FILTERX_OBJECT_REFCOUNT_STACK))
     {
       /* we can't use filterx_object_clone() directly, as that's an inline
        * function declared further below.  Also, filterx_object_clone() does
@@ -303,7 +252,10 @@ filterx_object_ref(FilterXObject *self)
   if (r >= FILTERX_OBJECT_REFCOUNT_PRESERVED)
     return self;
 
-  g_assert_not_reached();
+  g_assert(r + 1 < FILTERX_OBJECT_REFCOUNT_BARRIER && r > 0);
+
+  g_atomic_counter_inc(&self->ref_cnt);
+  return self;
 }
 
 static inline void
@@ -313,7 +265,7 @@ filterx_object_unref(FilterXObject *self)
     return;
 
   gint r = g_atomic_counter_get(&self->ref_cnt);
-  if (r == FILTERX_OBJECT_REFCOUNT_STACK)
+  if (G_UNLIKELY(r == FILTERX_OBJECT_REFCOUNT_STACK))
     {
       /* NOTE: Normally, stack based allocations are only used by a single
        * thread.  Furthermore, code where we use this object will only have
@@ -331,10 +283,11 @@ filterx_object_unref(FilterXObject *self)
       g_atomic_counter_set(&self->ref_cnt, 0);
       return;
     }
+
   if (r >= FILTERX_OBJECT_REFCOUNT_PRESERVED)
     return;
-  if (r <= 0)
-    g_assert_not_reached();
+
+  g_assert(r > 0);
 
   if (g_atomic_counter_dec_and_test(&self->ref_cnt))
     {

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -225,10 +225,8 @@ _filterx_object_is_type(FilterXObject *object, FilterXType *type)
 static inline gboolean
 filterx_object_is_type(FilterXObject *object, FilterXType *type)
 {
-#if SYSLOG_NG_ENABLE_DEBUG
-  if (filterx_type_is_cowable(type) && filterx_object_is_ref(object))
+  if (type->is_mutable && filterx_object_is_ref(object))
     g_assert("filterx_ref_unwrap() must be used before comparing to mutable types" && FALSE);
-#endif
 
   return _filterx_object_is_type(object, type);
 }

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -227,6 +227,12 @@ void filterx_object_free_method(FilterXObject *self);
 void filterx_json_associate_cached_object(struct json_object *jso, FilterXObject *filterx_object);
 
 static inline gboolean
+filterx_object_is_readonly(FilterXObject *self)
+{
+  return self->readonly;
+}
+
+static inline gboolean
 filterx_object_is_preserved(FilterXObject *self)
 {
   return g_atomic_counter_get(&self->ref_cnt) >= FILTERX_OBJECT_REFCOUNT_PRESERVED;

--- a/lib/filterx/filterx-ref.c
+++ b/lib/filterx/filterx-ref.c
@@ -113,6 +113,28 @@ _filterx_make_readonly(FilterXObject *s)
   filterx_object_make_readonly(self->value);
 }
 
+static gboolean
+_filterx_dedup(FilterXObject **pself, GHashTable *dedup_storage)
+{
+  FilterXRef *self = (FilterXRef *) *pself;
+
+  FilterXObject *orig_value = self->value;
+
+  if (!filterx_object_dedup(&self->value, dedup_storage))
+    return FALSE;
+
+  /* Mutable objects themselves should never be deduplicated,
+   * only the values INSIDE those recursive mutable objects
+   *
+   * In case one wants to support mutable object deduplication
+   * this assert should be removed and the fx_ref_cnt of the new value should
+   * be adjusted.
+   */
+  g_assert(orig_value == self->value);
+
+  return TRUE;
+}
+
 /* readonly methods */
 
 static gboolean
@@ -294,5 +316,6 @@ FILTERX_DEFINE_TYPE(ref, FILTERX_TYPE_NAME(object),
                     .len = _filterx_ref_len,
                     .add = _filterx_ref_add,
                     .make_readonly = _filterx_make_readonly,
+                    .dedup = _filterx_dedup,
                     .free_fn = _filterx_ref_free,
                    );

--- a/lib/filterx/filterx-ref.c
+++ b/lib/filterx/filterx-ref.c
@@ -289,7 +289,7 @@ FilterXObject *
 _filterx_ref_new(FilterXObject *value)
 {
 #if SYSLOG_NG_ENABLE_DEBUG
-  if (!filterx_object_is_cowable(value) || filterx_object_is_ref(value))
+  if (!value->type->is_mutable || filterx_object_is_ref(value))
     g_assert("filterx_ref_new() must only be used for a cowable object" && FALSE);
 #endif
   FilterXRef *self = g_new0(FilterXRef, 1);

--- a/lib/filterx/filterx-ref.c
+++ b/lib/filterx/filterx-ref.c
@@ -99,12 +99,9 @@ _filterx_ref_free(FilterXObject *s)
 {
   FilterXRef *self = (FilterXRef *) s;
 
-  if (self->value)
-    {
-      /* if we were frozen and then unfrozen, self->value will be NULL */
-      g_atomic_counter_dec_and_test(&self->value->fx_ref_cnt);
-      filterx_object_unref(self->value);
-    }
+  g_atomic_counter_dec_and_test(&self->value->fx_ref_cnt);
+  filterx_object_unref(self->value);
+
   filterx_object_free_method(s);
 }
 
@@ -114,31 +111,6 @@ _filterx_make_readonly(FilterXObject *s)
   FilterXRef *self = (FilterXRef *) s;
 
   filterx_object_make_readonly(self->value);
-}
-
-static void
-_filterx_ref_freeze(FilterXObject **s)
-{
-  FilterXRef *self = (FilterXRef *) *s;
-
-  filterx_object_freeze(&self->value);
-}
-
-static void
-_filterx_ref_unfreeze(FilterXObject *s)
-{
-  FilterXRef *self = (FilterXRef *) s;
-
-  /* when we are unfrozen, the next thing is to free self as well (as the
-   * only way to unfreeze is to free too).  This means that even though
-   * self->value may still exist for a short while, its destruction is
-   * inevitable too.  Let's drop our fx_ref_cnt though, to make sure it
-   * reaches 0 properly.  An unfrozen ref is inoperable, as our value will
-   * be NULL */
-
-  g_atomic_counter_dec_and_test(&self->value->fx_ref_cnt);
-  filterx_object_unfreeze_and_free(self->value);
-  self->value = NULL;
 }
 
 /* readonly methods */
@@ -322,7 +294,5 @@ FILTERX_DEFINE_TYPE(ref, FILTERX_TYPE_NAME(object),
                     .len = _filterx_ref_len,
                     .add = _filterx_ref_add,
                     .make_readonly = _filterx_make_readonly,
-                    .freeze = _filterx_ref_freeze,
-                    .unfreeze = _filterx_ref_unfreeze,
                     .free_fn = _filterx_ref_free,
                    );

--- a/lib/filterx/func-cache-json-file.c
+++ b/lib/filterx/func-cache-json-file.c
@@ -64,29 +64,8 @@ typedef struct FilterXFunctionCacheJsonFile_
   FilterXFunction super;
   gchar *filepath;
   gpointer cached_json;
-  GPtrArray *frozen_objects;
-  GPtrArray *frozen_objects_history[FROZEN_OBJECTS_HISTORY_SIZE];
-  gint history_index;
   FileMonitor *file_monitor;
 } FilterXFunctionCacheJsonFile;
-
-static void
-_free_all_frozen_objects(FilterXFunctionCacheJsonFile *self);
-
-static void
-_archive_frozen_objects(FilterXFunctionCacheJsonFile *self)
-{
-  if (!self->frozen_objects)
-    return;
-
-  // in case of reload fails somehow
-  if (self->history_index >= FROZEN_OBJECTS_HISTORY_SIZE)
-    _free_all_frozen_objects(self);
-
-  self->frozen_objects_history[self->history_index] = self->frozen_objects;
-  self->history_index++;
-  self->frozen_objects = NULL;
-}
 
 static gchar *
 _extract_filepath(FilterXFunctionArgs *args, GError **error)
@@ -183,22 +162,6 @@ _eval(FilterXExpr *s)
 }
 
 static void
-_free_all_frozen_objects(FilterXFunctionCacheJsonFile *self)
-{
-  main_loop_assert_main_thread();
-  for (int i = 0; i < FROZEN_OBJECTS_HISTORY_SIZE; i++)
-    {
-      if (self->frozen_objects_history[i])
-        {
-          g_ptr_array_unref(self->frozen_objects_history[i]);
-          self->frozen_objects_history[i] = NULL;
-        }
-    }
-
-  self->history_index = 0;
-}
-
-static void
 _free(FilterXExpr *s)
 {
   FilterXFunctionCacheJsonFile *self = (FilterXFunctionCacheJsonFile *) s;
@@ -209,9 +172,6 @@ _free(FilterXExpr *s)
       file_monitor_stop(self->file_monitor);
       file_monitor_free(self->file_monitor);
     }
-  _free_all_frozen_objects(self);
-  if (self->frozen_objects)
-    g_ptr_array_unref(self->frozen_objects);
   filterx_function_free_method(&self->super);
 }
 
@@ -223,15 +183,11 @@ _load_json_file_version(FilterXFunctionCacheJsonFile *self, GError **error)
     {
       return FALSE;
     }
-  _archive_frozen_objects(self);
-  self->frozen_objects = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unfreeze_and_free);
-  filterx_object_freeze(&cached_json);
-  g_ptr_array_add(self->frozen_objects, cached_json);
+  filterx_object_make_readonly(cached_json);
   g_atomic_pointer_set(&self->cached_json, cached_json);
   return TRUE;
 }
 
-// This function may trigger a configuration reload. Ensure proper handling of the configuration on the caller side.
 gboolean
 _file_monitor_callback(const FileMonitorEvent *event, gpointer user_data)
 {
@@ -246,11 +202,6 @@ _file_monitor_callback(const FileMonitorEvent *event, gpointer user_data)
     }
 
   main_loop_assert_main_thread();
-  if (self->history_index >= FROZEN_OBJECTS_HISTORY_SIZE)
-    {
-      main_loop_reload_config(main_loop);
-      return FALSE;
-    }
 
   /* needed for parent tracking of temporary non-frozen objects */
   FilterXEvalContext json_reload_context;

--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -44,6 +44,9 @@
 #define FILTERX_FUNC_STRPTIME_USAGE "Usage: strptime(time_str, format_str_1, ..., format_str_N)"
 #define FILTERX_FUNC_STRFTIME_USAGE "Usage: strftime(format_str, datetime)"
 
+#define FILTERX_DATETIME_CACHE_SIZE 1
+FilterXObject *fx_datetime_cache[FILTERX_DATETIME_CACHE_SIZE];
+
 typedef struct _FilterXDateTime
 {
   FilterXObject super;
@@ -99,7 +102,7 @@ FilterXObject *
 filterx_datetime_new(const UnixTime *ut)
 {
   if (ut->ut_sec == 0 && ut->ut_usec == 0)
-    return global_cache.datetime_cache[0];
+    return fx_datetime_cache[0];
   return _datetime_new(ut);
 }
 
@@ -599,14 +602,15 @@ filterx_datetime_global_init(void)
 {
   UnixTime zero = {0};
 
-  filterx_cache_object(&global_cache.datetime_cache[0], _datetime_new(&zero));
+  fx_datetime_cache[0] = _datetime_new(&zero);
+  filterx_object_hibernate(fx_datetime_cache[0]);
 }
 
 void
 filterx_datetime_global_deinit(void)
 {
-  for (gint i = 0; i < FILTERX_DATETIME_CACHE_LIMIT; i++)
+  for (gint i = 0; i < FILTERX_DATETIME_CACHE_SIZE; i++)
     {
-      filterx_uncache_object(&global_cache.datetime_cache[i]);
+      filterx_object_unhibernate_and_free(fx_datetime_cache[i]);
     }
 }

--- a/lib/filterx/object-dict.c
+++ b/lib/filterx/object-dict.c
@@ -743,40 +743,6 @@ filterx_dict_new_from_args(FilterXExpr *s, FilterXObject *args[], gsize args_len
   return NULL;
 }
 
-static gboolean
-_freeze_dict_item(FilterXObject **key, FilterXObject **value, gpointer user_data)
-{
-  filterx_object_freeze(key);
-  filterx_object_freeze(value);
-  return TRUE;
-}
-
-static void
-_filterx_dict_freeze(FilterXObject **s)
-{
-  FilterXDictObject *self = (FilterXDictObject *) *s;
-
-  /* dicts need to be freezable, if they are not we are ending in an abort */
-  g_assert(_table_foreach(self->table, _freeze_dict_item, NULL) == TRUE);
-}
-
-static gboolean
-_unfreeze_dict_item(FilterXObject **key, FilterXObject **value, gpointer user_data)
-{
-  filterx_object_unfreeze_and_free(*key);
-  filterx_object_unfreeze_and_free(*value);
-  *key = *value = NULL;
-  return TRUE;
-}
-
-static void
-_filterx_dict_unfreeze(FilterXObject *s)
-{
-  FilterXDictObject *self = (FilterXDictObject *) s;
-
-  g_assert(_table_foreach(self->table, _unfreeze_dict_item, NULL) == TRUE);
-}
-
 FILTERX_DEFINE_TYPE(dict_object, FILTERX_TYPE_NAME(dict),
                     .is_mutable = TRUE,
                     .truthy = _filterx_dict_truthy,
@@ -787,6 +753,4 @@ FILTERX_DEFINE_TYPE(dict_object, FILTERX_TYPE_NAME(dict),
                     .repr = _filterx_dict_repr,
                     .clone = _filterx_dict_clone,
                     .clone_container = _filterx_dict_clone_container,
-                    .freeze = _filterx_dict_freeze,
-                    .unfreeze = _filterx_dict_unfreeze,
                    );

--- a/lib/filterx/object-list.c
+++ b/lib/filterx/object-list.c
@@ -311,38 +311,6 @@ filterx_list_new_from_args(FilterXExpr *s, FilterXObject *args[], gsize args_len
   return NULL;
 }
 
-static gboolean
-_freeze_list_item(gsize index, FilterXObject **value, gpointer user_data)
-{
-  filterx_object_freeze(value);
-  return TRUE;
-}
-
-static void
-_filterx_list_freeze(FilterXObject **s)
-{
-  FilterXListObject *self = (FilterXListObject *) *s;
-
-  filterx_list_foreach(self, _freeze_list_item, NULL);
-}
-
-static gboolean
-_unfreeze_list_item(gsize index, FilterXObject **value, gpointer user_data)
-{
-  filterx_object_unfreeze_and_free(*value);
-  *value = NULL;
-  return TRUE;
-}
-
-static void
-_filterx_list_unfreeze(FilterXObject *s)
-{
-  FilterXListObject *self = (FilterXListObject *) s;
-
-  filterx_list_foreach(self, _unfreeze_list_item, NULL);
-}
-
-
 FILTERX_DEFINE_TYPE(list_object, FILTERX_TYPE_NAME(list),
                     .is_mutable = TRUE,
                     .truthy = _filterx_list_truthy,
@@ -353,6 +321,4 @@ FILTERX_DEFINE_TYPE(list_object, FILTERX_TYPE_NAME(list),
                     .repr = _filterx_list_repr,
                     .clone = _filterx_list_clone,
                     .clone_container = _filterx_list_clone_container,
-                    .freeze = _filterx_list_freeze,
-                    .unfreeze = _filterx_list_unfreeze,
                    );

--- a/lib/filterx/object-null.c
+++ b/lib/filterx/object-null.c
@@ -85,11 +85,12 @@ FILTERX_DEFINE_TYPE(null, FILTERX_TYPE_NAME(object),
 void
 filterx_null_global_init(void)
 {
-  filterx_cache_object(&null_object, _null_wrap());
+  null_object = _null_wrap();
+  filterx_object_hibernate(null_object);
 }
 
 void
 filterx_null_global_deinit(void)
 {
-  filterx_uncache_object(&null_object);
+  filterx_object_unhibernate_and_free(null_object);
 }

--- a/lib/filterx/object-primitive.h
+++ b/lib/filterx/object-primitive.h
@@ -24,8 +24,16 @@
 #define FILTERX_PRIMITIVE_H_INCLUDED
 
 #include "filterx/filterx-object.h"
-#include "filterx/filterx-globals.h"
 #include "generic-number.h"
+
+#define FILTERX_BOOL_CACHE_SIZE 2
+extern FilterXObject *fx_bool_cache[FILTERX_BOOL_CACHE_SIZE];
+
+#define FILTERX_INTEGER_CACHE_MIN -128
+#define FILTERX_INTEGER_CACHE_MAX 128
+#define FILTERX_INTEGER_CACHE_SIZE (FILTERX_INTEGER_CACHE_MAX - FILTERX_INTEGER_CACHE_MIN + 1)
+#define FILTERX_INTEGER_CACHE_IDX(v) ((v) - FILTERX_INTEGER_CACHE_MIN)
+extern FilterXObject *fx_integer_cache[FILTERX_INTEGER_CACHE_SIZE];
 
 FILTERX_DECLARE_TYPE(primitive);
 FILTERX_DECLARE_TYPE(integer);
@@ -105,14 +113,15 @@ filterx_boolean_unwrap(FilterXObject *s, gboolean *value)
 static inline FilterXObject *
 filterx_boolean_new(gboolean value)
 {
-  return filterx_object_ref(global_cache.bool_cache[!!(value)]);
+  return filterx_object_ref(fx_bool_cache[!!(value)]);
 }
 
 static inline FilterXObject *
 filterx_integer_new(gint64 value)
 {
-  if (value >= -FILTERX_INTEGER_CACHE_OFFSET && value < FILTERX_INTEGER_CACHE_LIMIT - FILTERX_INTEGER_CACHE_OFFSET)
-    return filterx_object_ref(global_cache.integer_cache[value + FILTERX_INTEGER_CACHE_OFFSET]);
+  if (value >= FILTERX_INTEGER_CACHE_MIN && value <= FILTERX_INTEGER_CACHE_MAX)
+    return filterx_object_ref(fx_integer_cache[(FILTERX_INTEGER_CACHE_IDX(value))]);
+
   return _filterx_integer_new(value);
 }
 

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -32,7 +32,6 @@
 #define FILTERX_STRING_FLAG_STR_ALLOCATED 0x01
 
 FilterXObject *fx_string_cache[FILTERX_STRING_CACHE_SIZE];
-GHashTable *fx_string_dedup_store;
 
 /* NOTE: Consider using filterx_object_extract_bytes_ref() to also support message_value. */
 const gchar *
@@ -178,20 +177,25 @@ _string_new(const gchar *str, gssize str_len, FilterXStringTranslateFunc transla
   return self;
 }
 
-static void
-_string_freeze(FilterXObject **pself)
+static gboolean
+_string_dedup(FilterXObject **pself, GHashTable *dedup_storage)
 {
   FilterXString *self = (FilterXString *) *pself;
 
-  FilterXObject *frozen_string = g_hash_table_lookup(fx_string_dedup_store, self->str);
-  if (frozen_string)
+  gchar *dedup_key = g_strdup_printf("string_%s", self->str);
+
+  FilterXObject *dedup_str = g_hash_table_lookup(dedup_storage, dedup_key);
+  if (dedup_str)
     {
       filterx_object_unref(*pself);
-      *pself = frozen_string;
-      return;
+      *pself = dedup_str;
+      g_free(dedup_key);
+      return TRUE;
     }
+
   _filterx_string_hash(self);
-  g_hash_table_insert(fx_string_dedup_store, (gchar *) self->str, self);
+  g_hash_table_insert(dedup_storage, dedup_key, self);
+  return TRUE;
 }
 
 static inline guint
@@ -436,7 +440,7 @@ FILTERX_DEFINE_TYPE(string, FILTERX_TYPE_NAME(object),
                     .repr = _string_repr,
                     .add = _string_add,
                     .clone = _string_clone,
-                    .freeze = _string_freeze,
+                    .dedup = _string_dedup,
                     .free_fn = _free,
                    );
 
@@ -462,8 +466,6 @@ FILTERX_DEFINE_TYPE(protobuf, FILTERX_TYPE_NAME(object),
 void
 filterx_string_global_init(void)
 {
-  fx_string_dedup_store = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, NULL);
-
   fx_string_cache[FILTERX_STRING_ZERO_LENGTH] = &_string_new("", 0, NULL)->super;
   filterx_object_hibernate(fx_string_cache[FILTERX_STRING_ZERO_LENGTH]);
 
@@ -478,8 +480,6 @@ filterx_string_global_init(void)
 void
 filterx_string_global_deinit(void)
 {
-  g_hash_table_unref(fx_string_dedup_store);
-
   for (gint i = 0; i < FILTERX_STRING_CACHE_SIZE; i++)
     {
       filterx_object_unhibernate_and_free(fx_string_cache[i]);

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -24,7 +24,25 @@
 #define FILTERX_OBJECT_STRING_H_INCLUDED
 
 #include "filterx-object.h"
-#include "filterx-globals.h"
+
+/* cache indices */
+enum
+{
+  FILTERX_STRING_ZERO_LENGTH,
+  FILTERX_STRING_NUMBER0,
+  FILTERX_STRING_NUMBER1,
+  FILTERX_STRING_NUMBER2,
+  FILTERX_STRING_NUMBER3,
+  FILTERX_STRING_NUMBER4,
+  FILTERX_STRING_NUMBER5,
+  FILTERX_STRING_NUMBER6,
+  FILTERX_STRING_NUMBER7,
+  FILTERX_STRING_NUMBER8,
+  FILTERX_STRING_NUMBER9,
+  FILTERX_STRING_CACHE_SIZE,
+};
+
+extern FilterXObject *fx_string_cache[FILTERX_STRING_CACHE_SIZE];
 
 typedef struct _FilterXString FilterXString;
 struct _FilterXString
@@ -83,12 +101,12 @@ filterx_string_new(const gchar *str, gssize str_len)
 {
   if (str_len == 0 || str[0] == 0)
     {
-      return filterx_object_ref(global_cache.string_cache[FILTERX_STRING_ZERO_LENGTH]);
+      return filterx_object_ref(fx_string_cache[FILTERX_STRING_ZERO_LENGTH]);
     }
   else if (str[0] >= '0' && str[0] < '9' && (str_len == 1 || str[1] == 0))
     {
       gint index = str[0] - '0';
-      return filterx_object_ref(global_cache.string_cache[FILTERX_STRING_NUMBER0 + index]);
+      return filterx_object_ref(fx_string_cache[FILTERX_STRING_NUMBER0 + index]);
     }
   return _filterx_string_new(str, str_len);
 }

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -111,6 +111,14 @@ filterx_string_new(const gchar *str, gssize str_len)
   return _filterx_string_new(str, str_len);
 }
 
+static inline FilterXObject *
+filterx_string_new_frozen(const gchar *str, GlobalConfig *cfg)
+{
+  FilterXObject *self = filterx_string_new(str, -1);
+  filterx_object_freeze(&self, cfg);
+  return self;
+}
+
 guint
 _filterx_string_hash(FilterXString *self);
 

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -132,13 +132,8 @@ filterx_string_hash(FilterXObject *s)
     return self->hash;
 
   /* although this is racy for parallel access on the same object, it's not
-   * really a problem, as:
-   *
-   * 1) we are only sharing frozen instances of the string, which calculates
-   *    the hash at freeze time
-   *
-   * 2) even if we do share a non-frozen string, the hash algorithm should
-   *    have the same result, so worst case, we calculate the hash 2 times.
+   * really a problem, as the hash algorithm should have the same result,
+   * so worst case, we calculate the hash 2 times.
    */
 
   return _filterx_string_hash(self);

--- a/lib/filterx/tests/test_object_cow.c
+++ b/lib/filterx/tests/test_object_cow.c
@@ -24,7 +24,7 @@
 #include "libtest/filterx-lib.h"
 
 #include "filterx/filterx-eval.h"
-#include "filterx/filterx-config.h"
+#include "filterx/object-string.h"
 #include "filterx/object-dict.h"
 #include "filterx/json-repr.h"
 #include "scratch-buffers.h"
@@ -48,13 +48,13 @@ Test(filterx_cow, test_filterx_cow_wrap_adds_an_xref_wrapper)
 static FilterXObject *
 _attr_string(const gchar *attr)
 {
-  return filterx_config_frozen_string(configuration, attr);
+  return filterx_string_new_frozen(attr, configuration);
 }
 
 static FilterXObject *
 _value_string(const gchar *attr)
 {
-  return filterx_config_frozen_string(configuration, attr);
+  return filterx_string_new_frozen(attr, configuration);
 }
 
 Test(filterx_cow, test_filterx_cow_child_objects_are_refs_too)

--- a/lib/filterx/tests/test_object_integer.c
+++ b/lib/filterx/tests/test_object_integer.c
@@ -71,10 +71,10 @@ Test(filterx_integer, test_filterx_primitive_small_negative_int_is_cached)
 
 Test(filterx_integer, test_filterx_primitive_larger_int_is_not_cached)
 {
-  FilterXObject *fobj = filterx_integer_new(128);
-  FilterXObject *fobj2 = filterx_integer_new(128);
-  assert_object_json_equals(fobj, "128");
-  assert_object_json_equals(fobj2, "128");
+  FilterXObject *fobj = filterx_integer_new(1024);
+  FilterXObject *fobj2 = filterx_integer_new(1024);
+  assert_object_json_equals(fobj, "1024");
+  assert_object_json_equals(fobj2, "1024");
   cr_assert(fobj != fobj2);
   filterx_object_unref(fobj);
   filterx_object_unref(fobj2);

--- a/lib/filterx/tests/test_object_string.c
+++ b/lib/filterx/tests/test_object_string.c
@@ -141,14 +141,6 @@ Test(filterx_string, test_filterx_string_typecast_from_protobuf)
   filterx_object_unref(obj);
 }
 
-Test(filterx_string, test_filterx_string_freeze_and_unfreeze)
-{
-  FilterXObject *o = filterx_string_new("foobar", 6);
-
-  filterx_object_freeze(&o);
-  filterx_object_unfreeze_and_free(o);
-}
-
 static void
 setup(void)
 {

--- a/lib/filterx/tests/test_object_string.c
+++ b/lib/filterx/tests/test_object_string.c
@@ -29,6 +29,7 @@
 
 #include "apphook.h"
 #include "scratch-buffers.h"
+#include "cfg.h"
 
 Test(filterx_string, test_filterx_object_string_marshals_to_the_stored_values)
 {
@@ -42,6 +43,16 @@ Test(filterx_string, test_filterx_object_string_maps_to_the_right_json_value)
   FilterXObject *fobj = filterx_string_new("foobarXXXNOTPARTOFTHESTRING", 6);
   assert_object_json_equals(fobj, "\"foobar\"");
   filterx_object_unref(fobj);
+}
+
+Test(filterx_string, test_frozen_string_deduplication)
+{
+  FilterXObject *str = filterx_string_new_frozen("abcd", configuration);
+  FilterXObject *str2 = filterx_string_new_frozen("abcd", configuration);
+  FilterXObject *str3 = filterx_string_new_frozen("abcde", configuration);
+
+  cr_assert_eq(str, str2);
+  cr_assert_neq(str, str3);
 }
 
 static void
@@ -145,11 +156,13 @@ static void
 setup(void)
 {
   app_startup();
+  configuration = cfg_new_snippet();
 }
 
 static void
 teardown(void)
 {
+  cfg_free(configuration);
   scratch_buffers_explicit_gc();
   app_shutdown();
 }


### PR DESCRIPTION
There were multiple problems with the frozen/hibernated object duality:

- hibernate() called the freeze() virtual method, causing confusion and possibly incorrect implementations:
  - FilterXRef implemented freeze() by calling filterx_object_freeze() on the inside value, but
    that call may have been coming from a hibernate() invocation.
  - Dict and list implementations did the same: they froze the key-values even if we were hibernating the dict
  - string implemented the freeze() method in a way that literal strings coming from the configuration were
    cached both in FilterXGlobalCache and FilterXConfig, but after a few reloads, FilterXConfig probably freed
    the objects that remained in FilterXGlobalCache:

```
strcmp (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
g_str_equal (in /usr/lib/libglib-2.0.so.0.8200.5)
g_hash_table_lookup (in /usr/lib/libglib-2.0.so.0.8200.5)
_string_freeze.lto_priv.0 (object-string.c:183)
UnknownInlinedFun (filterx-object.c:136)
UnknownInlinedFun (filterx-object.c:186)
filterx_object_freeze (filterx-object.c:173)
filterx_config_freeze_object (filterx-config.c:66)
construct_template_expr (filterx-grammar.y:74)
```

and

```
ERROR:./lib/filterx/filterx-object.h:308:filterx_object_ref: code should not be reached
Bail out! ERROR:./lib/filterx/filterx-object.h:308:filterx_object_ref: code should not be reached
```

These could have been fixed by introducing the `preserve()` and `thaw()` virtual methods, but there are other problems as well:

- the description in filterx-object says that hibernated objects have a lifetime bound to the config or to the syslog-ng process, and frozen objects can be unfrozen during runtime, but:
  - the configuration still uses freezing (filterx_config_freeze_object), not hibernating
  - _filterx_ref_unfreeze() has assumptions that are no longer true and there is no clean way to fix this
  - json-cache-file() does not use the ref-count behavior of freeze(), and I believe it can never do it safely
- dict() and list() shouldn't even be hibernated or frozen, their recursive nature would cause various complications
  that the current code does not handle correctly (more bugs).

----

So instead of trying to fix the current complex behavior, this PR tries to clarify and simplify reference types by concentrating on the storage during these operations:
- hibernated objects are stored until syslog-ng stops, they are global, the storage is handled by the callers
- frozen objects are stored until the configuration is reloaded, the storage is handled by the freeze() call
- recursive/mutable types can't be frozen or hibernated anymore
- deduplication of immutable values is now done explicitly, without hiding it inside the freeze() implementation
  (this is what actually fixes the crashes I mentioned).


TODO:

- [ ] reimplement `cache_json_file()` value deduplication using `filterx_object_dedup()`.
