### PR TITLE
ci: use mongo-c-driver@1 on macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,7 +44,7 @@ jobs:
 
           HOMEBREW_PREFIX="$(brew --prefix)"
           PYTHONUSERBASE="${HOME}/python_packages"
-          PKG_CONFIG_PATH="${HOMEBREW_PREFIX}/opt/openssl@3/lib/pkgconfig:${HOMEBREW_PREFIX}/opt/net-snmp/lib/pkgconfig:${HOMEBREW_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
+          PKG_CONFIG_PATH="${HOMEBREW_PREFIX}/opt/mongo-c-driver@1/lib/pkgconfig:${HOMEBREW_PREFIX}/opt/openssl@3/lib/pkgconfig:${HOMEBREW_PREFIX}/opt/net-snmp/lib/pkgconfig:${HOMEBREW_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
           CFLAGS="-I${HOMEBREW_PREFIX}/include/"
           CXXFLAGS="-std=c++17"
 

--- a/contrib/Brewfile
+++ b/contrib/Brewfile
@@ -19,7 +19,7 @@ brew "libdbi"
 brew "libmaxminddb"
 brew "libnet"
 brew "librdkafka"
-brew "mongo-c-driver"
+brew "mongo-c-driver@1"
 brew "net-snmp"
 brew "python@3", link: true, force: true
 brew "rabbitmq-c"


### PR DESCRIPTION
Until AxoSyslog is upgraded to the v2 API.