### PR TITLE
`loggen`: add `--client-port`

### DIFF
--- a/news/feature-709.md
+++ b/news/feature-709.md
@@ -1,0 +1,1 @@
+`loggen`: Added `--client-port` option to set the outbound (client) port

--- a/tests/light/functional_tests/source_drivers/network_source/test_client_port.py
+++ b/tests/light/functional_tests/source_drivers/network_source/test_client_port.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2025 Axoflow
+# Copyright (c) 2025 Attila Szakacs <attila.szakacs@axoflow.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import re
+
+
+def test_client_port(config, syslog_ng, port_allocator):
+    server_port = port_allocator()
+    client_port = port_allocator()
+
+    source = config.create_network_source(port=server_port)
+
+    file_destination = config.create_file_destination(file_name="output.txt")
+    config.create_logpath(statements=[source, file_destination])
+
+    syslog_ng.start(config)
+
+    source.write_log("almafa", client_port=client_port)
+
+    possible_client_connection_logs = syslog_ng.wait_for_message_in_console_log(":" + str(client_port))
+    pattern = r"Syslog connection accepted; fd='\d+', client='AF_INET\(127\.0\.0\.1:" + str(client_port) + r"\)', local='AF_INET\(0\.0\.0\.0:" + str(server_port) + r"\)'"
+    assert any(re.search(pattern, log) for log in possible_client_connection_logs)
+
+    syslog_ng.stop()

--- a/tests/light/src/axosyslog_light/driver_io/network/network_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/network/network_io.py
@@ -80,13 +80,13 @@ class NetworkIO():
             return "".join([str(len(message)) + " " + message for message in messages])
         return "".join([message + "\n" for message in messages])
 
-    def write_messages(self, messages, rate=None, transport=None, framed=None, rate_burst_start=False):
+    def write_messages(self, messages, rate=None, transport=None, framed=None, rate_burst_start=False, client_port=0):
         self.write_raw(
             self.__format_messages(messages, framed=framed), rate=rate, transport=transport,
-            extra_loggen_args={"rate_burst_start": rate_burst_start},
+            extra_loggen_args={"rate_burst_start": rate_burst_start, "client_port": client_port},
         )
 
-    def write_messages_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None, framed=None):
+    def write_messages_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None, framed=None, client_port=0):
         self.write_raw(
             self.__format_messages(messages, framed=framed),
             rate=rate,
@@ -97,6 +97,7 @@ class NetworkIO():
                 "proxy_dst_ip": dst_ip,
                 "proxy_src_port": str(src_port),
                 "proxy_dst_port": str(dst_port),
+                "client_port": client_port,
             },
         )
 

--- a/tests/light/src/axosyslog_light/helpers/loggen/loggen_executor.py
+++ b/tests/light/src/axosyslog_light/helpers/loggen/loggen_executor.py
@@ -38,6 +38,7 @@ from psutil import TimeoutExpired
 class LoggenStartParams:
     target: str
     port: int
+    client_port: int = 0
     inet: bool = False
     unix: bool = False
     stream: bool = False
@@ -123,6 +124,8 @@ class LoggenStartParams:
             params.append("--sdata")
         if self.no_framing is True:
             params.append("--no-framing")
+        if self.client_port:
+            params.append(f"--client-port={self.client_port}")
         if self.active_connections is not None:
             params.append(f"--active-connections={self.active_connections}")
         if self.idle_connections is not None:

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/network_source.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/network_source.py
@@ -61,11 +61,11 @@ class NetworkSource(SourceDriver):
         self.driver_name = "network"
         super(NetworkSource, self).__init__(stats_handler, prometheus_stats_handler, options=options)
 
-    def write_log(self, message, transport=None, framed=None):
-        self.io.write_messages([message], transport=transport, framed=framed)
+    def write_log(self, message, transport=None, framed=None, client_port=0):
+        self.io.write_messages([message], transport=transport, framed=framed, client_port=client_port)
 
-    def write_logs(self, messages, rate=None, transport=None, framed=None, rate_burst_start=False):
-        self.io.write_messages(messages, rate=rate, transport=transport, framed=framed, rate_burst_start=rate_burst_start)
+    def write_logs(self, messages, rate=None, transport=None, framed=None, rate_burst_start=False, client_port=0):
+        self.io.write_messages(messages, rate=rate, transport=transport, framed=framed, rate_burst_start=rate_burst_start, client_port=client_port)
 
-    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None, framed=None):
-        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate, transport=transport, framed=framed)
+    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None, framed=None, client_port=0):
+        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate, transport=transport, framed=framed, client_port=client_port)

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/syslog_source.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/sources/syslog_source.py
@@ -60,11 +60,11 @@ class SyslogSource(SourceDriver):
         self.driver_name = "syslog"
         super(SyslogSource, self).__init__(stats_handler, prometheus_stats_handler, options=options)
 
-    def write_log(self, message, rate=None, transport=None, framed=None):
-        self.io.write_messages([message], rate=rate, transport=transport, framed=framed)
+    def write_log(self, message, rate=None, transport=None, framed=None, client_port=0):
+        self.io.write_messages([message], rate=rate, transport=transport, framed=framed, client_port=client_port)
 
-    def write_logs(self, messages, rate=None, transport=None, framed=None):
-        self.io.write_messages(messages, rate=rate, transport=transport, framed=framed)
+    def write_logs(self, messages, rate=None, transport=None, framed=None, client_port=0):
+        self.io.write_messages(messages, rate=rate, transport=transport, framed=framed, client_port=client_port)
 
-    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None, framed=None):
-        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate, transport=transport, framed=framed)
+    def write_logs_with_proxy_header(self, proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=None, transport=None, framed=None, client_port=0):
+        self.io.write_messages_with_proxy_header(proxy_version, src_ip, dst_ip, src_port, dst_port, messages, rate=rate, transport=transport, framed=framed, client_port=client_port)

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -57,6 +57,7 @@ static PluginOption global_plugin_option =
   .use_ipv6 = 0,
   .target = NULL,
   .port = NULL,
+  .client_port = 0,
   .rate = 1000,
   .rate_burst_start = 0,
   .reconnect = 0,
@@ -107,6 +108,7 @@ static GOptionEntry loggen_options[] =
   { "proxy-dst-port", 0, 0, G_OPTION_ARG_STRING, &global_plugin_option.proxy_dst_port, "Destination port for the PROXY protocol header", "<port>" },
   { "sdata", 'p', 0, G_OPTION_ARG_STRING, &sdata_value, "Send the given sdata (e.g. \"[test name=\\\"value\\\"]\") in case of syslog-proto", NULL },
   { "rate-burst-start", 0, 0, G_OPTION_ARG_NONE, &global_plugin_option.rate_burst_start, "Do not start slow (for rate limit testing)", NULL },
+  { "client-port", 0, 0, G_OPTION_ARG_INT, &global_plugin_option.client_port, "Use this outbounds port to connect to the server", NULL },
   { "quiet", 'Q', 0, G_OPTION_ARG_NONE, &quiet, "Don't print periodic statistics", NULL },
   { "debug", 0, 0, G_OPTION_ARG_NONE, &debug, "Enable loggen debug messages", NULL },
   { NULL }

--- a/tests/loggen/loggen_helper.h
+++ b/tests/loggen/loggen_helper.h
@@ -51,7 +51,7 @@ void time_val_diff_in_timeval(struct timeval *res, const struct timeval *t1, con
 size_t get_now_timestamp(char *stamp, gsize stamp_size);
 size_t get_now_timestamp_bsd(char *stamp, gsize stamp_size);
 void format_timezone_offset_with_colon(char *timestamp, int timestamp_size, struct tm *tm);
-int connect_ip_socket(int sock_type, const char *target, const char *port, int use_ipv6);
+int connect_ip_socket(int sock_type, const char *target, const char *port, int use_ipv6, int client_port);
 int connect_unix_domain_socket(int sock_type, const char *path);
 SSL *open_ssl_connection(int sock_fd);
 void close_ssl_connection(SSL *ssl);

--- a/tests/loggen/loggen_plugin.h
+++ b/tests/loggen/loggen_plugin.h
@@ -44,6 +44,7 @@ typedef struct _plugin_option
   int use_ipv6;
   char *target; /* command line argument */
   char *port;
+  gint client_port;
   gint64 rate;
   int rate_burst_start;
   int reconnect;

--- a/tests/loggen/socket_plugin/socket_plugin.c
+++ b/tests/loggen/socket_plugin/socket_plugin.c
@@ -152,6 +152,12 @@ start(PluginOption *option)
       return FALSE;
     }
 
+  if (option->client_port > 0 && option->active_connections + option->idle_connections > 1)
+    {
+      ERROR("client port can only be specified for a single connection\n");
+      return FALSE;
+    }
+
   DEBUG("plugin (%d,%d,%d,%d)start\n",
         option->message_length,
         option->interval,
@@ -289,7 +295,7 @@ idle_thread_func(gpointer user_data)
   if (unix_socket_x)
     fd = connect_unix_domain_socket(sock_type, option->target);
   else
-    fd = connect_ip_socket(sock_type, option->target, option->port, option->use_ipv6);
+    fd = connect_ip_socket(sock_type, option->target, option->port, option->use_ipv6, option->client_port);
 
   if (fd<0)
     {
@@ -362,7 +368,7 @@ active_thread_func(gpointer user_data)
   if (unix_socket_x)
     fd = connect_unix_domain_socket(sock_type, option->target);
   else
-    fd = connect_ip_socket(sock_type, option->target, option->port, option->use_ipv6);
+    fd = connect_ip_socket(sock_type, option->target, option->port, option->use_ipv6, option->client_port);
 
   if (fd<0)
     {
@@ -443,7 +449,7 @@ active_thread_func(gpointer user_data)
           if (unix_socket_x)
             fd = connect_unix_domain_socket(sock_type, option->target);
           else
-            fd = connect_ip_socket(sock_type, option->target, option->port, option->use_ipv6);
+            fd = connect_ip_socket(sock_type, option->target, option->port, option->use_ipv6, option->client_port);
 
           while(fd < 0 && !thread_check_exit_criteria(thread_context))
             {
@@ -453,7 +459,7 @@ active_thread_func(gpointer user_data)
               if (unix_socket_x)
                 fd = connect_unix_domain_socket(sock_type, option->target);
               else
-                fd = connect_ip_socket(sock_type, option->target, option->port, option->use_ipv6);
+                fd = connect_ip_socket(sock_type, option->target, option->port, option->use_ipv6, option->client_port);
             }
 
           if(fd > 0)

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -269,7 +269,7 @@ idle_thread_func(gpointer user_data)
   PluginOption *option = thread_context->option;
   int thread_index = thread_context->index;
 
-  int sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);
+  int sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6, option->client_port);
 
   SSL *ssl = open_ssl_connection(sock_fd);
   if (ssl == NULL)
@@ -362,7 +362,7 @@ active_thread_func(gpointer user_data)
 
   char *message = g_malloc0(MAX_MESSAGE_LENGTH+1);
 
-  int sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);
+  int sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6, option->client_port);
 
   if(proxied_tls_passthrough)
     send_plaintext_proxy_header(thread_context, sock_fd, message, MAX_MESSAGE_LENGTH);
@@ -457,7 +457,7 @@ active_thread_func(gpointer user_data)
           close(sock_fd);
 
           ERROR("destination connection %s:%s (%p) is lost, try to reconnect\n", option->target, option->port, g_thread_self());
-          sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);
+          sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6, option->client_port);
           if(proxied_tls_passthrough)
             send_plaintext_proxy_header(thread_context, sock_fd, message, MAX_MESSAGE_LENGTH);
           ssl = open_ssl_connection(sock_fd);
@@ -467,7 +467,7 @@ active_thread_func(gpointer user_data)
               ERROR("can not reconnect to %s:%s (%p), try again after %d sec\n", option->target, option->port, g_thread_self(), 1);
               g_usleep(1e6);
 
-              sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);
+              sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6, option->client_port);
               if(proxied_tls_passthrough)
                 send_plaintext_proxy_header(thread_context, sock_fd, message, MAX_MESSAGE_LENGTH);
               ssl = open_ssl_connection(sock_fd);


### PR DESCRIPTION
It is useful if we want to control which outbounds
port is used to avoid possible collisions with
server ports.