### PR TITLE
Filterx: inline filterx_object_init_instance()

### DIFF
--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -106,14 +106,6 @@ filterx_object_free_method(FilterXObject *self)
   /* empty */
 }
 
-void
-filterx_object_init_instance(FilterXObject *self, FilterXType *type)
-{
-  g_atomic_counter_set(&self->ref_cnt, 1);
-  self->type = type;
-  self->readonly = !type->is_mutable;
-}
-
 FilterXObject *
 filterx_object_new(FilterXType *type)
 {

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -184,6 +184,14 @@ struct _FilterXObject
   FilterXType *type;
 };
 
+static inline void
+filterx_object_init_instance(FilterXObject *self, FilterXType *type)
+{
+  g_atomic_counter_set(&self->ref_cnt, 1);
+  self->type = type;
+  self->readonly = !type->is_mutable;
+}
+
 static inline gboolean
 filterx_object_is_ref(FilterXObject *self)
 {


### PR DESCRIPTION
Without:
bazsi@bzorp3:~/src/syslog-ng/syslog-ng$ time for i in `seq 1 200`; do cat dbld/install/pan_dump.txt ; done | nc -q0 localhost 2000

real	0m8.156s

With:
bazsi@bzorp3:~/src/syslog-ng/syslog-ng$ time for i in `seq 1 200`; do cat dbld/install/pan_dump.txt ; done | nc -q0 localhost 2000

real	0m8.083s
