### PR TITLE
light: fix sending unicode characters through framed syslog

### DIFF
--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "axosyslog-light"
-version = "1.9.0"
+version = "1.10.0"
 description = "Lightweight End-to-End Test Framework for AxoSyslog."
 authors = ["Andras Mitzki <andras.mitzki@axoflow.com>", "Attila Szakacs <attila.szakacs@axoflow.com>"]
 readme = "README.md"

--- a/tests/light/src/axosyslog_light/driver_io/network/network_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/network/network_io.py
@@ -77,7 +77,7 @@ class NetworkIO():
         if framed is None:
             framed = self.__framed
         if framed:
-            return "".join([str(len(message)) + " " + message for message in messages])
+            return "".join([str(len(message.encode(encoding="utf-8"))) + " " + message for message in messages])
         return "".join([message + "\n" for message in messages])
 
     def write_messages(self, messages, rate=None, transport=None, framed=None, rate_burst_start=False, client_port=0):


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
