### PR TITLE
logthrdest: fix slow destinations when flow-control is "misconfigured"

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1413,7 +1413,7 @@ dest_driver_option
 
 threaded_dest_driver_batch_option
         : KW_BATCH_LINES '(' nonnegative_integer ')' { log_threaded_dest_driver_set_batch_lines(last_driver, $3); }
-        | KW_BATCH_TIMEOUT '(' positive_integer ')' { log_threaded_dest_driver_set_batch_timeout(last_driver, $3); }
+        | KW_BATCH_TIMEOUT '(' nonnegative_integer ')' { log_threaded_dest_driver_set_batch_timeout(last_driver, $3); }
         ;
 
 threaded_dest_driver_workers_option

--- a/news/bugfix-753.md
+++ b/news/bugfix-753.md
@@ -1,0 +1,10 @@
+`google-pubsub()`, `logscale()`, `openobserver()`, `splunk()`, and other batching destinations: fix slowdown
+
+The default value of `batch-timeout()` is now 0.
+This prevents artificial slowdowns in destinations when flow control is enabled
+and the `log-iw-size()` option of sources is set to a value lower than `batch-lines()`.
+
+If you enable `batch-timeout()`, you can further improve batching performance,
+but you must also adjust the `log-iw-size()` option of your sources accordingly:
+
+`log-iw-size / max-connections >= batch-lines * workers`

--- a/scl/google/google-pubsub.conf
+++ b/scl/google/google-pubsub.conf
@@ -31,7 +31,7 @@ block destination google_pubsub(
   attributes("--scope rfc5424,all-nv-pairs --exclude MESSAGE")
   batch_lines(1000)
   batch_bytes(10MB)
-  batch_timeout(5000)
+  batch_timeout(0)
   workers(8)
   timeout(10)
   use_system_cert_store(yes)

--- a/scl/logscale/logscale.conf
+++ b/scl/logscale/logscale.conf
@@ -37,7 +37,7 @@ block destination logscale(
 
   batch_lines(1000)
   batch_bytes(1024kB)
-  batch_timeout(1)
+  batch_timeout(0)
   workers(20)
   timeout(10)
 

--- a/scl/openobserve/openobserve.conf
+++ b/scl/openobserve/openobserve.conf
@@ -31,7 +31,7 @@ block destination openobserve-log(
   stream("default")
   workers(4)
   batch_lines(100)
-  batch_timeout(1000)
+  batch_timeout(0)
   timeout(10)
   headers("Connection: keep-alive")
   record("--scope rfc5424 --exclude DATE --key ISODATE @timestamp=${ISODATE}")

--- a/scl/splunk/splunk.conf
+++ b/scl/splunk/splunk.conf
@@ -36,7 +36,7 @@ block destination splunk_hec_raw(
 
   batch_lines(5000)
   batch_bytes(4096kB)
-  batch_timeout(300)
+  batch_timeout(0)
   workers(8)
   timeout(10)
 
@@ -88,7 +88,7 @@ block destination splunk_hec_event(
 
   batch_lines(5000)
   batch_bytes(4096kB)
-  batch_timeout(300)
+  batch_timeout(0)
   workers(8)
   timeout(10)
 


### PR DESCRIPTION
log-iw-size()/max-connections() had to be greater than batch-lines()*workers() when flow-control was enabled, otherwise message delivery was slowed down artificially.

The given source stopped reading messages because of flow-control, but the destination didn't ack messages because it was waiting for the batch to be complete. After batch-timeout() milliseconds, the batch was finally sent out, and this repeated again and again.