### PR TITLE
filterx/expr-literal-container: consider an element literal even if it doesn't have a key

### DIFF
--- a/lib/filterx/expr-literal-container.c
+++ b/lib/filterx/expr-literal-container.c
@@ -61,7 +61,7 @@ _literal_element_optimize(FilterXLiteralElement *self)
 {
   self->key = filterx_expr_optimize(self->key);
   self->value = filterx_expr_optimize(self->value);
-  self->literal = filterx_expr_is_literal(self->key) && filterx_expr_is_literal(self->value);
+  self->literal = (!self->key || filterx_expr_is_literal(self->key)) && filterx_expr_is_literal(self->value);
 }
 
 static void


### PR DESCRIPTION
List literals use key==NULL and previously such literals were not considered literals.

22% performance improvement on the parse_csv() microbenchmark, due to the literal list not recognized as literal, does not have this big impact on AxoRouter production config.

Without the patch:
bazsi@bzorp3:~/src/syslog-ng/syslog-ng$ time for i in `seq 1 200`; do cat dbld/install/pan_dump.txt ; done | nc -q0 localhost 2000

real	0m8.106s

With the patch:
bazsi@bzorp3:~/src/syslog-ng/syslog-ng$ time for i in `seq 1 200`; do cat dbld/install/pan_dump.txt ; done | nc -q0 localhost 2000

real	0m6.386s

config is the same as in #807 