### PR TITLE
breaking(chart): overhaul

### DIFF
--- a/.github/workflows/axosyslog-charts-lint.yml
+++ b/.github/workflows/axosyslog-charts-lint.yml
@@ -19,7 +19,7 @@ defaults:
     working-directory: charts/axosyslog
 
 jobs:
-  axosyslog:
+  helm-lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -28,3 +28,26 @@ jobs:
       - name: Linter
         run: |
           docker run -v${PWD}:${PWD} alpine/helm lint ${PWD}
+
+  helm-docs:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install helm-docs
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Install helm-docs
+        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+
+      - name: Generate docs
+        run: scripts/helm-docs.sh
+
+      - name: Check README is up to date
+        run: git diff --exit-code charts/axosyslog/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ modules/python-modules/syslogng.egg-info
 tests/light/src/axosyslog_light.egg-info
 tests/light/dist
 aclocal.m4-e
+.envrc

--- a/charts/Makefile.am
+++ b/charts/Makefile.am
@@ -2,13 +2,14 @@ EXTRA_DIST += \
     charts/axosyslog/Chart.yaml \
     charts/axosyslog/.helmignore \
     charts/axosyslog/README.md \
-    charts/axosyslog/templates/syslog-statefulset.yaml \
+    charts/axosyslog/README.md.gotmpl \
+    charts/axosyslog/templates/aggregator-statefulset.yaml \
     charts/axosyslog/templates/NOTES.txt \
     charts/axosyslog/templates/podmonitor.yaml \
     charts/axosyslog/templates/service.yaml \
     charts/axosyslog/templates/clusterrole.yaml \
     charts/axosyslog/templates/serviceaccount.yaml \
-    charts/axosyslog/templates/syslog-config.yaml \
+    charts/axosyslog/templates/aggregator-config.yaml \
     charts/axosyslog/templates/_helpers.tpl \
     charts/axosyslog/templates/collector-daemonset.yaml \
     charts/axosyslog/templates/scc.yaml \

--- a/charts/axosyslog/.helmignore
+++ b/charts/axosyslog/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+
+README.md.gotmpl

--- a/charts/axosyslog/Chart.yaml
+++ b/charts/axosyslog/Chart.yaml
@@ -1,6 +1,32 @@
 apiVersion: v2
 name: axosyslog
-description: AxoSyslog for Kubernetes
+description: AxoSyslog is the cloud-native syslog-ng for Kubernetes
 type: application
 version: 0.19.0
 appVersion: "4.22.0"
+kubeVersion: ">=1.22.0-0"
+home: https://axoflow.com/docs/axosyslog-core/
+sources:
+  - https://github.com/axoflow/axosyslog
+keywords:
+  - logging
+  - syslog
+  - syslog-ng
+  - observability
+  - axoflow
+  - axosyslog
+  - opentelemetry
+  - otlp
+icon: https://raw.githubusercontent.com/axoflow/axosyslog/main/doc/axosyslog-white.svg
+maintainers:
+  - name: Axoflow
+    email: support@axoflow.com
+    url: https://axoflow.com/docs/axosyslog-core/support
+annotations:
+  artifacthub.io/links: |
+    - name: documentation
+      url: https://axoflow.com/docs/axosyslog-core
+    - name: support
+      url: https://axoflow.com/docs/axosyslog-core/support
+    - name: issues
+      url: https://github.com/axoflow/axosyslog/issues

--- a/charts/axosyslog/README.md
+++ b/charts/axosyslog/README.md
@@ -1,68 +1,105 @@
-# AxoSyslog Collector
+# axosyslog
 
-AxoSyslog Kubernetes log collector.
+![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![kube version: >=1.22.0-0](https://img.shields.io/badge/kube%20version->=1.22.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-axosyslog-informational?style=flat-square)](https://artifacthub.io/packages/helm/axosyslog/axosyslog)
 
-## Prerequisites
+AxoSyslog is the cloud-native syslog-ng for Kubernetes
 
-- Kubernetes 1.16+
-- Helm 3.0+
+**Homepage:** <https://axoflow.com/docs/axosyslog-core/>
 
+## TL;DR;
 
-## Configuration
-The following table lists the configurable parameters of the AxoSyslog Collector chart and their default values:
+```bash
+helm repo add axosyslog https://axoflow.github.io/axosyslog
+helm repo update
+helm install --generate-name axosyslog/axosyslog
+```
 
+## Introduction
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-|  image.repository  | The container image repository |  ghcr.io/axoflow/axosyslog  |
-|  image.pullPolicy  | The container image pull policy |  IfNotPresent  |
-|  image.tag  | The container image tag |  4.1.1  |
-|  imagePullSecrets  | The names of secrets containing private registry credentials |  []  |
-|  nameOverride  | Override the chart name |  ""  |
-|  fullnameOverride  | Override the full chart name |  ""  |
-|  collector.enabled  | Deploy AxoSyslog as a DaemonSet |  true  |
-|  collector.labels  | Additional labels to apply to the DaemonSet |  {}  |
-|  collector.annotations  | Additional annotations to apply to the DaemonSet |  {}  |
-|  collector.affinity  | Pod affinity |  {}  |
-|  collector.nodeSelector  | Node labels for pod assignment |  {}  |
-|  collector.resources  | Resource requests and limits |  {}  |
-|  collector.tolerations  | Tolerations for pod assignment |  []  |
-|  collector.hostAliases  | Add host aliases |  []  |
-|  collector.secretMounts  | Mount additional secrets as volumes |  []  |
-|  collector.extraVolumes  | Additional volumes to mount |  []  |
-|  collector.extraVolumeMounts  | Additional volume mounts |  []  |
-|  collector.securityContext  | Security context for the pod |  {}  |
-|  collector.maxUnavailable  | The maximum number of unavailable pods during a rolling update |  1  |
-|  collector.hostNetworking  | Whether to enable host networking |  false  |
-|  rbac.create  | Whether to create RBAC resources |  false  |
-|  rbac.extraRules  | Additional RBAC rules |  []  |
-|  openShift.enabled  | Whether to deploy on OpenShift |  false  |
-|  openShift.securityContextConstraints.create  | Whether to create SecurityContextConstraints on OpenShift |  true  |
-|  openShift.securityContextConstraints.annotations  | Annotations to apply to SecurityContextConstraints |  {}  |
-|  serviceAccount.create  | Whether to create a service account |  false  |
-|  serviceAccount.annotations  | Annotations to apply to the service account |  {}  |
-|  namespace  | The Kubernetes namespace to deploy to |  ""  |
-|  podAnnotations  | Additional annotations to apply to the pod |  {}  |
-|  podSecurityContext  | Security context for the pod |  {}  |
-|  securityContext  | Security context for the container |  {}  |
-|  resources  | Resource requests and limits for the container |  {}  |
-|  nodeSelector  | Node labels for pod assignment |  {}  |
-|  tolerations  | Tolerations for pod assignment |  []  |
-|  affinity  | Pod affinity |  {}  |
-|  updateStrategy  | Update strategy for the DaemonSet |  RollingUpdate  |
-|  kubernetes.enabled  | Enable kubernetes log collection  |  true  |
-|  kubernetes.prefix  | Set JSON prefix for logs collected from the k8s cluster  |  ""  |
-|  kubernetes.keyDelimiter  | Set JSON key delimiter for logs collected from the k8s cluster  |  ""  |
-|  extraVolumes | Additional volumes to mount | [] |
-|  extraVolumeMounts | Additional volume mounts | [] |
-|  syslog.enabled | Enable the syslog component | false |
-|  syslog.config | Syslog-ng configuration content | {} |
-|  syslog.labels | Additional labels for the StatefulSet | {} |
-|  syslog.annotations | Additional annotations for the StatefulSet | {} |
-|  syslog.logFileStorage.enabled | Enable persistent storage for log files | false |
-|  syslog.logFileStorage.size | Size of log file storage volume | 50Gi |
-|  syslog.bufferStorage.enabled | Enable persistent storage for syslog buffers | false |
-|  syslog.bufferStorage.size | Size of buffer storage volume | 10Gi |
-|  syslog.extraVolumeMounts | Additional volume mounts for the container | [] |
-|  syslog.extraVolumes | Additional volumes for the pod | [] |
+This chart bootstraps [AxoSyslog](https://axoflow.com/docs/axosyslog-core/) on a [Kubernetes](http://kubernetes.io) cluster.
 
+The chart deploys two complementary components that can run side by side:
+
+- A **collector DaemonSet** that tails pod logs from `/var/log/pods` and forwards them to configured destinations.
+- A **syslog StatefulSet** that receives incoming syslog/OTLP traffic, which can include logs forwarded by the collector.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Default affinity rules for all pods (overridden per component) |
+| aggregator | object | See values.yaml | Aggregator StatefulSet: receives incoming syslog/OTLP traffic (including from the collector) and routes it to destinations. |
+| aggregator.affinity | object | `{}` | Affinity rules for aggregator pod scheduling |
+| aggregator.annotations | object | `{}` | Additional annotations for the aggregator StatefulSet and its pods |
+| aggregator.bufferStorage.enabled | bool | `false` | Enable persistent volume for syslog-ng disk buffers |
+| aggregator.bufferStorage.size | string | `"10Gi"` | Size of the disk buffer PVC |
+| aggregator.bufferStorage.storageClass | string | `"standard"` | StorageClass for the disk buffer PVC |
+| aggregator.config.raw | string | `""` | Override the entire syslog-ng.conf content for the aggregator |
+| aggregator.extraVolumeMounts | list | `[]` | Additional volume mounts to add to the aggregator container |
+| aggregator.extraVolumes | list | `[]` | Additional volumes to add to the aggregator pod |
+| aggregator.hostAliases | list | `[]` | Custom entries added to /etc/hosts for aggregator pods |
+| aggregator.labels | object | `{}` | Additional labels for the aggregator StatefulSet and its pods |
+| aggregator.logFileStorage.enabled | bool | `false` | Enable persistent volume for written log files |
+| aggregator.logFileStorage.size | string | `"50Gi"` | Size of the log file PVC |
+| aggregator.logFileStorage.storageClass | string | `"standard"` | StorageClass for the log file PVC |
+| aggregator.nodeSelector | object | `{}` | Node selector for aggregator pod assignment |
+| aggregator.replicaCount | int | `1` | Number of aggregator replicas |
+| aggregator.resources | object | `{}` | CPU/memory resource requests and limits for the aggregator. Falls back to global `resources` if not set. |
+| aggregator.secretMounts | list | `[]` | Secrets to mount as files into the aggregator container |
+| aggregator.securityContext | object | `{}` | Container-level security context for the aggregator |
+| aggregator.tolerations | list | `[]` | Tolerations for aggregator pod scheduling |
+| collector | object | See values.yaml | Collector DaemonSet: runs on every node to tail /var/log/pods and forward logs to destinations. |
+| collector.affinity | object | `{}` | Affinity rules for collector pod scheduling |
+| collector.annotations | object | `{}` | Additional annotations for the collector DaemonSet and its pods |
+| collector.config.raw | string | `""` | Override the entire syslog-ng.conf content for the collector |
+| collector.extraVolumeMounts | list | `[]` | Additional volume mounts to add to the collector container |
+| collector.extraVolumes | list | `[]` | Additional volumes to add to the collector pod |
+| collector.hostAliases | list | `[]` | Custom entries added to /etc/hosts for collector pods |
+| collector.hostNetworking | bool | `false` | Use the host network namespace for collector pods |
+| collector.labels | object | `{}` | Additional labels for the collector DaemonSet and its pods |
+| collector.maxUnavailable | int | `1` | Maximum number of unavailable pods during a DaemonSet rolling update |
+| collector.nodeSelector | object | `{}` | Node selector for collector pod assignment |
+| collector.resources | object | `{}` | CPU/memory resource requests and limits for the collector. Falls back to global `resources` if not set. |
+| collector.secretMounts | list | `[]` | Secrets to mount as files into the collector container |
+| collector.securityContext | object | `{}` | Container-level security context for the collector |
+| collector.tolerations | list | `[]` | Tolerations for collector pod scheduling |
+| dnsConfig | object | `{}` | Custom DNS configuration for all pods |
+| extraVolumeMounts | list | `[]` | Default extra volume mounts for all pods (overridden per component) |
+| extraVolumes | list | `[]` | Default extra volumes for all pods (overridden per component) |
+| fullnameOverride | string | `""` | Override the fully qualified chart name |
+| hostAliases | list | `[]` | Default custom /etc/hosts entries for all pods (overridden per component) |
+| image.extraArgs | list | `[]` | Additional arguments passed to the syslog-ng process |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"ghcr.io/axoflow/axosyslog"` | Container image repository |
+| image.tag | string | `""` | Image tag (defaults to Chart.AppVersion) |
+| imagePullSecrets | list | `[]` | Secrets for pulling images from private registries |
+| metricsExporter.enabled | bool | `false` | Deploy axosyslog-metrics-exporter as a sidecar on the collector DaemonSet |
+| metricsExporter.image.pullPolicy | string | `nil` | Metrics exporter image pull policy (omitted when unset, letting Kubernetes apply its default) |
+| metricsExporter.image.repository | string | `"ghcr.io/axoflow/axosyslog-metrics-exporter"` | Metrics exporter image repository |
+| metricsExporter.image.tag | string | `"latest"` | Metrics exporter image tag |
+| metricsExporter.resources | object | `{}` | CPU/memory resource requests and limits for the metrics exporter sidecar |
+| metricsExporter.securityContext | object | `{}` | Container-level security context for the metrics exporter sidecar |
+| nameOverride | string | `""` | Override the chart name |
+| namespace | string | `""` | Namespace override (defaults to Release.Namespace) |
+| nodeSelector | object | `{}` | Default node selector for all pods (overridden per component) |
+| openShift.enabled | bool | `false` | Enable OpenShift-specific resources |
+| openShift.securityContextConstraints.annotations | object | `{}` | Annotations for the SecurityContextConstraints resource |
+| openShift.securityContextConstraints.create | bool | `true` | Create a SecurityContextConstraints resource for OpenShift |
+| podAnnotations | object | `{}` | Annotations applied to all pods |
+| podMonitor.annotations | object | `{}` | Additional annotations for the PodMonitor |
+| podMonitor.enabled | bool | `false` | Deploy a PodMonitor CR for Prometheus Operator (requires metricsExporter.enabled) |
+| podMonitor.labels | object | `{}` | Additional labels for the PodMonitor |
+| podSecurityContext | object | `{}` | Pod-level security context applied to all pods |
+| priorityClassName | string | `""` | Priority class name for all pods |
+| rbac.create | bool | `true` | Create ClusterRole and ClusterRoleBinding for the collector |
+| rbac.extraRules | list | `[]` | Additional RBAC rules to add to the ClusterRole |
+| resources | object | `{}` | Default CPU/memory resource requests and limits for all components (overridden per component via collector.resources / aggregator.resources) |
+| secretMounts | list | `[]` | Default secrets to mount as files (overridden per component) |
+| securityContext | object | `{}` | Default container-level security context for all components (overridden per component via collector.securityContext / aggregator.securityContext) |
+| service.create | bool | `true` | Create a Service for the aggregator StatefulSet |
+| service.extraPorts | list | `[]` | Additional ports to expose on the aggregator Service |
+| serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
+| serviceAccount.create | bool | `true` | Create a ServiceAccount for the pods |
+| terminationGracePeriodSeconds | int | `30` | Time in seconds given to pods to terminate gracefully |
+| tolerations | list | `[]` | Default tolerations for all pods (overridden per component) |
+| updateStrategy | string | `"RollingUpdate"` | Update strategy type for the DaemonSet and StatefulSet |

--- a/charts/axosyslog/README.md.gotmpl
+++ b/charts/axosyslog/README.md.gotmpl
@@ -1,0 +1,12 @@
+{{ template "chart.baseHead" . }}
+
+## Introduction
+
+This chart bootstraps [AxoSyslog](https://axoflow.com/docs/axosyslog-core/) on a [Kubernetes](http://kubernetes.io) cluster.
+
+The chart deploys two complementary components that can run side by side:
+
+- A **collector DaemonSet** that tails pod logs from `/var/log/pods` and forwards them to configured destinations.
+- A **syslog StatefulSet** that receives incoming syslog/OTLP traffic, which can include logs forwarded by the collector.
+
+{{ template "chart.valuesSection" . }}

--- a/charts/axosyslog/templates/NOTES.txt
+++ b/charts/axosyslog/templates/NOTES.txt
@@ -1,2 +1,2 @@
-1. Watch the {{ template "axosyslog.fullname" . }} container start.
-  $ kubectl get pods --namespace={{ .Release.Namespace }} -l app={{ template "axosyslog.fullname" . }} -w
+1. Watch the {{ template "axosyslog.fullname" . }} containers start.
+  $ kubectl get pods --namespace={{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "axosyslog.name" . }} -w

--- a/charts/axosyslog/templates/_helpers.tpl
+++ b/charts/axosyslog/templates/_helpers.tpl
@@ -67,19 +67,19 @@ app.kubernetes.io/component: collector
 {{- end }}
 
 {{/*
-Syslog component selector labels.
+Aggregator component selector labels.
 */}}
-{{- define "axosyslog.syslog.selectorLabels" -}}
+{{- define "axosyslog.aggregator.selectorLabels" -}}
 {{ include "axosyslog.selectorLabels" . }}
-app.kubernetes.io/component: syslog
+app.kubernetes.io/component: aggregator
 {{- end }}
 
 {{/*
-Syslog component labels.
+Aggregator component labels.
 */}}
-{{- define "axosyslog.syslog.labels" -}}
+{{- define "axosyslog.aggregator.labels" -}}
 {{ include "axosyslog.labels" . }}
-app.kubernetes.io/component: syslog
+app.kubernetes.io/component: aggregator
 {{- end }}
 
 {{/*

--- a/charts/axosyslog/templates/_helpers.tpl
+++ b/charts/axosyslog/templates/_helpers.tpl
@@ -31,7 +31,15 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
-Common labels
+Selector labels (immutable, used in spec.selector.matchLabels).
+*/}}
+{{- define "axosyslog.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "axosyslog.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Common labels (superset of selectorLabels, used on all metadata.labels).
 */}}
 {{- define "axosyslog.labels" -}}
 helm.sh/chart: {{ include "axosyslog.chart" . }}
@@ -43,11 +51,35 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels
+Collector component selector labels.
 */}}
-{{- define "axosyslog.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "axosyslog.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{- define "axosyslog.collector.selectorLabels" -}}
+{{ include "axosyslog.selectorLabels" . }}
+app.kubernetes.io/component: collector
+{{- end }}
+
+{{/*
+Collector component labels.
+*/}}
+{{- define "axosyslog.collector.labels" -}}
+{{ include "axosyslog.labels" . }}
+app.kubernetes.io/component: collector
+{{- end }}
+
+{{/*
+Syslog component selector labels.
+*/}}
+{{- define "axosyslog.syslog.selectorLabels" -}}
+{{ include "axosyslog.selectorLabels" . }}
+app.kubernetes.io/component: syslog
+{{- end }}
+
+{{/*
+Syslog component labels.
+*/}}
+{{- define "axosyslog.syslog.labels" -}}
+{{ include "axosyslog.labels" . }}
+app.kubernetes.io/component: syslog
 {{- end }}
 
 {{/*

--- a/charts/axosyslog/templates/aggregator-config.yaml
+++ b/charts/axosyslog/templates/aggregator-config.yaml
@@ -3,10 +3,10 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "axosyslog.labels" . | nindent 4 }}
-  name: {{ include "axosyslog.fullname" . }}-syslog
+  name: {{ include "axosyslog.fullname" . }}-aggregator
 data:
-{{- if .Values.syslog.config.raw }}
-  syslog-ng.conf: {{ tpl (toYaml .Values.syslog.config.raw) . | indent 2 }}
+{{- if .Values.aggregator.config.raw }}
+  syslog-ng.conf: {{ tpl (toYaml .Values.aggregator.config.raw) . | indent 2 }}
 {{- else }}
   syslog-ng.conf: |
     @version: {{ regexFind "^[0-9]+\\.[0-9]+" .Chart.AppVersion | default "current" }}
@@ -14,13 +14,13 @@ data:
 
     options {
       stats(
-        level({{ .Values.syslog.config.stats.level }})
+        level({{ .Values.aggregator.config.stats.level }})
       );
       ts-format(iso);
       frac-digits(6);
     };
 
-{{- with .Values.syslog.config.sources.syslog }}
+{{- with .Values.aggregator.config.sources.syslog }}
   {{- if .enabled }}
     source s_syslog {
       default-network-drivers(
@@ -56,7 +56,7 @@ data:
   {{- end }}
 {{- end }}
 
-{{- with .Values.syslog.config.sources.axosyslogOtlp }}
+{{- with .Values.aggregator.config.sources.axosyslogOtlp }}
   {{- if .enabled }}
     source s_syslogng_otlp {
       axosyslog-otlp();
@@ -65,14 +65,14 @@ data:
 {{- end }}
 
     log {
-{{- if .Values.syslog.config.sources.syslog.enabled }}
+{{- if .Values.aggregator.config.sources.syslog.enabled }}
       source (s_syslog);
 {{- end }}
-{{- if .Values.syslog.config.sources.axosyslogOtlp.enabled }}
+{{- if .Values.aggregator.config.sources.axosyslogOtlp.enabled }}
       source (s_syslogng_otlp);
 {{- end }}
 
-{{- with .Values.syslog.config.destinations.syslog }}
+{{- with .Values.aggregator.config.destinations.syslog }}
   {{- if .enabled }}
       destination {
         network(
@@ -89,7 +89,7 @@ data:
       };
   {{- end }}
 {{- end }}
-{{- with .Values.syslog.config.destinations.opensearch }}
+{{- with .Values.aggregator.config.destinations.opensearch }}
   {{- if .enabled }}
       destination {
         elasticsearch-http(
@@ -133,7 +133,7 @@ data:
       };
     {{- end }}
 {{- end }}
-{{- with .Values.syslog.config.destinations.axosyslogOtlp }}
+{{- with .Values.aggregator.config.destinations.axosyslogOtlp }}
   {{- if .enabled }}
       destination {
         axosyslog-otlp (
@@ -145,7 +145,7 @@ data:
       };
   {{- end }}
 {{- end }}
-{{- with .Values.syslog.config.destinations.file }}
+{{- with .Values.aggregator.config.destinations.file }}
   {{- if .enabled }}
       destination {
         file ({{ tpl .path $ | quote }}

--- a/charts/axosyslog/templates/aggregator-config.yaml
+++ b/charts/axosyslog/templates/aggregator-config.yaml
@@ -26,7 +26,11 @@ data:
       default-network-drivers(
         udp-port(1514)
         tcp-port(1514)
+        {{- if .tls }}
         rfc5424-tls-port(6514)
+        {{- else }}
+        rfc5424-tls-port(0)
+        {{- end }}
         rfc5424-tcp-port(1601)
         max-connections({{ .maxConnections | default 1000 }})
         log-iw-size({{ .initWindowSize | default 100000 }})

--- a/charts/axosyslog/templates/aggregator-statefulset.yaml
+++ b/charts/axosyslog/templates/aggregator-statefulset.yaml
@@ -1,38 +1,38 @@
-{{- if .Values.syslog.enabled }}
+{{- if .Values.aggregator.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "axosyslog.fullname" . }}-syslog
+  name: {{ template "axosyslog.fullname" . }}-aggregator
   namespace: {{ include "axosyslog.namespace" . }}
   labels:
-    {{- include "axosyslog.syslog.labels" . | nindent 4 }}
-    {{- range $key, $value := .Values.syslog.labels }}
+    {{- include "axosyslog.aggregator.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.aggregator.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
-  {{- if .Values.syslog.annotations }}
+  {{- if .Values.aggregator.annotations }}
   annotations:
-    {{- range $key, $value := .Values.syslog.annotations }}
+    {{- range $key, $value := .Values.aggregator.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- end }}
 spec:
   replicas: 1
-  serviceName: {{ template "axosyslog.fullname" . }}-syslog
+  serviceName: {{ template "axosyslog.fullname" . }}-aggregator
   selector:
     matchLabels:
-      {{- include "axosyslog.syslog.selectorLabels" . | nindent 6 }}
+      {{- include "axosyslog.aggregator.selectorLabels" . | nindent 6 }}
   updateStrategy:
     type: {{ .Values.updateStrategy }}
   template:
     metadata:
       annotations:
-        checksum/config: {{ tpl (toYaml .Values.syslog.config) . | sha256sum }}
+        checksum/config: {{ tpl (toYaml .Values.aggregator.config) . | sha256sum }}
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       labels:
-        {{- include "axosyslog.syslog.labels" . | nindent 8 }}
-        {{- range $key, $value := .Values.syslog.labels }}
+        {{- include "axosyslog.aggregator.labels" . | nindent 8 }}
+        {{- range $key, $value := .Values.aggregator.labels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
@@ -46,37 +46,37 @@ spec:
       {{- with .Values.podSecurityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
-      tolerations: {{ toYaml ( default .Values.tolerations .Values.syslog.tolerations ) | nindent 8 }}
-      nodeSelector: {{ toYaml ( default .Values.nodeSelector .Values.syslog.nodeSelector ) | nindent 8 }}
+      tolerations: {{ toYaml ( default .Values.tolerations .Values.aggregator.tolerations ) | nindent 8 }}
+      nodeSelector: {{ toYaml ( default .Values.nodeSelector .Values.aggregator.nodeSelector ) | nindent 8 }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      affinity: {{ toYaml ( default .Values.affinity .Values.syslog.affinity ) | nindent 8 }}
+      affinity: {{ toYaml ( default .Values.affinity .Values.aggregator.affinity ) | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- if .Values.dnsConfig }}
       dnsConfig: {{ toYaml .Values.dnsConfig | nindent 8 }}
       {{- end }}
-      {{- if default .Values.hostAliases .Values.syslog.hostAliases }}
-      hostAliases: {{ toYaml ( default .Values.hostAliases .Values.syslog.hostAliases ) | nindent 8 }}
+      {{- if default .Values.hostAliases .Values.aggregator.hostAliases }}
+      hostAliases: {{ toYaml ( default .Values.hostAliases .Values.aggregator.hostAliases ) | nindent 8 }}
       {{- end }}
       volumes:
-      {{- range default .Values.secretMounts .Values.syslog.secretMounts }}
+      {{- range default .Values.secretMounts .Values.aggregator.secretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
       {{- end }}
         - name: config
           configMap:
-            name: {{ include "axosyslog.fullname" . }}-syslog
-      {{- if default .Values.extraVolumes .Values.syslog.extraVolumes }}
-        {{- toYaml ( default .Values.extraVolumes .Values.syslog.extraVolumes ) | nindent 8 }}
+            name: {{ include "axosyslog.fullname" . }}-aggregator
+      {{- if default .Values.extraVolumes .Values.aggregator.extraVolumes }}
+        {{- toYaml ( default .Values.extraVolumes .Values.aggregator.extraVolumes ) | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          securityContext: {{ toYaml ( default .Values.securityContext .Values.syslog.securityContext ) | nindent 12 }}
-          resources: {{ toYaml ( default .Values.resources .Values.syslog.resources ) | nindent 12 }}
+          securityContext: {{ toYaml ( default .Values.securityContext .Values.aggregator.securityContext ) | nindent 12 }}
+          resources: {{ toYaml ( default .Values.resources .Values.aggregator.resources ) | nindent 12 }}
           ports:
           - containerPort: 1514
             name: rfc3164-tcp
@@ -90,7 +90,7 @@ spec:
           - containerPort: 4317
             name: otlp
           volumeMounts:
-          {{- range default .Values.secretMounts .Values.syslog.secretMounts }}
+          {{- range default .Values.secretMounts .Values.aggregator.secretMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}
               {{- if .subPath }}
@@ -100,16 +100,16 @@ spec:
           - mountPath: /etc/syslog-ng/syslog-ng.conf
             name: config
             subPath: syslog-ng.conf
-          {{- if .Values.syslog.logFileStorage.enabled }}
+          {{- if .Values.aggregator.logFileStorage.enabled }}
           - mountPath: /var/log
             name: logs
           {{- end }}
-          {{- if .Values.syslog.bufferStorage.enabled }}
+          {{- if .Values.aggregator.bufferStorage.enabled }}
           - mountPath: /var/lib/syslog-ng
             name: buffers
           {{- end }}
-          {{- if default .Values.extraVolumeMounts .Values.syslog.extraVolumeMounts }}
-            {{- toYaml ( default .Values.extraVolumeMounts .Values.syslog.extraVolumeMounts ) | nindent 10 }}
+          {{- if default .Values.extraVolumeMounts .Values.aggregator.extraVolumeMounts }}
+            {{- toYaml ( default .Values.extraVolumeMounts .Values.aggregator.extraVolumeMounts ) | nindent 10 }}
           {{- end }}
           livenessProbe:
             initialDelaySeconds: 5
@@ -119,7 +119,7 @@ spec:
             exec:
               command: ["syslog-ng-ctl", "healthcheck", "--timeout", "5"]
   volumeClaimTemplates:
-{{- with .Values.syslog.logFileStorage }}
+{{- with .Values.aggregator.logFileStorage }}
 {{- if .enabled }}
   - metadata:
       name: logs
@@ -131,7 +131,7 @@ spec:
       storageClassName: {{ .storageClass }}
 {{- end }}
 {{- end }}
-{{- with .Values.syslog.bufferStorage }}
+{{- with .Values.aggregator.bufferStorage }}
 {{- if .enabled }}
   - metadata:
       name: buffers

--- a/charts/axosyslog/templates/aggregator-statefulset.yaml
+++ b/charts/axosyslog/templates/aggregator-statefulset.yaml
@@ -78,17 +78,23 @@ spec:
           securityContext: {{ toYaml ( default .Values.securityContext .Values.aggregator.securityContext ) | nindent 12 }}
           resources: {{ toYaml ( default .Values.resources .Values.aggregator.resources ) | nindent 12 }}
           ports:
+          {{- if .Values.aggregator.config.sources.syslog.enabled }}
           - containerPort: 1514
             name: rfc3164-tcp
           - containerPort: 1514
             protocol: UDP
             name: rfc3164-udp
+          {{- if .Values.aggregator.config.sources.syslog.tls }}
           - containerPort: 6514
             name: rfc5424-tls
+          {{- end }}
           - containerPort: 1601
             name: rfc5424-tcp
+          {{- end }}
+          {{- if .Values.aggregator.config.sources.axosyslogOtlp.enabled }}
           - containerPort: 4317
             name: otlp
+          {{- end }}
           volumeMounts:
           {{- range default .Values.secretMounts .Values.aggregator.secretMounts }}
             - name: {{ .name }}

--- a/charts/axosyslog/templates/aggregator-statefulset.yaml
+++ b/charts/axosyslog/templates/aggregator-statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.aggregator.replicaCount }}
   serviceName: {{ template "axosyslog.fullname" . }}-aggregator
   selector:
     matchLabels:

--- a/charts/axosyslog/templates/aggregator-statefulset.yaml
+++ b/charts/axosyslog/templates/aggregator-statefulset.yaml
@@ -80,19 +80,23 @@ spec:
           ports:
           {{- if .Values.aggregator.config.sources.syslog.enabled }}
           - containerPort: 1514
+            protocol: TCP
             name: rfc3164-tcp
           - containerPort: 1514
             protocol: UDP
             name: rfc3164-udp
           {{- if .Values.aggregator.config.sources.syslog.tls }}
           - containerPort: 6514
+            protocol: TCP
             name: rfc5424-tls
           {{- end }}
           - containerPort: 1601
+            protocol: TCP
             name: rfc5424-tcp
           {{- end }}
           {{- if .Values.aggregator.config.sources.axosyslogOtlp.enabled }}
           - containerPort: 4317
+            protocol: TCP
             name: otlp
           {{- end }}
           volumeMounts:

--- a/charts/axosyslog/templates/collector-config.yaml
+++ b/charts/axosyslog/templates/collector-config.yaml
@@ -52,7 +52,7 @@ data:
   {{- if .enabled }}
       destination {
         network(
-          {{ .address | quote }}
+          {{ tpl .address $ | quote }}
           port({{ .port }})
           transport({{ .transport }})
     {{- if .template }}

--- a/charts/axosyslog/templates/collector-daemonset.yaml
+++ b/charts/axosyslog/templates/collector-daemonset.yaml
@@ -34,7 +34,7 @@ spec:
     type: {{ .Values.updateStrategy }}
   template:
     metadata:
-      {{- if .Values.podAnnotation }}
+      {{- if .Values.podAnnotations }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}

--- a/charts/axosyslog/templates/collector-daemonset.yaml
+++ b/charts/axosyslog/templates/collector-daemonset.yaml
@@ -6,14 +6,9 @@ metadata:
   name: {{ template "axosyslog.fullname" . }}-collector
   namespace: {{ include "axosyslog.namespace" . }}
   labels:
-    app: {{ template "axosyslog.fullname" . }}-collector
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    {{- if .Values.collector.labels }}
+    {{- include "axosyslog.collector.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.collector.labels }}
     {{ $key }}: {{ $value | quote }}
-    {{- end }}
     {{- end }}
   {{- if .Values.collector.annotations }}
   annotations:
@@ -24,8 +19,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: "{{ template "axosyslog.fullname" . }}"
-      release: {{ .Release.Name | quote }}
+      {{- include "axosyslog.collector.selectorLabels" . | nindent 6 }}
   updateStrategy:
     {{- if eq .Values.updateStrategy "RollingUpdate" }}
     rollingUpdate:
@@ -34,34 +28,26 @@ spec:
     type: {{ .Values.updateStrategy }}
   template:
     metadata:
-      {{- if .Values.podAnnotations }}
       annotations:
         checksum/config: {{ tpl (toYaml .Values.collector.config) . | sha256sum }}
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-      {{- else }}
-      annotations:
-        checksum/config: {{ tpl (toYaml .Values.collector.config) . | sha256sum }}
-      {{- end }}
-      name: "{{ template "axosyslog.fullname" . }}"
       labels:
-        app: "{{ template "axosyslog.fullname" . }}"
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        heritage: {{ .Release.Service | quote }}
-        release: {{ .Release.Name | quote }}
-        {{- if .Values.collector.labels }}
+        {{- include "axosyslog.collector.labels" . | nindent 8 }}
         {{- range $key, $value := .Values.collector.labels }}
         {{ $key }}: {{ $value | quote }}
-        {{- end }}
         {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "axosyslog.serviceAccountName" . }}
-      {{- end}}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
       tolerations: {{ toYaml ( default .Values.tolerations .Values.collector.tolerations ) | nindent 8 }}
       nodeSelector: {{ toYaml ( default .Values.nodeSelector .Values.collector.nodeSelector ) | nindent 8 }}
@@ -103,19 +89,17 @@ spec:
       {{- if default .Values.extraVolumes .Values.collector.extraVolumes }}
         {{- toYaml ( default .Values.extraVolumes .Values.collector.extraVolumes ) | nindent 8 }}
       {{- end }}
-      {{- end }}
       containers:
-        - name: "axosyslog"
+        - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "--persist-file"
             - "/var/log/syslog-ng.persist"
             {{- range .Values.image.extraArgs }}
             - {{ . }}
             {{- end }}
-          resources:
-{{ toYaml ( default .Values.resources .Values.collector.resources ) | indent 12 }}
+          resources: {{ toYaml ( default .Values.resources .Values.collector.resources ) | nindent 12 }}
           securityContext: {{ toYaml ( default .Values.securityContext .Values.collector.securityContext ) | nindent 12 }}
           volumeMounts:
             {{- range default .Values.secretMounts .Values.collector.secretMounts }}

--- a/charts/axosyslog/templates/collector-daemonset.yaml
+++ b/charts/axosyslog/templates/collector-daemonset.yaml
@@ -144,7 +144,9 @@ spec:
         {{- if .Values.metricsExporter.enabled }}
         - name: "metrics-exporter"
           image: "{{ .Values.metricsExporter.image.repository }}:{{ .Values.metricsExporter.image.tag }}"
-          imagePullPolicy: "{{ .Values.metricsExporter.image.pullPolicy }}"
+          {{- if .Values.metricsExporter.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.metricsExporter.image.pullPolicy | quote }}
+          {{- end }}
           args:
             - --socket.path=/var/lib/syslog-ng/syslog-ng.ctl
           volumeMounts:

--- a/charts/axosyslog/templates/collector-daemonset.yaml
+++ b/charts/axosyslog/templates/collector-daemonset.yaml
@@ -36,9 +36,13 @@ spec:
     metadata:
       {{- if .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ tpl (toYaml .Values.collector.config) . | sha256sum }}
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+      {{- else }}
+      annotations:
+        checksum/config: {{ tpl (toYaml .Values.collector.config) . | sha256sum }}
       {{- end }}
       name: "{{ template "axosyslog.fullname" . }}"
       labels:
@@ -55,12 +59,16 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "axosyslog.serviceAccountName" . }}
       {{- end}}
-      tolerations: {{ toYaml ( .Values.tolerations | default .Values.collector.tolerations ) | nindent 8 }}
-      nodeSelector: {{ toYaml ( .Values.nodeSelector | default .Values.collector.nodeSelector ) | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      tolerations: {{ toYaml ( default .Values.tolerations .Values.collector.tolerations ) | nindent 8 }}
+      nodeSelector: {{ toYaml ( default .Values.nodeSelector .Values.collector.nodeSelector ) | nindent 8 }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      affinity: {{ toYaml ( .Values.affinity | default .Values.collector.affinity ) | nindent 8 }}
+      affinity: {{ toYaml ( default .Values.affinity .Values.collector.affinity ) | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- if .Values.collector.hostNetworking }}
       hostNetwork: true
@@ -69,11 +77,11 @@ spec:
       {{- if .Values.dnsConfig }}
       dnsConfig: {{ toYaml .Values.dnsConfig | nindent 8 }}
       {{- end }}
-      {{- if .Values.hostAliases | default .Values.collector.hostAliases }}
-      hostAliases: {{ toYaml ( .Values.hostAliases | default .Values.collector.hostAliases ) | nindent 8 }}
+      {{- if default .Values.hostAliases .Values.collector.hostAliases }}
+      hostAliases: {{ toYaml ( default .Values.hostAliases .Values.collector.hostAliases ) | nindent 8 }}
       {{- end }}
       volumes:
-      {{- range .Values.secretMounts | default .Values.collector.secretMounts }}
+      {{- range default .Values.secretMounts .Values.collector.secretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
@@ -92,12 +100,9 @@ spec:
             path: /var/run/docker.sock
         - name: var-lib-syslog-ng
           emptyDir: {}
-      {{- if .Values.extraVolumes | default .Values.collector.extraVolumes }}
-{{ toYaml ( .Values.extraVolumes | default .Values.collector.extraVolumes ) | indent 8 }}
+      {{- if default .Values.extraVolumes .Values.collector.extraVolumes }}
+        {{- toYaml ( default .Values.extraVolumes .Values.collector.extraVolumes ) | nindent 8 }}
       {{- end }}
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
       containers:
         - name: "axosyslog"
@@ -110,10 +115,10 @@ spec:
             - {{ . }}
             {{- end }}
           resources:
-{{ toYaml ( .Values.resources | default .Values.collector.resources ) | indent 12 }}
-          securityContext: {{ toYaml ( .Values.podSecurityContext | default .Values.collector.securityContext ) | nindent 12 }}
+{{ toYaml ( default .Values.resources .Values.collector.resources ) | indent 12 }}
+          securityContext: {{ toYaml ( default .Values.securityContext .Values.collector.securityContext ) | nindent 12 }}
           volumeMounts:
-            {{- range .Values.secretMounts | default .Values.collector.secretMounts }}
+            {{- range default .Values.secretMounts .Values.collector.secretMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}
               {{- if .subPath }}
@@ -131,8 +136,8 @@ spec:
               mountPath: /var/run/docker.sock
             - name: var-lib-syslog-ng
               mountPath: /var/lib/syslog-ng
-          {{- if .Values.extraVolumeMounts | default .Values.collector.extraVolumeMounts }}
-{{ toYaml (.Values.extraVolumeMounts | default .Values.collector.extraVolumeMounts ) | indent 12 }}
+          {{- if default .Values.extraVolumeMounts .Values.collector.extraVolumeMounts }}
+            {{- toYaml ( default .Values.extraVolumeMounts .Values.collector.extraVolumeMounts ) | nindent 12 }}
           {{- end }}
           livenessProbe:
             initialDelaySeconds: 5
@@ -157,6 +162,6 @@ spec:
               name: exporter
               protocol: TCP
           resources: {{ toYaml ( .Values.metricsExporter.resources ) | nindent 12 }}
-          securityContext: {{ toYaml ( .Values.metricsExporter.securityContext | default .Values.collector.securityContext ) | nindent 12 }}
+          securityContext: {{ toYaml ( default .Values.collector.securityContext .Values.metricsExporter.securityContext ) | nindent 12 }}
         {{- end }}
 {{- end }}

--- a/charts/axosyslog/templates/podmonitor.yaml
+++ b/charts/axosyslog/templates/podmonitor.yaml
@@ -5,14 +5,9 @@ metadata:
   name: {{ template "axosyslog.fullname" . }}
   namespace: {{ include "axosyslog.namespace" . }}
   labels:
-    app: "{{ template "axosyslog.fullname" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    {{- with .Values.podMonitor.labels }}
-    {{- range $key, $value := . }}
+    {{- include "axosyslog.collector.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.podMonitor.labels }}
     {{ $key }}: {{ $value | quote }}
-    {{- end }}
     {{- end }}
   {{- with .Values.podMonitor.annotations }}
   annotations:
@@ -23,8 +18,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: "{{ template "axosyslog.fullname" . }}"
-      release: {{ .Release.Name | quote }}
+      {{- include "axosyslog.collector.selectorLabels" . | nindent 6 }}
   podMetricsEndpoints:
   - port: exporter
 {{- end }}

--- a/charts/axosyslog/templates/service.yaml
+++ b/charts/axosyslog/templates/service.yaml
@@ -3,9 +3,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "axosyslog.fullname" . }}-syslog
+  namespace: {{ include "axosyslog.namespace" . }}
+  labels:
+    {{- include "axosyslog.syslog.labels" . | nindent 4 }}
 spec:
   selector:
-    app: {{ template "axosyslog.fullname" . }}-syslog
+    {{- include "axosyslog.syslog.selectorLabels" . | nindent 4 }}
   type: NodePort
   ports:
 {{ if .Values.service.extraPorts }}

--- a/charts/axosyslog/templates/service.yaml
+++ b/charts/axosyslog/templates/service.yaml
@@ -27,11 +27,13 @@ spec:
       nodePort: {{ .syslog.rfc3164TcpPort | default 30514 }}
       port: 514
       targetPort: rfc3164-tcp
+    {{- if .syslog.tls }}
     - name: rfc5424-tls
       protocol: TCP
       nodePort: {{ .syslog.rfc5424TlsPort | default 30614 }}
       port: 6514
       targetPort: rfc5424-tls
+    {{- end }}
     - name: rfc5424-tcp
       protocol: TCP
       nodePort: {{ .syslog.rfc5424TcpPort | default 30601 }}

--- a/charts/axosyslog/templates/service.yaml
+++ b/charts/axosyslog/templates/service.yaml
@@ -2,20 +2,20 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "axosyslog.fullname" . }}-syslog
+  name: {{ template "axosyslog.fullname" . }}-aggregator
   namespace: {{ include "axosyslog.namespace" . }}
   labels:
-    {{- include "axosyslog.syslog.labels" . | nindent 4 }}
+    {{- include "axosyslog.aggregator.labels" . | nindent 4 }}
 spec:
   selector:
-    {{- include "axosyslog.syslog.selectorLabels" . | nindent 4 }}
+    {{- include "axosyslog.aggregator.selectorLabels" . | nindent 4 }}
   type: NodePort
   ports:
 {{ if .Values.service.extraPorts }}
 {{ toYaml ( .Values.service.extraPorts ) | nindent 4 }}
 {{ end }}
 
-{{- with .Values.syslog.config.sources }}
+{{- with .Values.aggregator.config.sources }}
 {{- if .syslog.enabled }}
     - name: rfc3164-udp
       protocol: UDP

--- a/charts/axosyslog/templates/syslog-statefulset.yaml
+++ b/charts/axosyslog/templates/syslog-statefulset.yaml
@@ -51,21 +51,21 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      tolerations: {{ toYaml ( .Values.tolerations | default .Values.syslog.tolerations ) | nindent 8 }}
-      nodeSelector: {{ toYaml ( .Values.nodeSelector | default .Values.syslog.nodeSelector ) | nindent 8 }}
+      tolerations: {{ toYaml ( default .Values.tolerations .Values.syslog.tolerations ) | nindent 8 }}
+      nodeSelector: {{ toYaml ( default .Values.nodeSelector .Values.syslog.nodeSelector ) | nindent 8 }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      affinity: {{ toYaml ( .Values.affinity | default .Values.syslog.affinity ) | nindent 8 }}
+      affinity: {{ toYaml ( default .Values.affinity .Values.syslog.affinity ) | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- if .Values.dnsConfig }}
       dnsConfig: {{ toYaml .Values.dnsConfig | nindent 8 }}
       {{- end }}
-      {{- if .Values.hostAliases | default .Values.syslog.hostAliases }}
-      hostAliases: {{ toYaml ( .Values.hostAliases | default .Values.syslog.hostAliases ) | nindent 8 }}
+      {{- if default .Values.hostAliases .Values.syslog.hostAliases }}
+      hostAliases: {{ toYaml ( default .Values.hostAliases .Values.syslog.hostAliases ) | nindent 8 }}
       {{- end }}
       volumes:
-      {{- range .Values.secretMounts | default .Values.syslog.secretMounts }}
+      {{- range default .Values.secretMounts .Values.syslog.secretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
@@ -73,15 +73,15 @@ spec:
         - name: config
           configMap:
             name: {{ include "axosyslog.fullname" . }}-syslog
-      {{- if .Values.extraVolumes | default .Values.syslog.extraVolumes }}
-{{ toYaml ( .Values.extraVolumes | default .Values.syslog.extraVolumes ) | indent 8 }}
+      {{- if default .Values.extraVolumes .Values.syslog.extraVolumes }}
+        {{- toYaml ( default .Values.extraVolumes .Values.syslog.extraVolumes ) | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          securityContext: {{ toYaml ( .Values.podSecurityContext | default .Values.syslog.securityContext ) | nindent 12 }}
-          resources: {{ toYaml ( .Values.syslog.resources | default .Values.resources ) | nindent 12 }}
+          securityContext: {{ toYaml ( default .Values.securityContext .Values.syslog.securityContext ) | nindent 12 }}
+          resources: {{ toYaml ( default .Values.resources .Values.syslog.resources ) | nindent 12 }}
           ports:
           - containerPort: 1514
             name: rfc3164-tcp
@@ -95,7 +95,7 @@ spec:
           - containerPort: 4317
             name: otlp
           volumeMounts:
-          {{- range .Values.secretMounts | default .Values.syslog.secretMounts }}
+          {{- range default .Values.secretMounts .Values.syslog.secretMounts }}
             - name: {{ .name }}
               mountPath: {{ .path }}
               {{- if .subPath }}
@@ -113,8 +113,8 @@ spec:
           - mountPath: /var/lib/syslog-ng
             name: buffers
           {{- end }}
-          {{- if .Values.extraVolumeMounts | default .Values.syslog.extraVolumeMounts }}
-{{ toYaml (.Values.extraVolumeMounts | default .Values.syslog.extraVolumeMounts ) | indent 10 }}
+          {{- if default .Values.extraVolumeMounts .Values.syslog.extraVolumeMounts }}
+            {{- toYaml ( default .Values.extraVolumeMounts .Values.syslog.extraVolumeMounts ) | nindent 10 }}
           {{- end }}
           livenessProbe:
             initialDelaySeconds: 5
@@ -148,5 +148,4 @@ spec:
       storageClassName: {{ .storageClass }}
 {{- end }}
 {{- end }}
-
 {{- end }}

--- a/charts/axosyslog/templates/syslog-statefulset.yaml
+++ b/charts/axosyslog/templates/syslog-statefulset.yaml
@@ -20,36 +20,68 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- end }}
-
-
 spec:
   replicas: 1
   serviceName: {{ template "axosyslog.fullname" . }}-syslog
   selector:
     matchLabels:
       {{- include "axosyslog.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy }}
   template:
     metadata:
+      {{- if .Values.podAnnotations }}
       annotations:
         checksum/config: {{ tpl (toYaml .Values.syslog.config) . | sha256sum }}
-    {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- else }}
+      annotations:
+        checksum/config: {{ tpl (toYaml .Values.syslog.config) . | sha256sum }}
+      {{- end }}
       labels:
         app: {{ template "axosyslog.fullname" . }}-syslog
         {{- include "axosyslog.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "axosyslog.serviceAccountName" . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-
+      tolerations: {{ toYaml ( .Values.tolerations | default .Values.syslog.tolerations ) | nindent 8 }}
+      nodeSelector: {{ toYaml ( .Values.nodeSelector | default .Values.syslog.nodeSelector ) | nindent 8 }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      affinity: {{ toYaml ( .Values.affinity | default .Values.syslog.affinity ) | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig: {{ toYaml .Values.dnsConfig | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hostAliases | default .Values.syslog.hostAliases }}
+      hostAliases: {{ toYaml ( .Values.hostAliases | default .Values.syslog.hostAliases ) | nindent 8 }}
+      {{- end }}
+      volumes:
+      {{- range .Values.secretMounts | default .Values.syslog.secretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+      {{- end }}
+        - name: config
+          configMap:
+            name: {{ include "axosyslog.fullname" . }}-syslog
+      {{- if .Values.extraVolumes | default .Values.syslog.extraVolumes }}
+{{ toYaml ( .Values.extraVolumes | default .Values.syslog.extraVolumes ) | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext: {{ toYaml ( .Values.podSecurityContext | default .Values.syslog.securityContext ) | nindent 12 }}
+          resources: {{ toYaml ( .Values.syslog.resources | default .Values.resources ) | nindent 12 }}
           ports:
           - containerPort: 1514
             name: rfc3164-tcp
@@ -63,39 +95,34 @@ spec:
           - containerPort: 4317
             name: otlp
           volumeMounts:
+          {{- range .Values.secretMounts | default .Values.syslog.secretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .path }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
+          {{- end }}
           - mountPath: /etc/syslog-ng/syslog-ng.conf
             name: config
             subPath: syslog-ng.conf
-        {{- if .Values.syslog.logFileStorage.enabled }}
+          {{- if .Values.syslog.logFileStorage.enabled }}
           - mountPath: /var/log
             name: logs
-        {{- end }}
-        {{- if .Values.syslog.bufferStorage.enabled }}
+          {{- end }}
+          {{- if .Values.syslog.bufferStorage.enabled }}
           - mountPath: /var/lib/syslog-ng
             name: buffers
-        {{- end }}
-        {{- if .Values.extraVolumeMounts | default .Values.syslog.extraVolumeMounts }}
+          {{- end }}
+          {{- if .Values.extraVolumeMounts | default .Values.syslog.extraVolumeMounts }}
 {{ toYaml (.Values.extraVolumeMounts | default .Values.syslog.extraVolumeMounts ) | indent 10 }}
-        {{- end }}
-      volumes:
-      - name: config
-        configMap:
-          name: {{ include "axosyslog.fullname" . }}-syslog
-      {{- if .Values.extraVolumes | default .Values.syslog.extraVolumes }}
-{{ toYaml ( .Values.extraVolumes | default .Values.syslog.extraVolumes ) | indent 6 }}
-      {{- end }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+          {{- end }}
+          livenessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+            exec:
+              command: ["syslog-ng-ctl", "healthcheck", "--timeout", "5"]
   volumeClaimTemplates:
 {{- with .Values.syslog.logFileStorage }}
 {{- if .enabled }}
@@ -105,7 +132,7 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage:  {{ .size }}
+          storage: {{ .size }}
       storageClassName: {{ .storageClass }}
 {{- end }}
 {{- end }}
@@ -117,7 +144,7 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage:  {{ .size }}
+          storage: {{ .size }}
       storageClassName: {{ .storageClass }}
 {{- end }}
 {{- end }}

--- a/charts/axosyslog/templates/syslog-statefulset.yaml
+++ b/charts/axosyslog/templates/syslog-statefulset.yaml
@@ -5,14 +5,9 @@ metadata:
   name: {{ template "axosyslog.fullname" . }}-syslog
   namespace: {{ include "axosyslog.namespace" . }}
   labels:
-    app: {{ template "axosyslog.fullname" . }}-syslog
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    {{- if .Values.syslog.labels }}
+    {{- include "axosyslog.syslog.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.syslog.labels }}
     {{ $key }}: {{ $value | quote }}
-    {{- end }}
     {{- end }}
   {{- if .Values.syslog.annotations }}
   annotations:
@@ -25,24 +20,21 @@ spec:
   serviceName: {{ template "axosyslog.fullname" . }}-syslog
   selector:
     matchLabels:
-      {{- include "axosyslog.selectorLabels" . | nindent 6 }}
+      {{- include "axosyslog.syslog.selectorLabels" . | nindent 6 }}
   updateStrategy:
     type: {{ .Values.updateStrategy }}
   template:
     metadata:
-      {{- if .Values.podAnnotations }}
       annotations:
         checksum/config: {{ tpl (toYaml .Values.syslog.config) . | sha256sum }}
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-      {{- else }}
-      annotations:
-        checksum/config: {{ tpl (toYaml .Values.syslog.config) . | sha256sum }}
-      {{- end }}
       labels:
-        app: {{ template "axosyslog.fullname" . }}-syslog
-        {{- include "axosyslog.selectorLabels" . | nindent 8 }}
+        {{- include "axosyslog.syslog.labels" . | nindent 8 }}
+        {{- range $key, $value := .Values.syslog.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "axosyslog.serviceAccountName" . }}
@@ -50,6 +42,9 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
       tolerations: {{ toYaml ( default .Values.tolerations .Values.syslog.tolerations ) | nindent 8 }}
       nodeSelector: {{ toYaml ( default .Values.nodeSelector .Values.syslog.nodeSelector ) | nindent 8 }}

--- a/charts/axosyslog/values.yaml
+++ b/charts/axosyslog/values.yaml
@@ -39,6 +39,8 @@ collector:
       syslog:
         enabled: true
         transport: tcp
+        address: '{{ include "axosyslog.fullname" . }}-aggregator.{{ include "axosyslog.namespace" . }}.svc.cluster.local'
+        port: 514
         template: "$(format-json .*)"
         extraOptionsRaw: "time-reopen(10)"
       opensearch:
@@ -57,7 +59,7 @@ collector:
         extraOptionsRaw: "time-reopen(10)"
       axosyslogOtlp:
         enabled: false
-        url: "192.168.77.133:4317"
+        url: '{{ include "axosyslog.fullname" . }}-aggregator.{{ include "axosyslog.namespace" . }}.svc.cluster.local:4317'
         extraOptionsRaw: "time-reopen(1) batch-timeout(1000) batch-lines(1000)"
   # -- Additional labels for the collector DaemonSet and its pods
   labels: {}

--- a/charts/axosyslog/values.yaml
+++ b/charts/axosyslog/values.yaml
@@ -1,18 +1,28 @@
 image:
+  # -- Container image repository
   repository: ghcr.io/axoflow/axosyslog
+  # -- Image pull policy
   pullPolicy: IfNotPresent
+  # -- Image tag (defaults to Chart.AppVersion)
   tag: ""
+  # -- Additional arguments passed to the syslog-ng process
   extraArgs: []
 
+# -- Secrets for pulling images from private registries
 imagePullSecrets: []
+# -- Override the chart name
 nameOverride: ""
+# -- Override the fully qualified chart name
 fullnameOverride: ""
 
-# collector daemonset to tail /var/log/pods
+# -- Collector DaemonSet: runs on every node to tail /var/log/pods and forward logs to destinations.
+# @default -- See values.yaml
 collector:
+  # @default -- true
   enabled: true
   config:
-    raw: ""  # Use this to manually set the contents of the syslog-ng.conf file.
+    # -- Override the entire syslog-ng.conf content for the collector
+    raw: ""
     stats:
       level: 2
     sources:
@@ -51,35 +61,59 @@ collector:
         enabled: false
         url: "192.168.77.133:4317"
         extraOptionsRaw: "time-reopen(1) batch-timeout(1000) batch-lines(1000)"
+  # -- Additional labels for the collector DaemonSet and its pods
   labels: {}
+  # -- Additional annotations for the collector DaemonSet and its pods
   annotations: {}
+  # -- Affinity rules for collector pod scheduling
   affinity: {}
+  # -- Node selector for collector pod assignment
   nodeSelector: {}
+  # -- CPU/memory resource requests and limits for the collector. Falls back to global `resources` if not set.
   resources: {}
+  # -- Tolerations for collector pod scheduling
   tolerations: []
+  # -- Custom entries added to /etc/hosts for collector pods
   hostAliases: []
+  # -- Secrets to mount as files into the collector container
   secretMounts: []
+  # -- Additional volumes to add to the collector pod
   extraVolumes: []
+  # -- Additional volume mounts to add to the collector container
   extraVolumeMounts: []
+  # -- Container-level security context for the collector
   securityContext: {}
+  # -- Maximum number of unavailable pods during a DaemonSet rolling update
   maxUnavailable: 1
+  # -- Use the host network namespace for collector pods
   hostNetworking: false
 
-# deployment to consume "syslog" traffic route it somewhere
+# -- Syslog StatefulSet: receives incoming syslog/OTLP traffic (including from the collector) and routes it to destinations.
+# @default -- See values.yaml
 syslog:
+  # @default -- true
   enabled: true
+  # -- Additional labels for the syslog StatefulSet and its pods
   labels: {}
+  # -- Additional annotations for the syslog StatefulSet and its pods
   annotations: {}
   logFileStorage:
+    # -- Enable persistent volume for written log files
     enabled: false
+    # -- StorageClass for the log file PVC
     storageClass: standard
+    # -- Size of the log file PVC
     size: 50Gi
   bufferStorage:
+    # -- Enable persistent volume for syslog-ng disk buffers
     enabled: false
+    # -- StorageClass for the disk buffer PVC
     storageClass: standard
+    # -- Size of the disk buffer PVC
     size: 10Gi
   config:
-    raw: ""  # Use this to manually set the contents of the syslog-ng.conf file.
+    # -- Override the entire syslog-ng.conf content for the syslog component
+    raw: ""
     stats:
       level: 2
     sources:
@@ -142,8 +176,11 @@ syslog:
         enabled: false
         url: "192.168.77.133:4317"
         extraOptionsRaw: "time-reopen(1) batch-timeout(1000) batch-lines(1000)"
+  # -- Affinity rules for syslog pod scheduling
   affinity: {}
+  # -- Node selector for syslog pod assignment
   nodeSelector: {}
+  # -- CPU/memory resource requests and limits for the syslog component. Falls back to global `resources` if not set.
   resources: {}
   # resources:
   #   limits:
@@ -152,39 +189,61 @@ syslog:
   #   requests:
   #     cpu: 100m
   #     memory: 128Mi
+  # -- Tolerations for syslog pod scheduling
   tolerations: []
+  # -- Custom entries added to /etc/hosts for syslog pods
   hostAliases: []
+  # -- Secrets to mount as files into the syslog container
   secretMounts: []
+  # -- Additional volumes to add to the syslog pod
   extraVolumes: []
+  # -- Additional volume mounts to add to the syslog container
   extraVolumeMounts: []
+  # -- Container-level security context for the syslog component
   securityContext: {}
+
 metricsExporter:
-  enabled: false  # deploy the axosyslog Deamonset with the axosyslog-metrics-exporter sidecar
+  # -- Deploy axosyslog-metrics-exporter as a sidecar on the collector DaemonSet
+  enabled: false
   image:
+    # -- Metrics exporter image repository
     repository: ghcr.io/axoflow/axosyslog-metrics-exporter
+    # -- Metrics exporter image tag
     tag: latest
+    # -- Metrics exporter image pull policy (omitted when unset, letting Kubernetes apply its default)
     pullPolicy: ~ # use k8s default behavior (Always for :latest, IfNotPresent otherwise)
+  # -- CPU/memory resource requests and limits for the metrics exporter sidecar
   resources: {}
+  # -- Container-level security context for the metrics exporter sidecar
   securityContext: {}
 
 podMonitor:
-  enabled: false  # deploy the PodMonitor CR for Prometheus Operator (requires metricsExporter.enabled)
+  # -- Deploy a PodMonitor CR for Prometheus Operator (requires metricsExporter.enabled)
+  enabled: false
+  # -- Additional labels for the PodMonitor
   labels: {}
+  # -- Additional annotations for the PodMonitor
   annotations: {}
 
-
 rbac:
+  # -- Create ClusterRole and ClusterRoleBinding for the collector
   create: true
+  # -- Additional RBAC rules to add to the ClusterRole
   extraRules: []
 
 openShift:
+  # -- Enable OpenShift-specific resources
   enabled: false
   securityContextConstraints:
+    # -- Create a SecurityContextConstraints resource for OpenShift
     create: true
+    # -- Annotations for the SecurityContextConstraints resource
     annotations: {}
 
 service:
+  # -- Create a Service for the syslog StatefulSet
   create: true
+  # -- Additional ports to expose on the syslog Service
   extraPorts: []
   #  - protocol: TCP
   #    port: 514
@@ -192,14 +251,21 @@ service:
   #    port: 601
 
 serviceAccount:
+  # -- Create a ServiceAccount for the pods
   create: true
+  # -- Annotations for the ServiceAccount
   annotations: {}
 
+# -- Namespace override (defaults to Release.Namespace)
 namespace: ""
+# -- Annotations applied to all pods
 podAnnotations: {}
+# -- Pod-level security context applied to all pods
 podSecurityContext: {}
 #   fsGroup: 2000
+# -- Default container-level security context for all components (overridden per component via collector.securityContext / syslog.securityContext)
 securityContext: {}
+# -- Default CPU/memory resource requests and limits for all components (overridden per component via collector.resources / syslog.resources)
 resources: {}
 #   limits:
 #     cpu: 100m
@@ -207,16 +273,25 @@ resources: {}
 #   requests:
 #     cpu: 100m
 #     memory: 128Mi
+# -- Default node selector for all pods (overridden per component)
 nodeSelector: {}
+# -- Default tolerations for all pods (overridden per component)
 tolerations: []
+# -- Default affinity rules for all pods (overridden per component)
 affinity: {}
+# -- Update strategy type for the DaemonSet and StatefulSet
 updateStrategy: RollingUpdate
+# -- Priority class name for all pods
 priorityClassName: ""
+# -- Custom DNS configuration for all pods
 dnsConfig: {}
+# -- Default custom /etc/hosts entries for all pods (overridden per component)
 hostAliases: []
+# -- Default secrets to mount as files (overridden per component)
 secretMounts: []
+# -- Default extra volumes for all pods (overridden per component)
 extraVolumes: []
+# -- Default extra volume mounts for all pods (overridden per component)
 extraVolumeMounts: []
-## How long (in seconds) a pod may take to exit (useful with lifecycle hooks to ensure lb deregistration is done)
-##
+# -- Time in seconds given to pods to terminate gracefully
 terminationGracePeriodSeconds: 30

--- a/charts/axosyslog/values.yaml
+++ b/charts/axosyslog/values.yaml
@@ -68,6 +68,8 @@ collector:
 # deployment to consume "syslog" traffic route it somewhere
 syslog:
   enabled: true
+  labels: {}
+  annotations: {}
   logFileStorage:
     enabled: false
     storageClass: standard
@@ -140,8 +142,22 @@ syslog:
         enabled: false
         url: "192.168.77.133:4317"
         extraOptionsRaw: "time-reopen(1) batch-timeout(1000) batch-lines(1000)"
+  affinity: {}
+  nodeSelector: {}
+  resources: {}
+  # resources:
+  #   limits:
+  #     cpu: 100m
+  #     memory: 128Mi
+  #   requests:
+  #     cpu: 100m
+  #     memory: 128Mi
+  tolerations: []
+  hostAliases: []
+  secretMounts: []
   extraVolumes: []
   extraVolumeMounts: []
+  securityContext: {}
 metricsExporter:
   enabled: false  # deploy the axosyslog Deamonset with the axosyslog-metrics-exporter sidecar
   image:

--- a/charts/axosyslog/values.yaml
+++ b/charts/axosyslog/values.yaml
@@ -93,6 +93,8 @@ collector:
 aggregator:
   # @default -- true
   enabled: true
+  # -- Number of aggregator replicas
+  replicaCount: 1
   # -- Additional labels for the aggregator StatefulSet and its pods
   labels: {}
   # -- Additional annotations for the aggregator StatefulSet and its pods

--- a/charts/axosyslog/values.yaml
+++ b/charts/axosyslog/values.yaml
@@ -28,33 +28,31 @@ collector:
     sources:
       kubernetes:
         enabled: true
-        #prefix: "k8s~"
-        #keyDelimiter: "~"
-        #maxContainers: 4096
+        # prefix: "k8s~"
+        # keyDelimiter: "~"
+        # maxContainers: 4096
     rewrites:
       set: {}
-      #  foo: "${foovalue}"
-      #  bar: "${barvalue}"
+        # foo: "${foovalue}"
+        # bar: "${barvalue}"
     destinations:
       syslog:
-        enabled: false
+        enabled: true
         transport: tcp
-        address: localhost
-        port: 12345
         template: "$(format-json .*)"
         extraOptionsRaw: "time-reopen(10)"
       opensearch:
         enabled: false
-        url: http://my-release-opensearch.default.svc.cluster.local:9200
-        index: "test-axoflow-index"
-        user: "admin"
-        password: "admin"
-        tls:
-          CAFile: "/path/to/CAFile.pem"
-          CADir: "/path/to/CADir/"
-          Cert: "/path/to/Cert.pem"
-          Key: "/path/to/Key.pem"
-          peerVerify: false
+        # url: http://my-release-opensearch.default.svc.cluster.local:9200
+        # index: "test-axoflow-index"
+        # user: "admin"
+        # password: "admin"
+        # tls:
+        #   CAFile: "/path/to/CAFile.pem"
+        #   CADir: "/path/to/CADir/"
+        #   Cert: "/path/to/Cert.pem"
+        #   Key: "/path/to/Key.pem"
+        #   peerVerify: false
         template: "$(format-json .*)"
         extraOptionsRaw: "time-reopen(10)"
       axosyslogOtlp:
@@ -121,62 +119,61 @@ aggregator:
     sources:
       syslog:
         enabled: true
-        # node ports for the syslog service
+        ## node ports for the syslog service
         rfc3164UdpPort: 30514
         rfc3164TcpPort: 30514
         rfc5424TlsPort: 30614
         rfc5424TcpPort: 30601
-        #maxConnections: 1000
-        #initWindowSize: 150000
-        #tls:
-        #  CAFile: "/path/to/CAFile.pem"
-        #  CADir: "/path/to/CADir/"
-        #  Cert: "/path/to/Cert.pem"
-        #  Key: "/path/to/Key.pem"
-        #  peerVerify: false
+        # maxConnections: 1000
+        # initWindowSize: 150000
+        # tls:
+        #   CAFile: "/path/to/CAFile.pem"
+        #   CADir: "/path/to/CADir/"
+        #   Cert: "/path/to/Cert.pem"
+        #   Key: "/path/to/Key.pem"
+        #   peerVerify: false
       axosyslogOtlp:
         enabled: true
-        # nodePort
         port: 30317
         extraOptionsRaw: ""
 
     rewrites:
       set: {}
-      #  foo: "${foovalue}"
-      #  bar: "${barvalue}"
+        # foo: "${foovalue}"
+        # bar: "${barvalue}"
     destinations:
       file:
         enabled: true
         path: "/var/log/syslog"
-        #template: "$ISODATE $HOST $MSGHDR$MSG\n"
+        # template: "$ISODATE $HOST $MSGHDR$MSG\n"
         extraOptionsRaw: "create-dirs(yes)"
       syslog:
-        enabled: true
+        enabled: false
         transport: tcp
-        address: 192.168.77.133
-        port: 12345
-        # convert incoming data to JSON
-        #template: "$(format-json .*)\n"
-        # use standard syslog logfile
-        #template: "$ISODATE $HOST $MSGHDR$MSG\n"
+        # address: ""
+        # port: 514
+        ## convert incoming data to JSON
+        # template: "$(format-json .*)\n"
+        ## use standard syslog logfile
+        # template: "$ISODATE $HOST $MSGHDR$MSG\n"
         extraOptionsRaw: "time-reopen(10)"
       opensearch:
-        enabled: true
-        url: http://my-release-opensearch.default.svc.cluster.local:9200
-        index: "test-axoflow-index"
-        user: "admin"
-        password: "admin"
-        #tls:
-        #  CAFile: "/path/to/CAFile.pem"
-        #  CADir: "/path/to/CADir/"
-        #  Cert: "/path/to/Cert.pem"
-        #  Key: "/path/to/Key.pem"
-        #  peerVerify: false
-        #template: "$(format-json --scope rfc5424 --exclude DATE --key ISODATE @timestamp=${ISODATE})"
+        enabled: false
+        # url: http://my-release-opensearch.default.svc.cluster.local:9200
+        # index: "test-axoflow-index"
+        # user: "admin"
+        # password: "admin"
+        # tls:
+        #   CAFile: "/path/to/CAFile.pem"
+        #   CADir: "/path/to/CADir/"
+        #   Cert: "/path/to/Cert.pem"
+        #   Key: "/path/to/Key.pem"
+        #   peerVerify: false
+        # template: "$(format-json --scope rfc5424 --exclude DATE --key ISODATE @timestamp=${ISODATE})"
         extraOptionsRaw: "time-reopen(10)"
       axosyslogOtlp:
         enabled: false
-        url: "192.168.77.133:4317"
+        # url: "192.168.77.133:4317"
         extraOptionsRaw: "time-reopen(1) batch-timeout(1000) batch-lines(1000)"
   # -- Affinity rules for aggregator pod scheduling
   affinity: {}

--- a/charts/axosyslog/values.yaml
+++ b/charts/axosyslog/values.yaml
@@ -88,14 +88,14 @@ collector:
   # -- Use the host network namespace for collector pods
   hostNetworking: false
 
-# -- Syslog StatefulSet: receives incoming syslog/OTLP traffic (including from the collector) and routes it to destinations.
+# -- Aggregator StatefulSet: receives incoming syslog/OTLP traffic (including from the collector) and routes it to destinations.
 # @default -- See values.yaml
-syslog:
+aggregator:
   # @default -- true
   enabled: true
-  # -- Additional labels for the syslog StatefulSet and its pods
+  # -- Additional labels for the aggregator StatefulSet and its pods
   labels: {}
-  # -- Additional annotations for the syslog StatefulSet and its pods
+  # -- Additional annotations for the aggregator StatefulSet and its pods
   annotations: {}
   logFileStorage:
     # -- Enable persistent volume for written log files
@@ -112,7 +112,7 @@ syslog:
     # -- Size of the disk buffer PVC
     size: 10Gi
   config:
-    # -- Override the entire syslog-ng.conf content for the syslog component
+    # -- Override the entire syslog-ng.conf content for the aggregator
     raw: ""
     stats:
       level: 2
@@ -176,11 +176,11 @@ syslog:
         enabled: false
         url: "192.168.77.133:4317"
         extraOptionsRaw: "time-reopen(1) batch-timeout(1000) batch-lines(1000)"
-  # -- Affinity rules for syslog pod scheduling
+  # -- Affinity rules for aggregator pod scheduling
   affinity: {}
-  # -- Node selector for syslog pod assignment
+  # -- Node selector for aggregator pod assignment
   nodeSelector: {}
-  # -- CPU/memory resource requests and limits for the syslog component. Falls back to global `resources` if not set.
+  # -- CPU/memory resource requests and limits for the aggregator. Falls back to global `resources` if not set.
   resources: {}
   # resources:
   #   limits:
@@ -189,17 +189,17 @@ syslog:
   #   requests:
   #     cpu: 100m
   #     memory: 128Mi
-  # -- Tolerations for syslog pod scheduling
+  # -- Tolerations for aggregator pod scheduling
   tolerations: []
-  # -- Custom entries added to /etc/hosts for syslog pods
+  # -- Custom entries added to /etc/hosts for aggregator pods
   hostAliases: []
-  # -- Secrets to mount as files into the syslog container
+  # -- Secrets to mount as files into the aggregator container
   secretMounts: []
-  # -- Additional volumes to add to the syslog pod
+  # -- Additional volumes to add to the aggregator pod
   extraVolumes: []
-  # -- Additional volume mounts to add to the syslog container
+  # -- Additional volume mounts to add to the aggregator container
   extraVolumeMounts: []
-  # -- Container-level security context for the syslog component
+  # -- Container-level security context for the aggregator
   securityContext: {}
 
 metricsExporter:
@@ -241,9 +241,9 @@ openShift:
     annotations: {}
 
 service:
-  # -- Create a Service for the syslog StatefulSet
+  # -- Create a Service for the aggregator StatefulSet
   create: true
-  # -- Additional ports to expose on the syslog Service
+  # -- Additional ports to expose on the aggregator Service
   extraPorts: []
   #  - protocol: TCP
   #    port: 514
@@ -263,9 +263,9 @@ podAnnotations: {}
 # -- Pod-level security context applied to all pods
 podSecurityContext: {}
 #   fsGroup: 2000
-# -- Default container-level security context for all components (overridden per component via collector.securityContext / syslog.securityContext)
+# -- Default container-level security context for all components (overridden per component via collector.securityContext / aggregator.securityContext)
 securityContext: {}
-# -- Default CPU/memory resource requests and limits for all components (overridden per component via collector.resources / syslog.resources)
+# -- Default CPU/memory resource requests and limits for all components (overridden per component via collector.resources / aggregator.resources)
 resources: {}
 #   limits:
 #     cpu: 100m

--- a/charts/docs/README.md
+++ b/charts/docs/README.md
@@ -1,0 +1,17 @@
+# Helm chart documentation
+
+README files for Helm charts are generated using [helm-docs](https://github.com/norwoodj/helm-docs).
+
+Each chart should contain a `README.md.gotmpl` file that describes how
+the `README.md` of the chart should be generated.
+
+Normally, this file can be the same as the primary template in [docs/templates/README.md.gotmpl] or a symlink pointing to it:
+
+```bash
+cd charts/CHART
+ls -s ../docs/templates/README.md.gotmpl
+```
+
+Copy the file to the chart directory if you want to customize the template.
+**Note:** Don't forget to add `README.md.gotmpl` to `.helmignore`.
+Then run `make docs` in the repository root.

--- a/charts/docs/templates/README.md.gotmpl
+++ b/charts/docs/templates/README.md.gotmpl
@@ -1,0 +1,11 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.typeBadge" . }} {{ template "chart.kubeVersionBadge" . }} {{ template "chart.artifactHubBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "tldr" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/charts/docs/templates/overrides.gotmpl
+++ b/charts/docs/templates/overrides.gotmpl
@@ -1,0 +1,43 @@
+{{- define "chart.typeBadge" -}}
+{{- if .Type -}}![type: {{ .Type }}](https://img.shields.io/badge/type-{{ .Type }}-informational?style=flat-square){{- end -}}
+{{- end -}}
+
+{{- define "chart.kubeVersionBadge" -}}
+{{- if .KubeVersion -}}![kube version: {{ .KubeVersion }}](https://img.shields.io/badge/kube%20version-{{ .KubeVersion | replace "-" "--" }}-informational?style=flat-square){{- end -}}
+{{- end -}}
+
+{{- define "chart.artifactHubBadge" -}}
+[![artifact hub](https://img.shields.io/badge/artifact%20hub-{{ .Name | replace "-" "--" }}-informational?style=flat-square)](https://artifacthub.io/packages/helm/axosyslog/{{ .Name }})
+{{- end -}}
+
+{{- define "tldr" -}}
+## TL;DR;
+
+```bash
+helm repo add axosyslog https://axoflow.github.io/axosyslog
+helm repo update
+helm install --generate-name axosyslog/{{ .Name }}
+```
+{{- end -}}
+
+{{- define "chart.badges" -}}
+{{ template "chart.typeBadge" . }} {{ template "chart.kubeVersionBadge" . }} {{ template "chart.artifactHubBadge" . }}
+{{- end -}}
+
+{{- define "chart.baseHead" -}}
+{{ template "chart.header" . }}
+
+{{ template "chart.badges" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "tldr" . }}
+{{- end -}}
+
+{{- define "chart.base" -}}
+{{ template "chart.baseHead" . }}
+
+{{ template "chart.valuesSection" . }}
+{{- end -}}

--- a/scripts/helm-docs.sh
+++ b/scripts/helm-docs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#############################################################################
+# Copyright (c) 2026 Axoflow
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+#
+# Generates README.md files for Helm charts using helm-docs.
+# Usage: scripts/helm-docs.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if ! command -v helm-docs &>/dev/null; then
+    echo "Error: helm-docs is not installed or not in PATH." >&2
+    echo "Install it from: https://github.com/norwoodj/helm-docs" >&2
+    exit 1
+fi
+
+helm-docs \
+    --chart-search-root="$REPO_ROOT/charts" \
+    --template-files="$REPO_ROOT/charts/docs/templates/overrides.gotmpl" \
+    --template-files="README.md.gotmpl"


### PR DESCRIPTION
## Summary

- Standardize labels/selectors: drop legacy app/chart/heritage/release labels, adopt `app.kubernetes.io/*` standard, introduce component-aware selector helpers for both components.
- Parity between collector ds and aggregator sts fields were met.   
- Fix default template usage: correct argument order (A | default B → default A B) so component-level values properly override globals.
- Fix `metricsExporter.image.pullPolicy`: no longer emits `imagePullPolicy: ""` when set to `~`
- Disable `rfc5424-tls port` when no TLS is configured: `default-network-drivers()` was opening port 6514 without a cert/key pair, causing a startup warning.
- Bootstrap helm-docs: add `README.md.gotmpl`, annotate values, add CI check to ensure docs are regenerated

### Fixes: https://github.com/axoflow/axosyslog/issues/877

## Breaking changes

- Values key syslog: renamed to aggregator, existing overrides must be updated
- Resource names change from *-syslog to *-aggregator, existing sts definitions must be deleted before upgrade (selectors are immutable).
- Selector labels changed from app/release to app.kubernetes.io/name+instance+component, same constraint applies to the ds resource too.

Manually tested:

```sh
# Default render
helm template test ./charts/axosyslog
```

```sh
# Global resources fallback
helm template test ./charts/axosyslog \
--set 'resources.requests.memory=256Mi,resources.limits.memory=512Mi' \
| grep -A6 resources
```

```sh
# Component-level resources override
helm template test ./charts/axosyslog \
--set 'resources.requests.memory=256Mi' \
--set 'syslog.resources.requests.memory=512Mi,syslog.resources.limits.memory=1Gi' \
| grep -A6 resources
```
