### PR TITLE
Filterx fix parse and format windows eventlog xml functions

### DIFF
--- a/modules/xml/filterx-func-format-windows-eventlog-xml.c
+++ b/modules/xml/filterx-func-format-windows-eventlog-xml.c
@@ -53,7 +53,10 @@ _append_inner_data_dict_element(FilterXObject *key, FilterXObject *value, gpoint
       return FALSE;
     }
 
-  g_string_append_printf(buffer, "<Data Name='%s'>%s</Data>", key_str, value_str);
+  if (value_str_len)
+    g_string_append_printf(buffer, "<Data Name='%s'>%s</Data>", key_str, value_str);
+  else
+    g_string_append_printf(buffer, "<Data Name='%s' />", key_str);
   return TRUE;
 }
 

--- a/modules/xml/filterx-parse-windows-eventlog-xml.c
+++ b/modules/xml/filterx-parse-windows-eventlog-xml.c
@@ -338,6 +338,21 @@ _end_elem(FilterXGeneratorFunctionParseXml *s,
 {
   FilterXParseWEVTState *state = (FilterXParseWEVTState *) st;
 
+  if (state->position == WEVT_POS_DATA && state->has_named_data)
+    {
+      FILTERX_STRING_DECLARE_ON_STACK(empty_value, "", 0);
+      FILTERX_STRING_DECLARE_ON_STACK(param_obj, state->last_data_name->str, state->last_data_name->len);
+      XmlElemContext *elem_context = xml_elem_context_stack_peek_last(state->super.xml_elem_context_stack);
+      if (!filterx_object_set_subscript(elem_context->current_obj, param_obj, &empty_value))
+        {
+          _set_error(error, "failed to add empty value text to EventData: \"%s\"", state->last_data_name->str);
+          return;
+        }
+      xml_elem_context_set_parent_obj(elem_context, elem_context->current_obj);
+      xml_elem_context_set_current_obj(elem_context, empty_value);
+      state->has_named_data = FALSE;
+    }
+
   _pop_position(state, element_name);
   filterx_parse_xml_end_elem_method(s, context, element_name, st, error);
 }

--- a/news/fx-bugfix-722.md
+++ b/news/fx-bugfix-722.md
@@ -1,0 +1,3 @@
+`xml`: fix `parse_windows_eventlog_xml` filterX function
+
+"<Data Name="key" />" is now parsed correctly, identical to "<Data Name="key"></Data>"

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -2284,6 +2284,54 @@ def test_parse_windows_eventlog_xml(config, syslog_ng):
     }
 
 
+def test_parse_windows_eventlog_xml_empty_elem(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, "xml=" + windows_eventlog_xml.replace("{eventdata}", """<Data Name='param1' /><Data Name='param2'>bar</Data>""") + "$MSG = json(parse_windows_eventlog_xml(xml));",
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert json.loads(file_true.read_log()) == {
+        "Event": {
+            "@xmlns": "http://schemas.microsoft.com/win/2004/08/events/event",
+            "System": {
+                "Provider": {"@Name": "EventCreate"},
+                "EventID": "999",
+                "EventIDQualifiers": "0",
+                "Version": "0",
+                "Level": "2",
+                "Task": "0",
+                "Opcode": "0",
+                "Keywords": "0x80000000000000",
+                "TimeCreated": {"@SystemTime": "2024-01-12T09:30:12.1566754Z"},
+                "EventRecordID": "934",
+                "Correlation": "",
+                "Execution": {"@ProcessID": "0", "@ThreadID": "0"},
+                "Channel": "Application",
+                "Computer": "DESKTOP-2MBFIV7",
+                "Security": {"@UserID": "S-1-5-21-3714454296-2738353472-899133108-1001"},
+            },
+            "RenderingInfo": {
+                "@Culture": "en-US",
+                "Message": "foobar",
+                "Level": "Error",
+                "Task": "",
+                "Opcode": "Info",
+                "Channel": "",
+                "Provider": "",
+                "Keywords": {"Keyword": "Classic"},
+            },
+            "EventData": {
+                "Data": {
+                    "param1": "",
+                    "param2": "bar",
+                },
+            },
+        },
+    }
+
+
 def test_parse_cef(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, r"""
@@ -2923,6 +2971,17 @@ def test_format_windows_eventlog_list(config, syslog_ng):
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
     assert file_true.read_log() == r"""<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='EventCreate'/><EventID Qualifiers='0'>999</EventID><Version>0</Version><Level>2</Level><Task>0</Task><Opcode>0</Opcode><Keywords>0x80000000000000</Keywords><TimeCreated SystemTime='2024-01-12T09:30:12.1566754Z'/><EventRecordID>934</EventRecordID><Correlation/><Execution ProcessID='0' ThreadID='0'/><Channel>Application</Channel><Computer>DESKTOP-2MBFIV7</Computer><Security UserID='S-1-5-21-3714454296-2738353472-899133108-1001'/></System><RenderingInfo Culture='en-US'><Message>foobar</Message><Level>Error</Level><Task/><Opcode>Info</Opcode><Channel/><Provider/><Keywords><Keyword>Classic</Keyword></Keywords></RenderingInfo><EventData><Data>foo</Data><Data>bar</Data></EventData></Event>"""
+
+
+def test_format_windows_eventlog_empty_element(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, "$MSG = " + windows_eventlog_dict.replace("{eventdata}", """{"Data":{"param1":"foo","param2":""}}"""),
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == r"""<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='EventCreate'/><EventID Qualifiers='0'>999</EventID><Version>0</Version><Level>2</Level><Task>0</Task><Opcode>0</Opcode><Keywords>0x80000000000000</Keywords><TimeCreated SystemTime='2024-01-12T09:30:12.1566754Z'/><EventRecordID>934</EventRecordID><Correlation/><Execution ProcessID='0' ThreadID='0'/><Channel>Application</Channel><Computer>DESKTOP-2MBFIV7</Computer><Security UserID='S-1-5-21-3714454296-2738353472-899133108-1001'/></System><RenderingInfo Culture='en-US'><Message>foobar</Message><Level>Error</Level><Task/><Opcode>Info</Opcode><Channel/><Provider/><Keywords><Keyword>Classic</Keyword></Keywords></RenderingInfo><EventData><Data Name='param1'>foo</Data><Data Name='param2' /></EventData></Event>"""
 
 
 def test_string_slicing(config, syslog_ng):

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -2200,46 +2200,45 @@ def test_parse_xml(config, syslog_ng):
     assert file_true.read_log() == "{\"a\":{\"b\":[{\"@attr\":\"attr_val\",\"#text\":\"c\"},\"e\"]}}"
 
 
+windows_eventlog_xml = """
+    "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
+        <System>
+            <Provider Name='EventCreate'/>
+            <EventID Qualifiers='0'>999</EventID>
+            <Version>0</Version>
+            <Level>2</Level>
+            <Task>0</Task>
+            <Opcode>0</Opcode>
+            <Keywords>0x80000000000000</Keywords>
+            <TimeCreated SystemTime='2024-01-12T09:30:12.1566754Z'/>
+            <EventRecordID>934</EventRecordID>
+            <Correlation/>
+            <Execution ProcessID='0' ThreadID='0'/>
+            <Channel>Application</Channel>
+            <Computer>DESKTOP-2MBFIV7</Computer>
+            <Security UserID='S-1-5-21-3714454296-2738353472-899133108-1001'/>
+        </System>
+        <RenderingInfo Culture='en-US'>
+            <Message>foobar</Message>
+            <Level>Error</Level>
+            <Task></Task>
+            <Opcode>Info</Opcode>
+            <Channel></Channel>
+            <Provider></Provider>
+            <Keywords>
+                <Keyword>Classic</Keyword>
+            </Keywords>
+        </RenderingInfo>
+        <EventData>
+            {eventdata}
+        </EventData>
+    </Event>";
+"""
+
+
 def test_parse_windows_eventlog_xml(config, syslog_ng):
     (file_true, file_false) = create_config(
-        config, r"""
-    xml = "
-        <Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
-            <System>
-                <Provider Name='EventCreate'/>
-                <EventID Qualifiers='0'>999</EventID>
-                <Version>0</Version>
-                <Level>2</Level>
-                <Task>0</Task>
-                <Opcode>0</Opcode>
-                <Keywords>0x80000000000000</Keywords>
-                <TimeCreated SystemTime='2024-01-12T09:30:12.1566754Z'/>
-                <EventRecordID>934</EventRecordID>
-                <Correlation/>
-                <Execution ProcessID='0' ThreadID='0'/>
-                <Channel>Application</Channel>
-                <Computer>DESKTOP-2MBFIV7</Computer>
-                <Security UserID='S-1-5-21-3714454296-2738353472-899133108-1001'/>
-            </System>
-            <RenderingInfo Culture='en-US'>
-                <Message>foobar</Message>
-                <Level>Error</Level>
-                <Task></Task>
-                <Opcode>Info</Opcode>
-                <Channel></Channel>
-                <Provider></Provider>
-                <Keywords>
-                    <Keyword>Classic</Keyword>
-                </Keywords>
-            </RenderingInfo>
-            <EventData>
-                <Data Name='param1'>foo</Data>
-                <Data Name='param2'>bar</Data>
-            </EventData>
-        </Event>
-    ";
-    $MSG = json(parse_windows_eventlog_xml(xml));
-    """,
+        config, "xml=" + windows_eventlog_xml.replace("{eventdata}", """<Data Name='param1'>foo</Data><Data Name='param2'>bar</Data>""") + "$MSG = json(parse_windows_eventlog_xml(xml));",
     )
     syslog_ng.start(config)
 
@@ -2837,7 +2836,7 @@ def test_parse_xml_format_xml(config, syslog_ng):
 
 
 windows_eventlog_dict = """
-    $MSG = format_windows_eventlog_xml({
+    format_windows_eventlog_xml({
         "Event": {
             "@xmlns": "http://schemas.microsoft.com/win/2004/08/events/event",
             "System": {
@@ -2874,45 +2873,7 @@ windows_eventlog_dict = """
 
 def test_parse_format_windows_eventlog_xml(config, syslog_ng):
     (file_true, file_false) = create_config(
-        config, r"""
-    xml = "
-        <Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
-            <System>
-                <Provider Name='EventCreate'/>
-                <EventID Qualifiers='0'>999</EventID>
-                <Version>0</Version>
-                <Level>2</Level>
-                <Task>0</Task>
-                <Opcode>0</Opcode>
-                <Keywords>0x80000000000000</Keywords>
-                <TimeCreated SystemTime='2024-01-12T09:30:12.1566754Z'/>
-                <EventRecordID>934</EventRecordID>
-                <Correlation/>
-                <Execution ProcessID='0' ThreadID='0'/>
-                <Channel>Application</Channel>
-                <Computer>DESKTOP-2MBFIV7</Computer>
-                <Security UserID='S-1-5-21-3714454296-2738353472-899133108-1001'/>
-            </System>
-            <RenderingInfo Culture='en-US'>
-                <Message>foobar</Message>
-                <Level>Error</Level>
-                <Task></Task>
-                <Opcode>Info</Opcode>
-                <Channel></Channel>
-                <Provider></Provider>
-                <Keywords>
-                    <Keyword>Classic</Keyword>
-                </Keywords>
-            </RenderingInfo>
-            <EventData>
-                <Data Name='param1'>foo</Data>
-                <Data Name='param2'>bar</Data>
-            </EventData>
-        </Event>
-    ";
-    dict = json(parse_windows_eventlog_xml(xml));
-    $MSG = format_windows_eventlog_xml(dict);
-    """,
+        config, "xml=" + windows_eventlog_xml.replace("{eventdata}", """<Data Name='param1'>foo</Data><Data Name='param2'>bar</Data>""") + "dict = json(parse_windows_eventlog_xml(xml));" + "$MSG = format_windows_eventlog_xml(dict);",
     )
     syslog_ng.start(config)
 
@@ -2923,7 +2884,7 @@ def test_parse_format_windows_eventlog_xml(config, syslog_ng):
 
 def test_format_windows_eventlog_xml_dict_1_elem(config, syslog_ng):
     (file_true, file_false) = create_config(
-        config, windows_eventlog_dict.replace("{eventdata}", """{"Data":{"param1":"foo"}}"""),
+        config, "$MSG = " + windows_eventlog_dict.replace("{eventdata}", """{"Data":{"param1":"foo"}}"""),
     )
     syslog_ng.start(config)
 
@@ -2933,7 +2894,7 @@ def test_format_windows_eventlog_xml_dict_1_elem(config, syslog_ng):
 
 def test_format_windows_eventlog_dict_2_elems(config, syslog_ng):
     (file_true, file_false) = create_config(
-        config, windows_eventlog_dict.replace("{eventdata}", """{"Data":{"param1":"foo","param2":"bar"}}"""),
+        config, "$MSG = " + windows_eventlog_dict.replace("{eventdata}", """{"Data":{"param1":"foo","param2":"bar"}}"""),
     )
     syslog_ng.start(config)
 
@@ -2944,7 +2905,7 @@ def test_format_windows_eventlog_dict_2_elems(config, syslog_ng):
 
 def test_format_windows_eventlog_single_elem(config, syslog_ng):
     (file_true, file_false) = create_config(
-        config, windows_eventlog_dict.replace("{eventdata}", """{"Data":"foo"}"""),
+        config, "$MSG = " + windows_eventlog_dict.replace("{eventdata}", """{"Data":"foo"}"""),
     )
     syslog_ng.start(config)
 
@@ -2955,7 +2916,7 @@ def test_format_windows_eventlog_single_elem(config, syslog_ng):
 
 def test_format_windows_eventlog_list(config, syslog_ng):
     (file_true, file_false) = create_config(
-        config, windows_eventlog_dict.replace("{eventdata}", """{"Data":["foo","bar"]}"""),
+        config, "$MSG = " + windows_eventlog_dict.replace("{eventdata}", """{"Data":["foo","bar"]}"""),
     )
     syslog_ng.start(config)
 


### PR DESCRIPTION
In case of the following input:
```
<EventData>
    <Data Name="SubjectUserSid">S-1-5-18</Data>
    <Data Name="SubjectUserName">WIN-GG82ULGC9GO$</Data>
    <Data Name="SubjectDomainName">CONTOSO</Data>
    <Data Name="SubjectLogonId">0x3e7</Data>
    <Data Name="NewProcessId">0x2bc</Data>
    <Data Name="NewProcessName">C:\Windows\System32\rundll32.exe</Data>
    <Data Name="TokenElevationType">%%1938</Data>
    <Data Name="ProcessId">0xe74</Data>
    <Data Name="CommandLine" />
    <Data Name="TargetUserSid">S-1-5-21-1377283216-344919071-3415362939-1104</Data>
    <Data Name="TargetUserName">dadmin</Data>
    <Data Name="TargetDomainName">CONTOSO</Data>
    <Data Name="TargetLogonId">0x4a5af0</Data>
    <Data Name="ParentProcessName">C:\Windows\explorer.exe</Data>
    <Data Name="MandatoryLabel">S-1-16-8192</Data>
</EventData>
```
Previously the following output was generated, by the `parse_windows_eventlog_xml` function:
```
"EventData":
    {"Data":
        {"SubjectUserSid":"S-1-5-18",
        "SubjectUserName":"WIN-GG82ULGC9GO$",
        "SubjectDomainName":"CONTOSO",
        "SubjectLogonId":"0x3e7",
        "NewProcessId":"0x2bc",
        "NewProcessName":"C:\\Windows\\System32\\rundll32.exe",
        "TokenElevationType":"%%1938",
        "ProcessId":"0xe74"},
    "CommandLine":"",
    "EventData":{
        "Data":
            {"TargetUserSid":"S-1-5-21-1377283216-344919071-3415362939-1104",
            "TargetUserName":"dadmin",
            "TargetDomainName":"CONTOSO",
            "TargetLogonId":"0x4a5af0",
            "ParentProcessName":"C:\\Windows\\explorer.exe",
            "MandatoryLabel":"S-1-16-8192"}
    }}
```
As can be seen, the empty `"CommandLine"` caused `Event`, and `EventData` to be reopened.
This caused the `format_windows_eventlog_xml` to fail, because of unexpected data types.
Now the following output is generated:
```
{"Data":
	{"SubjectUserSid":"S-1-5-18",
	"SubjectUserName":"WIN-GG82ULGC9GO$",
	"SubjectDomainName":"CONTOSO",
	"SubjectLogonId":"0x3e7",
	"NewProcessId":"0x2bc",
	"NewProcessName":"C:\\Windows\\System32\\rundll32.exe",
	"TokenElevationType":"%%1938",
	"ProcessId":"0xe74",
	"CommandLine":"",
	"TargetUserSid":"S-1-5-21-1377283216-344919071-3415362939-1104",
	"TargetUserName":"dadmin",
	"TargetDomainName":"CONTOSO",
	"TargetLogonId":"0x4a5af0",
	"ParentProcessName":"C:\\Windows\\explorer.exe",
	"MandatoryLabel":"S-1-16-8192"}
}
```
Which seems correct, and works with the formatter:
```
<EventData>
	<Data Name='SubjectUserSid'>S-1-5-18</Data>
	<Data Name='SubjectUserName'>WIN-GG82ULGC9GO$</Data>
	<Data Name='SubjectDomainName'>CONTOSO</Data>
	<Data Name='SubjectLogonId'>0x3e7</Data>
	<Data Name='NewProcessId'>0x2bc</Data>
	<Data Name='NewProcessName'>C:\Windows\System32\rundll32.exe</Data>
	<Data Name='TokenElevationType'>%%1938</Data>
	<Data Name='ProcessId'>0xe74</Data>
	<Data Name='CommandLine' />
	<Data Name='TargetUserSid'>S-1-5-21-1377283216-344919071-3415362939-1104</Data>
	<Data Name='TargetUserName'>dadmin</Data>
	<Data Name='TargetDomainName'>CONTOSO</Data>
	<Data Name='TargetLogonId'>0x4a5af0</Data>
	<Data Name='ParentProcessName'>C:\Windows\explorer.exe</Data>
	<Data Name='MandatoryLabel'>S-1-16-8192</Data>
</EventData>
```
