### PR TITLE
Filterx: lighter type checks

### DIFF
--- a/lib/filterx/expr-membership.c
+++ b/lib/filterx/expr-membership.c
@@ -63,16 +63,7 @@ _eval_in(FilterXExpr *s)
 
   FilterXObject *list_obj = filterx_ref_unwrap_ro(rhs_obj);
 
-  if (!filterx_object_is_type(list_obj, &FILTERX_TYPE_NAME(sequence)))
-    {
-      filterx_eval_push_error_info_printf("Failed to evaluate 'in' operator", &self->super.super,
-                                          "Right hand side must be list type, got: %s",
-                                          filterx_object_get_type_name(list_obj));
-      goto error;
-    }
-
   guint64 size;
-
   if (!filterx_object_len(list_obj, &size))
     {
       filterx_eval_push_error_static_info("Failed to evaluate 'in' operator", s, "len() method failed");

--- a/lib/filterx/filterx-mapping.c
+++ b/lib/filterx/filterx-mapping.c
@@ -44,8 +44,6 @@ _add_elem(FilterXObject *key_obj, FilterXObject *value_obj, gpointer user_data)
 gboolean
 filterx_mapping_merge(FilterXObject *s, FilterXObject *other)
 {
-  other = filterx_ref_unwrap_ro(other);
-  g_assert(filterx_object_is_type(other, &FILTERX_TYPE_NAME(mapping)));
   return filterx_object_iter(other, _add_elem, s);
 }
 
@@ -64,20 +62,10 @@ _add_elem_to_list(FilterXObject *key_obj, FilterXObject *value_obj, gpointer use
 gboolean
 filterx_mapping_keys(FilterXObject *s, FilterXObject **keys)
 {
-  g_assert(s);
-  g_assert(keys);
-  FilterXObject *obj = filterx_ref_unwrap_ro(s);
-  if (!filterx_object_is_type(obj, &FILTERX_TYPE_NAME(mapping)))
-    goto error;
-  g_assert(filterx_object_is_type(*keys, &FILTERX_TYPE_NAME(sequence)));
-
-  gboolean result = filterx_object_iter(obj, _add_elem_to_list, *keys);
+  gboolean result = filterx_object_iter(s, _add_elem_to_list, *keys);
 
   filterx_object_unref(s);
   return result;
-error:
-  filterx_object_unref(s);
-  return FALSE;
 }
 
 static FilterXObject *
@@ -140,10 +128,6 @@ filterx_mapping_init_instance(FilterXMapping *self, FilterXType *type)
 static FilterXObject *
 _add(FilterXObject *lhs_object, FilterXObject *rhs_object)
 {
-  rhs_object = filterx_ref_unwrap_ro(rhs_object);
-  if (!filterx_object_is_type(rhs_object, &FILTERX_TYPE_NAME(mapping)))
-    return NULL;
-
   FilterXObject *cloned = filterx_object_clone(lhs_object);
 
   if (!filterx_mapping_merge(cloned, rhs_object))

--- a/lib/filterx/filterx-mapping.c
+++ b/lib/filterx/filterx-mapping.c
@@ -23,6 +23,7 @@
 #include "filterx/filterx-mapping.h"
 #include "filterx/object-extractor.h"
 #include "filterx/object-string.h"
+#include "filterx/object-list.h"
 #include "filterx/filterx-sequence.h"
 #include "filterx/filterx-eval.h"
 #include "str-utils.h"
@@ -59,13 +60,16 @@ _add_elem_to_list(FilterXObject *key_obj, FilterXObject *value_obj, gpointer use
   return success;
 }
 
-gboolean
-filterx_mapping_keys(FilterXObject *s, FilterXObject **keys)
+FilterXObject *
+filterx_mapping_keys(FilterXObject *s)
 {
-  gboolean result = filterx_object_iter(s, _add_elem_to_list, *keys);
-
-  filterx_object_unref(s);
-  return result;
+  FilterXObject *keys = filterx_list_new();
+  if (!filterx_object_iter(s, _add_elem_to_list, keys))
+    {
+      filterx_object_unref(keys);
+      return NULL;
+    }
+  return keys;
 }
 
 static FilterXObject *

--- a/lib/filterx/filterx-mapping.h
+++ b/lib/filterx/filterx-mapping.h
@@ -36,7 +36,7 @@ struct FilterXMapping_
 };
 
 gboolean filterx_mapping_merge(FilterXObject *s, FilterXObject *other);
-gboolean filterx_mapping_keys(FilterXObject *s, FilterXObject **keys);
+FilterXObject *filterx_mapping_keys(FilterXObject *s);
 
 void filterx_mapping_init_instance(FilterXMapping *self, FilterXType *type);
 

--- a/lib/filterx/filterx-sequence.c
+++ b/lib/filterx/filterx-sequence.c
@@ -63,10 +63,10 @@ gboolean
 filterx_sequence_merge(FilterXObject *s, FilterXObject *other)
 {
   other = filterx_ref_unwrap_ro(other);
-  g_assert(filterx_object_is_type(other, &FILTERX_TYPE_NAME(sequence)));
 
   guint64 len;
-  g_assert(filterx_object_len(other, &len));
+  if (!filterx_object_len(other, &len))
+    return FALSE;
 
   for (guint64 i = 0; i < len; i++)
     {
@@ -125,14 +125,9 @@ filterx_sequence_init_instance(FilterXSequence *self, FilterXType *type)
 static FilterXObject *
 _add(FilterXObject *lhs_object, FilterXObject *rhs_object)
 {
-  rhs_object = filterx_ref_unwrap_ro(rhs_object);
-
-  if (!filterx_object_is_type(rhs_object, &FILTERX_TYPE_NAME(sequence)))
-    return NULL;
-
   FilterXObject *cloned = filterx_object_clone(lhs_object);
 
-  if(!filterx_sequence_merge(cloned, rhs_object))
+  if (!filterx_sequence_merge(cloned, rhs_object))
     goto error;
 
   return cloned;

--- a/lib/filterx/func-keys.c
+++ b/lib/filterx/func-keys.c
@@ -46,11 +46,12 @@ _eval(FilterXExpr *s)
       return NULL;
     }
 
-  FilterXObject *result = filterx_list_new();
-  if (!filterx_mapping_keys(object, &result))
+  FilterXObject *result = filterx_mapping_keys(object);
+  filterx_object_unref(object);
+
+  if (!result)
     {
       filterx_eval_push_error(FILTERX_FUNC_KEYS_ERR_NONDICT FILTERX_FUNC_KEYS_USAGE, s, NULL);
-      filterx_object_unref(result);
       return NULL;
     }
   return result;

--- a/lib/filterx/func-str.c
+++ b/lib/filterx/func-str.c
@@ -309,13 +309,8 @@ _eval_against_needle_expr_list(FilterXExprAffix *self, const gchar *haystack, gs
 {
   FilterXObject *list_needle = filterx_ref_unwrap_ro(needle_obj);
 
-  if (!filterx_object_is_type(list_needle, &FILTERX_TYPE_NAME(sequence)))
-    return NULL;
-
   guint64 len;
-  filterx_object_len(needle_obj, &len);
-
-  if (len == 0)
+  if (!filterx_object_len(needle_obj, &len) || len == 0)
     return NULL;
 
   gboolean matches = FALSE;

--- a/lib/filterx/tests/test_object_dict_interface.c
+++ b/lib/filterx/tests/test_object_dict_interface.c
@@ -108,16 +108,14 @@ Test(filterx_mapping, test_keys_empty)
   FilterXObject *dict = filterx_object_from_json("{}", -1, NULL);
   cr_assert_not_null(dict);
 
-  FilterXObject *keys = filterx_list_new();
-  cr_assert_not_null(keys);
+  FilterXObject *keys = filterx_mapping_keys(dict);
 
-  gboolean ok = filterx_mapping_keys(dict, &keys);
-  cr_assert(ok);
   cr_assert_not_null(keys);
 
   assert_object_repr_equals(keys, "[]");
 
   filterx_object_unref(keys);
+  filterx_object_unref(dict);
 }
 
 Test(filterx_mapping, test_keys_single)
@@ -125,16 +123,13 @@ Test(filterx_mapping, test_keys_single)
   FilterXObject *dict = filterx_object_from_json("{\"foo\":\"bar\"}", -1, NULL);
   cr_assert_not_null(dict);
 
-  FilterXObject *keys = filterx_list_new();
-  cr_assert_not_null(keys);
-
-  gboolean ok = filterx_mapping_keys(dict, &keys);
-  cr_assert(ok);
+  FilterXObject *keys = filterx_mapping_keys(dict);
   cr_assert_not_null(keys);
 
   assert_object_repr_equals(keys, "[\"foo\"]");
 
   filterx_object_unref(keys);
+  filterx_object_unref(dict);
 }
 
 
@@ -143,16 +138,13 @@ Test(filterx_mapping, test_keys_multi)
   FilterXObject *dict = filterx_object_from_json("{\"foo\":\"bar\", \"bar\": \"baz\"}", -1, NULL);
   cr_assert_not_null(dict);
 
-  FilterXObject *keys = filterx_list_new();
-  cr_assert_not_null(keys);
-
-  gboolean ok = filterx_mapping_keys(dict, &keys);
-  cr_assert(ok);
+  FilterXObject *keys = filterx_mapping_keys(dict);
   cr_assert_not_null(keys);
 
   assert_object_repr_equals(keys, "[\"foo\",\"bar\"]");
 
   filterx_object_unref(keys);
+  filterx_object_unref(dict);
 }
 
 Test(filterx_mapping, test_keys_nested)
@@ -160,47 +152,13 @@ Test(filterx_mapping, test_keys_nested)
   FilterXObject *dict = filterx_object_from_json("{\"foo\":{\"bar\":\"baz\"}, \"bar\":{\"baz\": null}}", -1, NULL);
   cr_assert_not_null(dict);
 
-  FilterXObject *keys = filterx_list_new();
-  cr_assert_not_null(keys);
-
-  gboolean ok = filterx_mapping_keys(dict, &keys);
-  cr_assert(ok);
+  FilterXObject *keys = filterx_mapping_keys(dict);
   cr_assert_not_null(keys);
 
   assert_object_repr_equals(keys, "[\"foo\",\"bar\"]");
 
   filterx_object_unref(keys);
-}
-
-Test(filterx_mapping, test_keys_null_dict, .signal=SIGABRT)
-{
-  FilterXObject *keys = filterx_list_new();
-  cr_assert_not_null(keys);
-
-  filterx_mapping_keys(NULL, &keys);
-
-  filterx_object_unref(keys);
-}
-
-Test(filterx_mapping, test_keys_null_keys, .signal=SIGABRT)
-{
-  FilterXObject *dict = filterx_object_from_json("{\"foo\":{\"bar\":\"baz\"}, \"bar\":{\"baz\": null}}", -1, NULL);
-  cr_assert_not_null(dict);
-
-  filterx_mapping_keys(dict, NULL);
-}
-
-Test(filterx_mapping, test_keys_key_type_is_not_list, .signal=SIGABRT)
-{
-  FilterXObject *dict = filterx_object_from_json("{\"foo\":{\"bar\":\"baz\"}, \"bar\":{\"baz\": null}}", -1, NULL);
-  cr_assert_not_null(dict);
-
-  FilterXObject *keys = filterx_string_new("this is string", -1);
-  cr_assert_not_null(keys);
-
-  filterx_mapping_keys(dict, &keys);
-
-  filterx_object_unref(keys);
+  filterx_object_unref(dict);
 }
 
 Test(filterx_mapping, test_keys_object_is_not_dict)
@@ -208,15 +166,10 @@ Test(filterx_mapping, test_keys_object_is_not_dict)
   FilterXObject *dict = filterx_string_new("{\"foo\":\"bar\", \"bar\": \"baz\"}", -1);
   cr_assert_not_null(dict);
 
-  FilterXObject *keys = filterx_list_new();
-  cr_assert_not_null(keys);
-
-  gboolean ok = filterx_mapping_keys(dict, &keys);
-  cr_assert(!ok);
-  guint64 len = G_MAXUINT64;
-  cr_assert(filterx_object_len(keys, &len));
-  cr_assert_eq(0, len);
+  FilterXObject *keys = filterx_mapping_keys(dict);
+  cr_assert(keys == NULL);
   filterx_object_unref(keys);
+  filterx_object_unref(dict);
 }
 
 static void


### PR DESCRIPTION
This PR removes some of the unneeded type checks from filterx-mapping and filterx-sequence. These were
preparatory steps for some of my performance improvements, but can be merged separately.

Also, it has a refactor on filterx_mapping_keys() which had a very arcane behaviour:
* it freed its first argument (e.g. self)
* it expected the caller to construct the list object where the results are returned

Both of these were changed to make filterx_mapping_keys() to be more consistent with the rest of the filterx implementation.