### PR TITLE
FilterX: null and error-safe dict elements

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -205,7 +205,7 @@ main_location_print (FILE *yyo, YYLTYPE const * const yylocp)
 %left   ';'
 
 /* operators in the filter language, the order of this determines precedence */
-%right KW_ASSIGN 9000, KW_PLUS_ASSIGN 9001, KW_NULLV_ASSIGN 9002
+%right KW_ASSIGN 9000, KW_PLUS_ASSIGN 9001, KW_NULLV_ASSIGN 9002, KW_NULLV_DICT_ELEM 9003
 %right '?' ':'
 %right KW_NULL_COALESCING
 %left  KW_OR 9010

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -320,6 +320,7 @@ word	[^ \#'"\(\)\{\}\[\]\\;\r\n\t,|\.@:]
 <filterx>!~                { return KW_REGEXP_NOMATCH; }
 <filterx>\?\?              { return KW_NULL_COALESCING; }
 <filterx>=\?\?             { return KW_NULLV_ASSIGN; }
+<filterx>:\?\?             { return KW_NULLV_DICT_ELEM; }
 
 <INITIAL,filterx>(-|\+)?{digit}+\.{digit}+  { yylval->fnum = strtod(yytext, NULL); return LL_FLOAT; }
 <INITIAL,filterx>0x{xdigit}+ {

--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -24,6 +24,7 @@
 #include "filterx/filterx-eval.h"
 #include "filterx/object-null.h"
 #include "filterx/object-message-value.h"
+#include "filterx/object-extractor.h"
 #include "scratch-buffers.h"
 
 static inline FilterXObject *
@@ -54,9 +55,7 @@ _nullv_assign_eval(FilterXExpr *s)
 
   FilterXObject *value = filterx_expr_eval(self->rhs);
 
-  if (!value || filterx_object_is_type(value, &FILTERX_TYPE_NAME(null))
-      || (filterx_object_is_type(value, &FILTERX_TYPE_NAME(message_value))
-          && filterx_message_value_get_type(value) == LM_VT_NULL))
+  if (!value || filterx_object_extract_null(value))
     {
       if (!value)
         return _suppress_error();

--- a/lib/filterx/expr-literal-container.c
+++ b/lib/filterx/expr-literal-container.c
@@ -29,6 +29,7 @@
 #include "filterx/filterx-object.h"
 #include "filterx/object-null.h"
 #include "filterx/object-message-value.h"
+#include "filterx/object-extractor.h"
 
 /* Object Members (e.g. key-value) */
 
@@ -146,11 +147,7 @@ _literal_container_eval(FilterXExpr *s)
           if (!value)
             filterx_eval_dump_errors("FilterX: null coalesce assignment suppressing error");
 
-          gboolean value_is_null_or_error = !value || filterx_object_is_type(value, &FILTERX_TYPE_NAME(null))
-                                            || (filterx_object_is_type(value, &FILTERX_TYPE_NAME(message_value))
-                                                && filterx_message_value_get_type(value) == LM_VT_NULL);
-
-          if (value_is_null_or_error)
+          if (!value || filterx_object_extract_null(value))
             {
               filterx_object_unref(key);
               filterx_object_unref(value);

--- a/lib/filterx/expr-literal-container.h
+++ b/lib/filterx/expr-literal-container.h
@@ -30,6 +30,7 @@ typedef struct FilterXLiteralElement_ FilterXLiteralElement;
 typedef struct FilterXLiteralContainer_ FilterXLiteralContainer;
 
 FilterXLiteralElement *filterx_literal_element_new(FilterXExpr *key, FilterXExpr *value);
+FilterXLiteralElement *filterx_nullv_literal_element_new(FilterXExpr *key, FilterXExpr *value);
 
 /* Literal Object expressions */
 

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -24,6 +24,7 @@
 #include "filterx/filterx-eval.h"
 #include "filterx/object-null.h"
 #include "filterx/object-message-value.h"
+#include "filterx/object-extractor.h"
 #include "scratch-buffers.h"
 #include "stats/stats-registry.h"
 #include "stats/stats-cluster-single.h"
@@ -72,9 +73,7 @@ _nullv_set_subscript_eval(FilterXExpr *s)
   FilterXObject *key = NULL;
 
   FilterXObject *new_value = filterx_expr_eval(self->new_value);
-  if (!new_value || filterx_object_is_type(new_value, &FILTERX_TYPE_NAME(null))
-      || (filterx_object_is_type(new_value, &FILTERX_TYPE_NAME(message_value))
-          && filterx_message_value_get_type(new_value) == LM_VT_NULL))
+  if (!new_value || filterx_object_extract_null(new_value))
     {
       if (!new_value)
         return _suppress_error();

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -25,6 +25,7 @@
 #include "filterx/filterx-eval.h"
 #include "filterx/object-null.h"
 #include "filterx/object-message-value.h"
+#include "filterx/object-extractor.h"
 #include "scratch-buffers.h"
 #include "stats/stats-registry.h"
 #include "stats/stats-cluster-single.h"
@@ -72,9 +73,7 @@ _nullv_setattr_eval(FilterXExpr *s)
   FilterXObject *result = NULL;
 
   FilterXObject *new_value = filterx_expr_eval(self->new_value);
-  if (!new_value || filterx_object_is_type(new_value, &FILTERX_TYPE_NAME(null))
-      || (filterx_object_is_type(new_value, &FILTERX_TYPE_NAME(message_value))
-          && filterx_message_value_get_type(new_value) == LM_VT_NULL))
+  if (!new_value || filterx_object_extract_null(new_value))
     {
       if (!new_value)
         return _suppress_error();

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -625,6 +625,7 @@ dict_elements
 
 dict_element
 	: expr ':' expr				{ $$ = filterx_literal_element_new($1, $3); }
+	| expr KW_NULLV_DICT_ELEM expr { $$ = filterx_nullv_literal_element_new($1, $3); }
 	;
 
 list_literal

--- a/news/fx-feature-736.md
+++ b/news/fx-feature-736.md
@@ -1,0 +1,9 @@
+Null and error-safe dict elements
+
+For example, the following fields won't be set:
+```
+$MSG = {
+    "nullidontwant":?? null,
+    "erroridontwant":?? nonexistingvar,
+};
+```

--- a/tests/light/functional_tests/filterx/test_filterx_dict.py
+++ b/tests/light/functional_tests/filterx/test_filterx_dict.py
@@ -52,3 +52,21 @@ def test_filterx_dict_message_value_key(syslog_ng, config):
 
     syslog_ng.start(config)
     assert destination.read_log() == "test_value"
+
+
+def test_filterx_dict_nullv_elements(syslog_ng, config):
+    source = config.create_example_msg_generator_source(num=1)
+    filterx = config.create_filterx(r"""
+        $MSG = {
+          "null": null,
+          "nullidontwant":?? null,
+          "erroridontwant":?? nonexistingvar,
+          "value":?? 3,
+        };
+""")
+    destination = config.create_file_destination(file_name="output.log", template='"$MSG\n"')
+
+    config.create_logpath(statements=[source, filterx, destination])
+
+    syslog_ng.start(config)
+    assert destination.read_log() == '{"null":null,"value":3}'


### PR DESCRIPTION
For example, the following fields won't be set:
```
$MSG = {
    "nullidontwant":?? null,
    "erroridontwant":?? nonexistingvar,
};
```