### PR TITLE
`syslog-ng-ctl stats prometheus`: show orphan metrics

### DIFF
--- a/lib/stats/stats-prometheus.c
+++ b/lib/stats/stats-prometheus.c
@@ -286,9 +286,6 @@ stats_format_prometheus(StatsCluster *sc, gint type, StatsCounterItem *counter, 
   if (!sc->key.name && !with_legacy)
     return;
 
-  if (stats_cluster_is_orphaned(sc))
-    return;
-
   ScratchBuffersMarker marker;
   scratch_buffers_mark(&marker);
 

--- a/news/other-715.md
+++ b/news/other-715.md
@@ -1,0 +1,8 @@
+`syslog-ng-ctl stats prometheus`: show orphan metrics
+
+Stale counters will be shown in order not to lose information, for example,
+when messages are sent using short-lived connections and metrics are scraped in
+minute intervals.
+
+We recommend using `syslog-ng-ctl stats --remove-orphans` during each configuration reload,
+but only after the values of those metrics have been scraped by all scrapers.


### PR DESCRIPTION
Stale counters will be shown in order not to lose information, for example,
when messages are sent using short-lived connections and metrics are scraped in
minute intervals.

We recommend using `syslog-ng-ctl stats --remove-orphans` during each configuration reload,
but only after the values of those metrics have been scraped by all scrapers.