### PR TITLE
`cloud-auth()`: add `scope()` option for `gcp(service-account())`

### DIFF
--- a/modules/cloud-auth/cloud-auth-grammar.ym
+++ b/modules/cloud-auth/cloud-auth-grammar.ym
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2023 Attila Szakacs
+ * Copyright (c) 2025 Axoflow
+ * Copyright (c) 2025 Attila Szakacs <attila.szakacs@axoflow.com>
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -123,6 +124,7 @@ google_dest_auth_service_account_options
 google_dest_auth_service_account_option
   : KW_KEY '(' path_secret ')' { google_authenticator_set_service_account_key_path(last_authenticator, $3); free($3); }
   | KW_AUDIENCE '(' string ')' { google_authenticator_set_service_account_audience(last_authenticator, $3); free($3); }
+  | KW_SCOPE '(' string ')' { google_authenticator_set_service_account_scope(last_authenticator, $3); free($3); }
   | KW_TOKEN_VALIDITY_DURATION '(' nonnegative_integer64 ')' { google_authenticator_set_service_account_token_validity_duration(last_authenticator, $3); }
   ;
 

--- a/modules/cloud-auth/google-auth.h
+++ b/modules/cloud-auth/google-auth.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2023 Attila Szakacs
+ * Copyright (c) 2025 Axoflow
+ * Copyright (c) 2025 Attila Szakacs <attila.szakacs@axoflow.com>
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -39,6 +40,7 @@ void google_authenticator_set_auth_mode(CloudAuthenticator *s, GoogleAuthenticat
 
 void google_authenticator_set_service_account_key_path(CloudAuthenticator *s, const gchar *key_path);
 void google_authenticator_set_service_account_audience(CloudAuthenticator *s, const gchar *audience);
+void google_authenticator_set_service_account_scope(CloudAuthenticator *s, const gchar *scope);
 void google_authenticator_set_service_account_token_validity_duration(CloudAuthenticator *s,
     guint64 token_validity_duration);
 

--- a/modules/cloud-auth/google-auth.hpp
+++ b/modules/cloud-auth/google-auth.hpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2023 Attila Szakacs
+ * Copyright (c) 2025 Axoflow
+ * Copyright (c) 2025 Attila Szakacs <attila.szakacs@axoflow.com>
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -39,13 +40,15 @@ namespace google {
 class ServiceAccountAuthenticator: public syslogng::cloud_auth::Authenticator
 {
 public:
-  ServiceAccountAuthenticator(const char *key_path, const char *audience, uint64_t token_validity_duration);
+  ServiceAccountAuthenticator(const char *key_path, const char *audience, const char *scope,
+                              uint64_t token_validity_duration);
   ~ServiceAccountAuthenticator() {};
 
   void handle_http_header_request(HttpHeaderRequestSignalData *data);
 
 private:
   std::string audience;
+  std::string scope;
   std::string email;
   std::string private_key;
   std::string private_key_id;

--- a/news/feature-738.md
+++ b/news/feature-738.md
@@ -1,0 +1,19 @@
+`cloud-auth()`: Added `scope()` option for `gcp(service-account())`
+
+Can be used for authentications using scope instead of audiance.
+For more info, see: https://google.aip.dev/auth/4111#scope-vs-audience
+
+Example usage:
+```
+http(
+  ...
+  cloud-auth(
+    gcp(
+      service-account(
+        key("/path/to/secret.json")
+        scope("https://www.googleapis.com/auth/example-scope")
+      )
+    )
+  )
+);
+```


### PR DESCRIPTION
Can be used for authentications using scope instead of audiance.
For more info, see: https://google.aip.dev/auth/4111#scope-vs-audience

Example usage:
```
http(
  ...
  cloud-auth(
    gcp(
      service-account(
        key("/path/to/secret.json")
        scope("https://www.googleapis.com/auth/example-scope")
      )
    )
  )
);
```