### PR TITLE
syslogformat: allow whitespaces around SDATA brackets

### DIFF
--- a/lib/tests/test_msgparse.c
+++ b/lib/tests/test_msgparse.c
@@ -696,15 +696,28 @@ Test(msgparse, test_expected_sd_pairs_1)
     {
       "<7>1 2006-10-29T01:59:59.156Z mymachine.example.com evntslog - ID47 [ exampleSDID@0 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@0 class=\"high\"] \xEF\xBB\xBF" "An application event log entry...",
       LP_PIGGYBACK_ERRORS | LP_SYSLOG_PROTOCOL, NULL,
-      43,             // pri
-      0, 0, 0,    // timestamp (sec/usec/zone)
-      NULL,        // host
-      "syslog-ng", //app
-      "Error processing log message: <7>1 2006-10-29T01:59:59.156Z mymachine.example.com evntslog - ID47 >@<[ exampleSDID@0 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@0 class=\"high\"] \xEF\xBB\xBF" "An application event log entry...", // msg
-      "",
-      NULL,//processid
-      NULL,//msgid
-      empty_sdata_pairs
+      7,             // pri
+      1162087199, 156000, 0,    // timestamp (sec/usec/zone)
+      "mymachine.example.com",        // host
+      "evntslog", //app
+      "An application event log entry...", // msg
+      "[exampleSDID@0 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@0 class=\"high\"]", //sd_str
+      "",//processid
+      "ID47",//msgid
+      expected_sd_pairs_test_1
+    },
+    {
+      "<7>1 2006-10-29T01:59:59.156Z mymachine.example.com evntslog - ID47 [exampleSDID@0 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@0 class=\"high\" ] \xEF\xBB\xBF" "An application event log entry...",
+      LP_PIGGYBACK_ERRORS | LP_SYSLOG_PROTOCOL, NULL,
+      7,             // pri
+      1162087199, 156000, 0,    // timestamp (sec/usec/zone)
+      "mymachine.example.com",        // host
+      "evntslog", //app
+      "An application event log entry...", // msg
+      "[exampleSDID@0 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@0 class=\"high\"]", //sd_str
+      "",//processid
+      "ID47",//msgid
+      expected_sd_pairs_test_1
     },
     {
       "<34>1 1987-01-01T12:00:27.000087+00:20 192.0.2.1 myproc 8710 - - %% It's time to make the do-nuts.", LP_SYSLOG_PROTOCOL, NULL,

--- a/modules/syslogformat/tests/test_syslog_format.c
+++ b/modules/syslogformat/tests/test_syslog_format.c
@@ -467,6 +467,19 @@ Test(syslog_format, test_sdata_enterprise_qualified_id_with_and_multiple_params)
   log_msg_unref(msg);
 }
 
+Test(syslog_format, test_sdata_whitespace_around_brackets)
+{
+  LogMessage *msg;
+  cr_assert(_extract_sdata_into_message("[ foo@1.2.3.4 bar=\"baz\" chew=\"chow\" peek=\"poke\" ][bar another=1 ]", &msg));
+  assert_log_message_value_by_name(msg, "SDATA",
+                                   "[bar another=\"1\"][foo@1.2.3.4 bar=\"baz\" chew=\"chow\" peek=\"poke\"]");
+  assert_log_message_value_by_name(msg, ".SDATA.foo@1.2.3.4.bar", "baz");
+  assert_log_message_value_by_name(msg, ".SDATA.foo@1.2.3.4.chew", "chow");
+  assert_log_message_value_by_name(msg, ".SDATA.foo@1.2.3.4.peek", "poke");
+  assert_log_message_value_by_name(msg, ".SDATA.bar.another", "1");
+  log_msg_unref(msg);
+}
+
 Test(syslog_format, test_sdata_missing_closing_bracket)
 {
   cr_assert_not(_extract_sdata_into_message("[foo bar=\"baz\"", NULL));


### PR DESCRIPTION
For example, Check Point Software's firewall produces such logs.