### PR TITLE
http: fix `curl_easy_setopt()` attribute type

### DIFF
--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -170,14 +170,14 @@ _setup_static_options_in_curl(HTTPDestinationWorker *self)
 
   if (owner->accept_redirects)
     {
-      curl_easy_setopt(self->curl, CURLOPT_FOLLOWLOCATION, 1);
-      curl_easy_setopt(self->curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL);
+      curl_easy_setopt(self->curl, CURLOPT_FOLLOWLOCATION, 1L);
+      curl_easy_setopt(self->curl, CURLOPT_POSTREDIR, (long)(CURL_REDIR_POST_ALL));
 #if SYSLOG_NG_HAVE_DECL_CURLOPT_REDIR_PROTOCOLS_STR
       curl_easy_setopt(self->curl, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
 #else
-      curl_easy_setopt(self->curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+      curl_easy_setopt(self->curl, CURLOPT_REDIR_PROTOCOLS, (long)(CURLPROTO_HTTP | CURLPROTO_HTTPS));
 #endif
-      curl_easy_setopt(self->curl, CURLOPT_MAXREDIRS, 3);
+      curl_easy_setopt(self->curl, CURLOPT_MAXREDIRS, 3L);
     }
   curl_easy_setopt(self->curl, CURLOPT_TIMEOUT, owner->timeout);
 

--- a/modules/http/http.h
+++ b/modules/http/http.h
@@ -55,7 +55,7 @@ typedef struct
   GString *body_prefix;
   GString *body_suffix;
   GString *delimiter;
-  int ssl_version;
+  long ssl_version;
   GString *accept_encoding;
   gint8 content_compression;
   gboolean peer_verify;


### PR DESCRIPTION
Fixes the `distcheck` CI job.