### PR TITLE
modules/appmodel: do not overwrite filterx-app-variable() if it is already set

### DIFF
--- a/modules/appmodel/app-parser-generator.c
+++ b/modules/appmodel/app-parser-generator.c
@@ -154,16 +154,16 @@ _generate_action(AppParserGenerator *self, Application *app)
     {
       g_string_append_printf(self->block,
                              "            filterx {\n"
-                             "                %s = '%s';\n"
+                             "                if (not isset(%s)) { %s = '%s'; }\n"
                              "            };\n",
-                             self->filterx_app_variable, app->super.name);
+                             self->filterx_app_variable, self->filterx_app_variable, app->super.name);
     }
   else
     {
       g_string_append_printf(self->block,
                              "            rewrite {\n"
                              "                set-tag('.app.%s');\n"
-                             "                set('%s' value('.app.name'));\n"
+                             "                set('%s' value('.app.name') condition('${.app.name}' eq ''));\n"
                              "            };\n",
                              app->super.name, app->super.name);
     }


### PR DESCRIPTION
A common pattern is to call inner app-parsers from app adapters. In this case the outer adapter
"relay"s the filtering of the message to the inner topic's adapters, so it should not overwrite the
filterx-app-variable() set by the inner adapter.

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
