### PR TITLE
haproxy: fix IPv6 optionality 

### DIFF
--- a/lib/transport/transport-haproxy.c
+++ b/lib/transport/transport-haproxy.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "syslog-ng.h"
 #include "messages.h"
 #include "str-utils.h"
 
@@ -521,6 +522,7 @@ _save_addresses(LogTransportHAProxy *self)
       log_transport_aux_data_set_local_addr_ref(&stack->aux_data,
                                                 g_sockaddr_inet_new(self->info.dst_ip, self->info.dst_port));
     }
+#if SYSLOG_NG_ENABLE_IPV6
   else if (self->info.ip_version == 6)
     {
       log_transport_aux_data_set_peer_addr_ref(&stack->aux_data,
@@ -528,6 +530,7 @@ _save_addresses(LogTransportHAProxy *self)
       log_transport_aux_data_set_local_addr_ref(&stack->aux_data,
                                                 g_sockaddr_inet6_new(self->info.dst_ip, self->info.dst_port));
     }
+#endif
   else
     g_assert_not_reached();
 }


### PR DESCRIPTION
Cherry-picked from syslog-ng/syslog-ng#5404