### PR TITLE
filterx: implement unary minus and plus operators

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -216,6 +216,7 @@ main_location_print (FILE *yyo, YYLTYPE const * const yylocp)
 
 %left  '+' '-'
 %left  '*' KW_SLASH '%'
+%left  PR_UPLUS PR_UMINUS
 %left '.' '[' ']'
 
 /* statements */

--- a/lib/filterx/expr-arithmetic-operators.h
+++ b/lib/filterx/expr-arithmetic-operators.h
@@ -28,5 +28,6 @@ FilterXExpr *filterx_arithmetic_operator_substraction_new(FilterXExpr *lhs, Filt
 FilterXExpr *filterx_arithmetic_operator_multiplication_new(FilterXExpr *lhs, FilterXExpr *rhs);
 FilterXExpr *filterx_arithmetic_operator_division_new(FilterXExpr *lhs, FilterXExpr *rhs);
 FilterXExpr *filterx_arithmetic_operator_modulo_new(FilterXExpr *lhs, FilterXExpr *rhs);
+FilterXExpr *filterx_arithmetic_operator_uminus_new(FilterXExpr *operand);
 
 #endif

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -344,6 +344,8 @@ arithmetic_operator
 	| expr '*' expr { $$ = filterx_arithmetic_operator_multiplication_new($1, $3); }
 	| expr KW_SLASH expr { $$ = filterx_arithmetic_operator_division_new($1, $3); }
 	| expr '%' expr { $$ = filterx_arithmetic_operator_modulo_new($1, $3); }
+	| '+' expr %prec PR_UPLUS { $$ = $2; }
+	| '-' expr %prec PR_UMINUS { $$ = filterx_arithmetic_operator_uminus_new($2); }
 	;
 
 string_operator

--- a/news/feature-788.md
+++ b/news/feature-788.md
@@ -1,0 +1,6 @@
+FilterX: unary `+` and `-` operators
+
+Useful for dynamic string slicing, for example:
+```
+str[..-tempvar]
+```


### PR DESCRIPTION
Useful for dynamic string slicing, for example:
```
str[..-tempvar]
```