### PR TITLE
affile: add exclude-pattern() option to wildcard-file()

### DIFF
--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -97,6 +97,7 @@ affile_grammar_set_wildcard_file_source_driver(WildcardSourceDriver *sd)
 %token KW_WILDCARD_FILE
 %token KW_BASE_DIR
 %token KW_FILENAME_PATTERN
+%token KW_EXCLUDE_PATTERN
 %token KW_RECURSIVE
 %token KW_MAX_FILES
 %token KW_MONITOR_METHOD
@@ -195,6 +196,11 @@ source_wildcard_option
 	    wildcard_sd_set_filename_pattern(last_driver, $3);
 	    free($3);
           }
+	| KW_EXCLUDE_PATTERN '(' string ')'
+	  {
+	    wildcard_sd_set_exclude_pattern(last_driver, $3);
+	    free($3);
+	  }
 	| KW_RECURSIVE '(' yesno ')' { wildcard_sd_set_recursive(last_driver, $3); }
 	| KW_MAX_FILES '(' positive_integer ')' { wildcard_sd_set_max_files(last_driver, $3); }
 	| KW_MONITOR_METHOD '(' string ')' { CHECK_ERROR(wildcard_sd_set_monitor_method(last_driver, $3), @3, "Invalid monitor-method"); free($3); }

--- a/modules/affile/affile-parser.c
+++ b/modules/affile/affile-parser.c
@@ -40,6 +40,7 @@ static CfgLexerKeyword affile_keywords[] =
   { "wildcard_file",      KW_WILDCARD_FILE },
   { "base_dir",           KW_BASE_DIR },
   { "filename_pattern",   KW_FILENAME_PATTERN },
+  { "exclude_pattern",    KW_EXCLUDE_PATTERN },
   { "recursive",          KW_RECURSIVE },
   { "max_files",          KW_MAX_FILES },
   { "monitor_method",     KW_MONITOR_METHOD },

--- a/modules/affile/wildcard-source.c
+++ b/modules/affile/wildcard-source.c
@@ -138,7 +138,9 @@ _create_file_reader(WildcardSourceDriver *self, const gchar *full_path)
 static void
 _handle_file_created(WildcardSourceDriver *self, const DirectoryMonitorEvent *event)
 {
-  if (g_pattern_spec_match_string(self->compiled_pattern, event->name))
+  if (g_pattern_spec_match_string(self->compiled_pattern, event->name)
+      && !(self->compiled_exclude && g_pattern_spec_match_string(self->compiled_exclude, event->name))
+     )
     {
       WildcardFileReader *reader = g_hash_table_lookup(self->file_readers, event->full_path);
 
@@ -296,6 +298,22 @@ _init_filename_pattern(WildcardSourceDriver *self)
   return TRUE;
 }
 
+static gboolean
+_init_exclude_pattern(WildcardSourceDriver *self)
+{
+  if (self->exclude_pattern)
+    {
+      self->compiled_exclude = g_pattern_spec_new(self->exclude_pattern);
+      if (!self->compiled_exclude)
+        {
+          msg_error("wildcard-file(): Invalid value for exclude-pattern()",
+                    evt_tag_str("exclude-pattern", self->exclude_pattern));
+          return FALSE;
+        }
+    }
+  return TRUE;
+}
+
 static DirectoryMonitor *
 _add_directory_monitor(WildcardSourceDriver *self, const gchar *directory)
 {
@@ -340,6 +358,11 @@ _init(LogPipe *s)
       return FALSE;
     }
 
+  if (!_init_exclude_pattern(self))
+    {
+      return FALSE;
+    }
+
   if (!_init_reader_options(self, cfg))
     return FALSE;
 
@@ -365,6 +388,7 @@ _deinit(LogPipe *s)
   WildcardSourceDriver *self = (WildcardSourceDriver *)s;
 
   g_pattern_spec_free(self->compiled_pattern);
+  g_pattern_spec_free(self->compiled_exclude);
   g_hash_table_foreach(self->file_readers, _deinit_reader, NULL);
   g_hash_table_remove_all(self->directory_monitors);
   return TRUE;
@@ -386,6 +410,15 @@ wildcard_sd_set_filename_pattern(LogDriver *s, const gchar *filename_pattern)
 
   g_free(self->filename_pattern);
   self->filename_pattern = g_strdup(filename_pattern);
+}
+
+void
+wildcard_sd_set_exclude_pattern(LogDriver *s, const gchar *exclude_pattern)
+{
+  WildcardSourceDriver *self = (WildcardSourceDriver *)s;
+
+  g_free(self->exclude_pattern);
+  self->exclude_pattern = g_strdup(exclude_pattern);
 }
 
 void
@@ -443,6 +476,7 @@ _free(LogPipe *s)
   file_opener_free(self->file_opener);
   g_free(self->base_dir);
   g_free(self->filename_pattern);
+  g_free(self->exclude_pattern);
   g_hash_table_unref(self->file_readers);
   g_hash_table_unref(self->directory_monitors);
   file_reader_options_deinit(&self->file_reader_options);

--- a/modules/affile/wildcard-source.h
+++ b/modules/affile/wildcard-source.h
@@ -36,6 +36,7 @@ typedef struct _WildcardSourceDriver
   LogSrcDriver super;
   gchar *base_dir;
   gchar *filename_pattern;
+  gchar *exclude_pattern;
   MonitorMethod monitor_method;
   guint32 max_files;
 
@@ -46,6 +47,7 @@ typedef struct _WildcardSourceDriver
   FileOpenerOptions file_opener_options;
 
   GPatternSpec *compiled_pattern;
+  GPatternSpec *compiled_exclude;
   GHashTable *file_readers;
   GHashTable *directory_monitors;
   FileOpener *file_opener;
@@ -57,6 +59,7 @@ LogDriver *wildcard_sd_new(GlobalConfig *cfg);
 
 void wildcard_sd_set_base_dir(LogDriver *s, const gchar *base_dir);
 void wildcard_sd_set_filename_pattern(LogDriver *s, const gchar *filename_pattern);
+void wildcard_sd_set_exclude_pattern(LogDriver *s, const gchar *exclude_pattern);
 void wildcard_sd_set_recursive(LogDriver *s, gboolean recursive);
 gboolean wildcard_sd_set_monitor_method(LogDriver *s, const gchar *method);
 void wildcard_sd_set_max_files(LogDriver *s, guint32 max_files);

--- a/news/feature-719.md
+++ b/news/feature-719.md
@@ -1,0 +1,1 @@
+affile: Add ability to refine the `wildcard-file()` `filename-pattern()` option with `exclude-pattern()`, to exclude some matching files. For example, match all `*.log` but exclude `*.?.log`.

--- a/tests/functional/func_test.py
+++ b/tests/functional/func_test.py
@@ -102,6 +102,7 @@ def run_testcase(test_name, config, verbose, test_case):
 
 # import test modules
 import test_file_source
+import test_file_source_exclude
 import test_filters
 import test_input_drivers
 import test_performance
@@ -109,7 +110,7 @@ import test_sql
 import test_python
 import test_map_value_pairs
 
-tests = (test_input_drivers, test_sql, test_file_source, test_filters, test_performance, test_python, test_map_value_pairs)
+tests = (test_input_drivers, test_sql, test_file_source, test_file_source_exclude, test_filters, test_performance, test_python, test_map_value_pairs)
 failed_tests = []
 
 init_env()

--- a/tests/functional/test_file_source_exclude.py
+++ b/tests/functional/test_file_source_exclude.py
@@ -1,0 +1,97 @@
+#############################################################################
+# Copyright (c) 2007-2015 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+from globals import *
+from log import *
+from messagegen import *
+from messagecheck import *
+from control import *
+
+config = """@version: %(syslog_ng_version)s
+
+options { ts_format(iso); chain_hostnames(no); keep_hostname(yes); threaded(yes); };
+
+source s_wildcard { wildcard_file(
+                    base_dir("wildcard")
+                    filename_pattern("*.log")
+                    exclude_pattern("*.?.log")
+                    monitor-method("auto")
+                    recursive(yes));
+                  };
+
+destination d_wildcard { file("test-wildcard.log"); };
+
+log { source(s_wildcard); destination(d_wildcard); };
+
+""" % locals()
+
+settle_time=4
+
+def create_source_files(recursive=False):
+    messages = (
+      'wildcard0',
+      'wildcard1',
+      'wildcard2',
+      'wildcard3',
+      'wildcard4',
+      'wildcard5',
+      'wildcard6',
+      'wildcard7',
+    )
+    expected = []
+
+    for ndx in range(0, len(messages)):
+        if not recursive:
+            s = FileSender('wildcard/%d.log' % (ndx % 4), repeat=100)
+        else:
+            s = FileSender('wildcard/wildcard%d/%d.log' % ((ndx % 2),(ndx % 4)), repeat=100)
+        expected.extend(s.sendMessages(messages[ndx]))
+    return expected
+
+def create_excluded_files(recursive=False):
+    messages = (
+      'excluded0',
+      'excluded1',
+      'excluded2',
+      'excluded3',
+      'excluded4',
+      'excluded5',
+      'excluded6',
+      'excluded7',
+    )
+    expected = []
+
+    for ndx in range(0, len(messages)):
+        if not recursive:
+            s = FileSender('wildcard/excluded.%d.log' % (ndx % 4), repeat=100)
+        else:
+            s = FileSender('wildcard/wildcard%d/excluded.%d.log' % ((ndx % 2),(ndx % 4)), repeat=100)
+        expected.extend(s.sendMessages(messages[ndx]))
+    return expected
+
+def test_excluded_files():
+    expected = create_source_files()
+    create_excluded_files()  # not expected
+
+    if not check_file_expected('test-wildcard', expected, settle_time=settle_time):
+        return False
+    return True


### PR DESCRIPTION
Add ability to refine wildcard-file( filename-pattern() ) option with
exclude-pattern() to exclude some matching files. Example:
match all *.log but exclude *.?.log.

Cherry-picked from syslog-ng/syslog-ng#5416