### PR TITLE
cfg-source: cache last source file

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1267,6 +1267,7 @@ cfg_lexer_init(CfgLexer *self, GlobalConfig *cfg)
 
   _cfg_lexer_lex_init_extra(self, &self->state);
   self->string_buffer = g_string_sized_new(32);
+  self->source_file_cache.content = g_string_sized_new(256);
   self->token_text = g_string_sized_new(32);
   self->token_pretext = g_string_sized_new(32);
   self->cfg = cfg;
@@ -1329,6 +1330,7 @@ cfg_lexer_free(CfgLexer *self)
   self->include_depth = 0;
   _cfg_lexer_lex_destroy(self->state);
   g_string_free(self->string_buffer, TRUE);
+  g_string_free(self->source_file_cache.content, TRUE);
   if (self->token_text)
     g_string_free(self->token_text, TRUE);
   if (self->token_pretext)

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -172,6 +172,12 @@ struct _CfgIncludeLevel
   struct yy_buffer_state *yybuf;
 };
 
+typedef struct _CfgSourceCache
+{
+  const gchar *file;
+  GString *content;
+} CfgSourceCache;
+
 /* Lexer class that encapsulates a flex generated lexer. This can be
  * instantiated multiple times in parallel, e.g.  doesn't use any global
  * state as we're using the "reentrant" code by flex
@@ -193,6 +199,7 @@ struct _CfgLexer
   gint preprocess_suppress_tokens;
   GString *token_pretext;
   GString *token_text;
+  CfgSourceCache source_file_cache;
   GlobalConfig *cfg;
   guint first_non_pragma_seen:1, ignore_pragma:1;
 };


### PR DESCRIPTION
In case of a huge configuratoin file:
```
$ time sbin/syslog-ng -Fe -f par.conf

before: 15.55 secs
after: 3.92 secs
```