### PR TITLE
charts: add extraVolumes / extraVolumeMounts to syslog sts

### DIFF
--- a/charts/axosyslog/Chart.yaml
+++ b/charts/axosyslog/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: axosyslog
 description: AxoSyslog for Kubernetes
 type: application
-version: 0.17.0
-appVersion: "4.15.0"
+version: 0.18.0
+appVersion: "4.17.0"

--- a/charts/axosyslog/README.md
+++ b/charts/axosyslog/README.md
@@ -20,19 +20,19 @@ The following table lists the configurable parameters of the AxoSyslog Collector
 |  imagePullSecrets  | The names of secrets containing private registry credentials |  []  |
 |  nameOverride  | Override the chart name |  ""  |
 |  fullnameOverride  | Override the full chart name |  ""  |
-|  daemonset.enabled  | Deploy AxoSyslog as a DaemonSet |  true  |
-|  daemonset.labels  | Additional labels to apply to the DaemonSet |  {}  |
-|  daemonset.annotations  | Additional annotations to apply to the DaemonSet |  {}  |
-|  daemonset.affinity  | Pod affinity |  {}  |
-|  daemonset.nodeSelector  | Node labels for pod assignment |  {}  |
-|  daemonset.resources  | Resource requests and limits |  {}  |
-|  daemonset.tolerations  | Tolerations for pod assignment |  []  |
-|  daemonset.hostAliases  | Add host aliases |  []  |
-|  daemonset.secretMounts  | Mount additional secrets as volumes |  []  |
-|  daemonset.extraVolumes  | Additional volumes to mount |  []  |
-|  daemonset.securityContext  | Security context for the pod |  {}  |
-|  daemonset.maxUnavailable  | The maximum number of unavailable pods during a rolling update |  1  |
-|  daemonset.hostNetworking  | Whether to enable host networking |  false  |
+|  collector.enabled  | Deploy AxoSyslog as a DaemonSet |  true  |
+|  collector.labels  | Additional labels to apply to the DaemonSet |  {}  |
+|  collector.annotations  | Additional annotations to apply to the DaemonSet |  {}  |
+|  collector.affinity  | Pod affinity |  {}  |
+|  collector.nodeSelector  | Node labels for pod assignment |  {}  |
+|  collector.resources  | Resource requests and limits |  {}  |
+|  collector.tolerations  | Tolerations for pod assignment |  []  |
+|  collector.hostAliases  | Add host aliases |  []  |
+|  collector.secretMounts  | Mount additional secrets as volumes |  []  |
+|  collector.extraVolumes  | Additional volumes to mount |  []  |
+|  collector.securityContext  | Security context for the pod |  {}  |
+|  collector.maxUnavailable  | The maximum number of unavailable pods during a rolling update |  1  |
+|  collector.hostNetworking  | Whether to enable host networking |  false  |
 |  rbac.create  | Whether to create RBAC resources |  false  |
 |  rbac.extraRules  | Additional RBAC rules |  []  |
 |  openShift.enabled  | Whether to deploy on OpenShift |  false  |

--- a/charts/axosyslog/README.md
+++ b/charts/axosyslog/README.md
@@ -30,6 +30,7 @@ The following table lists the configurable parameters of the AxoSyslog Collector
 |  collector.hostAliases  | Add host aliases |  []  |
 |  collector.secretMounts  | Mount additional secrets as volumes |  []  |
 |  collector.extraVolumes  | Additional volumes to mount |  []  |
+|  collector.extraVolumeMounts  | Additional volume mounts |  []  |
 |  collector.securityContext  | Security context for the pod |  {}  |
 |  collector.maxUnavailable  | The maximum number of unavailable pods during a rolling update |  1  |
 |  collector.hostNetworking  | Whether to enable host networking |  false  |
@@ -52,4 +53,16 @@ The following table lists the configurable parameters of the AxoSyslog Collector
 |  kubernetes.enabled  | Enable kubernetes log collection  |  true  |
 |  kubernetes.prefix  | Set JSON prefix for logs collected from the k8s cluster  |  ""  |
 |  kubernetes.keyDelimiter  | Set JSON key delimiter for logs collected from the k8s cluster  |  ""  |
+|  extraVolumes | Additional volumes to mount | [] |
+|  extraVolumeMounts | Additional volume mounts | [] |
+|  syslog.enabled | Enable the syslog component | false |
+|  syslog.config | Syslog-ng configuration content | {} |
+|  syslog.labels | Additional labels for the StatefulSet | {} |
+|  syslog.annotations | Additional annotations for the StatefulSet | {} |
+|  syslog.logFileStorage.enabled | Enable persistent storage for log files | false |
+|  syslog.logFileStorage.size | Size of log file storage volume | 50Gi |
+|  syslog.bufferStorage.enabled | Enable persistent storage for syslog buffers | false |
+|  syslog.bufferStorage.size | Size of buffer storage volume | 10Gi |
+|  syslog.extraVolumeMounts | Additional volume mounts for the container | [] |
+|  syslog.extraVolumes | Additional volumes for the pod | [] |
 

--- a/charts/axosyslog/templates/syslog-statefulset.yaml
+++ b/charts/axosyslog/templates/syslog-statefulset.yaml
@@ -74,10 +74,16 @@ spec:
           - mountPath: /var/lib/syslog-ng
             name: buffers
         {{- end }}
+        {{- if .Values.extraVolumeMounts | default .Values.syslog.extraVolumeMounts }}
+{{ toYaml (.Values.extraVolumeMounts | default .Values.syslog.extraVolumeMounts ) | indent 10 }}
+        {{- end }}
       volumes:
       - name: config
         configMap:
           name: {{ include "axosyslog.fullname" . }}-syslog
+      {{- if .Values.extraVolumes | default .Values.syslog.extraVolumes }}
+{{ toYaml ( .Values.extraVolumes | default .Values.syslog.extraVolumes ) | indent 6 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/axosyslog/values.yaml
+++ b/charts/axosyslog/values.yaml
@@ -71,7 +71,7 @@ syslog:
   logFileStorage:
     enabled: false
     storageClass: standard
-    size: 500Gi
+    size: 50Gi
   bufferStorage:
     enabled: false
     storageClass: standard

--- a/charts/axosyslog/values.yaml
+++ b/charts/axosyslog/values.yaml
@@ -60,6 +60,7 @@ collector:
   hostAliases: []
   secretMounts: []
   extraVolumes: []
+  extraVolumeMounts: []
   securityContext: {}
   maxUnavailable: 1
   hostNetworking: false
@@ -139,7 +140,8 @@ syslog:
         enabled: false
         url: "192.168.77.133:4317"
         extraOptionsRaw: "time-reopen(1) batch-timeout(1000) batch-lines(1000)"
-
+  extraVolumes: []
+  extraVolumeMounts: []
 metricsExporter:
   enabled: false  # deploy the axosyslog Deamonset with the axosyslog-metrics-exporter sidecar
   image:
@@ -198,6 +200,7 @@ dnsConfig: {}
 hostAliases: []
 secretMounts: []
 extraVolumes: []
+extraVolumeMounts: []
 ## How long (in seconds) a pod may take to exit (useful with lifecycle hooks to ensure lb deregistration is done)
 ##
 terminationGracePeriodSeconds: 30


### PR DESCRIPTION
The helm chart now supports adding extra volumes to the syslog sts.

Tested it, resulting in the following:
```yaml
        volumeMounts:
        - mountPath: /etc/syslog-ng/syslog-ng.conf
          name: config
          subPath: syslog-ng.conf
        - mountPath: /shared
          name: shared-storage
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
      volumes:
      - configMap:
          defaultMode: 420
          name: axosyslog-syslog
        name: config
      - name: shared-storage
        persistentVolumeClaim:
          claimName: axosyslog-shared-pvc
```

values.yaml snippet:
```yaml
syslog:
  enabled: true
  extraVolumeMounts:
    - name: shared-storage
      mountPath: /shared

  extraVolumes:
    - name: shared-storage
      persistentVolumeClaim:
        claimName: axosyslog-shared-pvc
```

TODO:

- [ ] add news file
- [ ] version bump chart

