### PR TITLE
`http`: support templating in `body-prefix()`

### DIFF
--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -155,7 +155,7 @@ http_option
     | KW_USER_AGENT '(' string ')'            { http_dd_set_user_agent(last_driver, $3); free($3); }
     | KW_HEADERS    '(' string_list ')'       { http_dd_set_headers(last_driver, $3); g_list_free_full($3, free); }
     | KW_METHOD     '(' string ')'            { http_dd_set_method(last_driver, $3); free($3); }
-    | KW_BODY_PREFIX '(' string ')'           { http_dd_set_body_prefix(last_driver, $3); free($3); }
+    | KW_BODY_PREFIX '(' template_name_or_content ')'  { http_dd_set_body_prefix(last_driver, $3); log_template_unref($3); }
     | KW_BODY_SUFFIX '(' string ')'           { http_dd_set_body_suffix(last_driver, $3); free($3); }
     | KW_DELIMITER  '(' string ')'            { http_dd_set_delimiter(last_driver, $3); free($3); }
     | KW_PROXY      '(' string ')'            { http_dd_set_proxy(last_driver, $3); free($3); }

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -429,7 +429,7 @@ default_map_http_status_to_worker_status(HTTPDestinationWorker *self, const gcha
 }
 
 static void
-_reinit_request_headers(HTTPDestinationWorker *self)
+_reset_request_headers(HTTPDestinationWorker *self)
 {
   list_remove_all(self->request_headers);
 }
@@ -812,7 +812,7 @@ _flush(LogThreadedDestWorker *s, LogThreadedFlushMode mode)
       url = alt_url;
     }
 
-  _reinit_request_headers(self);
+  _reset_request_headers(self);
 
   _reset_request_body(self);
   _init_request_body(self);
@@ -896,7 +896,7 @@ _init(LogThreadedDestWorker *s)
       return FALSE;
     }
   _setup_static_options_in_curl(self);
-  _reinit_request_headers(self);
+  _reset_request_headers(self);
 
   _reset_request_body(self);
   _init_request_body(self);

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -358,11 +358,12 @@ http_dd_set_batch_bytes(LogDriver *d, glong batch_bytes)
 }
 
 void
-http_dd_set_body_prefix(LogDriver *d, const gchar *body_prefix)
+http_dd_set_body_prefix(LogDriver *d, LogTemplate *body_prefix)
 {
   HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
 
-  g_string_assign(self->body_prefix, body_prefix);
+  log_template_unref(self->body_prefix_template);
+  self->body_prefix_template = log_template_ref(body_prefix);
 }
 
 void
@@ -475,7 +476,7 @@ http_dd_free(LogPipe *s)
   log_template_options_destroy(&self->template_options);
 
   g_string_free(self->delimiter, TRUE);
-  g_string_free(self->body_prefix, TRUE);
+  log_template_unref(self->body_prefix_template);
   g_string_free(self->body_suffix, TRUE);
   g_string_free(self->accept_encoding, TRUE);
   log_template_unref(self->body_template);
@@ -522,7 +523,6 @@ http_dd_new(GlobalConfig *cfg)
   /* disable batching even if the global batch_lines is specified */
   self->super.batch_lines = 0;
   self->batch_bytes = 0;
-  self->body_prefix = g_string_new("");
   self->body_suffix = g_string_new("");
   self->delimiter = g_string_new("\n");
   self->accept_encoding = g_string_new("");

--- a/modules/http/http.h
+++ b/modules/http/http.h
@@ -52,7 +52,7 @@ typedef struct
   gchar *ciphers;
   gchar *tls13_ciphers;
   gchar *proxy;
-  GString *body_prefix;
+  LogTemplate *body_prefix_template;
   GString *body_suffix;
   GString *delimiter;
   long ssl_version;
@@ -93,7 +93,7 @@ void http_dd_set_peer_verify(LogDriver *d, gboolean verify);
 gboolean http_dd_set_ocsp_stapling_verify(LogDriver *d, gboolean verify);
 void http_dd_set_timeout(LogDriver *d, glong timeout);
 void http_dd_set_batch_bytes(LogDriver *d, glong batch_bytes);
-void http_dd_set_body_prefix(LogDriver *d, const gchar *body_prefix);
+void http_dd_set_body_prefix(LogDriver *d, LogTemplate *body_prefix);
 void http_dd_set_body_suffix(LogDriver *d, const gchar *body_suffix);
 void http_dd_set_delimiter(LogDriver *d, const gchar *delimiter);
 void http_dd_insert_response_handler(LogDriver *d, HttpResponseHandler *response_handler);

--- a/modules/http/tests/test_http-signal_slot.c
+++ b/modules/http/tests/test_http-signal_slot.c
@@ -119,7 +119,11 @@ Test(test_http_signal_slot, basic)
 
 Test(test_http_signal_slot, single_with_prefix_suffix)
 {
-  http_dd_set_body_prefix((LogDriver *)driver, "[");
+  LogTemplate *prefix = log_template_new(configuration, NULL);
+  cr_assert(log_template_compile(prefix, "[", NULL));
+  http_dd_set_body_prefix((LogDriver *)driver, prefix);
+  log_template_unref(prefix);
+
   http_dd_set_body_suffix((LogDriver *)driver, "]");
   http_dd_set_delimiter((LogDriver *)driver, ",");
 
@@ -137,7 +141,11 @@ Test(test_http_signal_slot, single_with_prefix_suffix)
 
 Test(test_http_signal_slot, batch_with_prefix_suffix)
 {
-  http_dd_set_body_prefix((LogDriver *)driver, "[");
+  LogTemplate *prefix = log_template_new(configuration, NULL);
+  cr_assert(log_template_compile(prefix, "[", NULL));
+  http_dd_set_body_prefix((LogDriver *)driver, prefix);
+  log_template_unref(prefix);
+
   http_dd_set_body_suffix((LogDriver *)driver, "]");
   http_dd_set_delimiter((LogDriver *)driver, ",");
   log_threaded_dest_driver_set_batch_lines((LogDriver *)driver, 2);

--- a/news/feature-731.md
+++ b/news/feature-731.md
@@ -1,0 +1,22 @@
+`http`: Added templating support to `body-prefix()`
+
+In case of batching the templates in `body-prefix()` will be calculated
+from the first message. Make sure to use `worker-partition-key()` to
+group similar messages together.
+
+Literal dollar signs (`$`) used in `body-prefix()` must be escaped like `$$`.
+
+Example usage:
+```
+http(
+  ...
+  body-prefix('{"log_type": "$log_type", "entries": [')
+  body('"$MSG"')
+  delimiter(",")
+  body-suffix("]}")
+
+  batch-lines(1000)
+  batch-timeout(1000)
+  worker-partition-key("$log_type")
+);
+```


### PR DESCRIPTION
In case of batching the templates in `body-prefix()` will be calculated from the first message. Make sure to use `worker-partition-key()` to group similar messages together.

Literal dollar signs (`$`) used in `body-prefix()` must be escaped like `$$`.

Example usage:
```
http(
  ...
  body-prefix('{"log_type": "$log_type", "entries": [')
  body('"$MSG"')
  delimiter(",")
  body-suffix("]}")

  batch-lines(1000)
  batch-timeout(1000)
  worker-partition-key("$log_type")
);
```