### PR TITLE
filterx/expr-membership: fix finding message_values in arrays 

### DIFF
--- a/lib/filterx/expr-membership.c
+++ b/lib/filterx/expr-membership.c
@@ -40,7 +40,7 @@ _eval_in(FilterXExpr *s)
   FilterXOperatorIn *self = (FilterXOperatorIn *) s;
 
   FilterXObject *lhs_obj = self->literal_lhs ? filterx_object_ref(self->literal_lhs)
-                           : filterx_expr_eval(self->super.lhs);
+                           : filterx_expr_eval_typed(self->super.lhs);
 
   FilterXObject *lhs = filterx_ref_unwrap_ro(lhs_obj);
 

--- a/news/bugfix-791.md
+++ b/news/bugfix-791.md
@@ -1,0 +1,1 @@
+`in` FilterX operator: Fixed finding `message_value`s in arrays.

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -2699,6 +2699,23 @@ def test_not_in_operator_false(config, syslog_ng):
     assert file_true.read_log() == "found"
 
 
+def test_in_operator_message_value(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+        if (${values.str} in ['foo', 'string', 'bar']) {
+            $MSG = "found";
+        } else {
+            $MSG = "not found";
+        };
+""",
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "found"
+
+
 def test_arithmetic_operators_precedence(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, r"""


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
