### PR TITLE
filterx/dict: fix crash when iterator receive NULL for value parameter

### DIFF
--- a/lib/filterx/expr-regexp-search.c
+++ b/lib/filterx/expr-regexp-search.c
@@ -142,7 +142,7 @@ _store_matches_to_dict(pcre2_code_8 *pattern, const FilterXReMatchState *state)
       PCRE2_SIZE end_index = matches[2 * n + 1];
       const gchar *namedgroup_name = name_table + 2;
 
-      if (begin_index < 0 || end_index < 0)
+      if (begin_index == PCRE2_UNSET || end_index == PCRE2_UNSET)
         continue;
 
       g_snprintf(num_str_buf, sizeof(num_str_buf), "%" G_GUINT32_FORMAT, n);

--- a/lib/filterx/object-dict.c
+++ b/lib/filterx/object-dict.c
@@ -573,6 +573,8 @@ _filterx_dict_set_subscript(FilterXDict *s, FilterXObject *key, FilterXObject **
 {
   FilterXDictObject *self = (FilterXDictObject *) s;
 
+  g_assert(*new_value);
+
   if (!_is_string(key))
     return FALSE;
 


### PR DESCRIPTION
If the value parameter is NULL for `_format_and_append_dict_elem`, then the underlying `format_json` crashed.

Input that caused the crash:
`$MSG = regexp_search("bar", "(?<f>foo)?(?<b>bar)?");`