### PR TITLE
Fix slashstring

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -361,18 +361,18 @@ word	[^ \#'"\(\)\{\}\[\]\\;\r\n\t,|\.@:]
 			     g_string_truncate(yyextra->string_buffer, 0);
 			     yy_push_state(qstring, yyscanner);
 			   }
-<filterx>\/		   { return KW_SLASH; }
+<filterx>[/]		   { return KW_SLASH; }
 <INITIAL,filterx>.         { return (unsigned char) yytext[0]; }
 
     /* continuation line within a string: just move the location and skip the newline character as if it was never there */
 <string,qstring,slash_string>\\\r?\n    { _cfg_lex_extend_token_location_to_next_line(yyextra); }
-<string,slash_string>\\a		{ g_string_append_c(yyextra->string_buffer, 7); }
-<string,slash_string>\\n	   	{ g_string_append_c(yyextra->string_buffer, 10); }
-<string,slash_string>\\r		{ g_string_append_c(yyextra->string_buffer, 13); }
-<string,slash_string>\\t		{ g_string_append_c(yyextra->string_buffer, 9); }
-<string,slash_string>\\v		{ g_string_append_c(yyextra->string_buffer, 11); }
-<string,slash_string>\\x{xdigit}{1,2}   { g_string_append_c(yyextra->string_buffer, strtol(yytext+2, NULL, 16)); }
-<string,slash_string>\\o{odigit}{1,3}   { g_string_append_c(yyextra->string_buffer, strtol(yytext+2, NULL, 8)); }
+<string>\\a		{ g_string_append_c(yyextra->string_buffer, 7); }
+<string>\\n	   	{ g_string_append_c(yyextra->string_buffer, 10); }
+<string>\\r		{ g_string_append_c(yyextra->string_buffer, 13); }
+<string>\\t		{ g_string_append_c(yyextra->string_buffer, 9); }
+<string>\\v		{ g_string_append_c(yyextra->string_buffer, 11); }
+<string>\\x{xdigit}{1,2}   { g_string_append_c(yyextra->string_buffer, strtol(yytext+2, NULL, 16)); }
+<string>\\o{odigit}{1,3}   { g_string_append_c(yyextra->string_buffer, strtol(yytext+2, NULL, 8)); }
 <string>\\[^anrtv]	                { g_string_append_c(yyextra->string_buffer, yytext[1]); }
 <string>[^"\\\r\n]+	                { g_string_append(yyextra->string_buffer, yytext); }
 <string>\"		                {
@@ -380,13 +380,10 @@ word	[^ \#'"\(\)\{\}\[\]\\;\r\n\t,|\.@:]
 			                        yylval->cptr = strdup(yyextra->string_buffer->str);
 			                        return LL_STRING;
 		                        }
-<slash_string>\\b		        { g_string_append_c(yyextra->string_buffer, 8); }
-<slash_string>\\f		        { g_string_append_c(yyextra->string_buffer, 12); }
-<slash_string>\\\\	                { g_string_append_c(yyextra->string_buffer, '\\'); }
-<slash_string>\\\/	                { g_string_append_c(yyextra->string_buffer, '/'); }
-<slash_string>\\[^anrtvbfox]	        { g_string_append(yyextra->string_buffer, yytext); }
-<slash_string>[^\/\\\r\n]+              { g_string_append(yyextra->string_buffer, yytext); }
-<slash_string>\/	                {
+<slash_string>\\[/]	                { g_string_append_c(yyextra->string_buffer, '/'); }
+<slash_string>\\[^/]	                { g_string_append(yyextra->string_buffer, yytext); }
+<slash_string>[^/\r\n\\]+              { g_string_append(yyextra->string_buffer, yytext); }
+<slash_string>[/]	                {
 			                        yy_pop_state(yyscanner);
 			                        yylval->cptr = strdup(yyextra->string_buffer->str);
 			                        return LL_STRING;

--- a/news/bugfix-776.md
+++ b/news/bugfix-776.md
@@ -1,0 +1,8 @@
+`/string/`: fix escaping
+
+Strings between / characters are now treated literally. The only exception is `\/`, which can be used to represent a `/` character.
+
+This syntax allows you to construct regular expression patterns without worrying about double escaping.
+
+Note: Because of the simplified escaping rules, you cannot represent strings that end with a single `\` character,
+but such strings would not be valid regular expression patterns anyway.


### PR DESCRIPTION
Let's redefine what slash_string means in order to make the escaping rules
clear:

Everything between two / characters are treated literally, except for `\/`,
which can be used to include a `/` character within the string.
If you want to include `\/` within the string, you can do that too: `\\/`

This type of string literal syntax can be used to construct regexp
patterns.

pcre2 handles special non-printing characters (`\r`, `\n`, `\t`, etc.),
octals (`\oDDD`), and hex as well (`\xDD`), so no need to escape those in our
lexer.

Note: it is not possible to represent strings that end with a single `\`
but that would be an invalid regexp, so this limitation is acceptable.
