### PR TITLE
filterx: add string slicing operator 

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -29,6 +29,7 @@ set(FILTERX_HEADERS
     filterx/expr-template.h
     filterx/expr-unset.h
     filterx/expr-variable.h
+    filterx/expr-string-operators.h
     filterx/filterx-config.h
     filterx/filterx-error.h
     filterx/filterx-eval.h
@@ -106,6 +107,7 @@ set(FILTERX_SOURCES
     filterx/expr-template.c
     filterx/expr-unset.c
     filterx/expr-variable.c
+    filterx/expr-string-operators.c
     filterx/filterx-config.c
     filterx/filterx-error.c
     filterx/filterx-eval.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -31,6 +31,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/expr-template.h \
 	lib/filterx/expr-unset.h \
 	lib/filterx/expr-variable.h \
+	lib/filterx/expr-string-operators.h \
 	lib/filterx/filterx-config.h \
 	lib/filterx/filterx-error.h \
 	lib/filterx/filterx-eval.h \
@@ -107,6 +108,7 @@ filterx_sources = 				\
 	lib/filterx/expr-template.c \
 	lib/filterx/expr-unset.c \
 	lib/filterx/expr-variable.c \
+	lib/filterx/expr-string-operators.c \
 	lib/filterx/filterx-config.c \
 	lib/filterx/filterx-error.c \
 	lib/filterx/filterx-eval.c \

--- a/lib/filterx/expr-string-operators.c
+++ b/lib/filterx/expr-string-operators.c
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2025 László Várady
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "expr-string-operators.h"
+#include "filterx/expr-literal.h"
+#include "filterx/filterx-eval.h"
+#include "filterx/object-string.h"
+#include "filterx/object-extractor.h"
+
+
+typedef struct FilterXSlicingOperator_
+{
+  FilterXExpr super;
+  FilterXExpr *lhs;
+
+  FilterXExpr *start;
+  FilterXObject *start_literal;
+
+  FilterXExpr *end;
+  FilterXObject *end_literal;
+} FilterXSlicingOperator;
+
+static FilterXObject *
+_str_slice(FilterXSlicingOperator *self, const gchar *str, gsize str_len, gint64 start, gint64 end)
+{
+  start = MIN(start, str_len);
+  end = MIN(end, str_len);
+
+  if (start > end)
+    {
+      filterx_eval_push_error_info_printf("Failed to evaluate string slicing operator", &self->super,
+                                          "Start index must not be greater than end index");
+      return NULL;
+    }
+
+  return filterx_string_new(str + start, end - start);
+}
+
+static gboolean
+_extract_start(FilterXSlicingOperator *self, gint64 *start_idx)
+{
+  if (!self->start)
+    {
+      *start_idx = 0;
+      return TRUE;
+    }
+
+  FilterXObject *start = self->start_literal ? filterx_object_ref(self->start_literal) : filterx_expr_eval(self->start);
+  if (!start)
+    {
+      filterx_eval_push_error_static_info("Failed to evaluate string slicing operator", &self->super,
+                                          "Failed to evaluate start index");
+      return FALSE;
+    }
+
+  if (!filterx_object_extract_integer(start, start_idx))
+    {
+      filterx_eval_push_error_info_printf("Failed to evaluate string slicing operator", &self->super,
+                                          "Start index must be an integer, got: %s",
+                                          filterx_object_get_type_name(start));
+
+      filterx_object_unref(start);
+      return FALSE;
+    }
+
+  filterx_object_unref(start);
+  return TRUE;
+}
+
+static gboolean
+_extract_end(FilterXSlicingOperator *self, gsize str_len, gint64 *end_idx)
+{
+  if (!self->end)
+    {
+      *end_idx = str_len;
+      return TRUE;
+    }
+
+  FilterXObject *end = self->end_literal ? filterx_object_ref(self->end_literal) : filterx_expr_eval(self->end);
+  if (!end)
+    {
+      filterx_eval_push_error_static_info("Failed to evaluate string slicing operator", &self->super,
+                                          "Failed to evaluate end index");
+      return FALSE;
+    }
+
+  if (!filterx_object_extract_integer(end, end_idx))
+    {
+      filterx_eval_push_error_info_printf("Failed to evaluate string slicing operator", &self->super,
+                                          "End index must be an integer, got: %s",
+                                          filterx_object_get_type_name(end));
+      filterx_object_unref(end);
+      return FALSE;
+    }
+
+  filterx_object_unref(end);
+  return TRUE;
+}
+
+static FilterXObject *
+filterx_string_slicing_eval(FilterXExpr *s)
+{
+  FilterXSlicingOperator *self = (FilterXSlicingOperator *) s;
+
+  FilterXObject *lhs_object = filterx_expr_eval_typed(self->lhs);
+  if (!lhs_object)
+    {
+      filterx_eval_push_error_static_info("Failed to evaluate string slicing operator", &self->super,
+                                          "Failed to evaluate left hand side");
+      return NULL;
+    }
+
+  gsize str_len = 0;
+  const gchar *str = filterx_string_get_value_ref(lhs_object, &str_len);
+  if (!str)
+    {
+      filterx_eval_push_error_info_printf("Failed to evaluate string slicing operator", &self->super,
+                                          "Left hand side must be a string, got: %s",
+                                          filterx_object_get_type_name(lhs_object));
+      filterx_object_unref(lhs_object);
+      return NULL;
+    }
+
+
+  gint64 start_idx = 0, end_idx = 0;
+
+  if (!_extract_start(self, &start_idx))
+    {
+      filterx_object_unref(lhs_object);
+      return NULL;
+    }
+
+  if (!_extract_end(self, str_len, &end_idx))
+    {
+      filterx_object_unref(lhs_object);
+      return NULL;
+    }
+
+  FilterXObject *result = _str_slice(self, str, str_len, start_idx, end_idx);
+  filterx_object_unref(lhs_object);
+  return result;
+}
+
+void
+filterx_string_slicing_free(FilterXExpr *s)
+{
+  FilterXSlicingOperator *self = (FilterXSlicingOperator *) s;
+
+  filterx_expr_unref(self->lhs);
+  filterx_expr_unref(self->start);
+  filterx_expr_unref(self->end);
+  filterx_object_unref(self->start_literal);
+  filterx_object_unref(self->end_literal);
+  filterx_expr_free_method(s);
+}
+
+FilterXExpr *
+filterx_string_slicing_optimize(FilterXExpr *s)
+{
+  FilterXSlicingOperator *self = (FilterXSlicingOperator *) s;
+
+  self->lhs = filterx_expr_optimize(self->lhs);
+  self->start = filterx_expr_optimize(self->start);
+  self->end = filterx_expr_optimize(self->end);
+
+  if (filterx_expr_is_literal(self->start))
+    self->start_literal = filterx_expr_eval(self->start);
+
+  if (filterx_expr_is_literal(self->end))
+    self->end_literal = filterx_expr_eval(self->end);
+
+  return NULL;
+}
+
+gboolean
+filterx_string_slicing_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXSlicingOperator *self = (FilterXSlicingOperator *) s;
+
+  if (!filterx_expr_init(self->lhs, cfg))
+    return FALSE;
+
+  if (!filterx_expr_init(self->start, cfg))
+    {
+      filterx_expr_deinit(self->lhs, cfg);
+      return FALSE;
+    }
+
+  if (!filterx_expr_init(self->end, cfg))
+    {
+      filterx_expr_deinit(self->start, cfg);
+      filterx_expr_deinit(self->lhs, cfg);
+      return FALSE;
+    }
+
+  return filterx_expr_init_method(s, cfg);
+}
+
+void
+filterx_string_slicing_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXSlicingOperator *self = (FilterXSlicingOperator *) s;
+
+  filterx_expr_deinit(self->lhs, cfg);
+  filterx_expr_deinit(self->start, cfg);
+  filterx_expr_deinit(self->end, cfg);
+  filterx_expr_deinit_method(s, cfg);
+}
+
+FilterXExpr *
+filterx_string_slicing_new(FilterXExpr *lhs, FilterXExpr *start, FilterXExpr *end)
+{
+  FilterXSlicingOperator *self = g_new0(FilterXSlicingOperator, 1);
+
+  filterx_expr_init_instance(&self->super, "string_slicing");
+  self->super.optimize = filterx_string_slicing_optimize;
+  self->super.init = filterx_string_slicing_init;
+  self->super.deinit = filterx_string_slicing_deinit;
+  self->super.free_fn = filterx_string_slicing_free;
+
+  self->super.eval = filterx_string_slicing_eval;
+
+  g_assert(lhs);
+  g_assert(start || end);
+
+  self->lhs = lhs;
+  self->start = start;
+  self->end = end;
+
+  return &self->super;
+}

--- a/lib/filterx/expr-string-operators.h
+++ b/lib/filterx/expr-string-operators.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 László Várady
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_EXPR_STRING_OPERATORS_H
+#define FILTERX_EXPR_STRING_OPERATORS_H
+
+#include "filterx-expr.h"
+
+FilterXExpr *filterx_string_slicing_new(FilterXExpr *lhs, FilterXExpr *start, FilterXExpr *end);
+
+#endif

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -61,6 +61,7 @@
 #include "filterx/expr-break.h"
 #include "filterx/expr-membership.h"
 #include "filterx/expr-arithmetic-operators.h"
+#include "filterx/expr-string-operators.h"
 
 #include "template/templates.h"
 
@@ -151,6 +152,7 @@ _assign_location(FilterXExpr *expr, CfgLexer *lexer, CFG_LTYPE *lloc)
 %type <node> comparison_operator
 %type <node> membership_operator
 %type <node> arithmetic_operator
+%type <node> string_operator
 %type <node> expr_generator
 %type <node> __expr_generator
 %type <node> expr_plus_generator
@@ -431,6 +433,7 @@ expr_operator
 	| membership_operator
 	| comparison_operator
 	| arithmetic_operator
+	| string_operator
 	| ternary
 	| default
 	/* TODO extract lvalues */
@@ -473,6 +476,12 @@ arithmetic_operator
 	| expr '*' expr { $$ = filterx_arithmetic_operator_multiplication_new($1, $3); }
 	| expr KW_SLASH expr { $$ = filterx_arithmetic_operator_division_new($1, $3); }
 	| expr '%' expr { $$ = filterx_arithmetic_operator_modulo_new($1, $3); }
+	;
+
+string_operator
+	: expr '[' expr LL_DOTDOT expr ']' { $$ = filterx_string_slicing_new($1, $3, $5); }
+	| expr '[' LL_DOTDOT expr ']' { $$ = filterx_string_slicing_new($1, NULL, $4); }
+	| expr '[' expr LL_DOTDOT ']' { $$ = filterx_string_slicing_new($1, $3, NULL); }
 	;
 
 expr_value

--- a/news/fx-feature-720.md
+++ b/news/fx-feature-720.md
@@ -1,0 +1,12 @@
+Support string slicing
+
+For example:
+```
+filterx {
+    str = "example";
+    idx = 3;
+    str[idx..5] == "mp";
+    str[..idx] == "exa";
+    str[idx..] == "mple";
+};
+```

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -2962,3 +2962,22 @@ def test_format_windows_eventlog_list(config, syslog_ng):
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
     assert file_true.read_log() == r"""<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='EventCreate'/><EventID Qualifiers='0'>999</EventID><Version>0</Version><Level>2</Level><Task>0</Task><Opcode>0</Opcode><Keywords>0x80000000000000</Keywords><TimeCreated SystemTime='2024-01-12T09:30:12.1566754Z'/><EventRecordID>934</EventRecordID><Correlation/><Execution ProcessID='0' ThreadID='0'/><Channel>Application</Channel><Computer>DESKTOP-2MBFIV7</Computer><Security UserID='S-1-5-21-3714454296-2738353472-899133108-1001'/></System><RenderingInfo Culture='en-US'><Message>foobar</Message><Level>Error</Level><Task/><Opcode>Info</Opcode><Channel/><Provider/><Keywords><Keyword>Classic</Keyword></Keywords></RenderingInfo><EventData><Data>foo</Data><Data>bar</Data></EventData></Event>"""
+
+
+def test_string_slicing(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, r"""
+            str = "example";
+            idx = 3;
+            $MSG = {
+                "range": str[idx..5],
+                "prefix": str[..idx],
+                "suffix": str[idx..],
+            };
+        """,
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == '{"range":"mp","prefix":"exa","suffix":"mple"}'


### PR DESCRIPTION
For example:
```
filterx {
    str = "example";
    idx = 3;
    str[idx..5] == "mp";
    str[..idx] == "exa";
    str[idx..] == "mple";
};
```