### PR TITLE
Add ADC credentials option

### DIFF
--- a/modules/grpc/common/credentials/grpc-credentials-builder.h
+++ b/modules/grpc/common/credentials/grpc-credentials-builder.h
@@ -76,6 +76,8 @@ gboolean grpc_client_credentials_builder_service_account_set_key(GrpcClientCrede
     const gchar *key_path);
 void grpc_client_credentials_builder_service_account_set_validity_duration(GrpcClientCredentialsBuilderW *s,
     guint64 validity_duration);
+void grpc_client_credentials_builder_set_adc_service_account_key(GrpcClientCredentialsBuilderW *s,
+    const gchar *key_path);
 
 #include "compat/cpp-end.h"
 

--- a/modules/grpc/common/credentials/grpc-credentials-builder.hpp
+++ b/modules/grpc/common/credentials/grpc-credentials-builder.hpp
@@ -77,6 +77,9 @@ public:
   bool set_service_account_key_path(const char *key_path);
   void set_service_account_validity_duration(guint64 validity_duration);
 
+  /* ADC */
+  void set_adc_service_account_key(const char *key_path);
+
 private:
   ClientAuthMode mode = GCAM_INSECURE;
 
@@ -92,6 +95,9 @@ private:
     std::string key;
     guint64 validity_duration = 3600L;
   } service_account;
+
+  /* ADC */
+  std::string adc_service_account_key;
 };
 
 }

--- a/modules/grpc/common/grpc-grammar.ym
+++ b/modules/grpc/common/grpc-grammar.ym
@@ -55,6 +55,7 @@ GrpcClientCredentialsBuilderW *last_grpc_client_credentials_builder;
 %token KW_SERVICE_ACCOUNT
 %token KW_TOKEN_VALIDITY_DURATION
 %token KW_KEY
+%token KW_SERVICE_ACCOUNT_KEY
 %token KW_COMPRESSION
 %token KW_BATCH_BYTES
 %token KW_CONCURRENT_REQUESTS
@@ -284,7 +285,7 @@ grpc_client_credentials_option
   : KW_INSECURE { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_INSECURE); } '(' ')'
   | KW_TLS { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_TLS); } '(' grpc_client_credentials_builder_tls_options ')'
   | KW_ALTS { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_ALTS); } '(' grpc_client_credentials_builder_alts_options ')'
-  | KW_ADC { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_ADC); } '(' ')'
+  | KW_ADC { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_ADC); } '(' grpc_client_credentials_builder_application_credentials ')'
   | KW_SERVICE_ACCOUNT { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_SERVICE_ACCOUNT); } '(' grpc_client_credentials_builder_service_account_options ')'
   ;
 
@@ -338,6 +339,15 @@ grpc_client_credentials_builder_service_account_options
 grpc_client_credentials_builder_service_account_option
   : KW_KEY '(' path_secret ')' { grpc_client_credentials_builder_service_account_set_key(last_grpc_client_credentials_builder, $3); free($3); }
   | KW_TOKEN_VALIDITY_DURATION '(' nonnegative_integer64 ')' { grpc_client_credentials_builder_service_account_set_validity_duration(last_grpc_client_credentials_builder, $3); }
+  ;
+
+grpc_client_credentials_builder_application_credentials
+  : grpc_client_credentials_builder_application_credential grpc_client_credentials_builder_application_credentials
+  |
+  ;
+
+grpc_client_credentials_builder_application_credential
+  : KW_SERVICE_ACCOUNT_KEY '(' path_secret ')' { grpc_client_credentials_builder_set_adc_service_account_key(last_grpc_client_credentials_builder, $3); free($3); }
   ;
 
 /* END_RULES */

--- a/modules/grpc/common/grpc-parser.h
+++ b/modules/grpc/common/grpc-parser.h
@@ -37,6 +37,7 @@
   { "adc",                       KW_ADC }, \
   { "service_account",           KW_SERVICE_ACCOUNT }, \
   { "key",                       KW_KEY }, \
+  { "service_account_key",       KW_SERVICE_ACCOUNT_KEY }, \
   { "token_validity_duration",   KW_TOKEN_VALIDITY_DURATION }, \
   { "compression",               KW_COMPRESSION }, \
   { "batch_bytes",               KW_BATCH_BYTES }, \

--- a/news/feature-732.md
+++ b/news/feature-732.md
@@ -1,0 +1,14 @@
+bigquery(), google-pubsub-grpc(): add service-account-key option to ADC auth mode
+
+Example usage:
+```
+destination {
+        google-pubsub-grpc(
+            project("test")
+            topic("test")
+            auth(adc(service-account-key("absolute path to file")))
+       );
+};
+```
+
+Note: File path must be the absolute path.


### PR DESCRIPTION
Example usage:
```
destination {
    	google-pubsub-grpc(
      		project("test")
                topic("test")
      		auth(adc(service-account-key("absolute path to file")))
       );
};
```