### PR TITLE
light: use lower initial value for port allocator

### DIFF
--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "axosyslog-light"
-version = "1.6.0"
+version = "1.7.0"
 description = "Lightweight End-to-End Test Framework for AxoSyslog."
 authors = ["Andras Mitzki <andras.mitzki@axoflow.com>", "Attila Szakacs <attila.szakacs@axoflow.com>"]
 readme = "README.md"

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -316,7 +316,7 @@ def setup(request):
 def port_allocator():
     def get_next_port() -> int:
         with get_session_data() as session_data:
-            last_port = session_data.get("port_allocator_last_port", 30000)
+            last_port = session_data.get("port_allocator_last_port", 20000)
             port = last_port + 1
             session_data["port_allocator_last_port"] = port
         return port


### PR DESCRIPTION
Increases the number of available non-ephemeral
ports.

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
