### PR TITLE
mainloop-io-worker: use spearate work pools for source/destination/processing contexts

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -737,6 +737,7 @@ log_reader_init_watches(LogReader *self)
   self->idle_timer.handler = log_reader_idle_timeout;
 
   main_loop_io_worker_job_init(&self->io_job);
+  self->io_job.type = MLIOJ_SOURCE;
   self->io_job.user_data = self;
   self->io_job.work = log_reader_work_perform;
   self->io_job.completion = log_reader_work_finished;

--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -146,6 +146,7 @@ static void
 _partition_init(LogSchedulerPartition *partition, LogPipe *front_pipe)
 {
   main_loop_io_worker_job_init(&partition->io_job);
+  partition->io_job.type = MLIOJ_PROCESSING;
   partition->io_job.user_data = partition;
   partition->io_job.work = _work;
   partition->io_job.completion = _complete;

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1428,6 +1428,7 @@ log_writer_init_watches(LogWriter *self)
   self->queue_filled.handler = log_writer_queue_filled;
 
   main_loop_io_worker_job_init(&self->io_job);
+  self->io_job.type = MLIOJ_DESTINATION;
   self->io_job.user_data = self;
   self->io_job.work = (void (*)(void *, void *)) log_writer_work_perform;
   self->io_job.completion = (void (*)(void *, void *)) log_writer_work_finished;

--- a/lib/mainloop-io-worker.h
+++ b/lib/mainloop-io-worker.h
@@ -27,16 +27,26 @@
 
 #include <iv_work.h>
 
+typedef enum
+{
+  MLIOJ_SOURCE,
+  MLIOJ_DESTINATION,
+  MLIOJ_PROCESSING,
+  MLIOJ_MAX,
+} MainLoopIOWorkerJobType;
+
+
 typedef struct _MainLoopIOWorkerJob
 {
+  struct iv_work_item work_item;
   void (*engage)(gpointer user_data);
   void (*work)(gpointer user_data, gpointer arg);
   void (*completion)(gpointer user_data, gpointer arg);
   void (*release)(gpointer user_data);
+  MainLoopIOWorkerJobType type;
   gpointer user_data;
   gpointer arg;
   gboolean working;
-  struct iv_work_item work_item;
 } MainLoopIOWorkerJob;
 
 void main_loop_io_worker_job_init(MainLoopIOWorkerJob *self);


### PR DESCRIPTION
Prior to this patch we were only using a single workpool for all kinds of I/O events (source, destination and processing). However this can generate extra thread migrations due to different tasks scheduled to the same thread.

For example, if a source thread is waking up a destination, it might end up taking the same thread that the source was using. Meaning, the source will be scheduled to a different thread, losing its cache contents, etc.

With a separate work pool, the destination task will never take the same thread as the source task, so thread affinity should be improved.

With this change, we will oversubscribe the number of CPUs, as each work pool will take the same max_threads value. This will ultimately be resolved by the kernel scheduler. Scaling would suffer once we actually execute in more threads than available CPUs, but normally threads are only allocated on-demand.
