### PR TITLE
filterx-parse-kv: add stray_words_append_to_value mode

### DIFF
--- a/modules/kvformat/filterx-func-parse-kv.h
+++ b/modules/kvformat/filterx-func-parse-kv.h
@@ -26,7 +26,7 @@
 #include "plugin.h"
 #include "filterx/expr-function.h"
 
-#define FILTERX_FUNC_PARSE_KV_USAGE "Usage: parse_kv(msg, value_separator=\"=\", pair_separator=\", \", stray_words_key=\"stray_words\")"
+#define FILTERX_FUNC_PARSE_KV_USAGE "Usage: parse_kv(msg, value_separator=\"=\", pair_separator=\", \", stray_words_key=\"stray_words\", stray_words_append_to_value=true)"
 
 FILTERX_FUNCTION_DECLARE(parse_kv);
 

--- a/news/feature-770.md
+++ b/news/feature-770.md
@@ -1,0 +1,12 @@
+FilterX `parse_kv()`: add stray_words_append_to_value flag
+
+For example,
+```
+filterx {
+  $MSG = parse_kv($MSG, value_separator="=", pair_separator=" ", stray_words_append_to_value=true);
+};
+
+
+input: a=b b=c d e f=g
+output: {"a":"b","b":"c d e","f":"g"}
+```


### PR DESCRIPTION
FilterX `parse_kv()`: add stray_words_append_to_value flag

For example,
```
filterx {
  $MSG = parse_kv($MSG, value_separator="=", pair_separator=" ", stray_words_append_to_value=true);
};


input: a=b b=c d e f=g
output: {"a":"b","b":"c d e","f":"g"}
```
