### PR TITLE
Disk-buffer: don't save memory segments on reload

### DIFF
--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -140,23 +140,34 @@ _acquire_queue(LogDestDriver *dd, const gchar *persist_name, gint stats_level,
 {
   DiskQDestPlugin *self = log_driver_get_plugin(&dd->super, DiskQDestPlugin, DISKQ_PLUGIN_NAME);
   GlobalConfig *cfg = log_pipe_get_config(&dd->super.super);
-  LogQueue *queue;
+  LogQueue *queue = NULL;
   gchar *persist_qfile_name, *new_qfile_name = NULL;
 
   if (persist_name)
-    log_queue_unref(cfg_persist_config_fetch(cfg, persist_name));
+    queue = cfg_persist_config_fetch(cfg, persist_name);
+
+  if (queue && (!log_queue_has_type(queue, log_queue_disk_get_type()) ||
+      !log_queue_disk_has_compatible_options((LogQueueDisk *)queue, &self->options)))
+    {
+      log_queue_unref(queue);
+      queue = NULL;
+    }
 
   persist_qfile_name = persist_state_lookup_string(cfg->state, persist_name, NULL, NULL);
-  queue = _create_and_start_disk_queue_with_filename_from_persist(
-            self, persist_qfile_name, persist_name, stats_level, driver_sck_builder, queue_sck_builder);
+
   if (queue)
-    goto exit;
+    log_queue_disk_set_options((LogQueueDisk *)queue, &self->options);
+  else
+    queue = _create_and_start_disk_queue_with_filename_from_persist(
+              self, persist_qfile_name, persist_name, stats_level, driver_sck_builder, queue_sck_builder);
 
-  new_qfile_name = qdisk_get_next_filename(self->options.dir, self->options.reliable);
-  queue = _create_and_start_disk_queue_with_new_filename(self, new_qfile_name, persist_name, stats_level,
-                                                         driver_sck_builder, queue_sck_builder);
+  if (!queue)
+    {
+      new_qfile_name = qdisk_get_next_filename(self->options.dir, self->options.reliable);
+      queue = _create_and_start_disk_queue_with_new_filename(self, new_qfile_name, persist_name, stats_level,
+                                                             driver_sck_builder, queue_sck_builder);
+    }
 
-exit:
   if (queue)
     {
       log_queue_set_throttle(queue, dd->throttle);
@@ -174,22 +185,21 @@ exit:
 }
 
 void
+_free_queue(LogQueue *queue)
+{
+  diskq_global_metrics_file_released(log_queue_disk_get_filename(queue));
+  log_queue_unref(queue);
+}
+
+void
 _release_queue(LogDestDriver *dd, LogQueue *queue)
 {
   GlobalConfig *cfg = log_pipe_get_config(&dd->super.super);
-  gboolean persistent;
-
-  log_queue_disk_stop(queue, &persistent);
-  diskq_global_metrics_file_released(log_queue_disk_get_filename(queue));
 
   if (queue->persist_name)
-    {
-      cfg_persist_config_add(cfg, queue->persist_name, queue, (GDestroyNotify) log_queue_unref);
-    }
+    cfg_persist_config_add(cfg, queue->persist_name, queue, (GDestroyNotify) _free_queue);
   else
-    {
-      log_queue_unref(queue);
-    }
+    _free_queue(queue);
 }
 
 static gboolean

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -797,6 +797,11 @@ static void
 _maybe_move_part_of_input_to_front_cache(LogQueueDiskNonReliable *self, InputQueue *input_queue)
 {
   g_mutex_lock(&self->super.super.lock);
+
+  // The user can set a smaller front_cache size, than what we loaded from the disk
+  if (self->front_cache.len > self->front_cache.limit)
+    goto exit;
+
   gint num_msgs_to_send_to_front_cache = (qdisk_get_length(self->super.qdisk) == 0 && self->flow_control_window.len == 0)?
                                          MIN(self->front_cache.limit - self->front_cache.len, input_queue->len) : 0;
 

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -882,6 +882,9 @@ _free(LogQueue *s)
 {
   LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *)s;
 
+  gboolean persistent;
+  log_queue_disk_stop(&self->super.super, &persistent);
+
   for (gint i = 0; i < self->num_input_queues; i++)
     {
       g_assert(self->input_queues[i].len == 0);

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -456,6 +456,8 @@ _free(LogQueue *s)
 {
   LogQueueDiskReliable *self = (LogQueueDiskReliable *)s;
 
+  gboolean persistent;
+  log_queue_disk_stop(&self->super.super, &persistent);
 
   if (self->flow_control_window)
     {

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -491,6 +491,13 @@ log_queue_disk_deserialize_msg(LogQueueDisk *self, GString *serialized, LogMessa
 
   return TRUE;
 }
+
+QueueType
+log_queue_disk_get_type(void)
+{
+  return log_queue_disk_type;
+}
+
 void
 log_queue_disk_set_options(LogQueueDisk *self, DiskQueueOptions *options)
 {

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -496,3 +496,9 @@ log_queue_disk_set_options(LogQueueDisk *self, DiskQueueOptions *options)
 {
   qdisk_set_options(self->qdisk, options);
 }
+
+gboolean
+log_queue_disk_has_compatible_options(LogQueueDisk *self, DiskQueueOptions *options)
+{
+  return qdisk_is_compatible(self->qdisk, options);
+}

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -491,3 +491,8 @@ log_queue_disk_deserialize_msg(LogQueueDisk *self, GString *serialized, LogMessa
 
   return TRUE;
 }
+void
+log_queue_disk_set_options(LogQueueDisk *self, DiskQueueOptions *options)
+{
+  qdisk_set_options(self->qdisk, options);
+}

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -77,6 +77,7 @@ void log_queue_disk_drop_message(LogQueueDisk *self, LogMessage *msg, const LogP
 void log_queue_disk_drop_msg_and_suspend_src(LogQueueDisk *self, LogMessage *msg, const LogPathOptions *path_options);
 gboolean log_queue_disk_serialize_msg(LogQueueDisk *self, LogMessage *msg, GString *serialized);
 gboolean log_queue_disk_deserialize_msg(LogQueueDisk *self, GString *serialized, LogMessage **msg);
+QueueType log_queue_disk_get_type(void);
 void log_queue_disk_set_options(LogQueueDisk *self, DiskQueueOptions *options);
 gboolean log_queue_disk_has_compatible_options(LogQueueDisk *self, DiskQueueOptions *options);
 

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -78,5 +78,6 @@ void log_queue_disk_drop_msg_and_suspend_src(LogQueueDisk *self, LogMessage *msg
 gboolean log_queue_disk_serialize_msg(LogQueueDisk *self, LogMessage *msg, GString *serialized);
 gboolean log_queue_disk_deserialize_msg(LogQueueDisk *self, GString *serialized, LogMessage **msg);
 void log_queue_disk_set_options(LogQueueDisk *self, DiskQueueOptions *options);
+gboolean log_queue_disk_has_compatible_options(LogQueueDisk *self, DiskQueueOptions *options);
 
 #endif

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -77,5 +77,6 @@ void log_queue_disk_drop_message(LogQueueDisk *self, LogMessage *msg, const LogP
 void log_queue_disk_drop_msg_and_suspend_src(LogQueueDisk *self, LogMessage *msg, const LogPathOptions *path_options);
 gboolean log_queue_disk_serialize_msg(LogQueueDisk *self, LogMessage *msg, GString *serialized);
 gboolean log_queue_disk_deserialize_msg(LogQueueDisk *self, GString *serialized, LogMessage **msg);
+void log_queue_disk_set_options(LogQueueDisk *self, DiskQueueOptions *options);
 
 #endif

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1811,6 +1811,14 @@ qdisk_set_options(QDisk *self, DiskQueueOptions *options)
   self->options = options;
 }
 
+gboolean
+qdisk_is_compatible(QDisk *self, DiskQueueOptions *options)
+{
+  return (self->options->front_cache_size == options->front_cache_size &&
+          self->options->reliable == options->reliable &&
+          self->options->flow_control_window_bytes == options->flow_control_window_bytes);
+}
+
 QDisk *
 qdisk_new(DiskQueueOptions *options, const gchar *file_id, const gchar *filename)
 {

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1805,6 +1805,12 @@ qdisk_free(QDisk *self)
   g_free(self);
 }
 
+void
+qdisk_set_options(QDisk *self, DiskQueueOptions *options)
+{
+  self->options = options;
+}
+
 QDisk *
 qdisk_new(DiskQueueOptions *options, const gchar *file_id, const gchar *filename)
 {

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -98,6 +98,7 @@ void qdisk_reset_file_if_empty(QDisk *self);
 gboolean qdisk_started(QDisk *self);
 void qdisk_free(QDisk *self);
 void qdisk_set_options(QDisk *self, DiskQueueOptions *options);
+gboolean qdisk_is_compatible(QDisk *self, DiskQueueOptions *options);
 
 DiskQueueOptions *qdisk_get_options(QDisk *self);
 gint64 qdisk_get_length(QDisk *self);

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -97,6 +97,7 @@ gboolean qdisk_stop(QDisk *self, QDiskMemQSaveFunc func, gpointer user_data);
 void qdisk_reset_file_if_empty(QDisk *self);
 gboolean qdisk_started(QDisk *self);
 void qdisk_free(QDisk *self);
+void qdisk_set_options(QDisk *self, DiskQueueOptions *options);
 
 DiskQueueOptions *qdisk_get_options(QDisk *self);
 gint64 qdisk_get_length(QDisk *self);

--- a/news/bugfix-1030.md
+++ b/news/bugfix-1030.md
@@ -1,0 +1,4 @@
+`disk-buffer`: keep the queue alive during reload
+
+Keeping the disk-buffer alive on reload fixes a bug, where a full disk-buffer can
+grow infinitely by reloading. It can also cause significant reload speedup.

--- a/tests/light/functional_tests/destination_drivers/network_destination/disk_buffer/helper_functions.py
+++ b/tests/light/functional_tests/destination_drivers/network_destination/disk_buffer/helper_functions.py
@@ -161,7 +161,8 @@ def check_disk_buffer_state_save_attempts(syslog_ng, expected_save_attempts):
 def trigger_to_create_abandoned_disk_buffer(network_destination, config, port_allocator, syslog_ng):
     network_destination.options["port"] = port_allocator()
     network_destination.options["disk_buffer"]["front-cache-size"] = 2000
-    syslog_ng.reload(config)
+    syslog_ng.stop()
+    syslog_ng.start(config)
     return network_destination
 
 
@@ -227,7 +228,7 @@ def set_expected_metrics_state_when_sending_more_logs_than_buffer_can_handle_wit
     )
     TCParams = namedtuple(
         "TCParams", [
-            "last_msg_id", "is_suspended_source", "before_reload", "after_reload", "after_dst_alive",
+            "last_msg_id", "is_suspended_source", "before_reload", "after_dst_alive",
         ],
     )
     return TCParams(
@@ -242,17 +243,6 @@ def set_expected_metrics_state_when_sending_more_logs_than_buffer_can_handle_wit
             syslogng_disk_queue_disk_usage_bytes=1044480,
             syslogng_disk_queue_events=frontCache_size + qdisk_size + flow_control_window_size,
             syslogng_disk_queue_memory_usage_bytes=(frontCache_size + flow_control_window_size) * buffer_params.message_size_in_memory,
-            messages_in_disk_buffer=qdisk_size,
-        ),
-        after_reload=BufferState(
-            delivered_syslogng_output_events_total=0,
-            queued_syslogng_output_events_total=frontCache_size + qdisk_size + flow_control_window_size + flow_control_window_size,
-            dropped_syslogng_output_events_total=0,
-            syslogng_disk_queue_processed_events_total=frontCache_size + qdisk_size + flow_control_window_size + flow_control_window_size,
-            syslogng_disk_queue_disk_allocated_bytes=1048576,
-            syslogng_disk_queue_disk_usage_bytes=1044480,
-            syslogng_disk_queue_events=frontCache_size + qdisk_size + flow_control_window_size + flow_control_window_size,
-            syslogng_disk_queue_memory_usage_bytes=(frontCache_size + 2 * flow_control_window_size) * buffer_params.message_size_in_memory,
             messages_in_disk_buffer=qdisk_size,
         ),
         after_dst_alive=BufferState(

--- a/tests/light/functional_tests/destination_drivers/network_destination/disk_buffer/test_non_reliable_disk_buffer.py
+++ b/tests/light/functional_tests/destination_drivers/network_destination/disk_buffer/test_non_reliable_disk_buffer.py
@@ -339,8 +339,7 @@ def test_fill_up_buffers_for_non_reliable_disk_buffer_with_flow_control_then_aft
     syslog_ng.stop()
 
 
-def test_overwrite_buffers_with_reload_for_non_reliable_disk_buffer_with_flow_control_then_send_out_all_logs(config, port_allocator, syslog_ng, loggen, dqtool):
-    # reload will cause the overwrite of the existing buffers, with reading extra logs into flow control window
+def test_keep_buffers_with_reload_for_non_reliable_disk_buffer_with_flow_control_then_send_out_all_logs(config, port_allocator, syslog_ng, loggen, dqtool):
     config, network_source, network_destination = set_config_with_default_non_reliable_disk_buffer_values(config, port_allocator)
 
     extra_msg_number = 1000  # will be forwarded too
@@ -351,8 +350,8 @@ def test_overwrite_buffers_with_reload_for_non_reliable_disk_buffer_with_flow_co
     fill_up_and_check_initial_disk_buffer_metrics(config, loggen, dqtool, network_source, loggen_msg_counter_to_overflow_buffer, params.before_reload)
 
     syslog_ng.reload(config)
-    # axosyslog will read an extra buffer_params.count_flow_control_window messages into the flow control window
-    check_disk_buffer_metrics_after_reload(config, dqtool, params.after_reload)
+    # axosyslog will not read an extra buffer_params.count_flow_control_window messages into the flow control window
+    check_disk_buffer_metrics_after_reload(config, dqtool, params.before_reload)
 
     network_destination.start_listener()
     assert network_destination.read_until_logs([f"seq: {params.last_msg_id}"])
@@ -361,8 +360,8 @@ def test_overwrite_buffers_with_reload_for_non_reliable_disk_buffer_with_flow_co
     syslog_ng.stop()
     validate_disk_buffer(dqtool, 0, disk_buffer_file="./syslog-ng-00000.qf")
     check_if_source_suspended(syslog_ng, params.is_suspended_source)
-    check_disk_buffer_state_load_attempts(syslog_ng, expected_load_attempts=2)
-    check_disk_buffer_state_save_attempts(syslog_ng, expected_save_attempts=2)
+    check_disk_buffer_state_load_attempts(syslog_ng, expected_load_attempts=1)
+    check_disk_buffer_state_save_attempts(syslog_ng, expected_save_attempts=1)
 
 
 def test_fill_up_buffers_for_non_reliable_disk_buffer_without_flow_control_then_send_out_all_logs(config, port_allocator, syslog_ng, loggen, dqtool):


### PR DESCRIPTION
If the queue is present in the persist only drop it if it's a different type of queue, or it is not compatible with the new buffer. Otherwise use it.