### PR TITLE
Light: Improved crash detection

### DIFF
--- a/tests/light/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_missing_trap_obj.py
+++ b/tests/light/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_missing_trap_obj.py
@@ -34,5 +34,6 @@ def test_snmp_dest_missing_trap_obj(config, syslog_ng, snmptrapd, snmp_test_para
     )
     config.create_logpath(statements=[generator_source, snmp_destination])
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exec_info:
         syslog_ng.start(config)
+    assert "syslog-ng config syntax error" in str(exec_info.value)

--- a/tests/light/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_wrong_version.py
+++ b/tests/light/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_wrong_version.py
@@ -36,5 +36,6 @@ def test_snmp_dest_wrong_version(config, syslog_ng, snmptrapd, snmp_test_params)
     )
     config.create_logpath(statements=[generator_source, snmp_destination])
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exec_info:
         syslog_ng.start(config)
+    assert "syslog-ng config syntax error" in str(exec_info.value)

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -1046,8 +1046,9 @@ def test_strptime_error_result(config, syslog_ng):
         $MSG = strptime("2024-04-10T08:09:10Z"); # wrong arg set
 """,
     )
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exec_info:
         syslog_ng.start(config)
+    assert "syslog-ng config syntax error" in str(exec_info.value)
 
 
 def test_strftime_error_result(config, syslog_ng):
@@ -1056,8 +1057,9 @@ def test_strftime_error_result(config, syslog_ng):
         $MSG = strftime("2024-04-10T08:09:10Z"); # wrong arg set
 """,
     )
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exec_info:
         syslog_ng.start(config)
+    assert "syslog-ng config syntax error" in str(exec_info.value)
 
 
 def test_strptime_success_result(config, syslog_ng):
@@ -1122,8 +1124,9 @@ def test_set_timestamp_wrong_param_error_result(config, syslog_ng):
         set_timestamp(datetime, bad_param); # wrong parameter
 """,
     )
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exec_info:
         syslog_ng.start(config)
+    assert "syslog-ng config syntax error" in str(exec_info.value)
 
 
 def test_set_timestamp_invalid_stamp_value_error_result(config, syslog_ng):
@@ -1133,8 +1136,9 @@ def test_set_timestamp_invalid_stamp_value_error_result(config, syslog_ng):
         set_timestamp(datetime, stamp="processed"); # wrong parameter
 """,
     )
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exec_info:
         syslog_ng.start(config)
+    assert "syslog-ng config syntax error" in str(exec_info.value)
 
 
 def test_set_timestamp_set_stamp(config, syslog_ng):
@@ -1188,8 +1192,9 @@ def test_set_pri_no_arg_error_result(config, syslog_ng):
         set_pri(); # wrong arg set
 """,
     )
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exec_info:
         syslog_ng.start(config)
+    assert "syslog-ng config syntax error" in str(exec_info.value)
 
 
 def test_set_pri_wrong_arg_set_error_result(config, syslog_ng):
@@ -1306,8 +1311,9 @@ def test_regexp_match_error_in_pattern(config, syslog_ng):
     "foo" =~ /(/;
 """,
     )
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exec_info:
         syslog_ng.start(config)
+    assert "syslog-ng config syntax error" in str(exec_info.value)
 
 
 def test_regexp_search(config, syslog_ng):
@@ -1390,8 +1396,9 @@ def test_regexp_search_error_in_pattern(config, syslog_ng):
     $MSG = regexp_search("foo", /(/);
 """,
     )
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exec_info:
         syslog_ng.start(config)
+    assert "syslog-ng is not running" in str(exec_info.value)
 
 
 def test_parse_kv_default_option_set_is_skippable(config, syslog_ng):
@@ -1928,8 +1935,9 @@ def test_regexp_subst_all_args_are_mandatory(config, syslog_ng):
         $MSG = regexp_subst("foobarbaz", "(fo|az)");
     """,
     )
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exec_info:
         syslog_ng.start(config)
+    assert "syslog-ng config syntax error" in str(exec_info.value)
 
 
 def test_add_operator_for_base_types(config, syslog_ng):

--- a/tests/light/functional_tests/filterx/test_filterx_control.py
+++ b/tests/light/functional_tests/filterx/test_filterx_control.py
@@ -486,8 +486,9 @@ def test_switch_duplicate_literal_case(config, syslog_ng):
             $MSG=result;
         """,
     )
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exec_info:
         syslog_ng.start(config)
+    assert "syslog-ng is not running" in str(exec_info.value)
 
 
 def test_switch_duplicate_default_case(config, syslog_ng):
@@ -506,8 +507,9 @@ def test_switch_duplicate_default_case(config, syslog_ng):
             $MSG=result;
         """,
     )
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exec_info:
         syslog_ng.start(config)
+    assert "syslog-ng is not running" in str(exec_info.value)
 
 
 def test_switch_invalid_selector(config, syslog_ng):

--- a/tests/light/functional_tests/parsers/regexp-parser/test_regexp_parser.py
+++ b/tests/light/functional_tests/parsers/regexp-parser/test_regexp_parser.py
@@ -63,5 +63,6 @@ def test_regexp_parser(config, syslog_ng, input_message, prefix, patterns, flags
         else:
             assert regexp_parser.get_query().get('discarded', -1) == 1
     else:
-        with pytest.raises(Exception):
+        with pytest.raises(Exception) as exec_info:
             syslog_ng.start(config)
+        assert "syslog-ng config syntax error" in str(exec_info.value)

--- a/tests/light/functional_tests/source_drivers/file_source/test_follow_freq_value.py
+++ b/tests/light/functional_tests/source_drivers/file_source/test_follow_freq_value.py
@@ -42,5 +42,6 @@ def test_follow_freq_value(config, syslog_ng, follow_freq, expected):
     if expected is True:
         syslog_ng.start(config)
     else:
-        with pytest.raises(Exception):
+        with pytest.raises(Exception) as exec_info:
             syslog_ng.start(config)
+        assert "syslog-ng config syntax error" in str(exec_info.value)

--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "axosyslog-light"
-version = "1.3.0"
+version = "1.4.0"
 description = "Lightweight End-to-End Test Framework for AxoSyslog."
 authors = ["Andras Mitzki <andras.mitzki@axoflow.com>", "Attila Szakacs <attila.szakacs@axoflow.com>"]
 readme = "README.md"

--- a/tests/light/src/axosyslog_light/syslog_ng/console_log_reader.py
+++ b/tests/light/src/axosyslog_light/syslog_ng/console_log_reader.py
@@ -67,7 +67,7 @@ class ConsoleLogReader(object):
         return stderr_file.wait_for_lines(expected_messages, timeout=5)
 
     def check_for_unexpected_messages(self, unexpected_messages=None):
-        unexpected_patterns = ["Plugin module not found", "assertion failed", "^Bail out!", "CRITICAL"]
+        unexpected_patterns = ["Plugin module not found", "assertion failed"]
         if unexpected_messages is not None:
             unexpected_patterns.extend(unexpected_messages)
 


### PR DESCRIPTION
After this PR:
- in case of those functional tests where we want to check if syslog-ng could not start we also check the exception error message, which help to validate more precisely why syslog-ng could not start
- Light will check syslog-ng's return code more stricter, instead of checking various patterns in stdout or stderr outputs (which can be different in various platforms).
