### PR TITLE
timeutils/wallclocktime: fix strftime for %Z 

### DIFF
--- a/lib/timeutils/tests/test_wallclocktime.c
+++ b/lib/timeutils/tests/test_wallclocktime.c
@@ -494,6 +494,18 @@ Test(wallclocktime, test_strptime_percent_z_is_mandatory)
   cr_assert_null(wall_clock_time_strptime(&wct, "%Y-%m-%d %T%z", "2011-06-25 20:00:04"));
 }
 
+Test(wallclocktime, test_strftime_negative_not_whole_gmtoff)
+{
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+  gchar buf[128];
+
+  /* America/Caracas */
+  wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S.%f %z", "May  7 2021 09:29:12.123456 -04:30");
+
+  wall_clock_time_strftime(&wct, buf, sizeof(buf), "%Z");
+  cr_assert_str_eq(buf, "-04:30");
+}
+
 Test(wallclocktime, test_strftime_percent_f)
 {
   WallClockTime wct = WALL_CLOCK_TIME_INIT;

--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -1200,7 +1200,8 @@ __strftime_fmt_1(WallClockTime *wct, char (*s)[100], size_t *l, int f, int pad)
         }
       *l = snprintf(*s, sizeof *s, "%c%02ld:%02ld",
                     wct->wct_gmtoff < 0 ? '-' : '+',
-                    (wct->wct_gmtoff > 0 ? wct->wct_gmtoff : -wct->wct_gmtoff)/3600, wct->wct_gmtoff%3600/60);
+                    (wct->wct_gmtoff > 0 ? wct->wct_gmtoff : -wct->wct_gmtoff)/3600,
+                    (wct->wct_gmtoff > 0 ? wct->wct_gmtoff : -wct->wct_gmtoff)%3600/60);
       return *s;
     case '%':
       *l = 1;

--- a/news/bugfix-811.md
+++ b/news/bugfix-811.md
@@ -1,0 +1,3 @@
+`strftime()` FilterX function: Fixed %Z formatting for some rare cases
+
+America/Caracas (-04:30) time offset will now be correctly formatted.


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
