### PR TITLE
ci: keep 60 days of nightly images

### DIFF
--- a/.github/workflows/axosyslog-nightly.yml
+++ b/.github/workflows/axosyslog-nightly.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const nightliesToKeep = 60 * 2
+            const nightliesToKeep = 60
             const nightlyTagPattern = /^[0-9.]+_git[0-9]+/
 
             const package_name = "axosyslog"


### PR DESCRIPTION
We no longer have -dbg variants.
