### PR TITLE
add subnet() and ip() types to filterx

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -74,6 +74,7 @@ set(FILTERX_HEADERS
     filterx/func-glob.h
     filterx/object-datetime.h
     filterx/object-subnet.h
+    filterx/object-ip.h
     filterx/object-dict.h
     filterx/object-extractor.h
     filterx/object-list.h
@@ -160,6 +161,7 @@ set(FILTERX_SOURCES
     filterx/func-glob.c
     filterx/object-datetime.c
     filterx/object-subnet.c
+    filterx/object-ip.c
     filterx/object-dict.c
     filterx/object-list.c
     filterx/object-message-value.c

--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -73,6 +73,7 @@ set(FILTERX_HEADERS
     filterx/func-encode.h
     filterx/func-glob.h
     filterx/object-datetime.h
+    filterx/object-subnet.h
     filterx/object-dict.h
     filterx/object-extractor.h
     filterx/object-list.h
@@ -158,6 +159,7 @@ set(FILTERX_SOURCES
     filterx/func-encode.c
     filterx/func-glob.c
     filterx/object-datetime.c
+    filterx/object-subnet.c
     filterx/object-dict.c
     filterx/object-list.c
     filterx/object-message-value.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -76,6 +76,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/func-encode.h \
 	lib/filterx/func-glob.h \
 	lib/filterx/object-datetime.h \
+	lib/filterx/object-subnet.h \
 	lib/filterx/object-dict.h \
 	lib/filterx/object-list.h \
 	lib/filterx/object-extractor.h \
@@ -161,6 +162,7 @@ filterx_sources = 				\
 	lib/filterx/func-encode.c \
 	lib/filterx/func-glob.c \
 	lib/filterx/object-datetime.c \
+	lib/filterx/object-subnet.c \
 	lib/filterx/object-dict.c \
 	lib/filterx/object-list.c \
 	lib/filterx/object-message-value.c \

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -77,6 +77,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/func-glob.h \
 	lib/filterx/object-datetime.h \
 	lib/filterx/object-subnet.h \
+	lib/filterx/object-ip.h \
 	lib/filterx/object-dict.h \
 	lib/filterx/object-list.h \
 	lib/filterx/object-extractor.h \
@@ -163,6 +164,7 @@ filterx_sources = 				\
 	lib/filterx/func-glob.c \
 	lib/filterx/object-datetime.c \
 	lib/filterx/object-subnet.c \
+	lib/filterx/object-ip.c \
 	lib/filterx/object-dict.c \
 	lib/filterx/object-list.c \
 	lib/filterx/object-message-value.c \

--- a/lib/filterx/expr-membership.c
+++ b/lib/filterx/expr-membership.c
@@ -31,43 +31,7 @@
 typedef struct FilterXOperatorIn_
 {
   FilterXBinaryOp super;
-  FilterXObject *literal_lhs;
-  FilterXObject *literal_rhs;
 } FilterXOperatorIn;
-
-static FilterXObject *
-_eval_in_dict(FilterXOperatorIn *self, FilterXObject *dict_obj, FilterXObject *needle_obj)
-{
-  gboolean is_key_set = filterx_object_is_key_set(dict_obj, needle_obj);
-  return filterx_boolean_new(is_key_set);
-}
-
-static FilterXObject *
-_eval_in_list(FilterXOperatorIn *self, FilterXObject *list_obj, FilterXObject *needle_obj)
-{
-  guint64 size;
-
-  if (!filterx_object_len(list_obj, &size))
-    {
-      filterx_eval_push_error_static_info("Failed to evaluate 'in' operator", &self->super.super, "len() method failed");
-      return NULL;
-    }
-
-  FilterXObject *needle = filterx_ref_unwrap_ro(needle_obj);
-  for (guint64 i = 0; i < size; i++)
-    {
-      FilterXObject *elt = filterx_sequence_get_subscript(list_obj, i);
-
-      if (filterx_compare_objects(needle, elt, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_EQ))
-        {
-          filterx_object_unref(elt);
-          return filterx_boolean_new(TRUE);
-        }
-      filterx_object_unref(elt);
-    }
-
-  return filterx_boolean_new(FALSE);
-}
 
 static FilterXObject *
 _eval_in(FilterXExpr *s)
@@ -75,47 +39,28 @@ _eval_in(FilterXExpr *s)
   FilterXOperatorIn *self = (FilterXOperatorIn *) s;
   FilterXObject *result = NULL;
 
-  FilterXObject *lhs_obj = self->literal_lhs ? filterx_object_ref(self->literal_lhs)
-                           : filterx_expr_eval_typed(self->super.lhs);
+  FilterXObject *member = filterx_expr_eval_typed(self->super.lhs);
 
-  if (!lhs_obj)
+  if (!member)
     {
       filterx_eval_push_error_info_printf("Failed to evaluate 'in' operator", &self->super.super,
-                                          "Failed to evaluate left hand side");
+                                          "Failed to evaluate member expression");
       return NULL;
     }
 
-
-  FilterXObject *rhs_obj = self->literal_rhs ? filterx_object_ref(self->literal_rhs)
-                           : filterx_expr_eval(self->super.rhs);
-
-  if (!rhs_obj)
+  FilterXObject *container = filterx_expr_eval(self->super.rhs);
+  if (!container)
     {
       filterx_eval_push_error_info_printf("Failed to evaluate 'in' operator", &self->super.super,
-                                          "Failed to evaluate right hand side");
+                                          "Failed to evaluate container expression");
       goto exit;
     }
 
-  FilterXObject *iterable_obj = filterx_ref_unwrap_ro(rhs_obj);
-
-  gboolean is_list_obj = filterx_object_is_type(iterable_obj, &FILTERX_TYPE_NAME(sequence));
-  gboolean is_dict_obj = filterx_object_is_type(iterable_obj, &FILTERX_TYPE_NAME(dict));
-  if (!is_list_obj && !is_dict_obj)
-    {
-      filterx_eval_push_error_info_printf("Failed to evaluate 'in' operator", &self->super.super,
-                                          "Right hand side must be list or dict type, got: %s",
-                                          filterx_object_get_type_name(iterable_obj));
-      goto exit;
-    }
-
-  if (is_list_obj)
-    result = _eval_in_list(self, iterable_obj, lhs_obj);
-  else
-    result = _eval_in_dict(self, iterable_obj, lhs_obj);
+  result = filterx_object_is_member_of(container, member);
 
 exit:
-  filterx_object_unref(rhs_obj);
-  filterx_object_unref(lhs_obj);
+  filterx_object_unref(container);
+  filterx_object_unref(member);
   return result;
 }
 
@@ -123,26 +68,21 @@ static FilterXExpr *
 _optimize_in(FilterXExpr *s)
 {
   FilterXOperatorIn *self = (FilterXOperatorIn *) s;
+  FilterXExpr *result = NULL;
+  FilterXObject *member = NULL;
+  FilterXObject *container = NULL;
 
   if (filterx_expr_is_literal(self->super.lhs))
-    self->literal_lhs = filterx_literal_get_value(self->super.lhs);
+    member = filterx_literal_get_value(self->super.lhs);
 
   if (filterx_expr_is_literal(self->super.rhs))
-    self->literal_rhs = filterx_literal_get_value(self->super.rhs);
+    container = filterx_literal_get_value(self->super.rhs);
 
-  if (self->literal_lhs && self->literal_rhs)
-    return filterx_literal_new(_eval_in(&self->super.super));
-  return NULL;
-}
-
-static void
-_free_in(FilterXExpr *s)
-{
-  FilterXOperatorIn *self = (FilterXOperatorIn *) s;
-  filterx_object_unref(self->literal_lhs);
-  filterx_object_unref(self->literal_rhs);
-
-  filterx_binary_op_free_method(&self->super.super);
+  if (member && container)
+    result = filterx_literal_new(filterx_object_is_member_of(container, member));
+  filterx_object_unref(member);
+  filterx_object_unref(container);
+  return result;
 }
 
 FilterXExpr *
@@ -153,7 +93,6 @@ filterx_membership_in_new(FilterXExpr *lhs, FilterXExpr *rhs)
   filterx_binary_op_init_instance(&self->super, "in", FXE_READ, lhs, rhs);
   self->super.super.optimize = _optimize_in;
   self->super.super.eval = _eval_in;
-  self->super.super.free_fn = _free_in;
 
   return &self->super.super;
 }

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -29,6 +29,7 @@
 #include "filterx/object-dict.h"
 #include "filterx/object-list.h"
 #include "filterx/object-datetime.h"
+#include "filterx/object-subnet.h"
 #include "filterx/object-message-value.h"
 #include "filterx/filterx-sequence.h"
 #include "filterx/filterx-mapping.h"
@@ -97,6 +98,7 @@ _simple_init(void)
   g_assert(filterx_builtin_simple_function_register("format_json", filterx_format_json_call));
   g_assert(filterx_builtin_simple_function_register("parse_json", filterx_parse_json_call));
   g_assert(filterx_builtin_simple_function_register("datetime", filterx_typecast_datetime));
+  g_assert(filterx_builtin_simple_function_register("subnet", filterx_typecast_subnet));
   g_assert(filterx_builtin_simple_function_register("isodate", filterx_typecast_datetime_isodate));
   g_assert(filterx_builtin_simple_function_register("string", filterx_typecast_string));
   g_assert(filterx_builtin_simple_function_register("repr", filterx_simple_function_repr));
@@ -274,6 +276,7 @@ filterx_global_init(void)
   filterx_type_init(&FILTERX_TYPE_NAME(protobuf));
 
   filterx_type_init(&FILTERX_TYPE_NAME(datetime));
+  filterx_type_init(&FILTERX_TYPE_NAME(subnet));
   filterx_type_init(&FILTERX_TYPE_NAME(message_value));
 
   filterx_type_init(&FILTERX_TYPE_NAME(metrics_labels));

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -30,6 +30,7 @@
 #include "filterx/object-list.h"
 #include "filterx/object-datetime.h"
 #include "filterx/object-subnet.h"
+#include "filterx/object-ip.h"
 #include "filterx/object-message-value.h"
 #include "filterx/filterx-sequence.h"
 #include "filterx/filterx-mapping.h"
@@ -99,6 +100,7 @@ _simple_init(void)
   g_assert(filterx_builtin_simple_function_register("parse_json", filterx_parse_json_call));
   g_assert(filterx_builtin_simple_function_register("datetime", filterx_typecast_datetime));
   g_assert(filterx_builtin_simple_function_register("subnet", filterx_typecast_subnet));
+  g_assert(filterx_builtin_simple_function_register("ip", filterx_typecast_ip));
   g_assert(filterx_builtin_simple_function_register("isodate", filterx_typecast_datetime_isodate));
   g_assert(filterx_builtin_simple_function_register("string", filterx_typecast_string));
   g_assert(filterx_builtin_simple_function_register("repr", filterx_simple_function_repr));
@@ -277,6 +279,7 @@ filterx_global_init(void)
 
   filterx_type_init(&FILTERX_TYPE_NAME(datetime));
   filterx_type_init(&FILTERX_TYPE_NAME(subnet));
+  filterx_type_init(&FILTERX_TYPE_NAME(ip));
   filterx_type_init(&FILTERX_TYPE_NAME(message_value));
 
   filterx_type_init(&FILTERX_TYPE_NAME(metrics_labels));

--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -88,6 +88,7 @@ _filterx_type_init_methods(FilterXType *type)
   INIT_TYPE_METHOD(type, len);
   INIT_TYPE_METHOD(type, add);
   INIT_TYPE_METHOD(type, add_inplace);
+  INIT_TYPE_METHOD(type, is_member_of);
   INIT_TYPE_METHOD(type, free_fn);
 
   if (!type->is_abstract)

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -68,6 +68,7 @@ struct _FilterXType
   /* operators */
   FilterXObject *(*add)(FilterXObject *self, FilterXObject *object);
   FilterXObject *(*add_inplace)(FilterXObject *self, FilterXObject *container, FilterXObject *object);
+  FilterXObject *(*is_member_of)(FilterXObject *self, FilterXObject *object);
 
   /* lifecycle management (caching, deduplication) */
   void (*make_readonly)(FilterXObject *self);
@@ -584,6 +585,14 @@ static inline FilterXObject *
 filterx_object_add_inplace(FilterXObject *self, FilterXObject *object)
 {
   return self->type->add_inplace(self, NULL, object);
+}
+
+static inline FilterXObject *
+filterx_object_is_member_of(FilterXObject *self, FilterXObject *object)
+{
+  if (self->type->is_member_of)
+    return self->type->is_member_of(self, object);
+  return NULL;
 }
 
 static inline gboolean

--- a/lib/filterx/filterx-ref.c
+++ b/lib/filterx/filterx-ref.c
@@ -476,6 +476,13 @@ _filterx_ref_is_key_set(FilterXObject *s, FilterXObject *key)
   return filterx_object_is_key_set(self->value, key);
 }
 
+static FilterXObject *
+_filterx_ref_is_member_of(FilterXObject *s, FilterXObject *member)
+{
+  FilterXRef *self = (FilterXRef *) s;
+  return filterx_object_is_member_of(self->value, member);
+}
+
 static gboolean
 _filterx_ref_iter(FilterXObject *s, FilterXObjectIterFunc func, gpointer user_data)
 {
@@ -603,6 +610,7 @@ FILTERX_DEFINE_TYPE(ref, FILTERX_TYPE_NAME(object),
                     .get_subscript = _filterx_ref_get_subscript,
                     .set_subscript = _filterx_ref_set_subscript,
                     .is_key_set = _filterx_ref_is_key_set,
+                    .is_member_of = _filterx_ref_is_member_of,
                     .unset_key = _filterx_ref_unset_key,
                     .move_key = _filterx_ref_move_key,
                     .iter = _filterx_ref_iter,

--- a/lib/filterx/object-dict.c
+++ b/lib/filterx/object-dict.c
@@ -637,6 +637,24 @@ _filterx_dict_is_key_set(FilterXObject *s, FilterXObject *key)
   return _table_isset(self->table, key);
 }
 
+static FilterXObject *
+_filterx_dict_is_member_of(FilterXObject *s, FilterXObject *member)
+{
+  FilterXDictObject *self = (FilterXDictObject *) s;
+
+  const gchar *error = NULL;
+  if (!filterx_mapping_normalize_key(member, NULL, NULL, &error))
+    {
+      filterx_eval_push_error(error, NULL, member);
+      return FALSE;
+    }
+
+  if (!self->table)
+    return FALSE;
+
+  return filterx_boolean_new(_table_isset(self->table, member));
+}
+
 static gboolean
 _filterx_dict_unset_key(FilterXObject *s, FilterXObject *key)
 {
@@ -900,6 +918,7 @@ FILTERX_DEFINE_TYPE(dict, FILTERX_TYPE_NAME(mapping),
                     .get_subscript = _filterx_dict_get_subscript,
                     .set_subscript = _filterx_dict_set_subscript,
                     .is_key_set = _filterx_dict_is_key_set,
+                    .is_member_of = _filterx_dict_is_member_of,
                     .unset_key = _filterx_dict_unset_key,
                     .move_key = _filterx_dict_move_key,
                     .iter = _filterx_dict_iter,

--- a/lib/filterx/object-ip.c
+++ b/lib/filterx/object-ip.c
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "filterx/object-ip.h"
+#include "filterx/filterx-eval.h"
+#include "filterx/filterx-globals.h"
+#include "filterx/object-extractor.h"
+#include "gsocket.h"
+#include <string.h>
+#include <arpa/inet.h>
+
+typedef struct _FilterXIP
+{
+  FilterXObject super;
+  /* AF_INET or AF_INET6 */
+  gint family;
+  union
+  {
+    struct in_addr ipv4;
+    struct in6_addr ipv6;
+  };
+} FilterXIP;
+
+static gboolean
+_ip_truthy(FilterXObject *s)
+{
+  return TRUE;
+}
+
+static void
+_ip_to_string(FilterXIP *self, GString *target)
+{
+  gchar buf[INET6_ADDRSTRLEN];
+
+  switch (self->family)
+    {
+    case AF_INET:
+      g_inet_ntoa(buf, sizeof(buf), self->ipv4);
+      break;
+    case AF_INET6:
+      inet_ntop(AF_INET6, &self->ipv6, buf, sizeof(buf));
+      break;
+    default:
+      g_assert_not_reached();
+    }
+  g_string_append(target, buf);
+}
+
+static gboolean
+_ip_marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
+{
+  FilterXIP *self = (FilterXIP *) s;
+
+  *t = LM_VT_STRING;
+  _ip_to_string(self, repr);
+  return TRUE;
+}
+
+static gboolean
+_ip_format_json(FilterXObject *s, GString *repr)
+{
+  FilterXIP *self = (FilterXIP *) s;
+
+  g_string_append_c(repr, '"');
+  _ip_to_string(self, repr);
+  g_string_append_c(repr, '"');
+  return TRUE;
+}
+
+static gboolean
+_ip_repr(FilterXObject *s, GString *repr)
+{
+  FilterXIP *self = (FilterXIP *) s;
+
+  g_string_append(repr, "ip('");
+  _ip_to_string(self, repr);
+  g_string_append(repr, "')");
+  return TRUE;
+}
+
+static FilterXIP *
+_ip_new(void)
+{
+  FilterXIP *self = filterx_new_object(FilterXIP);
+
+  filterx_object_init_instance(&self->super, &FILTERX_TYPE_NAME(ip));
+  return self;
+}
+
+static FilterXObject *
+_ip_clone(FilterXObject *s)
+{
+  FilterXIP *self = (FilterXIP *) s;
+  FilterXIP *clone = _ip_new();
+
+  clone->family = self->family;
+  switch (self->family)
+    {
+    case AF_INET:
+      clone->ipv4 = self->ipv4;
+      break;
+    case AF_INET6:
+      clone->ipv6 = self->ipv6;
+      break;
+    default:
+      g_assert_not_reached();
+    }
+  return &clone->super;
+}
+
+const struct in_addr *
+filterx_ip_get_v4(FilterXObject *obj)
+{
+  if (!filterx_object_is_type(obj, &FILTERX_TYPE_NAME(ip)))
+    return NULL;
+  FilterXIP *self = (FilterXIP *) obj;
+  if (self->family != AF_INET)
+    return NULL;
+  return &self->ipv4;
+}
+
+const struct in6_addr *
+filterx_ip_get_v6(FilterXObject *obj)
+{
+  if (!filterx_object_is_type(obj, &FILTERX_TYPE_NAME(ip)))
+    return NULL;
+  FilterXIP *self = (FilterXIP *) obj;
+  if (self->family != AF_INET6)
+    return NULL;
+  return &self->ipv6;
+}
+
+/* NOTE: returns NULL for invalid IP addresses */
+FilterXObject *
+filterx_ip_new_from_string(const gchar *ip_str)
+{
+  FilterXIP *self = _ip_new();
+
+  if (inet_aton(ip_str, &self->ipv4) == 1)
+    {
+      self->family = AF_INET;
+      return &self->super;
+    }
+
+  if (inet_pton(AF_INET6, ip_str, &self->ipv6) == 1)
+    {
+      self->family = AF_INET6;
+      return &self->super;
+    }
+
+  filterx_object_unref(&self->super);
+  return NULL;
+}
+
+FILTERX_DEFINE_TYPE(ip, FILTERX_TYPE_NAME(object),
+                    .clone = _ip_clone,
+                    .truthy = _ip_truthy,
+                    .format_json = _ip_format_json,
+                    .marshal = _ip_marshal,
+                    .repr = _ip_repr,
+                   );
+
+FilterXObject *
+filterx_typecast_ip(FilterXExpr *s, FilterXObject *args[], gsize args_len)
+{
+  FilterXObject *object = filterx_typecast_get_arg(s, args, args_len);
+  if (!object)
+    return NULL;
+
+  if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(ip)))
+    {
+      filterx_object_ref(object);
+      return object;
+    }
+
+  const gchar *str;
+  if (!filterx_object_extract_string_as_cstr(object, &str))
+    {
+      filterx_eval_push_error_static_info("Failed to cast to ip()", s, "Argument is not a string");
+      return NULL;
+    }
+
+  object = filterx_ip_new_from_string(str);
+  if (!object)
+    {
+      filterx_eval_push_error_static_info("Failed to cast to ip()", s, "Argument is not a valid IP address");
+      return NULL;
+    }
+  return object;
+}

--- a/lib/filterx/object-ip.h
+++ b/lib/filterx/object-ip.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef FILTERX_OBJECT_IP_H_INCLUDED
+#define FILTERX_OBJECT_IP_H_INCLUDED
+
+#include "filterx-object.h"
+#include "expr-function.h"
+#include <netinet/in.h>
+
+FILTERX_DECLARE_TYPE(ip);
+
+/* NOTE: returns NULL for invalid IP addresses */
+FilterXObject *filterx_ip_new_from_string(const gchar *ip_str);
+FilterXObject *filterx_typecast_ip(FilterXExpr *s, FilterXObject *args[], gsize args_len);
+
+/*
+ * Address family accessors for use by subnet's is_member_of.
+ * Return NULL if the object is not an ip() or the family does not match.
+ */
+const struct in_addr *filterx_ip_get_v4(FilterXObject *obj);
+const struct in6_addr *filterx_ip_get_v6(FilterXObject *obj);
+
+#endif

--- a/lib/filterx/object-list.c
+++ b/lib/filterx/object-list.c
@@ -29,6 +29,7 @@
 #include "filterx/filterx-eval.h"
 #include "filterx/object-extractor.h"
 #include "filterx/json-repr.h"
+#include "filterx/expr-comparison.h"
 #include "logmsg/type-hinting.h"
 #include "utf8utils.h"
 #include "str-format.h"
@@ -174,6 +175,24 @@ _filterx_list_is_key_set(FilterXObject *s, FilterXObject *key)
   const gchar *error;
   return filterx_sequence_normalize_index(key, self->array->len, &normalized_index, FALSE, &error);
 }
+
+static FilterXObject *
+_filterx_list_is_member_of(FilterXObject *s, FilterXObject *member)
+{
+  FilterXListObject *self = (FilterXListObject *) s;
+
+  member = filterx_ref_unwrap_ro(member);
+  for (guint64 i = 0; i < self->array->len; i++)
+    {
+      FilterXObject *elt = (FilterXObject *) g_ptr_array_index(self->array, i);
+
+      if (filterx_compare_objects(member, elt, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_EQ))
+        return filterx_boolean_new(TRUE);
+    }
+
+  return filterx_boolean_new(FALSE);
+}
+
 
 FilterXObject *
 filterx_list_new(void)
@@ -388,6 +407,7 @@ FILTERX_DEFINE_TYPE(list, FILTERX_TYPE_NAME(sequence),
                     .get_subscript = _filterx_list_get_subscript,
                     .set_subscript = _filterx_list_set_subscript,
                     .is_key_set = _filterx_list_is_key_set,
+                    .is_member_of = _filterx_list_is_member_of,
                     .unset_key = _filterx_list_unset_key,
                     .iter = _filterx_list_iter,
                     .len = _filterx_list_len,

--- a/lib/filterx/object-subnet.c
+++ b/lib/filterx/object-subnet.c
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "filterx/object-subnet.h"
+#include "filterx/filterx-eval.h"
+#include "filterx/filterx-globals.h"
+#include "filterx/object-extractor.h"
+#include "gsocket.h"
+#include "str-format.h"
+
+typedef struct _FilterXSubnet
+{
+  FilterXObject super;
+  /* AF_INET or AF_INET6 */
+  gint family;
+  union
+  {
+    struct
+    {
+      struct in_addr address;
+      struct in_addr netmask;
+    } ipv4;
+    struct
+    {
+      struct in6_addr address;
+      struct in6_addr netmask;
+    } ipv6;
+  };
+} FilterXSubnet;
+
+static gboolean
+_subnet_truthy(FilterXObject *s)
+{
+  FilterXSubnet *self = (FilterXSubnet *) s;
+  switch (self->family)
+    {
+    case AF_INET:
+      return self->ipv4.address.s_addr != INADDR_ANY;
+    case AF_INET6:
+      return memcmp(self->ipv6.address.s6_addr, in6addr_any.s6_addr, sizeof(in6addr_any.s6_addr)) == 0;
+    default:
+      g_assert_not_reached();
+    }
+}
+
+static void
+_subnet_ipv4_to_string(FilterXSubnet *self, GString *target)
+{
+  gchar buf[32];
+
+  g_inet_ntoa(buf, sizeof(buf), self->ipv4.address);
+  g_string_append(target, buf);
+  g_string_append_c(target, '/');
+  g_inet_ntoa(buf, sizeof(buf), self->ipv4.netmask);
+  g_string_append(target, buf);
+}
+
+static void
+_subnet_ipv6_to_string(FilterXSubnet *self, GString *target)
+{
+  gchar buf[32];
+
+  inet_ntop(AF_INET6, &self->ipv6.address, buf, sizeof(buf));
+  g_string_append(target, buf);
+  g_string_append_c(target, '/');
+  inet_ntop(AF_INET6, &self->ipv6.netmask, buf, sizeof(buf));
+  g_string_append(target, buf);
+}
+
+
+static void
+_subnet_to_string(FilterXSubnet *self, GString *target)
+{
+  switch (self->family)
+    {
+    case AF_INET:
+      _subnet_ipv4_to_string(self, target);
+      break;
+    case AF_INET6:
+      _subnet_ipv6_to_string(self, target);
+      break;
+    default:
+      g_assert_not_reached();
+    }
+}
+
+static gboolean
+_subnet_marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
+{
+  FilterXSubnet *self = (FilterXSubnet *) s;
+
+  *t = LM_VT_STRING;
+  _subnet_to_string(self, repr);
+  return TRUE;
+}
+
+static gboolean
+_subnet_format_json(FilterXObject *s, GString *repr)
+{
+  FilterXSubnet *self = (FilterXSubnet *) s;
+
+  g_string_append_c(repr, '"');
+  _subnet_to_string(self, repr);
+  g_string_append_c(repr, '"');
+  return TRUE;
+}
+
+static gboolean
+_subnet_repr(FilterXObject *s, GString *repr)
+{
+  FilterXSubnet *self = (FilterXSubnet *) s;
+
+  g_string_append(repr, "subnet('");
+  _subnet_to_string(self, repr);
+  g_string_append(repr, "')");
+  return TRUE;
+}
+
+static FilterXSubnet *
+_subnet_new(void)
+{
+  FilterXSubnet *self = filterx_new_object(FilterXSubnet);
+
+  filterx_object_init_instance(&self->super, &FILTERX_TYPE_NAME(subnet));
+  return self;
+}
+
+static FilterXObject *
+_subnet_clone(FilterXObject *s)
+{
+  FilterXSubnet *self = (FilterXSubnet *) s;
+  FilterXSubnet *clone = _subnet_new();
+
+  clone->family = self->family;
+  switch (self->family)
+    {
+    case AF_INET:
+      clone->ipv4 = self->ipv4;
+      break;
+    case AF_INET6:
+      clone->ipv6 = self->ipv6;
+      break;
+    default:
+      g_assert_not_reached();
+    }
+  return &clone->super;
+}
+
+static gboolean
+_parse_ipv4_cidr(FilterXSubnet *self, const gchar *cidr)
+{
+  gchar buf[64];
+
+  const gchar *slash = strchr(cidr, '/');
+  if (strlen(cidr) >= sizeof(buf) || !slash)
+    {
+      if (inet_aton(cidr, &self->ipv4.address) != 1)
+        return FALSE;
+      self->ipv4.netmask.s_addr = htonl(0xFFFFFFFF);
+    }
+  else
+    {
+      strncpy(buf, cidr, slash - cidr);
+      buf[slash - cidr] = 0;
+      if (inet_aton(buf, &self->ipv4.address) != 1)
+        return FALSE;
+
+      if (strchr(slash + 1, '.'))
+        {
+          if (inet_aton(slash + 1, &self->ipv4.netmask) != 1)
+            return FALSE;
+        }
+      else
+        {
+          gchar *endptr = NULL;
+          gint prefix = strtol(slash + 1, &endptr, 10);
+          if (*endptr != 0)
+            return FALSE;
+          if (prefix > 32)
+            return FALSE;
+          if (prefix == 32)
+            self->ipv4.netmask.s_addr = htonl(0xFFFFFFFF);
+          else
+            self->ipv4.netmask.s_addr = htonl(((1 << prefix) - 1) << (32 - prefix));
+        }
+    }
+  self->family = AF_INET;
+  self->ipv4.address.s_addr &= self->ipv4.netmask.s_addr;
+  return TRUE;
+}
+
+static void
+_derive_ipv6_netmask(FilterXSubnet *self, gint prefix)
+{
+  gint pos = 0;
+  memset(self->ipv6.netmask.s6_addr, 0xFF, prefix / 8);
+  pos += prefix / 8;
+  if (pos < sizeof(self->ipv6.netmask.s6_addr))
+    {
+      gint bit_count = prefix % 8;
+      self->ipv6.netmask.s6_addr[pos] = ((1 << bit_count) - 1) << (8 - bit_count);
+      pos++;
+      memset(&self->ipv6.netmask.s6_addr[pos], 0x00, sizeof(self->ipv6.netmask.s6_addr) - pos);
+    }
+}
+
+static void
+_apply_ipv6_mask(FilterXSubnet *self, struct in6_addr *addr)
+{
+  for (gint i = 0; i < sizeof(addr->s6_addr); i++)
+    {
+      addr->s6_addr[i] &= self->ipv6.netmask.s6_addr[i];
+    }
+}
+
+static gboolean
+_parse_ipv6_cidr(FilterXSubnet *self, const gchar *cidr)
+{
+  gchar buf[INET6_ADDRSTRLEN];
+  const gchar *slash = strchr(cidr, '/');
+  gint prefix = 0;
+
+  if (strlen(cidr) >= sizeof(buf) || !slash)
+    {
+      if (inet_pton(AF_INET6, cidr, &self->ipv6.address) != 1)
+        return FALSE;
+      prefix = 128;
+    }
+  else
+    {
+      gchar *endptr = NULL;
+      prefix = strtol(slash + 1, &endptr, 10);
+      if (*endptr != 0)
+        return FALSE;
+      if (prefix > 128)
+        return FALSE;
+
+      strncpy(buf, cidr, slash - cidr);
+      buf[slash - cidr] = 0;
+      if (inet_pton(AF_INET6, buf, &self->ipv6.address) != 1)
+        return FALSE;
+    }
+
+  _derive_ipv6_netmask(self, prefix);
+  _apply_ipv6_mask(self, &self->ipv6.address);
+
+  self->family = AF_INET6;
+  return TRUE;
+}
+
+static FilterXObject *
+_subnet_is_string_member_of(FilterXSubnet *self, FilterXObject *member)
+{
+  const gchar *str;
+  if (!filterx_object_extract_string_as_cstr(member, &str))
+    {
+      filterx_eval_push_error("Failed to check subnet() membership, argument is not a string or ip()", NULL, member);
+      return NULL;
+    }
+  switch (self->family)
+    {
+    case AF_INET:
+      {
+        struct in_addr addr;
+        if (g_inet_aton(str, &addr) == 1)
+          return filterx_boolean_new((addr.s_addr & self->ipv4.netmask.s_addr) == (self->ipv4.address.s_addr));
+        break;
+      }
+    case AF_INET6:
+      {
+        struct in6_addr addr;
+
+        if (inet_pton(AF_INET6, str, &addr) == 1)
+          {
+            _apply_ipv6_mask(self, &addr);
+            gboolean address_in_range = memcmp(addr.s6_addr, self->ipv6.address.s6_addr, sizeof(addr.s6_addr)) == 0;
+
+            return filterx_boolean_new(address_in_range);
+          }
+        break;
+      }
+    default:
+      g_assert_not_reached();
+    }
+  filterx_eval_push_error("Failed to check subnet() membership, error parsing IP address", NULL, member);
+  return NULL;
+}
+
+static FilterXObject *
+_subnet_is_member_of(FilterXObject *s, FilterXObject *member)
+{
+  FilterXSubnet *self = (FilterXSubnet *) s;
+  FilterXObject *result;
+
+  const gchar *str;
+  if (!filterx_object_extract_string_as_cstr(member, &str))
+    {
+      filterx_eval_push_error("Failed to check subnet() membership, argument is not a string", NULL, member);
+      return NULL;
+    }
+
+  return _subnet_is_string_member_of(self, member);
+}
+
+/* NOTE: returns NULL for invalid CIDR values */
+FilterXObject *
+filterx_subnet_new_from_cidr(const gchar *cidr)
+{
+  FilterXSubnet *self = _subnet_new();
+
+  if (_parse_ipv4_cidr(self, cidr))
+    return &self->super;
+
+  if (_parse_ipv6_cidr(self, cidr))
+    return &self->super;
+
+  filterx_object_unref(&self->super);
+  return NULL;
+}
+
+FILTERX_DEFINE_TYPE(subnet, FILTERX_TYPE_NAME(object),
+                    .clone = _subnet_clone,
+                    .truthy = _subnet_truthy,
+                    .format_json = _subnet_format_json,
+                    .marshal = _subnet_marshal,
+                    .repr = _subnet_repr,
+                    .is_member_of = _subnet_is_member_of,
+                   );
+
+FilterXObject *
+filterx_typecast_subnet(FilterXExpr *s, FilterXObject *args[], gsize args_len)
+{
+  FilterXObject *object = filterx_typecast_get_arg(s, args, args_len);
+  if (!object)
+    return NULL;
+
+  if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(subnet)))
+    {
+      filterx_object_ref(object);
+      return object;
+    }
+
+  const gchar *str;
+  if (!filterx_object_extract_string_as_cstr(object, &str))
+    {
+      filterx_eval_push_error_static_info("Failed to cast string to subnet()", s, "Argument is not a string");
+      return NULL;
+    }
+
+  object = filterx_subnet_new_from_cidr(str);
+  if (!object)
+    {
+      filterx_eval_push_error_static_info("Failed to cast string to subnet()", s, "Argument is not well formed CIDR");
+      return NULL;
+    }
+  return object;
+}

--- a/lib/filterx/object-subnet.c
+++ b/lib/filterx/object-subnet.c
@@ -21,6 +21,7 @@
  *
  */
 #include "filterx/object-subnet.h"
+#include "filterx/object-ip.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/filterx-globals.h"
 #include "filterx/object-extractor.h"
@@ -306,17 +307,41 @@ _subnet_is_string_member_of(FilterXSubnet *self, FilterXObject *member)
 }
 
 static FilterXObject *
+_subnet_is_ip_member_of(FilterXSubnet *self, FilterXObject *member)
+{
+  switch (self->family)
+    {
+    case AF_INET:
+      {
+        const struct in_addr *addr = filterx_ip_get_v4(member);
+        if (addr)
+          return filterx_boolean_new((addr->s_addr & self->ipv4.netmask.s_addr) == self->ipv4.address.s_addr);
+        break;
+      }
+    case AF_INET6:
+      {
+        const struct in6_addr *addr = filterx_ip_get_v6(member);
+        if (addr)
+          {
+            struct in6_addr masked = *addr;
+            _apply_ipv6_mask(self, &masked);
+            return filterx_boolean_new(memcmp(masked.s6_addr, self->ipv6.address.s6_addr, sizeof(masked.s6_addr)) == 0);
+          }
+        break;
+      }
+    default:
+      g_assert_not_reached();
+    }
+  return filterx_boolean_new(FALSE);
+}
+
+static FilterXObject *
 _subnet_is_member_of(FilterXObject *s, FilterXObject *member)
 {
   FilterXSubnet *self = (FilterXSubnet *) s;
-  FilterXObject *result;
 
-  const gchar *str;
-  if (!filterx_object_extract_string_as_cstr(member, &str))
-    {
-      filterx_eval_push_error("Failed to check subnet() membership, argument is not a string", NULL, member);
-      return NULL;
-    }
+  if (filterx_object_is_type(member, &FILTERX_TYPE_NAME(ip)))
+    return _subnet_is_ip_member_of(self, member);
 
   return _subnet_is_string_member_of(self, member);
 }

--- a/lib/filterx/object-subnet.h
+++ b/lib/filterx/object-subnet.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef FILTERX_OBJECT_SUBNET_H_INCLUDED
+#define FILTERX_OBJECT_SUBNET_H_INCLUDED
+
+#include "filterx-object.h"
+#include "expr-function.h"
+
+FILTERX_DECLARE_TYPE(subnet);
+
+/* NOTE: returns NULL for invalid CIDR values */
+FilterXObject *filterx_subnet_new_from_cidr(const gchar *cidr);
+FilterXObject *filterx_typecast_subnet(FilterXExpr *s, FilterXObject *args[], gsize args_len);
+
+#endif

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -37,3 +37,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_func_encode DEPENDS json-plugin ${JS
 add_unit_test(LIBTEST CRITERION TARGET test_func_str_utf8 DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_func_glob DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_subnet DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_object_ip DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -36,3 +36,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_func_digest DEPENDS json-plugin ${JS
 add_unit_test(LIBTEST CRITERION TARGET test_func_encode DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_func_str_utf8 DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_func_glob DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_object_subnet DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -40,7 +40,8 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_func_encode \
 		lib/filterx/tests/test_func_str_utf8 \
 		lib/filterx/tests/test_func_glob \
-		lib/filterx/tests/test_object_subnet
+		lib/filterx/tests/test_object_subnet \
+		lib/filterx/tests/test_object_ip
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt
 
@@ -165,3 +166,6 @@ lib_filterx_tests_test_func_glob_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_object_subnet_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_object_subnet_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_object_ip_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_object_ip_LDADD   = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -39,7 +39,8 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_func_digest \
 		lib/filterx/tests/test_func_encode \
 		lib/filterx/tests/test_func_str_utf8 \
-		lib/filterx/tests/test_func_glob
+		lib/filterx/tests/test_func_glob \
+		lib/filterx/tests/test_object_subnet
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt
 
@@ -161,3 +162,6 @@ lib_filterx_tests_test_func_str_utf8_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_func_glob_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_func_glob_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_object_subnet_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_object_subnet_LDADD   = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/test_object_ip.c
+++ b/lib/filterx/tests/test_object_ip.c
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/filterx-lib.h"
+
+#include "filterx/object-ip.h"
+#include "filterx/object-string.h"
+#include "filterx/object-primitive.h"
+#include "filterx/filterx-object.h"
+#include "filterx/expr-function.h"
+
+#include "apphook.h"
+#include "scratch-buffers.h"
+
+/* Construction */
+
+Test(filterx_object_ip, ipv4_valid)
+{
+  FilterXObject *obj = filterx_ip_new_from_string("192.168.1.1");
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(ip)));
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_ip, ipv6_valid)
+{
+  FilterXObject *obj = filterx_ip_new_from_string("2001:db8::1");
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(ip)));
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_ip, ipv4_loopback)
+{
+  FilterXObject *obj = filterx_ip_new_from_string("127.0.0.1");
+  cr_assert_not_null(obj);
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_ip, ipv6_loopback)
+{
+  FilterXObject *obj = filterx_ip_new_from_string("::1");
+  cr_assert_not_null(obj);
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_ip, rejects_invalid_string)
+{
+  FilterXObject *obj = filterx_ip_new_from_string("not-an-ip");
+  cr_assert_null(obj);
+}
+
+Test(filterx_object_ip, rejects_cidr_notation)
+{
+  FilterXObject *obj = filterx_ip_new_from_string("192.168.0.0/24");
+  cr_assert_null(obj);
+}
+
+Test(filterx_object_ip, rejects_ipv6_cidr_notation)
+{
+  FilterXObject *obj = filterx_ip_new_from_string("2001:db8::/32");
+  cr_assert_null(obj);
+}
+
+/* Truthy */
+
+Test(filterx_object_ip, ip_is_always_truthy)
+{
+  FilterXObject *obj = filterx_ip_new_from_string("192.168.1.1");
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_truthy(obj));
+  filterx_object_unref(obj);
+
+  obj = filterx_ip_new_from_string("0.0.0.0");
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_truthy(obj));
+  filterx_object_unref(obj);
+
+  obj = filterx_ip_new_from_string("::1");
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_truthy(obj));
+  filterx_object_unref(obj);
+
+  obj = filterx_ip_new_from_string("::");
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_truthy(obj));
+  filterx_object_unref(obj);
+}
+
+/* Marshal / repr */
+
+Test(filterx_object_ip, ipv4_marshal)
+{
+  FilterXObject *obj = filterx_ip_new_from_string("10.0.0.1");
+  cr_assert_not_null(obj);
+  assert_marshaled_object(obj, "10.0.0.1", LM_VT_STRING);
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_ip, ipv6_marshal)
+{
+  FilterXObject *obj = filterx_ip_new_from_string("2001:db8::1");
+  cr_assert_not_null(obj);
+  assert_marshaled_object(obj, "2001:db8::1", LM_VT_STRING);
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_ip, ipv4_repr)
+{
+  FilterXObject *obj = filterx_ip_new_from_string("192.168.0.1");
+  cr_assert_not_null(obj);
+  assert_object_repr_equals(obj, "ip('192.168.0.1')");
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_ip, ipv4_format_json)
+{
+  FilterXObject *obj = filterx_ip_new_from_string("172.16.0.1");
+  cr_assert_not_null(obj);
+  assert_object_json_equals(obj, "\"172.16.0.1\"");
+  filterx_object_unref(obj);
+}
+
+/* Typecast */
+
+Test(filterx_object_ip, typecast_from_string)
+{
+  FilterXObject *args[] = { filterx_string_new("192.168.0.1", -1) };
+
+  FilterXObject *obj = filterx_typecast_ip(NULL, args, G_N_ELEMENTS(args));
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(ip)));
+  assert_marshaled_object(obj, "192.168.0.1", LM_VT_STRING);
+
+  filterx_object_unref(obj);
+  filterx_simple_function_free_args(args, G_N_ELEMENTS(args));
+}
+
+Test(filterx_object_ip, typecast_ipv6_from_string)
+{
+  FilterXObject *args[] = { filterx_string_new("::1", -1) };
+
+  FilterXObject *obj = filterx_typecast_ip(NULL, args, G_N_ELEMENTS(args));
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(ip)));
+  assert_marshaled_object(obj, "::1", LM_VT_STRING);
+
+  filterx_object_unref(obj);
+  filterx_simple_function_free_args(args, G_N_ELEMENTS(args));
+}
+
+Test(filterx_object_ip, typecast_identity)
+{
+  FilterXObject *ip = filterx_ip_new_from_string("10.0.0.1");
+  FilterXObject *args[] = { filterx_object_ref(ip) };
+
+  FilterXObject *obj = filterx_typecast_ip(NULL, args, G_N_ELEMENTS(args));
+  cr_assert_not_null(obj);
+  cr_assert(obj == ip);
+
+  filterx_object_unref(obj);
+  filterx_object_unref(ip);
+  filterx_simple_function_free_args(args, G_N_ELEMENTS(args));
+}
+
+Test(filterx_object_ip, typecast_rejects_integer)
+{
+  FilterXObject *args[] = { filterx_integer_new(42) };
+
+  FilterXObject *obj = filterx_typecast_ip(NULL, args, G_N_ELEMENTS(args));
+  cr_assert_null(obj);
+
+  filterx_simple_function_free_args(args, G_N_ELEMENTS(args));
+}
+
+Test(filterx_object_ip, typecast_rejects_cidr_string)
+{
+  FilterXObject *args[] = { filterx_string_new("192.168.0.0/24", -1) };
+
+  FilterXObject *obj = filterx_typecast_ip(NULL, args, G_N_ELEMENTS(args));
+  cr_assert_null(obj);
+
+  filterx_simple_function_free_args(args, G_N_ELEMENTS(args));
+}
+
+Test(filterx_object_ip, typecast_rejects_invalid_string)
+{
+  FilterXObject *args[] = { filterx_string_new("not-an-ip", -1) };
+
+  FilterXObject *obj = filterx_typecast_ip(NULL, args, G_N_ELEMENTS(args));
+  cr_assert_null(obj);
+
+  filterx_simple_function_free_args(args, G_N_ELEMENTS(args));
+}
+
+Test(filterx_object_ip, typecast_rejects_empty_args)
+{
+  FilterXObject *obj = filterx_typecast_ip(NULL, NULL, 0);
+  cr_assert_null(obj);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  init_libtest_filterx();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  deinit_libtest_filterx();
+  app_shutdown();
+}
+
+TestSuite(filterx_object_ip, .init = setup, .fini = teardown);

--- a/lib/filterx/tests/test_object_ip.c
+++ b/lib/filterx/tests/test_object_ip.c
@@ -25,6 +25,7 @@
 #include "libtest/filterx-lib.h"
 
 #include "filterx/object-ip.h"
+#include "filterx/object-subnet.h"
 #include "filterx/object-string.h"
 #include "filterx/object-primitive.h"
 #include "filterx/filterx-object.h"
@@ -140,6 +141,102 @@ Test(filterx_object_ip, ipv4_format_json)
   cr_assert_not_null(obj);
   assert_object_json_equals(obj, "\"172.16.0.1\"");
   filterx_object_unref(obj);
+}
+
+/* Membership via subnet */
+
+Test(filterx_object_ip, ipv4_ip_member_of_subnet)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("192.168.0.0/24");
+  FilterXObject *ip = filterx_ip_new_from_string("192.168.0.100");
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, ip);
+  cr_assert_not_null(result);
+
+  gboolean b;
+  cr_assert(filterx_boolean_unwrap(result, &b));
+  cr_assert(b);
+
+  filterx_object_unref(result);
+  filterx_object_unref(ip);
+  filterx_object_unref(subnet);
+}
+
+Test(filterx_object_ip, ipv4_ip_not_member_of_subnet)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("192.168.0.0/24");
+  FilterXObject *ip = filterx_ip_new_from_string("192.168.1.1");
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, ip);
+  cr_assert_not_null(result);
+
+  gboolean b;
+  cr_assert(filterx_boolean_unwrap(result, &b));
+  cr_assert_not(b);
+
+  filterx_object_unref(result);
+  filterx_object_unref(ip);
+  filterx_object_unref(subnet);
+}
+
+Test(filterx_object_ip, ipv6_ip_member_of_subnet)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("2001:db8::/32");
+  FilterXObject *ip = filterx_ip_new_from_string("2001:db8::1");
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, ip);
+  cr_assert_not_null(result);
+
+  gboolean b;
+  cr_assert(filterx_boolean_unwrap(result, &b));
+  cr_assert(b);
+
+  filterx_object_unref(result);
+  filterx_object_unref(ip);
+  filterx_object_unref(subnet);
+}
+
+Test(filterx_object_ip, ipv6_ip_not_member_of_subnet)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("2001:db8::/32");
+  FilterXObject *ip = filterx_ip_new_from_string("2001:db9::1");
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, ip);
+  cr_assert_not_null(result);
+
+  gboolean b;
+  cr_assert(filterx_boolean_unwrap(result, &b));
+  cr_assert_not(b);
+
+  filterx_object_unref(result);
+  filterx_object_unref(ip);
+  filterx_object_unref(subnet);
+}
+
+Test(filterx_object_ip, ipv4_subnet_rejects_ipv6_ip)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("192.168.0.0/24");
+  FilterXObject *ip = filterx_ip_new_from_string("2001:db8::1");
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, ip);
+  cr_assert_not_null(result);
+  cr_assert(filterx_object_falsy(result));
+
+  filterx_object_unref(ip);
+  filterx_object_unref(subnet);
+}
+
+Test(filterx_object_ip, ipv6_subnet_rejects_ipv4_ip)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("2001:db8::/32");
+  FilterXObject *ip = filterx_ip_new_from_string("192.168.0.1");
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, ip);
+  cr_assert_not_null(result);
+  cr_assert(filterx_object_falsy(result));
+
+  filterx_object_unref(ip);
+  filterx_object_unref(subnet);
 }
 
 /* Typecast */

--- a/lib/filterx/tests/test_object_subnet.c
+++ b/lib/filterx/tests/test_object_subnet.c
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/filterx-lib.h"
+
+#include "filterx/object-subnet.h"
+#include "filterx/object-string.h"
+#include "filterx/object-primitive.h"
+#include "filterx/filterx-object.h"
+#include "filterx/expr-function.h"
+
+#include "apphook.h"
+#include "scratch-buffers.h"
+
+/* Construction */
+
+Test(filterx_object_subnet, ipv4_prefix_notation)
+{
+  FilterXObject *obj = filterx_subnet_new_from_cidr("192.168.0.0/24");
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(subnet)));
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_subnet, ipv4_netmask_notation)
+{
+  FilterXObject *obj = filterx_subnet_new_from_cidr("192.168.0.0/255.255.255.0");
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(subnet)));
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_subnet, ipv4_host_without_prefix)
+{
+  FilterXObject *obj = filterx_subnet_new_from_cidr("192.168.1.1");
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(subnet)));
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_subnet, ipv6_prefix_notation)
+{
+  FilterXObject *obj = filterx_subnet_new_from_cidr("2001:db8::/32");
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(subnet)));
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_subnet, ipv6_host_without_prefix)
+{
+  FilterXObject *obj = filterx_subnet_new_from_cidr("::1");
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(subnet)));
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_subnet, rejects_invalid_cidr)
+{
+  FilterXObject *obj = filterx_subnet_new_from_cidr("not-a-subnet");
+  cr_assert_null(obj);
+}
+
+Test(filterx_object_subnet, rejects_ipv4_prefix_too_large)
+{
+  FilterXObject *obj = filterx_subnet_new_from_cidr("192.168.0.0/33");
+  cr_assert_null(obj);
+}
+
+Test(filterx_object_subnet, rejects_ipv6_prefix_too_large)
+{
+  FilterXObject *obj = filterx_subnet_new_from_cidr("2001:db8::/129");
+  cr_assert_null(obj);
+}
+
+Test(filterx_object_subnet, ipv4_host_bits_are_masked)
+{
+  /* 192.168.0.5/24 should store 192.168.0.0/255.255.255.0 */
+  FilterXObject *obj = filterx_subnet_new_from_cidr("192.168.0.5/24");
+  cr_assert_not_null(obj);
+  assert_marshaled_object(obj, "192.168.0.0/255.255.255.0", LM_VT_STRING);
+  filterx_object_unref(obj);
+}
+
+/* Marshal / repr */
+
+Test(filterx_object_subnet, ipv4_marshal)
+{
+  FilterXObject *obj = filterx_subnet_new_from_cidr("192.168.0.0/24");
+  cr_assert_not_null(obj);
+  assert_marshaled_object(obj, "192.168.0.0/255.255.255.0", LM_VT_STRING);
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_subnet, ipv4_host_marshal)
+{
+  FilterXObject *obj = filterx_subnet_new_from_cidr("10.0.0.1");
+  cr_assert_not_null(obj);
+  assert_marshaled_object(obj, "10.0.0.1/255.255.255.255", LM_VT_STRING);
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_subnet, ipv4_repr)
+{
+  FilterXObject *obj = filterx_subnet_new_from_cidr("10.0.0.0/8");
+  cr_assert_not_null(obj);
+  assert_object_repr_equals(obj, "subnet('10.0.0.0/255.0.0.0')");
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_subnet, ipv6_marshal)
+{
+  FilterXObject *obj = filterx_subnet_new_from_cidr("2001:db8::/32");
+  cr_assert_not_null(obj);
+  assert_marshaled_object(obj, "2001:db8::/ffff:ffff::", LM_VT_STRING);
+  filterx_object_unref(obj);
+}
+
+Test(filterx_object_subnet, ipv4_format_json)
+{
+  FilterXObject *obj = filterx_subnet_new_from_cidr("172.16.0.0/12");
+  cr_assert_not_null(obj);
+  assert_object_json_equals(obj, "\"172.16.0.0/255.240.0.0\"");
+  filterx_object_unref(obj);
+}
+
+/* Membership */
+
+Test(filterx_object_subnet, ipv4_member_returns_true)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("192.168.0.0/24");
+  FilterXObject *ip = filterx_string_new("192.168.0.100", -1);
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, ip);
+  cr_assert_not_null(result);
+
+  gboolean b;
+  cr_assert(filterx_boolean_unwrap(result, &b));
+  cr_assert(b);
+
+  filterx_object_unref(result);
+  filterx_object_unref(ip);
+  filterx_object_unref(subnet);
+}
+
+Test(filterx_object_subnet, ipv4_non_member_returns_false)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("192.168.0.0/24");
+  FilterXObject *ip = filterx_string_new("192.168.1.1", -1);
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, ip);
+  cr_assert_not_null(result);
+
+  gboolean b;
+  cr_assert(filterx_boolean_unwrap(result, &b));
+  cr_assert_not(b);
+
+  filterx_object_unref(result);
+  filterx_object_unref(ip);
+  filterx_object_unref(subnet);
+}
+
+Test(filterx_object_subnet, ipv4_boundary_addresses)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("10.0.0.0/8");
+  FilterXObject *first = filterx_string_new("10.0.0.0", -1);
+  FilterXObject *last  = filterx_string_new("10.255.255.255", -1);
+  FilterXObject *beyond = filterx_string_new("11.0.0.0", -1);
+
+  FilterXObject *r1 = filterx_object_is_member_of(subnet, first);
+  FilterXObject *r2 = filterx_object_is_member_of(subnet, last);
+  FilterXObject *r3 = filterx_object_is_member_of(subnet, beyond);
+
+  gboolean b;
+  cr_assert(filterx_boolean_unwrap(r1, &b) && b);
+  cr_assert(filterx_boolean_unwrap(r2, &b) && b);
+  cr_assert(filterx_boolean_unwrap(r3, &b) && !b);
+
+  filterx_object_unref(r1);
+  filterx_object_unref(r2);
+  filterx_object_unref(r3);
+  filterx_object_unref(first);
+  filterx_object_unref(last);
+  filterx_object_unref(beyond);
+  filterx_object_unref(subnet);
+}
+
+Test(filterx_object_subnet, ipv6_member_returns_true)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("2001:db8::/32");
+  FilterXObject *ip = filterx_string_new("2001:db8::1", -1);
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, ip);
+  cr_assert_not_null(result);
+
+  gboolean b;
+  cr_assert(filterx_boolean_unwrap(result, &b));
+  cr_assert(b);
+
+  filterx_object_unref(result);
+  filterx_object_unref(ip);
+  filterx_object_unref(subnet);
+}
+
+Test(filterx_object_subnet, ipv6_non_member_returns_false)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("2001:db8::/32");
+  FilterXObject *ip = filterx_string_new("2001:db9::1", -1);
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, ip);
+  cr_assert_not_null(result);
+
+  gboolean b;
+  cr_assert(filterx_boolean_unwrap(result, &b));
+  cr_assert_not(b);
+
+  filterx_object_unref(result);
+  filterx_object_unref(ip);
+  filterx_object_unref(subnet);
+}
+
+Test(filterx_object_subnet, member_of_rejects_non_string)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("192.168.0.0/24");
+  FilterXObject *not_a_string = filterx_integer_new(42);
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, not_a_string);
+  cr_assert_null(result);
+
+  filterx_object_unref(not_a_string);
+  filterx_object_unref(subnet);
+}
+
+Test(filterx_object_subnet, member_of_rejects_invalid_ip)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("192.168.0.0/24");
+  FilterXObject *bad_ip = filterx_string_new("not-an-ip", -1);
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, bad_ip);
+  cr_assert_null(result);
+
+  filterx_object_unref(bad_ip);
+  filterx_object_unref(subnet);
+}
+
+Test(filterx_object_subnet, ipv4_subnet_rejects_ipv6_address)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("192.168.0.0/24");
+  FilterXObject *ipv6 = filterx_string_new("2001:db8::1", -1);
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, ipv6);
+  cr_assert_null(result);
+
+  filterx_object_unref(ipv6);
+  filterx_object_unref(subnet);
+}
+
+Test(filterx_object_subnet, ipv6_subnet_rejects_ipv4_address)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("2001:db8::/32");
+  FilterXObject *ipv4 = filterx_string_new("192.168.0.1", -1);
+
+  FilterXObject *result = filterx_object_is_member_of(subnet, ipv4);
+  cr_assert_null(result);
+
+  filterx_object_unref(ipv4);
+  filterx_object_unref(subnet);
+}
+
+/* Typecast */
+
+Test(filterx_object_subnet, typecast_from_string)
+{
+  FilterXObject *args[] = { filterx_string_new("192.168.0.0/24", -1) };
+
+  FilterXObject *obj = filterx_typecast_subnet(NULL, args, G_N_ELEMENTS(args));
+  cr_assert_not_null(obj);
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(subnet)));
+  assert_marshaled_object(obj, "192.168.0.0/255.255.255.0", LM_VT_STRING);
+
+  filterx_object_unref(obj);
+  filterx_simple_function_free_args(args, G_N_ELEMENTS(args));
+}
+
+Test(filterx_object_subnet, typecast_identity)
+{
+  FilterXObject *subnet = filterx_subnet_new_from_cidr("192.168.0.0/24");
+  FilterXObject *args[] = { filterx_object_ref(subnet) };
+
+  FilterXObject *obj = filterx_typecast_subnet(NULL, args, G_N_ELEMENTS(args));
+  cr_assert_not_null(obj);
+  cr_assert(obj == subnet);
+
+  filterx_object_unref(obj);
+  filterx_object_unref(subnet);
+  filterx_simple_function_free_args(args, G_N_ELEMENTS(args));
+}
+
+Test(filterx_object_subnet, typecast_rejects_integer)
+{
+  FilterXObject *args[] = { filterx_integer_new(42) };
+
+  FilterXObject *obj = filterx_typecast_subnet(NULL, args, G_N_ELEMENTS(args));
+  cr_assert_null(obj);
+
+  filterx_simple_function_free_args(args, G_N_ELEMENTS(args));
+}
+
+Test(filterx_object_subnet, typecast_rejects_invalid_cidr_string)
+{
+  FilterXObject *args[] = { filterx_string_new("not-a-cidr", -1) };
+
+  FilterXObject *obj = filterx_typecast_subnet(NULL, args, G_N_ELEMENTS(args));
+  cr_assert_null(obj);
+
+  filterx_simple_function_free_args(args, G_N_ELEMENTS(args));
+}
+
+Test(filterx_object_subnet, typecast_rejects_empty_args)
+{
+  FilterXObject *obj = filterx_typecast_subnet(NULL, NULL, 0);
+  cr_assert_null(obj);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  init_libtest_filterx();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  deinit_libtest_filterx();
+  app_shutdown();
+}
+
+TestSuite(filterx_object_subnet, .init = setup, .fini = teardown);

--- a/libtest/filterx-lib.c
+++ b/libtest/filterx-lib.c
@@ -327,6 +327,7 @@ deinit_libtest_filterx(void)
 {
   log_msg_unref(filterx_env.msg);
   filterx_scope_free(filterx_env.scope);
+  filterx_eval_clear_errors();
   filterx_eval_end_context(&filterx_env.context);
 }
 

--- a/news/feature-1021.md
+++ b/news/feature-1021.md
@@ -1,0 +1,18 @@
+New filterx types `subnet()` and `ip()`: these new types encapsulate an
+IPv4/IPv6 subnet (in CIDR notation) or a single IP address. Both types takes
+their string representation and will return an ERROR if the format cannot be
+parsed.
+
+Example configuration:
+
+    a = subnet("192.168.0.0/24");
+
+    "192.168.0.5" in a;
+    "192.168.1.5" in a or true;
+    ip("192.168.0.11") in a;
+
+    a6 = subnet("DEAD:BEEF::1/64");
+
+    "DEAD:BEEF::2" in a6;
+    "DEAD:BABE::1" in a6 or true;
+    ip("DEAD:BEEF::00ac") in a6;

--- a/tests/light/functional_tests/filterx/test_filterx_funcs.py
+++ b/tests/light/functional_tests/filterx/test_filterx_funcs.py
@@ -1436,3 +1436,41 @@ def test_subnet_host_bits_are_masked(config, syslog_ng):
 
     assert file_final.get_stats()["processed"] == 1
     assert file_final.read_log() == "subnet('192.168.0.0/255.255.255.0')"
+
+
+def test_ip_ipv4_repr(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    $MSG = repr(ip("192.168.1.1"));
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == "ip('192.168.1.1')"
+
+
+def test_ip_ipv6_repr(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    $MSG = repr(ip("2001:db8::1"));
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == "ip('2001:db8::1')"
+
+
+def test_ip_typecast_from_variable(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    addr = "10.1.2.3";
+    net = subnet("10.0.0.0/8");
+    $MSG = string(ip(addr) in net);
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == "true"

--- a/tests/light/functional_tests/filterx/test_filterx_funcs.py
+++ b/tests/light/functional_tests/filterx/test_filterx_funcs.py
@@ -1362,3 +1362,77 @@ def test_glob_match_multiple_patterns(config, syslog_ng):
 
     assert file_final.get_stats()["processed"] == 1
     assert file_final.read_log() == '{"first_matches":true,"second_matches":true,"none_matches":false}'
+
+
+def test_subnet_ipv4_membership(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    net = subnet("192.168.0.0/24");
+    result = json();
+    result.member = "192.168.0.100" in net;
+    result.non_member = "192.168.1.1" in net;
+    $MSG = result;
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == '{"member":true,"non_member":false}'
+
+
+def test_subnet_ipv6_membership(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    net = subnet("2001:db8::/32");
+    result = json();
+    result.member = "2001:db8::1" in net;
+    result.non_member = "2001:db9::1" in net;
+    $MSG = result;
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == '{"member":true,"non_member":false}'
+
+
+def test_subnet_repr(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    $MSG = repr(subnet("192.168.0.0/24"));
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == "subnet('192.168.0.0/255.255.255.0')"
+
+
+def test_subnet_typecast_from_variable(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    cidr = "10.0.0.0/8";
+    net = subnet(cidr);
+    result = json();
+    result.member = "10.1.2.3" in net;
+    result.non_member = "11.0.0.1" in net;
+    $MSG = result;
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == '{"member":true,"non_member":false}'
+
+
+def test_subnet_host_bits_are_masked(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    # host bits in 192.168.0.5/24 should be masked: stored as 192.168.0.0/255.255.255.0
+    $MSG = repr(subnet("192.168.0.5/24"));
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == "subnet('192.168.0.0/255.255.255.0')"

--- a/tests/light/functional_tests/filterx/test_filterx_funcs.py
+++ b/tests/light/functional_tests/filterx/test_filterx_funcs.py
@@ -1462,6 +1462,38 @@ def test_ip_ipv6_repr(config, syslog_ng):
     assert file_final.read_log() == "ip('2001:db8::1')"
 
 
+def test_ip_ipv4_in_subnet(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    net = subnet("192.168.0.0/24");
+    result = json();
+    result.member = ip("192.168.0.100") in net;
+    result.non_member = ip("192.168.1.1") in net;
+    $MSG = result;
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == '{"member":true,"non_member":false}'
+
+
+def test_ip_ipv6_in_subnet(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    net = subnet("2001:db8::/32");
+    result = json();
+    result.member = ip("2001:db8::1") in net;
+    result.non_member = ip("2001:db9::1") in net;
+    $MSG = result;
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == '{"member":true,"non_member":false}'
+
+
 def test_ip_typecast_from_variable(config, syslog_ng):
     (file_final,) = create_config(
         config, r"""
@@ -1474,3 +1506,19 @@ def test_ip_typecast_from_variable(config, syslog_ng):
 
     assert file_final.get_stats()["processed"] == 1
     assert file_final.read_log() == "true"
+
+
+def test_ip_family_mismatch_fails(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    $MSG = "ok";
+    net = subnet("192.168.0.0/24");
+    if (ip("2001:db8::1") in net) {
+        $MSG = "should not reach here";
+    }
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == "ok"


### PR DESCRIPTION
This is the example configuration to try it. No tests yet. WIP.

```
@version: current

log {
	source { stdin(); };

	filterx {
		a = subnet("192.168.0.0/24");

		"192.168.0.5" in a;
		"192.168.1.5" in a or true;

		a6 = subnet("DEAD:BEEF::1/64");

		"DEAD:BEEF::2" in a6;
		"DEAD:BABE::1" in a6 or true;
	};
};
```