### PR TITLE
Filterx: expr init must be called before eval

### DIFF
--- a/lib/filterx/expr-arithmetic-operators.c
+++ b/lib/filterx/expr-arithmetic-operators.c
@@ -89,10 +89,10 @@ _optimize_arithmetic_operators_common(FilterXArithmeticOperator *self)
     g_assert_not_reached();
 
   if (filterx_expr_is_literal(self->super.lhs))
-    self->literal_lhs = filterx_expr_eval_typed(self->super.lhs);
+    self->literal_lhs = filterx_literal_get_value(self->super.lhs);
 
   if (filterx_expr_is_literal(self->super.rhs))
-    self->literal_rhs = filterx_expr_eval(self->super.rhs);
+    self->literal_rhs = filterx_literal_get_value(self->super.rhs);
 }
 
 static void

--- a/lib/filterx/expr-boolalg.c
+++ b/lib/filterx/expr-boolalg.c
@@ -27,7 +27,7 @@
 static inline gboolean
 _literal_expr_truthy(FilterXExpr *expr)
 {
-  FilterXObject *result = filterx_expr_eval(expr);
+  FilterXObject *result = filterx_literal_get_value(expr);
   g_assert(result);
 
   gboolean truthy = filterx_object_truthy(result);

--- a/lib/filterx/expr-comparison.c
+++ b/lib/filterx/expr-comparison.c
@@ -274,12 +274,11 @@ _optimize(FilterXExpr *s)
 
   g_assert(!filterx_binary_op_optimize_method(s));
 
-  gint compare_mode = self->operator & FCMPX_MODE_MASK;
   if (filterx_expr_is_literal(self->super.lhs))
-    self->literal_lhs = _eval_based_on_compare_mode(self->super.lhs, compare_mode);
+    self->literal_lhs = filterx_literal_get_value(self->super.lhs);
 
   if (filterx_expr_is_literal(self->super.rhs))
-    self->literal_rhs = _eval_based_on_compare_mode(self->super.rhs, compare_mode);
+    self->literal_rhs = filterx_literal_get_value(self->super.rhs);
 
   if (self->literal_lhs && self->literal_rhs)
     return filterx_literal_new(_eval_comparison(&self->super.super));

--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -163,7 +163,7 @@ _optimize(FilterXExpr *s)
   if (!filterx_expr_is_literal(self->condition))
     return NULL;
 
-  FilterXObject *condition_value = filterx_expr_eval(self->condition);
+  FilterXObject *condition_value = filterx_literal_get_value(self->condition);
 
   g_assert(condition_value);
   gboolean condition_truthy = filterx_object_truthy(condition_value);

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -444,7 +444,7 @@ _get_literal_string_from_expr(FilterXExpr *expr, gsize *len)
   if (!filterx_expr_is_literal(expr))
     goto error;
 
-  obj = filterx_expr_eval(expr);
+  obj = filterx_literal_get_value(expr);
   if (!obj)
     goto error;
 
@@ -481,7 +481,7 @@ filterx_function_args_is_literal_null(FilterXFunctionArgs *self, guint64 index)
   if (!filterx_expr_is_literal(expr))
     return FALSE;
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = filterx_literal_get_value(expr);
   if (!obj)
     return FALSE;
 
@@ -521,7 +521,7 @@ filterx_function_args_get_named_literal_object(FilterXFunctionArgs *self, const 
   if (!filterx_expr_is_literal(expr))
     return NULL;
 
-  return filterx_expr_eval(expr);
+  return filterx_literal_get_value(expr);
 }
 
 
@@ -606,7 +606,7 @@ filterx_function_args_get_named_literal_generic_number(FilterXFunctionArgs *self
   if (!filterx_expr_is_literal(expr))
     goto error;
 
-  obj = filterx_expr_eval(expr);
+  obj = filterx_literal_get_value(expr);
   if (!obj)
     goto error;
 

--- a/lib/filterx/expr-literal.c
+++ b/lib/filterx/expr-literal.c
@@ -27,6 +27,16 @@ typedef struct _FilterXLiteral
   FilterXObject *object;
 } FilterXLiteral;
 
+FilterXObject *
+filterx_literal_get_value(FilterXExpr *s)
+{
+  g_assert(filterx_expr_is_literal(s));
+  FilterXLiteral *self = (FilterXLiteral *) s;
+
+  return filterx_object_ref(self->object);
+}
+
+
 static FilterXObject *
 _eval_literal(FilterXExpr *s)
 {

--- a/lib/filterx/expr-literal.h
+++ b/lib/filterx/expr-literal.h
@@ -35,4 +35,7 @@ filterx_expr_is_literal(FilterXExpr *expr)
   return expr && expr->type == FILTERX_EXPR_TYPE_NAME(literal);
 }
 
+FilterXObject *
+filterx_literal_get_value(FilterXExpr *expr);
+
 #endif

--- a/lib/filterx/expr-membership.c
+++ b/lib/filterx/expr-membership.c
@@ -91,10 +91,10 @@ _optimize_in(FilterXExpr *s)
     g_assert_not_reached();
 
   if (filterx_expr_is_literal(self->super.lhs))
-    self->literal_lhs = filterx_expr_eval_typed(self->super.lhs);
+    self->literal_lhs = filterx_literal_get_value(self->super.lhs);
 
   if (filterx_expr_is_literal(self->super.rhs))
-    self->literal_rhs = filterx_expr_eval(self->super.rhs);
+    self->literal_rhs = filterx_literal_get_value(self->super.rhs);
 
   if (self->literal_lhs && self->literal_rhs)
     return filterx_literal_new(_eval_in(&self->super.super));

--- a/lib/filterx/expr-null-coalesce.c
+++ b/lib/filterx/expr-null-coalesce.c
@@ -70,7 +70,7 @@ _optimize(FilterXExpr *s)
   if (!filterx_expr_is_literal(self->super.lhs))
     return NULL;
 
-  FilterXObject *lhs_object = filterx_expr_eval(self->super.lhs);
+  FilterXObject *lhs_object = filterx_literal_get_value(self->super.lhs);
   if (!lhs_object || filterx_object_is_type(lhs_object, &FILTERX_TYPE_NAME(null)))
     {
       filterx_object_unref(lhs_object);

--- a/lib/filterx/expr-plus.c
+++ b/lib/filterx/expr-plus.c
@@ -73,10 +73,10 @@ _optimize(FilterXExpr *s)
     g_assert_not_reached();
 
   if (filterx_expr_is_literal(self->super.lhs))
-    self->literal_lhs = filterx_expr_eval_typed(self->super.lhs);
+    self->literal_lhs = filterx_literal_get_value(self->super.lhs);
 
   if (filterx_expr_is_literal(self->super.rhs))
-    self->literal_rhs = filterx_expr_eval(self->super.rhs);
+    self->literal_rhs = filterx_literal_get_value(self->super.rhs);
 
   if (self->literal_lhs && self->literal_rhs)
     return filterx_literal_new(_eval_plus(&self->super.super));

--- a/lib/filterx/expr-regexp-search.c
+++ b/lib/filterx/expr-regexp-search.c
@@ -240,7 +240,7 @@ _regexp_search_init(FilterXExpr *s, GlobalConfig *cfg)
       goto error;
     }
 
-  pattern_obj = filterx_expr_eval(self->pattern_expr);
+  pattern_obj = filterx_literal_get_value(self->pattern_expr);
 
   gsize pattern_len;
   const gchar *pattern = filterx_string_get_value_ref(pattern_obj, &pattern_len);

--- a/lib/filterx/expr-regexp-subst.c
+++ b/lib/filterx/expr-regexp-subst.c
@@ -260,7 +260,7 @@ _init_subst_pattern(FilterXFuncRegexpSubst *self, GlobalConfig *cfg)
     }
 
   gsize pattern_len;
-  FilterXObject *pattern_obj = filterx_expr_eval(self->pattern_expr);
+  FilterXObject *pattern_obj = filterx_literal_get_value(self->pattern_expr);
   const gchar *pattern = filterx_string_get_value_ref(pattern_obj, &pattern_len);
   if (!pattern)
     {

--- a/lib/filterx/expr-string-operators.c
+++ b/lib/filterx/expr-string-operators.c
@@ -183,10 +183,10 @@ filterx_string_slicing_optimize(FilterXExpr *s)
   self->end = filterx_expr_optimize(self->end);
 
   if (filterx_expr_is_literal(self->start))
-    self->start_literal = filterx_expr_eval(self->start);
+    self->start_literal = filterx_literal_get_value(self->start);
 
   if (filterx_expr_is_literal(self->end))
-    self->end_literal = filterx_expr_eval(self->end);
+    self->end_literal = filterx_literal_get_value(self->end);
 
   return NULL;
 }

--- a/lib/filterx/expr-switch.c
+++ b/lib/filterx/expr-switch.c
@@ -102,7 +102,7 @@ _try_to_cache_literal_switch_case(FilterXSwitch *self, FilterXExpr *switch_case_
   if (!filterx_expr_is_literal(switch_case->super.operand))
     return FALSE;
 
-  FilterXObject *case_value = filterx_expr_eval(switch_case->super.operand);
+  FilterXObject *case_value = filterx_literal_get_value(switch_case->super.operand);
   if (!case_value)
     return FALSE;
 

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -92,6 +92,10 @@ struct _FilterXExpr
 static inline FilterXObject *
 filterx_expr_eval(FilterXExpr *self)
 {
+#if SYSLOG_NG_ENABLE_DEBUG
+  g_assert(self->inited);
+#endif
+
   stats_counter_inc(self->eval_count);
 
   return self->eval(self);

--- a/lib/filterx/filterx-metrics-labels.c
+++ b/lib/filterx/filterx-metrics-labels.c
@@ -400,7 +400,7 @@ filterx_metrics_labels_optimize(FilterXMetricsLabels *self)
       for (guint i = 0; i < self->literal_labels->len; i++)
         {
           FilterXMetricsLabel *label = g_ptr_array_index(self->literal_labels, i);
-          gboolean is_empty;
+          gboolean is_empty = FALSE;
 
           _label_optimize(label, &is_empty);
 

--- a/lib/filterx/filterx-metrics-labels.c
+++ b/lib/filterx/filterx-metrics-labels.c
@@ -68,6 +68,19 @@ _format_str_obj(FilterXObject *obj)
 }
 
 static gboolean
+_format_value(FilterXObject *obj, gchar **formatted_value)
+{
+  if (_is_value_empty(obj))
+    {
+      /* empty values should not be added, but it is not a failure */
+      return TRUE;
+    }
+
+  *formatted_value = _format_str_obj(obj);
+  return (*formatted_value) != NULL;
+}
+
+static gboolean
 _format_value_expr(FilterXExpr *expr, gchar **formatted_value)
 {
   gboolean success = TRUE;
@@ -80,21 +93,11 @@ _format_value_expr(FilterXExpr *expr, gchar **formatted_value)
                                           "Failed to evaluate expression");
       goto exit;
     }
-
-  if (_is_value_empty(obj))
+  success = _format_value(obj, formatted_value);
+  if (!success)
     {
-      /* empty values should not be added, but it is not a failure */
-      goto exit;
-    }
-
-  *formatted_value = _format_str_obj(obj);
-  if (!(*formatted_value))
-    {
-      success = FALSE;
       filterx_eval_push_error("Failed to format metrics label value: str() failed", expr, obj);
-      goto exit;
     }
-
 exit:
   filterx_object_unref(obj);
   return success;
@@ -152,8 +155,13 @@ _label_optimize(FilterXMetricsLabel *self, gboolean *is_empty)
 
   ScratchBuffersMarker marker;
   scratch_buffers_mark(&marker);
+
   gchar *formatted_value = NULL;
-  g_assert(_format_value_expr(self->value.expr, &formatted_value));
+
+  FilterXObject *value = filterx_literal_get_value(self->value.expr);
+  g_assert(_format_value(value, &formatted_value));
+  filterx_object_unref(value);
+
   self->value.str = g_strdup(formatted_value);
   scratch_buffers_reclaim_marked(marker);
 
@@ -195,7 +203,7 @@ _init_label_name(FilterXExpr *name)
       return NULL;
     }
 
-  FilterXObject *obj = filterx_expr_eval_typed(name);
+  FilterXObject *obj = filterx_literal_get_value(name);
   gchar *str = g_strdup(filterx_string_get_value_ref(obj, NULL));
   if (!str)
     {

--- a/lib/filterx/filterx-metrics.c
+++ b/lib/filterx/filterx-metrics.c
@@ -113,7 +113,7 @@ _optimize_key(FilterXMetrics *self)
   if (!filterx_expr_is_literal(self->key.expr))
     return;
 
-  FilterXObject *key_obj = filterx_expr_eval_typed(self->key.expr);
+  FilterXObject *key_obj = filterx_literal_get_value(self->key.expr);
   if (!filterx_object_is_type(key_obj, &FILTERX_TYPE_NAME(string)))
     {
       filterx_object_unref(key_obj);

--- a/lib/filterx/func-failure-info.c
+++ b/lib/filterx/func-failure-info.c
@@ -133,6 +133,35 @@ _failure_info_clear_eval(FilterXExpr *s)
   return filterx_boolean_new(TRUE);
 }
 
+static gboolean
+_failure_info_meta_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionFailureInfoMeta *self = (FilterXFunctionFailureInfoMeta *) s;
+
+  if (!filterx_expr_init(self->metadata_expr, cfg))
+    return FALSE;
+
+  return filterx_function_init_method(&self->super, cfg);
+}
+
+static void
+_failure_info_meta_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionFailureInfoMeta *self = (FilterXFunctionFailureInfoMeta *) s;
+
+  filterx_expr_deinit(self->metadata_expr, cfg);
+  filterx_function_deinit_method(&self->super, cfg);
+}
+
+static FilterXExpr *
+_failure_info_meta_optimize(FilterXExpr *s)
+{
+  FilterXFunctionFailureInfoMeta *self = (FilterXFunctionFailureInfoMeta *) s;
+
+  self->metadata_expr = filterx_expr_optimize(self->metadata_expr);
+  return filterx_function_optimize_method(&self->super);
+}
+
 static FilterXObject *
 _failure_info_meta_eval(FilterXExpr *s)
 {
@@ -283,6 +312,9 @@ filterx_fn_failure_info_meta_new(FilterXFunctionArgs *args, GError **error)
 {
   FilterXFunctionFailureInfoMeta *self = g_new0(FilterXFunctionFailureInfoMeta, 1);
   filterx_function_init_instance(&self->super, "failure_info_meta");
+  self->super.super.init = _failure_info_meta_init;
+  self->super.super.deinit = _failure_info_meta_deinit;
+  self->super.super.optimize = _failure_info_meta_optimize;
   self->super.super.eval = _failure_info_meta_eval;
   self->super.super.free_fn = _failure_info_meta_free;
 

--- a/lib/filterx/func-set-fields.c
+++ b/lib/filterx/func-set-fields.c
@@ -374,7 +374,7 @@ _extract_field_key_obj(FilterXExpr *key, GError **error)
   if (!filterx_expr_is_literal(key))
     goto exit;
 
-  key_obj = filterx_expr_eval(key);
+  key_obj = filterx_literal_get_value(key);
   if (!filterx_object_is_type(key_obj, &FILTERX_TYPE_NAME(string)))
     {
       filterx_object_unref(key_obj);

--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -263,6 +263,35 @@ typedef struct FilterXFunctionStrptime_
   GPtrArray *formats;
 } FilterXFunctionStrptime;
 
+static FilterXExpr *
+_strptime_optimize(FilterXExpr *s)
+{
+  FilterXFunctionStrptime *self = (FilterXFunctionStrptime *) s;
+
+  self->time_str_expr = filterx_expr_optimize(self->time_str_expr);
+  return filterx_function_optimize_method(&self->super);
+}
+
+static gboolean
+_strptime_init(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionStrptime *self = (FilterXFunctionStrptime *) s;
+
+  if (!filterx_expr_init(self->time_str_expr, cfg))
+    return FALSE;
+
+  return filterx_function_init_method(&self->super, cfg);
+}
+
+static void
+_strptime_deinit(FilterXExpr *s, GlobalConfig *cfg)
+{
+  FilterXFunctionStrptime *self = (FilterXFunctionStrptime *) s;
+
+  filterx_expr_deinit(self->time_str_expr, cfg);
+  filterx_function_deinit_method(&self->super, cfg);
+}
+
 static FilterXObject *
 _strptime_eval(FilterXExpr *s)
 {
@@ -400,6 +429,9 @@ filterx_function_strptime_new(FilterXFunctionArgs *args, GError **error)
 {
   FilterXFunctionStrptime *self = g_new0(FilterXFunctionStrptime, 1);
   filterx_function_init_instance(&self->super, "strptime");
+  self->super.super.init = _strptime_init;
+  self->super.super.deinit = _strptime_deinit;
+  self->super.super.optimize = _strptime_optimize;
   self->super.super.eval = _strptime_eval;
   self->super.super.free_fn = _strptime_free;
 

--- a/lib/filterx/tests/test_builtin_functions.c
+++ b/lib/filterx/tests/test_builtin_functions.c
@@ -22,6 +22,7 @@
 
 #include <criterion/criterion.h>
 #include "libtest/cr_template.h"
+#include "libtest/filterx-lib.h"
 
 #include "filterx/filterx-object.h"
 #include "filterx/object-primitive.h"
@@ -145,7 +146,7 @@ Test(builtin_functions, test_builtin_function_ctors_lookup)
   FilterXExpr *func_expr = ctor(filterx_function_args_new(NULL, NULL), NULL);
   cr_assert(func_expr != NULL);
 
-  FilterXObject *res = filterx_expr_eval(func_expr);
+  FilterXObject *res = init_and_eval_expr(func_expr);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
   gsize len;
   const gchar *str = filterx_string_get_value_ref(res, &len);

--- a/lib/filterx/tests/test_expr_comparison.c
+++ b/lib/filterx/tests/test_expr_comparison.c
@@ -22,6 +22,7 @@
 
 #include <criterion/criterion.h>
 #include "libtest/cr_template.h"
+#include "libtest/filterx-lib.h"
 
 #include "filterx/filterx-object.h"
 #include "filterx/object-primitive.h"
@@ -36,14 +37,18 @@
 #include "apphook.h"
 #include "scratch-buffers.h"
 
-static void _assert_comparison(FilterXObject *lhs, FilterXObject *rhs, gint operator, gboolean expected)
+static void
+_assert_comparison(FilterXObject *lhs, FilterXObject *rhs, gint operator, gboolean expected)
 {
   FilterXExpr *lhse = filterx_literal_new(lhs);
   FilterXExpr *rhse = filterx_literal_new(rhs);
+
   FilterXExpr *cmp = filterx_comparison_new(lhse, rhse, operator);
   cr_assert_not_null(cmp);
-  FilterXObject *result = filterx_expr_eval(cmp);
+
+  FilterXObject *result = init_and_eval_expr(cmp);
   cr_assert_not_null(result);
+
   cr_assert(filterx_object_truthy(result) == expected);
   filterx_expr_unref(cmp);
   // note that comparison expression unref operands

--- a/lib/filterx/tests/test_expr_compound.c
+++ b/lib/filterx/tests/test_expr_compound.c
@@ -64,7 +64,7 @@ _assert_set_test_variable(const char *var_name, FilterXExpr *expr)
   FilterXExpr *assign = _assert_assign_var(var_name, expr);
   cr_assert(assign != NULL);
 
-  FilterXObject *assign_eval_res = filterx_expr_eval(assign);
+  FilterXObject *assign_eval_res = init_and_eval_expr(assign);
   cr_assert(assign_eval_res != NULL);
   cr_assert(filterx_object_truthy(assign_eval_res));
 
@@ -77,7 +77,7 @@ _assert_get_test_variable(const char *var_name)
 {
   FilterXExpr *control_variable = filterx_msg_variable_expr_new(var_name);
   cr_assert(control_variable != NULL);
-  FilterXObject *result = filterx_expr_eval(control_variable);
+  FilterXObject *result = init_and_eval_expr(control_variable);
   filterx_expr_unref(control_variable);
   return result;
 }
@@ -91,8 +91,7 @@ Test(expr_compound, test_compound_all_the_statements_must_execute_and_return_tru
                                                        _assert_assign_var("$control-value3", _string_to_filterXExpr("matching3")),
                                                        NULL);
 
-
-  FilterXObject *res = filterx_expr_eval(compound);
+  FilterXObject *res = init_and_eval_expr(compound);
   cr_assert(res != NULL);
   cr_assert(filterx_object_truthy(res));
   filterx_object_unref(res);
@@ -118,8 +117,7 @@ Test(expr_compound, test_compound_all_the_statements_must_execute_and_return_the
                                                        _assert_assign_var("$control-value3", _string_to_filterXExpr("matching3")),
                                                        NULL);
 
-
-  FilterXObject *res = filterx_expr_eval(compound);
+  FilterXObject *res = init_and_eval_expr(compound);
   cr_assert(res != NULL);
   cr_assert(filterx_object_truthy(res));
   cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching3", res));

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -73,7 +73,7 @@ _assert_set_test_variable(const char *var_name, FilterXExpr *expr)
   FilterXExpr *assign = _assert_assign_var(var_name, expr);
   cr_assert(assign != NULL);
 
-  FilterXObject *assign_eval_res = filterx_expr_eval(assign);
+  FilterXObject *assign_eval_res = init_and_eval_expr(assign);
   cr_assert(assign_eval_res != NULL);
   cr_assert(filterx_object_truthy(assign_eval_res));
 
@@ -86,7 +86,7 @@ _assert_get_test_variable(const char *var_name)
 {
   FilterXExpr *control_variable = filterx_msg_variable_expr_new(var_name);
   cr_assert(control_variable != NULL);
-  FilterXObject *result = filterx_expr_eval(control_variable);
+  FilterXObject *result = init_and_eval_expr(control_variable);
   filterx_expr_unref(control_variable);
   return result;
 }
@@ -109,7 +109,7 @@ Test(expr_condition, test_condition_matching_expression)
   filterx_conditional_set_true_branch(cond,
                                       filterx_compound_expr_new_va(FALSE, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")), NULL));
 
-  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  FilterXObject *cond_eval = init_and_eval_expr(cond);
   cr_assert(cond_eval != NULL);
   cr_assert(filterx_object_truthy(cond_eval) == TRUE);
 
@@ -128,7 +128,7 @@ Test(expr_condition, test_condition_non_matching_expression)
   FilterXExpr *cond = filterx_conditional_new(filterx_literal_new(filterx_boolean_new(false)));
   filterx_conditional_set_true_branch(cond,
                                       filterx_compound_expr_new_va(FALSE, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")), NULL));
-  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  FilterXObject *cond_eval = init_and_eval_expr(cond);
   cr_assert(cond_eval != NULL);
   cr_assert(filterx_object_truthy(cond_eval) == TRUE);
 
@@ -160,7 +160,7 @@ Test(expr_condition, test_condition_matching_elif_expression)
 
   filterx_conditional_set_false_branch(cond, elif_cond);
 
-  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  FilterXObject *cond_eval = init_and_eval_expr(cond);
   cr_assert(cond_eval != NULL);
   cr_assert(filterx_object_truthy(cond_eval) == TRUE);
 
@@ -191,7 +191,7 @@ Test(expr_condition, test_condition_non_matching_elif_expression)
 
   filterx_conditional_set_false_branch(cond, elif_cond);
 
-  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  FilterXObject *cond_eval = init_and_eval_expr(cond);
   cr_assert(cond_eval != NULL);
   cr_assert(filterx_object_truthy(cond_eval) == TRUE);
 
@@ -230,7 +230,7 @@ Test(expr_condition, test_condition_matching_else_expression)
                                        filterx_compound_expr_new_va(FALSE, _assert_assign_var("$control-value", _string_to_filterXExpr("else-matching")),
                                            NULL));
 
-  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  FilterXObject *cond_eval = init_and_eval_expr(cond);
   cr_assert(cond_eval != NULL);
   cr_assert(filterx_object_truthy(cond_eval) == TRUE);
 
@@ -279,7 +279,7 @@ Test(expr_condition, test_condition_subsequent_conditions_must_create_nested_con
                                        filterx_compound_expr_new_va(FALSE, _assert_assign_var("$control-value", _string_to_filterXExpr("else-matching")),
                                            NULL));
 
-  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  FilterXObject *cond_eval = init_and_eval_expr(cond);
   cr_assert(cond_eval != NULL);
   cr_assert(filterx_object_truthy(cond_eval) == TRUE);
 
@@ -303,7 +303,7 @@ Test(expr_condition, test_condition_falsey_statement_must_interrupt_sequential_c
                                           _assert_assign_var("$control-value3", _string_to_filterXExpr("matching3")),
                                           NULL));
 
-  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  FilterXObject *cond_eval = init_and_eval_expr(cond);
   /* a false statement is converted into an error return */
   cr_assert_null(cond_eval);
 
@@ -329,7 +329,7 @@ Test(expr_condition, test_condition_error_statement_must_return_null)
                                           NULL));
 
 
-  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  FilterXObject *cond_eval = init_and_eval_expr(cond);
   cr_assert_null(cond_eval);
 
   FilterXObject *control_value = _assert_get_test_variable("$control-value");
@@ -356,7 +356,8 @@ Test(expr_condition, test_condition_return_expr_result_on_missing_stmts)
   g_clear_error(&error);
 
   FilterXExpr *cond = filterx_conditional_new(func);
-  FilterXObject *res = filterx_expr_eval(cond);
+
+  FilterXObject *res = init_and_eval_expr(cond);
   cr_assert_not_null(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
   const gchar *strval = filterx_string_get_value_ref(res, NULL);
@@ -373,7 +374,7 @@ Test(expr_condition, test_condition_must_not_fail_on_empty_else_block)
 
   filterx_conditional_set_false_branch(cond,
                                        filterx_compound_expr_new(FALSE));
-  FilterXObject *res = filterx_expr_eval(cond);
+  FilterXObject *res = init_and_eval_expr(cond);
   cr_assert_not_null(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(boolean)));
   cr_assert(filterx_object_truthy(res));
@@ -392,7 +393,7 @@ Test(expr_condition, test_condition_with_complex_expression_to_check_memory_leak
                                        filterx_compound_expr_new_va(TRUE,
                                            filterx_literal_new(filterx_string_new("foobar", -1)),
                                            NULL));
-  FilterXObject *res = filterx_expr_eval(cond);
+  FilterXObject *res = init_and_eval_expr(cond);
   cr_assert_not_null(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
   const gchar *str = filterx_string_get_value_ref(res, NULL);

--- a/lib/filterx/tests/test_expr_function.c
+++ b/lib/filterx/tests/test_expr_function.c
@@ -22,6 +22,7 @@
 
 #include <criterion/criterion.h>
 #include "libtest/cr_template.h"
+#include "libtest/filterx-lib.h"
 
 #include "filterx/filterx-object.h"
 #include "filterx/object-primitive.h"
@@ -98,7 +99,7 @@ Test(expr_function, test_function_valid_arg)
   cr_assert_null(error);
   g_clear_error(&error);
 
-  FilterXObject *res = filterx_expr_eval(func);
+  FilterXObject *res = init_and_eval_expr(func);
   cr_assert_not_null(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
   const gchar *str = filterx_string_get_value_ref(res, NULL);
@@ -121,7 +122,7 @@ Test(expr_function, test_function_multiple_args)
   cr_assert_null(error);
   g_clear_error(&error);
   cr_assert_not_null(func);
-  FilterXObject *res = filterx_expr_eval(func);
+  FilterXObject *res = init_and_eval_expr(func);
   cr_assert_not_null(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
   const gchar *str = filterx_string_get_value_ref(res, NULL);

--- a/lib/filterx/tests/test_expr_null_coalesce.c
+++ b/lib/filterx/tests/test_expr_null_coalesce.c
@@ -48,9 +48,11 @@ Test(expr_null_coalesce, test_coalescing_soft_null)
   FilterXExpr *coalesce = filterx_null_coalesce_new(filterx_literal_new(filterx_null_new()),
                                                     filterx_non_literal_new(filterx_test_unknown_object_new()));
   cr_assert(coalesce);
+  cr_assert(filterx_expr_init(coalesce, configuration));
   FilterXObject *res = filterx_expr_eval(coalesce);
   cr_assert(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(test_unknown_object)));
+  filterx_expr_deinit(coalesce, configuration);
   filterx_expr_unref(coalesce);
   filterx_object_unref(res);
 }
@@ -63,6 +65,7 @@ Test(expr_null_coalesce, test_coalescing_supressing_lhs_eval_error)
   // passing errorous expression as lhs
   FilterXExpr *coalesce = filterx_null_coalesce_new(err_expr, filterx_non_literal_new(filterx_test_unknown_object_new()));
   cr_assert(coalesce);
+  cr_assert(filterx_expr_init(coalesce, configuration));
 
   // eval returns rhs value, since lhs fails during eval
   FilterXObject *res = filterx_expr_eval(coalesce);
@@ -72,6 +75,7 @@ Test(expr_null_coalesce, test_coalescing_supressing_lhs_eval_error)
   // lhs expr eval errors must supressed by null_coalesce
   cr_assert(filterx_eval_get_error_count() == 0);
 
+  filterx_expr_deinit(coalesce, configuration);
   filterx_expr_unref(coalesce);
   filterx_object_unref(res);
 }
@@ -85,6 +89,7 @@ Test(expr_null_coalesce, test_coalescing_keep_rhs_eval_error)
   FilterXExpr *coalesce = filterx_null_coalesce_new(filterx_non_literal_new(filterx_null_new()),
                                                     err_expr);
   cr_assert(coalesce);
+  cr_assert(filterx_expr_init(coalesce, configuration));
 
   // null_coalesce returns null, since lhs is null and rhs fails
   FilterXObject *res = filterx_expr_eval(coalesce);
@@ -95,6 +100,7 @@ Test(expr_null_coalesce, test_coalescing_keep_rhs_eval_error)
   cr_assert_not_null(last_error);
   cr_assert_str_eq(error_msg, last_error);
 
+  filterx_expr_deinit(coalesce, configuration);
   filterx_expr_unref(coalesce);
   filterx_object_unref(res);
 }
@@ -109,6 +115,7 @@ Test(expr_null_coalesce, test_coalescing_keep_rhs_eval_error_on_double_fail)
   // passing errorous expressions
   FilterXExpr *coalesce = filterx_null_coalesce_new(err_expr_lhs, err_expr_rhs);
   cr_assert(coalesce);
+  cr_assert(filterx_expr_init(coalesce, configuration));
 
   // null_coalesce returns null, since both lhs and rhs fails
   FilterXObject *res = filterx_expr_eval(coalesce);
@@ -119,6 +126,7 @@ Test(expr_null_coalesce, test_coalescing_keep_rhs_eval_error_on_double_fail)
   cr_assert_not_null(last_error);
   cr_assert_str_eq(error_msg, last_error);
 
+  filterx_expr_deinit(coalesce, configuration);
   filterx_expr_unref(coalesce);
   filterx_object_unref(res);
 }

--- a/lib/filterx/tests/test_expr_plus.c
+++ b/lib/filterx/tests/test_expr_plus.c
@@ -56,10 +56,9 @@ Test(expr_plus, test_string_success)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)));
-
 
   gsize size;
   const gchar *res = filterx_string_get_value_ref(obj, &size);
@@ -79,7 +78,7 @@ Test(expr_plus, test_string_add_wrong_type)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_null(obj);
   filterx_expr_unref(expr);
 }
@@ -97,7 +96,7 @@ Test(expr_plus, test_datetime_add_datetime)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_null(obj); // datetime + datetime operation is not supported currently
 
   filterx_object_unref(obj);
@@ -114,7 +113,7 @@ Test(expr_plus, test_datetime_add_integer)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(datetime)));
 
@@ -134,7 +133,7 @@ Test(expr_plus, test_datetime_add_double)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(datetime)));
 
@@ -153,7 +152,7 @@ Test(expr_plus, test_datetime_add_wrong_type)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_null(obj);
   filterx_expr_unref(expr);
 }
@@ -166,7 +165,7 @@ Test(expr_plus, test_integer_add_integer)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(integer)));
 
@@ -186,7 +185,7 @@ Test(expr_plus, test_integer_add_double)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(double)));
 
@@ -208,7 +207,7 @@ Test(expr_plus, test_integer_add_wrong_type)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_null(obj);
   filterx_expr_unref(expr);
 }
@@ -221,7 +220,7 @@ Test(expr_plus, test_double_add_double)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(double)));
 
@@ -243,7 +242,7 @@ Test(expr_plus, test_double_add_integer)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(double)));
 
@@ -266,7 +265,7 @@ Test(expr_plus, test_double_add_wrong_type)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_null(obj);
   filterx_expr_unref(expr);
 }
@@ -279,7 +278,7 @@ Test(expr_plus, test_list_add_list)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(list)));
 
@@ -298,7 +297,7 @@ Test(expr_plus, test_list_add_wrong_type)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_null(obj);
   filterx_expr_unref(expr);
 }
@@ -311,7 +310,7 @@ Test(expr_plus, test_dict_add_dict)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(dict)));
 
@@ -329,7 +328,7 @@ Test(expr_plus, test_dict_add_wrong_type)
   FilterXExpr *expr = filterx_operator_plus_new(lhs, rhs);
   cr_assert_not_null(expr);
 
-  FilterXObject *obj = filterx_expr_eval(expr);
+  FilterXObject *obj = init_and_eval_expr(expr);
   cr_assert_null(obj);
   filterx_expr_unref(expr);
 }

--- a/lib/filterx/tests/test_expr_plus_generator.c
+++ b/lib/filterx/tests/test_expr_plus_generator.c
@@ -103,7 +103,7 @@ Test(expr_plus_generator, test_list_add_two_generators_with_post_set_fillable)
   FilterXExpr *fillable = filterx_literal_new(list);
   filterx_generator_set_fillable(expr, filterx_expr_ref(fillable));
 
-  FilterXObject *res_object = filterx_expr_eval(expr);
+  FilterXObject *res_object = init_and_eval_expr(expr);
   cr_assert_not_null(res_object);
   cr_assert(filterx_object_is_type(res_object, &FILTERX_TYPE_NAME(list)));
 
@@ -132,7 +132,7 @@ Test(expr_plus_generator, test_list_add_variable_to_generator_with_post_set_fill
   FilterXExpr *fillable = filterx_literal_new(list);
   filterx_generator_set_fillable(expr, filterx_expr_ref(fillable));
 
-  FilterXObject *res_object = filterx_expr_eval(expr);
+  FilterXObject *res_object = init_and_eval_expr(expr);
   cr_assert_not_null(res_object);
   cr_assert(filterx_object_is_type(res_object, &FILTERX_TYPE_NAME(list)));
 
@@ -162,7 +162,7 @@ Test(expr_plus_generator, test_list_add_generator_to_variable_with_post_set_fill
   FilterXExpr *fillable = filterx_literal_new(list);
   filterx_generator_set_fillable(expr, filterx_expr_ref(fillable));
 
-  FilterXObject *res_object = filterx_expr_eval(expr);
+  FilterXObject *res_object = init_and_eval_expr(expr);
   cr_assert_not_null(res_object);
   cr_assert(filterx_object_is_type(res_object, &FILTERX_TYPE_NAME(list)));
 
@@ -204,7 +204,7 @@ Test(expr_plus_generator, test_nested_dict_add_two_generators_with_post_set_fill
   FilterXExpr *fillable = filterx_literal_new(dict);
   filterx_generator_set_fillable(expr, filterx_expr_ref(fillable));
 
-  FilterXObject *res_object = filterx_expr_eval(expr);
+  FilterXObject *res_object = init_and_eval_expr(expr);
   cr_assert_not_null(res_object);
   cr_assert(filterx_object_is_type(res_object, &FILTERX_TYPE_NAME(dict)));
 
@@ -234,7 +234,7 @@ Test(expr_plus_generator, test_nested_dict_add_variable_to_generator_with_post_s
   FilterXExpr *fillable = filterx_literal_new(dict);
   filterx_generator_set_fillable(expr, filterx_expr_ref(fillable));
 
-  FilterXObject *res_object = filterx_expr_eval(expr);
+  FilterXObject *res_object = init_and_eval_expr(expr);
   cr_assert_not_null(res_object);
   cr_assert(filterx_object_is_type(res_object, &FILTERX_TYPE_NAME(dict)));
 
@@ -265,7 +265,7 @@ Test(expr_plus_generator, test_nested_dict_add_generator_to_variable_with_post_s
   FilterXExpr *fillable = filterx_literal_new(dict);
   filterx_generator_set_fillable(expr, filterx_expr_ref(fillable));
 
-  FilterXObject *res_object = filterx_expr_eval(expr);
+  FilterXObject *res_object = init_and_eval_expr(expr);
   cr_assert_not_null(res_object);
   cr_assert(filterx_object_is_type(res_object, &FILTERX_TYPE_NAME(dict)));
 

--- a/lib/filterx/tests/test_expr_regexp.c
+++ b/lib/filterx/tests/test_expr_regexp.c
@@ -38,7 +38,7 @@ _check_match(const gchar *lhs, const gchar *pattern)
 {
   FilterXExpr *expr = filterx_expr_regexp_match_new(filterx_literal_new(filterx_string_new(lhs, -1)), pattern);
 
-  FilterXObject *result_obj = filterx_expr_eval(expr);
+  FilterXObject *result_obj = init_and_eval_expr(expr);
   cr_assert(result_obj);
   gboolean result;
   cr_assert(filterx_boolean_unwrap(result_obj, &result));

--- a/lib/filterx/tests/test_filterx_eval.c
+++ b/lib/filterx/tests/test_filterx_eval.c
@@ -54,7 +54,7 @@ _create_embedded_exprs(gint depth, gboolean set_location)
       if (set_location)
         filterx_test_expr_set_location_with_text(fx_root, "syslog-ng.conf", i + 1, 0, i + 1, text->len - 1, text->str);
     }
-
+  filterx_expr_init(fx_root, configuration);
   return fx_root;
 }
 
@@ -90,6 +90,7 @@ Test(filterx_eval, test_filterx_eval_full_error_stack)
     for (gint i = 0; i < FILTERX_CONTEXT_ERROR_STACK_SIZE; i++)
       _assert_error_in_logs(i);
 
+    filterx_expr_deinit(expr, configuration);
     filterx_expr_unref(expr);
   }
   FILTERX_EVAL_END_CONTEXT(eval_context);
@@ -113,6 +114,7 @@ Test(filterx_eval, test_filterx_eval_error_stack_overflow)
     for (gint i = 0; i < FILTERX_CONTEXT_ERROR_STACK_SIZE; i++)
       _assert_error_in_logs(i);
 
+    filterx_expr_deinit(expr, configuration);
     filterx_expr_unref(expr);
   }
   FILTERX_EVAL_END_CONTEXT(eval_context);
@@ -144,6 +146,7 @@ Test(filterx_eval, test_filterx_eval_error_stack_location_backfill)
         assert_grabbed_log_contains(error_log->str);
       }
 
+    filterx_expr_deinit(expr, configuration);
     filterx_expr_unref(expr);
   }
   FILTERX_EVAL_END_CONTEXT(eval_context);

--- a/lib/filterx/tests/test_func_flatten.c
+++ b/lib/filterx/tests/test_func_flatten.c
@@ -54,13 +54,13 @@ _assert_flatten(GList *args, const gchar *expected_repr)
   FilterXExpr *func = filterx_function_flatten_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert(!err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
   cr_assert(obj);
   gboolean success;
   cr_assert(filterx_boolean_unwrap(obj, &success));
   cr_assert(success);
 
-  FilterXObject *modifiable_object = filterx_expr_eval(modifiable_object_expr);
+  FilterXObject *modifiable_object = init_and_eval_expr(modifiable_object_expr);
   cr_assert(modifiable_object);
 
   assert_object_repr_equals(modifiable_object, expected_repr);

--- a/lib/filterx/tests/test_func_istype.c
+++ b/lib/filterx/tests/test_func_istype.c
@@ -113,7 +113,7 @@ Test(filterx_func_istype, non_matching_type)
   FilterXExpr *func_expr = filterx_function_istype_new(filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
-  FilterXObject *result_obj = filterx_expr_eval(func_expr);
+  FilterXObject *result_obj = init_and_eval_expr(func_expr);
   cr_assert(result_obj);
 
   gboolean result;
@@ -134,7 +134,7 @@ Test(filterx_func_istype, matching_type)
   FilterXExpr *func_expr = filterx_function_istype_new(filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
-  FilterXObject *result_obj = filterx_expr_eval(func_expr);
+  FilterXObject *result_obj = init_and_eval_expr(func_expr);
   cr_assert(result_obj);
 
   gboolean result;
@@ -155,7 +155,7 @@ Test(filterx_func_istype, matching_type_for_super_type)
   FilterXExpr *func_expr = filterx_function_istype_new(filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
-  FilterXObject *result_obj = filterx_expr_eval(func_expr);
+  FilterXObject *result_obj = init_and_eval_expr(func_expr);
   cr_assert(result_obj);
 
   gboolean result;
@@ -176,7 +176,7 @@ Test(filterx_func_istype, matching_type_for_root_type)
   FilterXExpr *func_expr = filterx_function_istype_new(filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
-  FilterXObject *result_obj = filterx_expr_eval(func_expr);
+  FilterXObject *result_obj = init_and_eval_expr(func_expr);
   cr_assert(result_obj);
 
   gboolean result;

--- a/lib/filterx/tests/test_func_keys.c
+++ b/lib/filterx/tests/test_func_keys.c
@@ -77,7 +77,7 @@ Test(filterx_func_keys, invalid_arg_type)
   FilterXExpr *fn = filterx_function_keys_new(filterx_function_args_new(args, NULL), &error);
   cr_assert_not_null(fn);
   cr_assert_null(error);
-  FilterXObject *res = filterx_expr_eval(fn);
+  FilterXObject *res = init_and_eval_expr(fn);
   cr_assert_null(res);
 
   const gchar *last_error = filterx_eval_get_last_error();
@@ -98,7 +98,7 @@ Test(filterx_func_keys, valid_input)
   FilterXExpr *fn = filterx_function_keys_new(filterx_function_args_new(args, NULL), &error);
   cr_assert_not_null(fn);
   cr_assert_null(error);
-  FilterXObject *res = filterx_expr_eval(fn);
+  FilterXObject *res = init_and_eval_expr(fn);
   cr_assert_not_null(res);
   cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(list)));
 

--- a/lib/filterx/tests/test_func_unset_empties.c
+++ b/lib/filterx/tests/test_func_unset_empties.c
@@ -57,13 +57,13 @@ _assert_unset_empties(GList *args, const gchar *expected_repr)
   FilterXExpr *func = filterx_function_unset_empties_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert(!err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
   cr_assert(obj);
   gboolean success;
   cr_assert(filterx_boolean_unwrap(obj, &success));
   cr_assert(success);
 
-  FilterXObject *modifiable_object = filterx_expr_eval(modifiable_object_expr);
+  FilterXObject *modifiable_object = init_and_eval_expr(modifiable_object_expr);
   cr_assert(modifiable_object);
 
   assert_object_repr_equals(modifiable_object, expected_repr);

--- a/lib/filterx/tests/test_metrics_labels.c
+++ b/lib/filterx/tests/test_metrics_labels.c
@@ -45,6 +45,7 @@ Test(filterx_metrics_labels, null_labels)
   cr_assert(metrics_labels);
 
   filterx_metrics_labels_optimize(metrics_labels);
+  cr_assert(filterx_metrics_labels_init(metrics_labels, configuration));
 
   cr_assert(filterx_metrics_labels_is_const(metrics_labels));
 
@@ -55,6 +56,7 @@ Test(filterx_metrics_labels, null_labels)
   cr_assert(filterx_metrics_labels_format(metrics_labels, store, &sc_labels, &len));
   cr_assert_eq(len, 0);
 
+  filterx_metrics_labels_deinit(metrics_labels, configuration);
   filterx_metrics_labels_free(metrics_labels);
 }
 
@@ -66,6 +68,7 @@ Test(filterx_metrics_labels, const_literal_generator_empty_labels)
   cr_assert(metrics_labels);
 
   filterx_metrics_labels_optimize(metrics_labels);
+  cr_assert(filterx_metrics_labels_init(metrics_labels, configuration));
 
   cr_assert(filterx_metrics_labels_is_const(metrics_labels));
 
@@ -76,6 +79,7 @@ Test(filterx_metrics_labels, const_literal_generator_empty_labels)
   cr_assert(filterx_metrics_labels_format(metrics_labels, store, &sc_labels, &len));
   cr_assert_eq(len, 0);
 
+  filterx_metrics_labels_deinit(metrics_labels, configuration);
   filterx_metrics_labels_free(metrics_labels);
 }
 
@@ -87,6 +91,7 @@ Test(filterx_metrics_labels, non_literal_empty_labels)
   cr_assert(metrics_labels);
 
   filterx_metrics_labels_optimize(metrics_labels);
+  cr_assert(filterx_metrics_labels_init(metrics_labels, configuration));
 
   cr_assert_not(filterx_metrics_labels_is_const(metrics_labels));
 
@@ -97,6 +102,7 @@ Test(filterx_metrics_labels, non_literal_empty_labels)
   cr_assert(filterx_metrics_labels_format(metrics_labels, store, &sc_labels, &len));
   cr_assert_eq(len, 0);
 
+  filterx_metrics_labels_deinit(metrics_labels, configuration);
   filterx_metrics_labels_free(metrics_labels);
 }
 
@@ -117,6 +123,7 @@ Test(filterx_metrics_labels, const_literal_generator_labels)
   cr_assert(metrics_labels);
 
   filterx_metrics_labels_optimize(metrics_labels);
+  cr_assert(filterx_metrics_labels_init(metrics_labels, configuration));
 
   cr_assert(filterx_metrics_labels_is_const(metrics_labels));
 
@@ -132,6 +139,7 @@ Test(filterx_metrics_labels, const_literal_generator_labels)
   cr_assert_str_eq(sc_labels[1].name, "foo");
   cr_assert_str_eq(sc_labels[1].value, "foovalue");
 
+  filterx_metrics_labels_deinit(metrics_labels, configuration);
   filterx_metrics_labels_free(metrics_labels);
 }
 
@@ -152,6 +160,7 @@ Test(filterx_metrics_labels, non_const_literal_generator_labels)
   cr_assert(metrics_labels);
 
   filterx_metrics_labels_optimize(metrics_labels);
+  cr_assert(filterx_metrics_labels_init(metrics_labels, configuration));
 
   cr_assert_not(filterx_metrics_labels_is_const(metrics_labels));
 
@@ -167,6 +176,7 @@ Test(filterx_metrics_labels, non_const_literal_generator_labels)
   cr_assert_str_eq(sc_labels[1].name, "foo");
   cr_assert_str_eq(sc_labels[1].value, "foovalue");
 
+  filterx_metrics_labels_deinit(metrics_labels, configuration);
   filterx_metrics_labels_free(metrics_labels);
 }
 

--- a/lib/filterx/tests/test_object_datetime.c
+++ b/lib/filterx/tests/test_object_datetime.c
@@ -266,7 +266,7 @@ Test(filterx_datetime, test_filterx_datetime_strptime_non_matching_timefmt)
   FilterXExpr *func_expr = filterx_function_strptime_new(filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
-  FilterXObject *obj = filterx_expr_eval(func_expr);
+  FilterXObject *obj = init_and_eval_expr(func_expr);
   cr_assert(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(null)));
 
@@ -285,7 +285,7 @@ Test(filterx_datetime, test_filterx_datetime_strptime_matching_timefmt)
   FilterXExpr *func_expr = filterx_function_strptime_new(filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
-  FilterXObject *obj = filterx_expr_eval(func_expr);
+  FilterXObject *obj = init_and_eval_expr(func_expr);
   cr_assert(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(datetime)));
 
@@ -308,7 +308,7 @@ Test(filterx_datetime, test_filterx_datetime_strptime_matching_nth_timefmt)
   FilterXExpr *func_expr = filterx_function_strptime_new(filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
-  FilterXObject *obj = filterx_expr_eval(func_expr);
+  FilterXObject *obj = init_and_eval_expr(func_expr);
   cr_assert(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(datetime)));
 
@@ -331,7 +331,7 @@ Test(filterx_datetime, test_filterx_datetime_strptime_non_matching_nth_timefmt)
   FilterXExpr *func_expr = filterx_function_strptime_new(filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
-  FilterXObject *obj = filterx_expr_eval(func_expr);
+  FilterXObject *obj = init_and_eval_expr(func_expr);
   cr_assert(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(null)));
 

--- a/libtest/filterx-lib.c
+++ b/libtest/filterx-lib.c
@@ -274,6 +274,15 @@ filterx_test_expr_set_location_with_text(FilterXExpr *expr, const gchar *filenam
   filterx_expr_set_location_with_text(expr, &lloc, text);
 }
 
+FilterXObject *
+init_and_eval_expr(FilterXExpr *expr)
+{
+  cr_assert(filterx_expr_init(expr, configuration));
+  FilterXObject *result = filterx_expr_eval(expr);
+  filterx_expr_deinit(expr, configuration);
+  return result;
+}
+
 static struct
 {
   LogMessage *msg;

--- a/libtest/filterx-lib.h
+++ b/libtest/filterx-lib.h
@@ -53,4 +53,6 @@ void filterx_test_expr_set_location_with_text(FilterXExpr *expr, const gchar *fi
 void init_libtest_filterx(void);
 void deinit_libtest_filterx(void);
 
+FilterXObject *init_and_eval_expr(FilterXExpr *expr);
+
 #endif

--- a/modules/cef/tests/test-filterx-function-parse-cef.c
+++ b/modules/cef/tests/test-filterx-function-parse-cef.c
@@ -53,7 +53,7 @@ Test(filterx_func_parse_cef, test_invalid_input)
 
   FilterXExpr *func = _new_parser(fx_args, &error);
   cr_assert_null(error);
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
   cr_assert_null(obj);
 
   cr_assert_str_eq("Failed to evaluate event format parser: " EVENT_FORMAT_PARSER_ERR_NOT_STRING_INPUT_MSG,

--- a/modules/cef/tests/test-filterx-function-parse-leef.c
+++ b/modules/cef/tests/test-filterx-function-parse-leef.c
@@ -53,7 +53,7 @@ Test(filterx_func_parse_leef, test_invalid_input)
 
   FilterXExpr *func = _new_parser(fx_args, &error);
   cr_assert_null(error);
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
   cr_assert_null(obj);
 
   cr_assert_str_eq("Failed to evaluate event format parser: " EVENT_FORMAT_PARSER_ERR_NOT_STRING_INPUT_MSG,

--- a/modules/cef/tests/test_helpers.c
+++ b/modules/cef/tests/test_helpers.c
@@ -120,7 +120,7 @@ _eval_input_inner(GError **error, va_list vargs)
 {
   FilterXExpr *func = _new_parser(_assert_create_args_inner(vargs), error);
   cr_assert_not_null(func);
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
   filterx_expr_unref(func);
   return obj;
 }

--- a/modules/csvparser/filterx-func-parse-csv.c
+++ b/modules/csvparser/filterx-func-parse-csv.c
@@ -487,7 +487,7 @@ _add_literal_column(gsize index, FilterXExpr *column, gpointer user_data)
   if (!filterx_expr_is_literal(column))
     return FALSE;
 
-  FilterXObject *column_name = filterx_expr_eval_typed(column);
+  FilterXObject *column_name = filterx_literal_get_value(column);
 
   if (!filterx_object_is_type(column_name, &FILTERX_TYPE_NAME(string)))
     {

--- a/modules/csvparser/tests/test_filterx_func_format_csv.c
+++ b/modules/csvparser/tests/test_filterx_func_format_csv.c
@@ -51,7 +51,7 @@ _assert_format_csv(GList *args, const gchar *expected_output)
   FilterXExpr *func = filterx_function_format_csv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert(!err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
   cr_assert(obj);
 
   const gchar *output = filterx_string_get_value_ref(obj, NULL);

--- a/modules/csvparser/tests/test_filterx_func_parse_csv.c
+++ b/modules/csvparser/tests/test_filterx_func_parse_csv.c
@@ -122,7 +122,7 @@ Test(filterx_func_parse_csv, test_skipped_opts_causes_default_behaviour)
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(list)));
@@ -152,7 +152,7 @@ Test(filterx_func_parse_csv, test_set_optional_first_argument_column_names)
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(dict_object)));
@@ -183,7 +183,7 @@ Test(filterx_func_parse_csv, test_column_names_sets_expected_column_size_additio
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(dict_object)));
@@ -213,7 +213,7 @@ Test(filterx_func_parse_csv, test_optional_argument_delimiters)
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(list)));
@@ -243,7 +243,7 @@ Test(filterx_func_parse_csv, test_optional_argument_dialect)
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(list)));
@@ -276,7 +276,7 @@ Test(filterx_func_parse_csv, test_optional_argument_flag_greedy)
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(dict_object)));
@@ -309,7 +309,7 @@ Test(filterx_func_parse_csv, test_optional_argument_flag_non_greedy)
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(dict_object)));
@@ -342,7 +342,7 @@ Test(filterx_func_parse_csv, test_optional_argument_flag_strip_whitespace)
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(list)));
@@ -375,7 +375,7 @@ Test(filterx_func_parse_csv, test_optional_argument_flag_not_to_strip_whitespace
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(list)));
@@ -406,7 +406,7 @@ Test(filterx_func_parse_csv, test_optional_argument_string_delimiters)
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(list)));
@@ -439,7 +439,7 @@ Test(filterx_func_parse_csv, test_optional_argument_string_delimiters_and_delimi
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(list)));
@@ -472,7 +472,7 @@ Test(filterx_func_parse_csv, test_optional_argument_delimiter_default_unset_when
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(list)));

--- a/modules/grpc/filterx/tests/test_protobuf_message.c
+++ b/modules/grpc/filterx/tests/test_protobuf_message.c
@@ -182,7 +182,7 @@ Test(filterx_protobuf_message, assign_vars)
 
   FilterXExpr *func = _assert_protobuf_message_init_success(args);
 
-  FilterXObject *result = filterx_expr_eval(func);
+  FilterXObject *result = init_and_eval_expr(func);
   cr_assert(result);
 
   cr_assert(filterx_object_is_type(result, &FILTERX_TYPE_NAME(protobuf)));

--- a/modules/kvformat/tests/test_filterx_func_format_kv.c
+++ b/modules/kvformat/tests/test_filterx_func_format_kv.c
@@ -52,7 +52,7 @@ _assert_format_kv(GList *args, const gchar *expected_output)
   FilterXExpr *func = filterx_function_format_kv_new(filterx_function_args_new(args, &args_err), &err);
   cr_assert(!err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
   cr_assert(obj);
 
   const gchar *output = filterx_string_get_value_ref(obj, NULL);

--- a/modules/kvformat/tests/test_filterx_func_parse_kv.c
+++ b/modules/kvformat/tests/test_filterx_func_parse_kv.c
@@ -76,7 +76,7 @@ Test(filterx_func_parse_kv, test_skipped_opts_causes_default_behaviour)
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(dict)));
@@ -109,7 +109,7 @@ Test(filterx_func_parse_kv, test_optional_value_separator_option_first_character
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(dict)));
@@ -163,7 +163,7 @@ Test(filterx_func_parse_kv, test_optional_pair_separator_option)
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(dict)));
@@ -197,7 +197,7 @@ Test(filterx_func_parse_kv, test_optional_stray_words_key_option)
   cr_assert_null(args_err);
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = init_and_eval_expr(func);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(dict)));

--- a/modules/metrics-probe/filterx/func-update-metric.c
+++ b/modules/metrics-probe/filterx/func-update-metric.c
@@ -108,7 +108,7 @@ _optimize_increment(FilterXFunctionUpdateMetric *self)
   if (!self->increment.expr || !filterx_expr_is_literal(self->increment.expr))
     return;
 
-  FilterXObject *increment_obj = filterx_expr_eval(self->increment.expr);
+  FilterXObject *increment_obj = filterx_literal_get_value(self->increment.expr);
   if (!increment_obj)
     return;
 

--- a/modules/metrics-probe/tests/test_filterx_func_update_metric.c
+++ b/modules/metrics-probe/tests/test_filterx_func_update_metric.c
@@ -39,7 +39,7 @@ _add_label(FilterXExpr *labels_expr, const gchar *name, const gchar *value)
 {
   FilterXObject *name_obj = filterx_string_new(name, -1);
   FilterXObject *value_obj = filterx_string_new(value, -1);
-  FilterXObject *labels_obj = filterx_expr_eval(labels_expr);
+  FilterXObject *labels_obj = init_and_eval_expr(labels_expr);
 
   cr_assert(filterx_object_set_subscript(labels_obj, name_obj, &value_obj));
 
@@ -76,7 +76,7 @@ _create_func(FilterXExpr *key, FilterXExpr *labels, FilterXExpr *increment, Filt
 static gboolean
 _eval(FilterXExpr *func)
 {
-  FilterXObject *result = filterx_expr_eval(func);
+  FilterXObject *result = init_and_eval_expr(func);
 
   if (!result)
     return FALSE;

--- a/modules/xml/tests/test_filterx_parse_windows_eventlog_xml.c
+++ b/modules/xml/tests/test_filterx_parse_windows_eventlog_xml.c
@@ -100,7 +100,7 @@ _assert_parse_event_data(const gchar *event_data_xml, const gchar *expected_even
 {
   FilterXExpr *func = _create_expr(_create_input_from_event_data(event_data_xml), filterx_dict_new());
 
-  FilterXObject *result = filterx_expr_eval(func);
+  FilterXObject *result = init_and_eval_expr(func);
   cr_assert(result);
   cr_assert(filterx_eval_get_error_count() == 0);
 
@@ -141,7 +141,7 @@ _assert_parse_fail(const gchar *xml)
 {
   FilterXExpr *func = _create_expr(xml, filterx_dict_new());
 
-  FilterXObject *result = filterx_expr_eval(func);
+  FilterXObject *result = init_and_eval_expr(func);
   cr_assert(!result);
   cr_assert(filterx_eval_get_last_error());
 

--- a/modules/xml/tests/test_filterx_parse_xml.c
+++ b/modules/xml/tests/test_filterx_parse_xml.c
@@ -59,7 +59,7 @@ _assert_parse_xml_fail(const gchar *raw_xml)
 {
   FilterXExpr *func = _create_parse_xml_expr(raw_xml, filterx_dict_new());
 
-  FilterXObject *result = filterx_expr_eval(func);
+  FilterXObject *result = init_and_eval_expr(func);
   cr_assert(!result);
   cr_assert(filterx_eval_get_last_error());
 
@@ -72,7 +72,7 @@ _assert_parse_xml_with_fillable(const gchar *raw_xml, const gchar *expected_json
 {
   FilterXExpr *func = _create_parse_xml_expr(raw_xml, fillable);
 
-  FilterXObject *result = filterx_expr_eval(func);
+  FilterXObject *result = init_and_eval_expr(func);
   cr_assert(result);
   cr_assert(filterx_eval_get_error_count() == 0);
 

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -1495,6 +1495,20 @@ def test_parse_csv_optional_arg_columns(config, syslog_ng):
     assert file_true.read_log() == '{"1st":"foo","2nd":"bar","3rd":"baz"}'
 
 
+def test_parse_csv_literal_arg_columns(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+    custom_message = "foo,bar,baz";
+    $MSG = parse_csv(custom_message, columns=["1st","2nd","3rd"]);
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == '{"1st":"foo","2nd":"bar","3rd":"baz"}'
+
+
 def test_parse_csv_optional_arg_delimiters(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """


### PR DESCRIPTION
This PR makes sure that all expressions are initialized before being evaluated.

High level summary of the changes:
* unit tests will now invoke filterx_expr_init() before calling eval
* extracting literal arguments in function calls will now use filterx_literal_get_value() instead of evaluating the expr. This seems to be the same in the case of literals, but get_value() can be called without init and eval() can assert on being initialized
* fixes an strptime() error with init/deinit/optimize
* 