### PR TITLE
helm: make syslog Service type configurable

### DIFF
--- a/charts/axosyslog/README.md
+++ b/charts/axosyslog/README.md
@@ -41,6 +41,8 @@ The following table lists the configurable parameters of the AxoSyslog Collector
 |  openShift.securityContextConstraints.annotations  | Annotations to apply to SecurityContextConstraints |  {}  |
 |  serviceAccount.create  | Whether to create a service account |  false  |
 |  serviceAccount.annotations  | Annotations to apply to the service account |  {}  |
+|  service.type | Type of the service to create | NodePort |
+|  service.loadBalancerIP | IP to use if service.type is LoadBalancer | "" |
 |  namespace  | The Kubernetes namespace to deploy to |  ""  |
 |  podAnnotations  | Additional annotations to apply to the pod |  {}  |
 |  podSecurityContext  | Security context for the pod |  {}  |

--- a/charts/axosyslog/templates/service.yaml
+++ b/charts/axosyslog/templates/service.yaml
@@ -6,7 +6,10 @@ metadata:
 spec:
   selector:
     app: {{ template "axosyslog.fullname" . }}-syslog
-  type: NodePort
+  type: {{ .Values.service.type | default "NodePort" }}
+  {{- with .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
   ports:
 {{ if .Values.service.extraPorts }}
 {{ toYaml ( .Values.service.extraPorts ) | nindent 4 }}
@@ -16,29 +19,39 @@ spec:
 {{- if .syslog.enabled }}
     - name: rfc3164-udp
       protocol: UDP
-      nodePort: {{ .syslog.rfc3164UdpPort | default 30514 }}
+      {{- if .syslog.rfc3164UdpPort }}
+      nodePort: {{ .syslog.rfc3164UdpPort }}
+      {{- end }}
       port: 514
       targetPort: rfc3164-udp
     - name: rfc3164-tcp
       protocol: TCP
-      nodePort: {{ .syslog.rfc3164TcpPort | default 30514 }}
+      {{- if .syslog.rfc3164TcpPort }}
+      nodePort: {{ .syslog.rfc3164TcpPort }}
+      {{- end }}
       port: 514
       targetPort: rfc3164-tcp
     - name: rfc5424-tls
       protocol: TCP
-      nodePort: {{ .syslog.rfc5424TlsPort | default 30614 }}
+      {{- if .syslog.rfc5424TlsPort }}
+      nodePort: {{ .syslog.rfc5424TlsPort }}
+      {{- end }}
       port: 6514
       targetPort: rfc5424-tls
     - name: rfc5424-tcp
       protocol: TCP
-      nodePort: {{ .syslog.rfc5424TcpPort | default 30601 }}
+      {{- if .syslog.rfc5424TcpPort }}
+      nodePort: {{ .syslog.rfc5424TcpPort }}
+      {{- end }}
       port: 601
       targetPort: rfc5424-tcp
 {{- end }}
 {{- if .axosyslogOtlp.enabled }}
     - name: otlp
       protocol: TCP
-      nodePort: {{ .axosyslogOtlp.port | default 30317 }}
+      {{- if .axosyslogOtlp.port }}
+      nodePort: {{ .axosyslogOtlp.port }}
+      {{- end }}
       port: 4317
       targetPort: otlp
 {{- end }}

--- a/charts/axosyslog/values.yaml
+++ b/charts/axosyslog/values.yaml
@@ -169,6 +169,8 @@ openShift:
 
 service:
   create: true
+  type: NodePort  # NodePort, LoadBalancer, or ClusterIP
+  # loadBalancerIP: ""  # set when type is LoadBalancer
   extraPorts: []
   #  - protocol: TCP
   #    port: 514


### PR DESCRIPTION
The Service type was hardcoded to NodePort, making it impossible to use LoadBalancer or ClusterIP without post-render patching.

- Add service.type value (default: NodePort for backwards compatibility)
- Add service.loadBalancerIP value for LoadBalancer deployments
- Only emit nodePort fields when explicitly set in values, avoiding conflicts when service type is LoadBalancer or ClusterIP

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
