### PR TITLE
charts: use max-containers() instead of max-files()

### DIFF
--- a/charts/axosyslog/templates/collector-config.yaml
+++ b/charts/axosyslog/templates/collector-config.yaml
@@ -31,7 +31,7 @@ data:
         key-delimiter({{ .keyDelimiter | quote }})
   {{- end }}
   {{- if .maxContainers }}
-        max-files({{ .maxContainers }})
+        max-containers({{ .maxContainers }})
   {{- end }}
       );
     };


### PR DESCRIPTION
The former sets a good default for the window size as well.

Merge it only after the 4.15.0 release.
