### PR TITLE
lib/metrics: add new metric input_transport_errors_total

### DIFF
--- a/lib/logproto/logproto-auto-server.c
+++ b/lib/logproto/logproto-auto-server.c
@@ -32,6 +32,7 @@ G_STATIC_ASSERT(LOG_TRANSPORT_RA_BUFFER_SIZE >= RFC6587_MAX_FRAME_LEN_DIGITS + 1
 typedef struct _LogProtoAutoServer
 {
   LogProtoServer super;
+  StatsClusterKeyBuilder *kb;
 } LogProtoAutoServer;
 
 static inline gboolean
@@ -68,7 +69,7 @@ _construct_detected_proto(LogProtoAutoServer *self, const gchar *detect_buffer, 
 
       msg_debug("Auto-detected octet-counted-framing, using framed protocol",
                 evt_tag_int("fd", fd));
-      return log_proto_framed_server_new(NULL, self->super.options);
+      return log_proto_framed_server_new(NULL, self->super.options, self->kb);
     }
 
   if (detect_buffer[0] == '<')
@@ -125,7 +126,8 @@ log_proto_auto_handshake(LogProtoServer *s, gboolean *handshake_finished, LogPro
 }
 
 LogProtoServer *
-log_proto_auto_server_new(LogTransport *transport, const LogProtoServerOptions *options)
+log_proto_auto_server_new(LogTransport *transport, const LogProtoServerOptions *options,
+                          StatsClusterKeyBuilder *kb)
 {
   LogProtoAutoServer *self = g_new0(LogProtoAutoServer, 1);
 
@@ -135,5 +137,6 @@ log_proto_auto_server_new(LogTransport *transport, const LogProtoServerOptions *
   log_proto_server_init(&self->super, transport, options);
   self->super.handshake = log_proto_auto_handshake;
   self->super.poll_prepare = log_proto_auto_server_poll_prepare;
+  self->kb = kb;
   return &self->super;
 }

--- a/lib/logproto/logproto-auto-server.h
+++ b/lib/logproto/logproto-auto-server.h
@@ -24,6 +24,7 @@
 
 #include "logproto-server.h"
 
-LogProtoServer *log_proto_auto_server_new(LogTransport *transport, const LogProtoServerOptions *options);
+LogProtoServer *log_proto_auto_server_new(LogTransport *transport, const LogProtoServerOptions *options,
+                                          StatsClusterKeyBuilder *kb);
 
 #endif

--- a/lib/logproto/logproto-builtins.c
+++ b/lib/logproto/logproto-builtins.c
@@ -39,8 +39,8 @@ DEFINE_LOG_PROTO_SERVER(log_proto_text);
 DEFINE_LOG_PROTO_SERVER(log_proto_text_with_nuls);
 DEFINE_LOG_PROTO_SERVER(log_proto_nul_terminated);
 DEFINE_LOG_PROTO_CLIENT(log_proto_framed);
-DEFINE_LOG_PROTO_SERVER(log_proto_framed);
-DEFINE_LOG_PROTO_SERVER(log_proto_auto);
+DEFINE_LOG_PROTO_SERVER_WITH_KB(log_proto_framed);
+DEFINE_LOG_PROTO_SERVER_WITH_KB(log_proto_auto);
 
 static Plugin framed_server_plugins[] =
 {

--- a/lib/logproto/logproto-framed-server.c
+++ b/lib/logproto/logproto-framed-server.c
@@ -425,7 +425,8 @@ log_proto_framed_server_free(LogProtoServer *s)
 }
 
 LogProtoServer *
-log_proto_framed_server_new(LogTransport *transport, const LogProtoServerOptions *options)
+log_proto_framed_server_new(LogTransport *transport, const LogProtoServerOptions *options,
+                            StatsClusterKeyBuilder *kb)
 {
   LogProtoFramedServer *self = g_new0(LogProtoFramedServer, 1);
 

--- a/lib/logproto/logproto-framed-server.c
+++ b/lib/logproto/logproto-framed-server.c
@@ -24,6 +24,9 @@
 #include "logproto.h"
 #include "messages.h"
 #include "str-utils.h"
+#include "gsocket.h"
+#include "stats/stats-registry.h"
+#include "stats/stats-cluster-single.h"
 
 #include <errno.h>
 #include <ctype.h>
@@ -63,6 +66,12 @@ typedef struct _LogProtoFramedServer
   /* auxiliary data (e.g. GSockAddr, other transport related meta
    * data) associated with the already buffered data */
   LogTransportAuxData buffer_aux;
+
+  struct
+  {
+    StatsClusterKey *invalid_frame_header_key;
+    StatsCounterItem *invalid_frame_header_counter;
+  } metrics;
 } LogProtoFramedServer;
 
 static LogProtoPrepareAction
@@ -143,10 +152,40 @@ log_proto_framed_server_fetch_data(LogProtoFramedServer *self, gboolean *may_rea
   return TRUE;
 }
 
+static void
+_handle_invalid_frame_header(LogProtoFramedServer *self, guint32 frame_start)
+{
+  gchar peer_buf[MAX_SOCKADDR_STRING] = "unknown";
+  gchar local_buf[MAX_SOCKADDR_STRING] = "unknown";
+
+  GSockAddr *peer_addr = g_socket_get_peer_name(self->super.transport_stack.fd);
+  if (peer_addr)
+    {
+      g_sockaddr_format(peer_addr, peer_buf, sizeof(peer_buf), GSA_FULL);
+      g_sockaddr_unref(peer_addr);
+    }
+
+  GSockAddr *local_addr = g_socket_get_local_name(self->super.transport_stack.fd);
+  if (local_addr)
+    {
+      g_sockaddr_format(local_addr, local_buf, sizeof(local_buf), GSA_FULL);
+      g_sockaddr_unref(local_addr);
+    }
+
+  msg_error("Invalid frame header",
+            evt_tag_mem("header", &self->buffer[frame_start],
+                        MIN(self->buffer_end - frame_start, RFC6587_MAX_FRAME_LEN_DIGITS)),
+            evt_tag_str("peer_addr", peer_buf),
+            evt_tag_str("local_addr", local_buf));
+
+  stats_counter_inc(self->metrics.invalid_frame_header_counter);
+}
+
 static gboolean
 log_proto_framed_server_extract_frame_length(LogProtoFramedServer *self, gboolean *need_more_data)
 {
   gint i;
+  guint32 frame_start = self->buffer_pos;
 
   *need_more_data = TRUE;
   self->frame_len = 0;
@@ -164,8 +203,7 @@ log_proto_framed_server_extract_frame_length(LogProtoFramedServer *self, gboolea
         }
       else
         {
-          msg_error("Invalid frame header",
-                    evt_tag_mem("header", &self->buffer[self->buffer_pos], (i - self->buffer_pos)));
+          _handle_invalid_frame_header(self, frame_start);
           return FALSE;
         }
     }
@@ -396,6 +434,27 @@ _step_state_machine(LogProtoFramedServer *self, const guchar **msg, gsize *msg_l
     }
 }
 
+static void
+_register_stats(LogProtoFramedServer *self, StatsClusterKeyBuilder *kb)
+{
+  if (!kb)
+    return;
+
+  stats_cluster_key_builder_push(kb);
+  stats_cluster_key_builder_set_name(kb, METRIC(input_transport_errors_total));
+  stats_cluster_key_builder_add_label(kb, stats_cluster_label("reason", "invalid-frame-header"));
+
+  self->metrics.invalid_frame_header_key = stats_cluster_key_builder_build_single(kb);
+  stats_cluster_key_builder_pop(kb);
+
+  stats_lock();
+  {
+    stats_register_counter(STATS_LEVEL1, self->metrics.invalid_frame_header_key, SC_TYPE_SINGLE_VALUE,
+                           &self->metrics.invalid_frame_header_counter);
+  }
+  stats_unlock();
+}
+
 static LogProtoStatus
 log_proto_framed_server_fetch(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read,
                               LogTransportAuxData *aux, Bookmark *bookmark)
@@ -414,10 +473,31 @@ log_proto_framed_server_fetch(LogProtoServer *s, const guchar **msg, gsize *msg_
   return status;
 }
 
+
+
+static void
+_unregister_stats(LogProtoFramedServer *self)
+{
+  if (!self->metrics.invalid_frame_header_key)
+    return;
+
+  stats_lock();
+  {
+    stats_unregister_counter(self->metrics.invalid_frame_header_key, SC_TYPE_SINGLE_VALUE,
+                             &self->metrics.invalid_frame_header_counter);
+  }
+  stats_unlock();
+
+  stats_cluster_key_free(self->metrics.invalid_frame_header_key);
+  self->metrics.invalid_frame_header_key = NULL;
+}
+
 static void
 log_proto_framed_server_free(LogProtoServer *s)
 {
   LogProtoFramedServer *self = (LogProtoFramedServer *) s;
+
+  _unregister_stats(self);
   g_free(self->buffer);
 
   log_transport_aux_data_destroy(&self->buffer_aux);
@@ -436,5 +516,8 @@ log_proto_framed_server_new(LogTransport *transport, const LogProtoServerOptions
   self->super.free_fn = log_proto_framed_server_free;
   self->half_message_in_buffer = FALSE;
   self->state = LPFSS_FRAME_READ;
+
+  _register_stats(self, kb);
+
   return &self->super;
 }

--- a/lib/logproto/logproto-framed-server.h
+++ b/lib/logproto/logproto-framed-server.h
@@ -25,6 +25,7 @@
 
 #include "logproto-server.h"
 
-LogProtoServer *log_proto_framed_server_new(LogTransport *transport, const LogProtoServerOptions *options);
+LogProtoServer *log_proto_framed_server_new(LogTransport *transport, const LogProtoServerOptions *options,
+                                            StatsClusterKeyBuilder *kb);
 
 #endif

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -194,6 +194,24 @@ log_proto_server_set_ack_tracker(LogProtoServer *s, AckTracker *ack_tracker)
 }
 
 #define DEFINE_LOG_PROTO_SERVER(prefix, options...) \
+  static LogProtoServer *                                               \
+  prefix ## _server_new_wrapper(LogTransport *transport,                \
+                                const LogProtoServerOptions *opts,      \
+                                StatsClusterKeyBuilder *kb) \
+  {                                                                     \
+    return prefix ## _server_new(transport, opts);                      \
+  }                                                                     \
+  static gpointer                                                       \
+  prefix ## _server_plugin_construct(Plugin *self)                      \
+  {                                                                     \
+    static LogProtoServerFactory proto = {                              \
+      .construct = prefix ## _server_new_wrapper,               \
+      ##options \
+    };                                                                  \
+    return &proto;                                                      \
+  }
+
+#define DEFINE_LOG_PROTO_SERVER_WITH_KB(prefix, options...) \
   static gpointer                                                       \
   prefix ## _server_plugin_construct(Plugin *self)                      \
   {                                                                     \
@@ -222,15 +240,16 @@ typedef struct _LogProtoServerFactory LogProtoServerFactory;
 
 struct _LogProtoServerFactory
 {
-  LogProtoServer *(*construct)(LogTransport *transport, const LogProtoServerOptions *options);
+  LogProtoServer *(*construct)(LogTransport *transport, const LogProtoServerOptions *options,
+                               StatsClusterKeyBuilder *kb);
   gint default_inet_port;
 };
 
 static inline LogProtoServer *
 log_proto_server_factory_construct(LogProtoServerFactory *self, LogTransport *transport,
-                                   const LogProtoServerOptions *options)
+                                   const LogProtoServerOptions *options, StatsClusterKeyBuilder *kb)
 {
-  return self->construct(transport, options);
+  return self->construct(transport, options, kb);
 }
 
 LogProtoServerFactory *log_proto_server_get_factory(PluginContext *context, const gchar *name);

--- a/lib/logproto/tests/test-auto-server.c
+++ b/lib/logproto/tests/test-auto-server.c
@@ -38,7 +38,8 @@ Test(log_proto, test_log_proto_initial_framing_too_long)
             log_transport_mock_stream_new(
               "100000000 too long\n", -1,
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(),
+            NULL);
 
   assert_proto_server_handshake_failure(&proto, LPS_SUCCESS);
   assert_proto_server_fetch_failure(proto, LPS_ERROR, NULL);
@@ -52,7 +53,8 @@ Test(log_proto, test_log_proto_error_in_initial_frame)
   proto = log_proto_auto_server_new(
             log_transport_mock_stream_new(
               LTM_INJECT_ERROR(EIO)),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(),
+            NULL);
 
   assert_proto_server_handshake_failure(&proto, LPS_ERROR);
   log_proto_server_free(proto);
@@ -69,7 +71,8 @@ Test(log_proto, test_log_proto_auto_server_no_framing)
               "01234567\0", 9,
               "abcdef", -1,
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(),
+            NULL);
 
   assert_proto_server_handshake(&proto);
   assert_proto_server_fetch(proto, "abcdefghijklmnopqstuvwxyz", -1);
@@ -91,7 +94,8 @@ Test(log_proto, test_log_proto_auto_server_opening_bracket)
               "01234567\0", 9,
               "abcdef", -1,
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(),
+            NULL);
 
   assert_proto_server_handshake(&proto);
   assert_proto_server_fetch(proto, "<55> abcdefghijklmnopqstuvwxyz", -1);
@@ -120,7 +124,8 @@ Test(log_proto, test_log_proto_auto_server_with_framing)
               "32 \x00\x00\x00\xe1\x00\x00\x00\x72\x00\x00\x00\x76\x00\x00\x00\xed"      /* |...á...r...v...í| */
               "\x00\x00\x00\x7a\x00\x00\x00\x74\x00\x00\x01\x71\x00\x00\x00\x72", 35,    /* |...z...t...ű...r|  */
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(),
+            NULL);
 
   assert_proto_server_handshake(&proto);
   assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", -1);

--- a/lib/logproto/tests/test-framed-server.c
+++ b/lib/logproto/tests/test-framed-server.c
@@ -49,7 +49,7 @@ Test(log_proto, test_log_proto_framed_server_simple_messages)
               "32 \x00\x00\x00\xe1\x00\x00\x00\x72\x00\x00\x00\x76\x00\x00\x00\xed"      /* |...á...r...v...í| */
               "\x00\x00\x00\x7a\x00\x00\x00\x74\x00\x00\x01\x71\x00\x00\x00\x72", 35,    /* |...z...t...ű...r|  */
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(), NULL);
   assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", -1);
   assert_proto_server_fetch(proto, "01234567\n\n", -1);
   assert_proto_server_fetch(proto, "01234567\0\0", 10);
@@ -74,7 +74,7 @@ Test(log_proto, test_log_proto_framed_server_io_error)
               "32 0123456789ABCDEF0123456789ABCDEF", -1,
               LTM_INJECT_ERROR(EIO),
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(), NULL);
   assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", -1);
   assert_proto_server_fetch_failure(proto, LPS_ERROR, "Error reading RFC6587 style framed data");
   log_proto_server_free(proto);
@@ -90,7 +90,7 @@ Test(log_proto, test_log_proto_framed_server_invalid_header)
             log_transport_mock_stream_new(
               "1q 0123456789ABCDEF0123456789ABCDEF", -1,
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(), NULL);
   assert_proto_server_fetch_failure(proto, LPS_ERROR, "Invalid frame header");
   log_proto_server_free(proto);
 }
@@ -104,7 +104,7 @@ Test(log_proto, test_log_proto_framed_server_too_long_line)
             log_transport_mock_stream_new(
               "48 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF", -1,
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(), NULL);
   assert_proto_server_fetch_failure(proto, LPS_ERROR, "Incoming frame larger than log_msg_size()");
   log_proto_server_free(proto);
 }
@@ -121,7 +121,7 @@ Test(log_proto, test_log_proto_framed_server_too_long_line_trimmed)
             log_transport_mock_stream_new(
               "48 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF", -1,
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(), NULL);
   assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", 32);
   assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
@@ -144,7 +144,7 @@ Test(log_proto, test_log_proto_framed_server_too_long_line_trimmed_multiple_cycl
               "7 1abcdef", -1,
               "1 2", -1,
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(), NULL);
   assert_proto_server_fetch(proto, "0",  1);
   assert_proto_server_fetch(proto, "1a", 2);
   assert_proto_server_fetch(proto, "2",  1);
@@ -175,7 +175,7 @@ Test(log_proto, test_log_proto_framed_server_too_long_line_trimmed_frame_at_the_
               "12345674",  -1,
               " 2abc",     -1,
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(), NULL);
   assert_proto_server_fetch(proto, "01\n",     3);
   assert_proto_server_fetch(proto, "1abcdefg", 8);
   // dropping: 1234567
@@ -196,7 +196,7 @@ Test(log_proto, test_log_proto_framed_server_too_long_line_trimmed_one_big_messa
             log_transport_mock_stream_new(
               "2 ab16 0123456789ABCDEF", -1,
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(), NULL);
   assert_proto_server_fetch(proto, "ab",          2);
   assert_proto_server_fetch(proto, "0123456789", 10);
   log_proto_server_free(proto);
@@ -214,7 +214,7 @@ Test(log_proto, test_log_proto_framed_server_message_exceeds_buffer)
             log_transport_mock_records_new(
               "16 0123456789ABCDE\n16 0123456789ABCDE\n", -1,
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(), NULL);
   assert_proto_server_fetch(proto, "0123456789ABCDE\n", -1);
   assert_proto_server_fetch(proto, "0123456789ABCDE\n", -1);
   log_proto_server_free(proto);
@@ -234,7 +234,7 @@ Test(log_proto, test_log_proto_framed_server_buffer_shift_before_fetch)
               "7 012345\n4", 10,
               " 123\n", -1,
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(), NULL);
   assert_proto_server_fetch(proto, "012345\n", -1);
   assert_proto_server_fetch(proto, "123\n", -1);
   log_proto_server_free(proto);
@@ -254,7 +254,7 @@ Test(log_proto, test_log_proto_framed_server_buffer_shift_to_make_space_for_a_fr
               "6 01234\n4 ", 10,
               "123\n", -1,
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(), NULL);
   assert_proto_server_fetch(proto, "01234\n", -1);
   assert_proto_server_fetch(proto, "123\n", -1);
   log_proto_server_free(proto);
@@ -272,7 +272,7 @@ Test(log_proto, test_log_proto_framed_server_multi_read)
               "6 fooba", -1,
               LTM_INJECT_ERROR(EIO),
               LTM_EOF),
-            get_inited_proto_server_options());
+            get_inited_proto_server_options(), NULL);
   assert_proto_server_fetch(proto, "foobar\n", -1);
   /* with multi-read, we get the injected failure at the 2nd fetch */
   assert_proto_server_fetch_failure(proto, LPS_ERROR, "Error reading RFC6587 style framed data");

--- a/lib/metrics/metric-names.h
+++ b/lib/metrics/metric-names.h
@@ -46,6 +46,7 @@
   M(fx_xxx_evals_total) \
   M(input_event_bytes_total) \
   M(input_events_total) \
+  M(input_transport_errors_total) \
   M(input_window_available) \
   M(input_window_capacity) \
   M(input_window_full_total) \

--- a/lib/transport/logtransport.h
+++ b/lib/transport/logtransport.h
@@ -26,6 +26,7 @@
 
 #include "syslog-ng.h"
 #include "transport/transport-aux-data.h"
+#include "stats/stats-cluster-key-builder.h"
 
 #define LOG_TRANSPORT_RA_BUFFER_SIZE 16
 
@@ -67,6 +68,7 @@ struct _LogTransport
   gssize (*writev)(LogTransport *self, struct iovec *iov, gint iov_count);
   void (*shutdown)(LogTransport *self);
   void (*free_fn)(LogTransport *self);
+  void (*register_stats)(LogTransport *self, StatsClusterKeyBuilder *kb);
 
   /* read ahead */
   struct

--- a/lib/transport/transport-stack.c
+++ b/lib/transport/transport-stack.c
@@ -113,6 +113,17 @@ log_transport_stack_move(LogTransportStack *self, LogTransportStack *other)
 }
 
 void
+log_transport_stack_register_stats(LogTransportStack *self, StatsClusterKeyBuilder *kb)
+{
+  for (gint i = 0; i < LOG_TRANSPORT__MAX; i++)
+    {
+      LogTransport *transport = log_transport_stack_get_or_create_transport(self, i);
+      if (transport && transport->register_stats)
+        transport->register_stats(transport, kb);
+    }
+}
+
+void
 log_transport_stack_shutdown(LogTransportStack *self)
 {
   LogTransport *active_transport = log_transport_stack_get_active(self);

--- a/lib/transport/transport-stack.h
+++ b/lib/transport/transport-stack.h
@@ -193,6 +193,7 @@ void log_transport_stack_add_transport(LogTransportStack *self, gint index, LogT
 gboolean log_transport_stack_switch(LogTransportStack *self, gint index);
 void log_transport_stack_move(LogTransportStack *self, LogTransportStack *other);
 void log_transport_stack_shutdown(LogTransportStack *self);
+void log_transport_stack_register_stats(LogTransportStack *self, StatsClusterKeyBuilder *kb);
 
 void log_transport_stack_init(LogTransportStack *self, LogTransport *initial_transport);
 void log_transport_stack_deinit(LogTransportStack *self);

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -26,6 +26,9 @@
 #include "transport/transport-adapter.h"
 
 #include "messages.h"
+#include "stats/stats-cluster-key-builder.h"
+#include "stats/stats-cluster-single.h"
+#include "stats/stats-registry.h"
 
 #include <openssl/ssl.h>
 #include <openssl/err.h>
@@ -36,6 +39,8 @@ typedef struct _LogTransportTLS
   LogTransportAdapter super;
   TLSSession *tls_session;
   gboolean sending_shutdown;
+
+  StatsClusterKeyBuilder *kb;
 } LogTransportTLS;
 
 const gchar *TLS_TRANSPORT_NAME = "tls";
@@ -202,6 +207,44 @@ log_transport_tls_aux_data_add_peer_info(LogTransportTLS *self, LogTransportAuxD
   return TRUE;
 }
 
+static void
+_inc_tls_handshake_error_counter(LogTransportTLS *self)
+{
+  if (!self->kb)
+    return;
+
+  gulong ssl_error = ERR_peek_error();
+  const char *lib = ERR_lib_error_string(ssl_error) ? : "";
+  const char *reason = ERR_reason_error_string(ssl_error) ? : "";
+
+  char tls_error[32];
+  g_snprintf(tls_error, sizeof(tls_error), "%08lX", ssl_error);
+
+  char tls_error_string[256];
+  g_snprintf(tls_error_string, sizeof(tls_error_string), "%s::%s", lib, reason);
+
+  stats_cluster_key_builder_push(self->kb);
+  stats_cluster_key_builder_set_name(self->kb, METRIC(input_transport_errors_total));
+  stats_cluster_key_builder_add_label(self->kb, stats_cluster_label("reason", "tls-handshake"));
+  stats_cluster_key_builder_add_label(self->kb, stats_cluster_label("tls_error", tls_error));
+  stats_cluster_key_builder_add_label(self->kb, stats_cluster_label("tls_error_string", tls_error_string));
+
+  StatsClusterKey *key = stats_cluster_key_builder_build_single(self->kb);
+  stats_cluster_key_builder_pop(self->kb);
+
+  StatsCluster *cluster;
+  StatsCounterItem *counter;
+  stats_lock();
+  {
+    cluster = stats_register_dynamic_counter(STATS_LEVEL1, key, SC_TYPE_SINGLE_VALUE, &counter);
+    stats_counter_inc(counter);
+    stats_unregister_dynamic_counter(cluster, SC_TYPE_SINGLE_VALUE, &counter);
+  }
+  stats_unlock();
+
+  stats_cluster_key_free(key);
+}
+
 static gssize
 log_transport_tls_read_method(LogTransport *s, gpointer buf, gsize buflen, LogTransportAuxData *aux)
 {
@@ -269,6 +312,8 @@ log_transport_tls_read_method(LogTransport *s, gpointer buf, gsize buflen, LogTr
   return rc;
 tls_error:
 
+  _inc_tls_handshake_error_counter(self);
+
   msg_error("SSL error while reading stream",
             tls_context_format_tls_error_tag(self->tls_session->ctx),
             tls_context_format_location_tag(self->tls_session->ctx));
@@ -332,6 +377,8 @@ log_transport_tls_write_method(LogTransport *s, const gpointer buf, gsize buflen
 
 tls_error:
 
+  _inc_tls_handshake_error_counter(self);
+
   msg_error("SSL error while writing stream",
             tls_context_format_tls_error_tag(self->tls_session->ctx),
             tls_context_format_location_tag(self->tls_session->ctx));
@@ -362,6 +409,7 @@ log_transport_tls_shutdown_method(LogTransport *s)
 }
 
 static void log_transport_tls_free_method(LogTransport *s);
+static void log_transport_tls_register_stats(LogTransport *s, StatsClusterKeyBuilder *kb);
 
 LogTransport *
 log_transport_tls_new(TLSSession *tls_session, LogTransportIndex base)
@@ -374,6 +422,7 @@ log_transport_tls_new(TLSSession *tls_session, LogTransportIndex base)
   self->super.super.write = log_transport_tls_write_method;
   self->super.super.shutdown = log_transport_tls_shutdown_method;
   self->super.super.free_fn = log_transport_tls_free_method;
+  self->super.super.register_stats = log_transport_tls_register_stats;
   self->tls_session = tls_session;
 
   BIO *bio = BIO_transport_new(self);
@@ -388,6 +437,14 @@ log_transport_tls_free_method(LogTransport *s)
 
   tls_session_free(self->tls_session);
   log_transport_adapter_free_method(s);
+}
+
+static void
+log_transport_tls_register_stats(LogTransport *s, StatsClusterKeyBuilder *kb)
+{
+  LogTransportTLS *self = (LogTransportTLS *) s;
+
+  self->kb = kb;
 }
 
 void

--- a/libtest/proto_lib.c
+++ b/libtest/proto_lib.c
@@ -99,7 +99,7 @@ construct_server_proto_plugin(const gchar *name, LogTransport *transport)
   log_proto_server_options_init(&proto_server_options, configuration);
   proto_factory = log_proto_server_get_factory(&configuration->plugin_context, name);
   cr_assert_not_null(proto_factory, "error looking up proto factory");
-  return log_proto_server_factory_construct(proto_factory, transport, &proto_server_options);
+  return log_proto_server_factory_construct(proto_factory, transport, &proto_server_options, NULL);
 }
 
 void

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -163,6 +163,8 @@ afsocket_sc_init(LogPipe *s)
           return FALSE;
         }
 
+      log_transport_stack_register_stats(&proto->transport_stack, kb);
+
       self->reader = log_reader_new(s->cfg);
       log_pipe_set_options(&self->reader->super.super, &self->super.options);
       log_reader_open(self->reader, proto, poll_fd_events_new(self->sock));

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -142,19 +142,24 @@ afsocket_sc_init(LogPipe *s)
   AFSocketSourceConnection *self = (AFSocketSourceConnection *) s;
   LogProtoServer *proto;
 
+  StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+  afsocket_sc_format_stats_key(self, kb);
+
   gboolean restored_kept_alive_source = !!self->reader;
   if (!restored_kept_alive_source)
     {
       proto = log_proto_server_factory_construct(self->owner->proto_factory, NULL,
-                                                 &self->owner->reader_options.proto_options.super);
+                                                 &self->owner->reader_options.proto_options.super, kb);
       if (!proto)
         {
+          stats_cluster_key_builder_free(kb);
           return FALSE;
         }
 
       if (!transport_mapper_setup_stack(self->owner->transport_mapper, &proto->transport_stack, self->sock))
         {
           log_proto_server_free(proto);
+          stats_cluster_key_builder_free(kb);
           return FALSE;
         }
 
@@ -164,9 +169,6 @@ afsocket_sc_init(LogPipe *s)
       log_reader_set_peer_addr(self->reader, self->peer_addr);
       log_reader_set_local_addr(self->reader, self->local_addr);
     }
-
-  StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
-  afsocket_sc_format_stats_key(self, kb);
   log_reader_set_options(self->reader, &self->super,
                          &self->owner->reader_options,
                          self->owner->super.super.id,

--- a/news/feature-1026.md
+++ b/news/feature-1026.md
@@ -1,0 +1,3 @@
+`syslog()`, `network()` sources: add `syslogng_input_transport_errors_total` metric
+
+It shows `invalid-frame-header` or `tls-handshake` related transport errors.

--- a/tests/light/functional_tests/Makefile.am
+++ b/tests/light/functional_tests/Makefile.am
@@ -75,6 +75,7 @@ EXTRA_DIST += \
 	tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_syslog_proto.py \
 	tests/light/functional_tests/source_drivers/network_source/test_network_transports.py \
 	tests/light/functional_tests/source_drivers/network_source/test_syslog_parser_timestamp_spinning.py \
+	tests/light/functional_tests/source_drivers/network_source/test_transport_error_metrics.py \
 	tests/light/functional_tests/source_drivers/network_source/text_with_nuls/test_embedded_nul.py \
 	tests/light/functional_tests/source_drivers/network_source/text_with_nuls/test_nul_terminated.py \
 	tests/light/functional_tests/source_drivers/opentelemetry_source/test_opentelemetry_source_acceptance.py \

--- a/tests/light/functional_tests/source_drivers/network_source/test_transport_error_metrics.py
+++ b/tests/light/functional_tests/source_drivers/network_source/test_transport_error_metrics.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+# Copyright (c) 2026 Szilard Parrag <szilard.parrag@axoflow.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import socket
+import ssl
+
+from axosyslog_light.common.blocking import wait_until_true
+from axosyslog_light.common.file import copy_shared_file
+from axosyslog_light.syslog_ng_ctl.prometheus_stats_handler import MetricFilter
+
+
+#  Only for TCP/TLS transport errors, not for UDP
+METRIC_NAME = "syslogng_input_transport_errors_total"
+
+
+def _get_samples(config, reason):
+    return config.get_prometheus_samples([MetricFilter(METRIC_NAME, {"reason": reason})])
+
+
+def _get_metric_value(config, reason):
+    return sum(s.value for s in _get_samples(config, reason))
+
+
+def test_invalid_frame_header_metric(config, syslog_ng, port_allocator, testcase_parameters):
+    config.update_global_options(stats_level=1)
+
+    source = config.create_syslog_source(
+        ip="localhost",
+        port=port_allocator(),
+        transport="tcp",
+    )
+    file_destination = config.create_file_destination(file_name="output.log")
+    config.create_logpath(statements=[source, file_destination])
+
+    syslog_ng.start(config)
+
+    # Send raw data that is not a valid RFC6587 frame header (starts with a letter, not a digit)
+    msg_to_send = "INVALID_FRAME_HEADER\n"
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect(("localhost", source.options["port"]))
+    sock.sendall(bytes(msg_to_send, "utf-8"))
+    sock.close()
+
+    assert wait_until_true(lambda: _get_metric_value(config, "invalid-frame-header") == 1)
+    syslog_ng.wait_for_message_in_console_log(
+        f"Invalid frame header; header='{msg_to_send[:10]}'",
+    )
+
+
+def test_tls_handshake_error_metric(config, syslog_ng, port_allocator, testcase_parameters):
+    config.update_global_options(stats_level=1)
+
+    server_key_path = copy_shared_file(testcase_parameters, "server.key")
+    server_cert_path = copy_shared_file(testcase_parameters, "server.crt")
+
+    source = config.create_network_source(
+        ip="localhost",
+        port=port_allocator(),
+        transport="tls",
+        tls={
+            "key-file": server_key_path,
+            "cert-file": server_cert_path,
+            "peer-verify": "optional-untrusted",
+        },
+    )
+    file_destination = config.create_file_destination(file_name="output.log")
+    config.create_logpath(statements=[source, file_destination])
+
+    syslog_ng.start(config)
+
+    # Connect with plain TCP (no TLS handshake) to trigger a TLS handshake error
+    sock_tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock_tcp.connect(("localhost", source.options["port"]))
+    sock_tcp.sendall(b"THIS IS NOT A TLS HANDSHAKE\n")
+    sock_tcp.close()
+
+    assert wait_until_true(lambda: _get_metric_value(config, "tls-handshake") == 1)
+
+    samples = _get_samples(config, "tls-handshake")
+    assert len(samples) == 1
+    assert samples[0].labels["tls_error"] == "0A00010B"
+    assert samples[0].labels["tls_error_string"] == "SSL routines::wrong version number"
+
+
+def test_tls_wrong_client_cert_metric(config, syslog_ng, port_allocator, testcase_parameters):
+    config.update_global_options(stats_level=1)
+
+    server_key_path = copy_shared_file(testcase_parameters, "server.key")
+    server_cert_path = copy_shared_file(testcase_parameters, "server.crt")
+    trusted_ca_path = copy_shared_file(testcase_parameters, "valid-ca.crt")
+
+    source = config.create_network_source(
+        ip="localhost",
+        port=port_allocator(),
+        transport="tls",
+        tls={
+            "key-file": server_key_path,
+            "cert-file": server_cert_path,
+            "ca-file": trusted_ca_path,
+            "peer-verify": "required-trusted",
+        },
+    )
+    file_destination = config.create_file_destination(file_name="output.log")
+    config.create_logpath(statements=[source, file_destination])
+
+    syslog_ng.start(config)
+
+    # TLS connection without client cert, server requires one and will reject
+    client_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    client_ctx.check_hostname = False
+    client_ctx.verify_mode = ssl.CERT_NONE
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect(("localhost", source.options["port"]))
+    try:
+        ssl_sock = client_ctx.wrap_socket(sock, server_hostname="localhost", do_handshake_on_connect=False)
+        ssl_sock.do_handshake()
+    except ssl.SSLError:  # This is intentional
+        pass
+    finally:
+        sock.close()
+
+    assert wait_until_true(lambda: _get_metric_value(config, "tls-handshake") == 1)
+    assert syslog_ng.wait_for_message_in_console_log("SSL error while reading stream") != []
+
+    samples = _get_samples(config, "tls-handshake")
+    assert len(samples) == 1
+    assert samples[0].labels["tls_error"] == "0A0000C7"
+    assert samples[0].labels["tls_error_string"] == "SSL routines::peer did not return a certificate"


### PR DESCRIPTION
Example:
```
syslogng_input_transport_errors_total{address="127.0.0.1:5514",driver="syslog",peer_address="127.0.0.1",reason="invalid-frame-header",transport="tls"} 0
syslogng_input_transport_errors_total{address="127.0.0.1:5514",driver="syslog",peer_address="127.0.0.1",reason="tls-handshake",transport="tls"} 2
```