### PR TITLE
grpc/filterx: add missing DEPENDENCIES to Makefile

### DIFF
--- a/modules/grpc/filterx/Makefile.am
+++ b/modules/grpc/filterx/Makefile.am
@@ -42,6 +42,7 @@ modules_grpc_filterx_libgrpc_filterx_la_LDFLAGS = $(MODULE_LDFLAGS)
 
 modules_grpc_filterx_libgrpc_filterx_la_DEPENDENCIES = \
   $(MODULE_DEPS_LIBS) \
+  $(GRPC_COMMON_LIBS) \
   $(top_builddir)/modules/grpc/protos/libgrpc-protos.la \
   $(top_builddir)/modules/grpc/filterx/libgrpc-filterx-cpp.la
 


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
