### PR TITLE
modules/xml: add error message on missing xmlns attribute

### DIFF
--- a/modules/xml/filterx-parse-windows-eventlog-xml.c
+++ b/modules/xml/filterx-parse-windows-eventlog-xml.c
@@ -153,21 +153,22 @@ _collect_attrs(const gchar **attribute_names, const gchar **attribute_values,
 static gboolean
 _has_valid_schema_url(const gchar **attribute_names, const gchar **attribute_values, GError **error)
 {
-  if (!attribute_names[0])
-    return FALSE;
-
-  if (g_strcmp0(attribute_names[0], "xmlns") != 0)
-    return FALSE;
+  if (!attribute_names[0] ||
+      g_strcmp0(attribute_names[0], "xmlns") != 0)
+    {
+      _set_error(error, "missing xmlns attribute in the Event element");
+      return FALSE;
+    }
 
   if (g_strcmp0(attribute_values[0], "http://schemas.microsoft.com/win/2004/08/events/event") != 0)
     {
-      _set_error(error, "unexpected schema URL: %s", attribute_values[0]);
+      _set_error(error, "unexpected schema URL in the Event element: %s", attribute_values[0]);
       return FALSE;
     }
 
   if (attribute_names[1])
     {
-      _set_error(error, "unexpected attribute in Event, number of attributes must be 1, got: %s", attribute_names[1]);
+      _set_error(error, "unexpected attribute in the Event element: %s", attribute_names[1]);
       return FALSE;
     }
 


### PR DESCRIPTION
I tried to parse a sample of Windows  Eventlog XML and I didn't get an error message, which took me a while to recognize.

I used an incorrect sample, which I didn't realize. This should make it easier to find these cases.
