### PR TITLE
Light mark timing related tests

### DIFF
--- a/tests/light/CMakeLists.txt
+++ b/tests/light/CMakeLists.txt
@@ -11,7 +11,8 @@ add_custom_target(light-self-check
 
 add_custom_target(light-check
    COMMAND ${LIGHT_POETRY_CMD} install
-   COMMAND ${LIGHT_PYTEST_CMD} ${LIGHT_SOURCE_DIR}/functional_tests -n auto --installdir=${CMAKE_INSTALL_PREFIX} $$EXTRA_ARGS)
+   COMMAND ${LIGHT_PYTEST_CMD} ${LIGHT_SOURCE_DIR}/functional_tests -m "not timing" -n auto --installdir=${CMAKE_INSTALL_PREFIX} $$EXTRA_ARGS
+   COMMAND ${LIGHT_PYTEST_CMD} ${LIGHT_SOURCE_DIR}/functional_tests -m "timing" -n0 --installdir=${CMAKE_INSTALL_PREFIX} $$EXTRA_ARGS)
 
 add_custom_target(light-linters
    COMMAND ${LIGHT_POETRY_CMD} install

--- a/tests/light/Makefile.am
+++ b/tests/light/Makefile.am
@@ -12,10 +12,11 @@ include tests/light/src/axosyslog_light/Makefile.am
 
 
 if HAVE_POETRY
+TS := $(shell date +"%Y-%m-%d-%H-%M-%S-%6N")
 
 PYTEST_SUBDIR ?=
 PYTEST_VERBOSE ?= false
-PYTEST_OPTS ?=
+PYTEST_OPTS ?= --reports reports/$(TS)/
 PYTEST_WORKERS ?= -n auto
 
 LIGHT_SRC_DIR=$(abs_top_srcdir)/tests/light
@@ -30,7 +31,10 @@ light-self-check pytest-self-check: light-venv
 	@$(LIGHT_PYTEST_CMD) $(LIGHT_SRC_DIR)/src/axosyslog_light
 
 light-check pytest-check: light-venv
-	LSAN_OPTIONS="suppressions=$(abs_top_srcdir)/tests/axosyslog-lsan.supp" $(LIGHT_PYTEST_CMD) -o log_cli=$(PYTEST_VERBOSE) $(LIGHT_SRC_DIR)/functional_tests/$(PYTEST_SUBDIR) $(PYTEST_WORKERS) $(PYTEST_OPTS) --installdir=${prefix} --show-capture=no
+	exit_code=0; \
+	LSAN_OPTIONS="suppressions=$(abs_top_srcdir)/tests/axosyslog-lsan.supp" $(LIGHT_PYTEST_CMD) -o log_cli=$(PYTEST_VERBOSE) $(LIGHT_SRC_DIR)/functional_tests/$(PYTEST_SUBDIR) $(PYTEST_WORKERS) $(PYTEST_OPTS) -m "not timing" --installdir=${prefix} --show-capture=no || exit_code=1; \
+	LSAN_OPTIONS="suppressions=$(abs_top_srcdir)/tests/axosyslog-lsan.supp" $(LIGHT_PYTEST_CMD) -o log_cli=$(PYTEST_VERBOSE) $(LIGHT_SRC_DIR)/functional_tests/$(PYTEST_SUBDIR) $(PYTEST_OPTS) -m timing -n0 --installdir=${prefix} --show-capture=no || exit_code=1; \
+	exit $$exit_code
 
 light-valgrind-check pytest-valgrind-check: light-venv
 	$(LIGHT_PYTEST_CMD) -o log_cli=$(PYTEST_VERBOSE) $(LIGHT_SRC_DIR)/functional_tests/$(PYTEST_SUBDIR) $(PYTEST_OPTS) --installdir=${prefix} --show-capture=no --run-under=valgrind

--- a/tests/light/functional_tests/filters/rate-limit/test_rate_limit_filter_acceptance.py
+++ b/tests/light/functional_tests/filters/rate-limit/test_rate_limit_filter_acceptance.py
@@ -37,6 +37,7 @@ def generate_messages_with_different_program_fields(bsd_formatter, number_of_all
     return input_messages
 
 
+@pytest.mark.timing
 @pytest.mark.parametrize(
     "message_counter, message_rate_by_sec, different_program_fields, rate_limit_rate_by_sec, expected_number_of_matched_messages, expected_number_of_not_matched_messages", [
         # All incoming messages=100, which arrives in one sec where every PROGRAM field is the same. From same PROGRAM fields we accept 100 in one sec. At the end we will have 100 matched and 0 not matched messages.

--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "axosyslog-light"
-version = "1.15.0"
+version = "1.16.0"
 description = "Lightweight End-to-End Test Framework for AxoSyslog."
 authors = ["Andras Mitzki <andras.mitzki@axoflow.com>", "Attila Szakacs <attila.szakacs@axoflow.com>"]
 readme = "README.md"

--- a/tests/light/pytest.ini
+++ b/tests/light/pytest.ini
@@ -5,3 +5,5 @@ log_cli_format= %(asctime)s:%(msecs)d - %(filename)s:%(lineno)d->%(funcName)s - 
 log_file_format= %(asctime)s:%(msecs)d - %(filename)s:%(lineno)d->%(funcName)s - %(levelname)s - %(message)s
 markers =
     snmp: mark test cases which are related to snmp
+    timing: mark test cases where the timing factor is important. These test cases can fail on slower machines.
+    They should be run separately with -m "timing" option with `-n0` parameter.

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -106,6 +106,9 @@ def pytest_addoption(parser):
     )
 
 
+_test_results = []
+
+
 def get_current_date():
     return datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
 
@@ -123,6 +126,14 @@ def pytest_collection_modifyitems(config, items):
 def pytest_runtest_logreport(report):
     if report.outcome == "failed":
         logger.error("\n{}".format(report.longrepr))
+    if report.when == "call":
+        _test_results.append(
+            {
+                "nodeid": report.nodeid,
+                "outcome": report.outcome,
+                "longrepr": str(report.longrepr) if report.longrepr else None,
+            },
+        )
 
 
 # Pytest Fixtures
@@ -300,7 +311,27 @@ def pytest_sessionstart(session):
         session_data["base_number_of_open_fds"] = base_number_of_open_fds
 
 
+def _write_testsuite_summary(session):
+    if xdist.is_xdist_worker(session):
+        return
+    try:
+        reports_dir = Path(session.config.getoption("--reports")).resolve().absolute()
+    except TypeError:
+        reports_dir = Path("reports", get_current_date()).resolve().absolute()
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = Path(reports_dir, "testsuite_summary.reportlog")
+    with summary_path.open("a") as f:
+        for result in _test_results:
+            status = result["outcome"].upper()
+            f.write(f"{status}: {result['nodeid']}\n")
+            if result["longrepr"]:
+                f.write(f"{result['longrepr']}\n")
+                f.write("\n")
+
+
 def pytest_sessionfinish(session, exitstatus):
+    _write_testsuite_summary(session)
+
     if xdist.is_xdist_controller(session):
         return
 


### PR DESCRIPTION
This PR contains 2 separate Light improvements:

1, separate timing related testcases from main testsuite run, with disabled numprocesses start arg (-n0)
  - currently functional_tests/filters/rate-limit/test_rate_limit_filter_acceptance.py can fail due to rare timing issues


2, adds new reports/[datetime]/testsuite_summary.reportlog for collecting all testcase outcomes 
  - this can help to quickly find the failed (with assertion logs) / passed testcases
