### PR TITLE
FilterX: fix escaping in format_xml and format_windows_eventlog_xml functions

### DIFF
--- a/modules/xml/filterx-func-format-windows-eventlog-xml.c
+++ b/modules/xml/filterx-func-format-windows-eventlog-xml.c
@@ -54,7 +54,11 @@ _append_inner_data_dict_element(FilterXObject *key, FilterXObject *value, gpoint
     }
 
   if (value_str_len)
-    g_string_append_printf(buffer, "<Data Name='%s'>%s</Data>", key_str, value_str);
+    {
+      gchar *escaped_value = g_markup_escape_text(value_str, value_str_len);
+      g_string_append_printf(buffer, "<Data Name='%s'>%s</Data>", key_str, escaped_value);
+      g_free(escaped_value);
+    }
   else
     g_string_append_printf(buffer, "<Data Name='%s' />", key_str);
   return TRUE;
@@ -87,7 +91,9 @@ _append_data_element(FilterXObject *key, FilterXObject *value, gpointer user_dat
       return FALSE;
     }
 
-  self->append_leaf(key_str, value_str, value_str_len, buffer);
+  gchar *escaped_value = g_markup_escape_text(value_str, value_str_len);
+  self->append_leaf(key_str, escaped_value, strlen(escaped_value), buffer);
+  g_free (escaped_value);
   return TRUE;
 }
 

--- a/news/fx-bugfix-743.md
+++ b/news/fx-bugfix-743.md
@@ -1,0 +1,4 @@
+`xml`: Fix escaping in element values
+
+Example:
+<b> -> &lt;b&gt;

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -2836,6 +2836,7 @@ def test_format_xml_valid_input(config, syslog_ng):
         $MSG.float_leaf = format_xml({"a":100.0});
         datetime = strptime("2000-01-01T00:00:00 +0200", "%Y-%m-%dT%H:%M:%S %z");
         $MSG.datetime_leaf = format_xml({"a":datetime});
+        $MSG.escaped = format_xml({"a":"<b>"});
 """,
     )
     syslog_ng.start(config)
@@ -2863,7 +2864,8 @@ def test_format_xml_valid_input(config, syslog_ng):
         r""""multiple_root":"<a>b</a><a>c</a>","""
         r""""integer_leaf":"<a>100</a>","""
         r""""float_leaf":"<a>100.0</a>","""
-        r""""datetime_leaf":"<a>946677600.000000</a>"}"""
+        r""""datetime_leaf":"<a>946677600.000000</a>","""
+        r""""escaped":"<a>&lt;b&gt;</a>"}"""
     )
     assert file_true.read_log() == exp
 


### PR DESCRIPTION
Example:
`<b>` -> `&lt;b&gt;`