### PR TITLE
filterx/func-glob: add glob_match()

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -71,6 +71,7 @@ set(FILTERX_HEADERS
     filterx/func-uuid.h
     filterx/func-digest.h
     filterx/func-encode.h
+    filterx/func-glob.h
     filterx/object-datetime.h
     filterx/object-dict.h
     filterx/object-extractor.h
@@ -155,6 +156,7 @@ set(FILTERX_SOURCES
     filterx/func-uuid.c
     filterx/func-digest.c
     filterx/func-encode.c
+    filterx/func-glob.c
     filterx/object-datetime.c
     filterx/object-dict.c
     filterx/object-list.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -74,6 +74,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/func-uuid.h \
 	lib/filterx/func-digest.h \
 	lib/filterx/func-encode.h \
+	lib/filterx/func-glob.h \
 	lib/filterx/object-datetime.h \
 	lib/filterx/object-dict.h \
 	lib/filterx/object-list.h \
@@ -158,6 +159,7 @@ filterx_sources = 				\
 	lib/filterx/func-uuid.c \
 	lib/filterx/func-digest.c \
 	lib/filterx/func-encode.c \
+	lib/filterx/func-glob.c \
 	lib/filterx/object-datetime.c \
 	lib/filterx/object-dict.c \
 	lib/filterx/object-list.c \

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -51,6 +51,7 @@
 #include "filterx/func-uuid.h"
 #include "filterx/func-digest.h"
 #include "filterx/func-encode.h"
+#include "filterx/func-glob.h"
 #include "filterx/expr-regexp-search.h"
 #include "filterx/expr-regexp-subst.h"
 #include "filterx/expr-regexp.h"
@@ -132,6 +133,7 @@ _simple_init(void)
                                                     filterx_simple_function_has_sdata));
   g_assert(filterx_builtin_simple_function_register("get_sdata",
                                                     filterx_simple_function_get_sdata));
+  g_assert(filterx_builtin_simple_function_register("glob_match", filterx_simple_function_glob_match));
 }
 
 static void

--- a/lib/filterx/func-glob.c
+++ b/lib/filterx/func-glob.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/func-glob.h"
+#include "filterx/object-primitive.h"
+#include "filterx/object-extractor.h"
+#include "filterx/filterx-sequence.h"
+#include "filterx/filterx-eval.h"
+#include "str-utils.h"
+#include <fnmatch.h>
+
+#define FILTERX_FUNC_GLOB_MATCH_USAGE "Usage: glob_match(string, patterns)"
+
+static FilterXObject *
+_match_pattern(FilterXExpr *s, const gchar *filename, FilterXObject *pattern_obj)
+{
+  const gchar *pattern;
+  if (!filterx_object_extract_string_as_cstr(pattern_obj, &pattern))
+    {
+      filterx_simple_function_argument_error(s, "Patterns must be strings. " FILTERX_FUNC_GLOB_MATCH_USAGE);
+      return NULL;
+    }
+
+  gboolean matched = (fnmatch(pattern, filename, FNM_PATHNAME | FNM_PERIOD) == 0);
+  return filterx_boolean_new(matched);
+}
+
+FilterXObject *
+filterx_simple_function_glob_match(FilterXExpr *s, FilterXObject *args[], gsize args_len)
+{
+  if (args_len != 2)
+    {
+      filterx_simple_function_argument_error(s, "Requires exactly two arguments. " FILTERX_FUNC_GLOB_MATCH_USAGE);
+      return NULL;
+    }
+
+  const gchar *filename;
+  if (!filterx_object_extract_string_as_cstr(args[0], &filename))
+    {
+      filterx_simple_function_argument_error(s, "First argument must be a string. " FILTERX_FUNC_GLOB_MATCH_USAGE);
+      return NULL;
+    }
+
+  FilterXObject *patterns = args[1];
+  if (!filterx_object_is_type_or_ref(patterns, &FILTERX_TYPE_NAME(sequence)))
+    {
+      /* not a sequence, handle it as a pattern */
+      return _match_pattern(s, filename, patterns);
+    }
+
+  guint64 len = 0;
+  filterx_object_len(patterns, &len);
+  for (guint64 i = 0; i < len; i++)
+    {
+      FilterXObject *pattern = filterx_sequence_get_subscript(patterns, (gint64) i);
+      if (!pattern)
+        {
+          filterx_simple_function_argument_error(s, "Failed to get pattern from list. " FILTERX_FUNC_GLOB_MATCH_USAGE);
+          return NULL;
+        }
+
+      FilterXObject *result = _match_pattern(s, filename, pattern);
+      filterx_object_unref(pattern);
+
+      if (!result || filterx_object_truthy(result))
+        return result;
+    }
+
+  return filterx_boolean_new(FALSE);
+}

--- a/lib/filterx/func-glob.h
+++ b/lib/filterx/func-glob.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_FUNC_GLOB_H_INCLUDED
+#define FILTERX_FUNC_GLOB_H_INCLUDED
+
+#include "filterx/expr-function.h"
+
+FilterXObject *filterx_simple_function_glob_match(FilterXExpr *s, FilterXObject *args[], gsize args_len);
+
+#endif

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -35,3 +35,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_func_uuid DEPENDS json-plugin ${JSON
 add_unit_test(LIBTEST CRITERION TARGET test_func_digest DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_func_encode DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_func_str_utf8 DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_func_glob DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -38,7 +38,8 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_func_uuid \
 		lib/filterx/tests/test_func_digest \
 		lib/filterx/tests/test_func_encode \
-		lib/filterx/tests/test_func_str_utf8
+		lib/filterx/tests/test_func_str_utf8 \
+		lib/filterx/tests/test_func_glob
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt
 
@@ -157,3 +158,6 @@ lib_filterx_tests_test_func_encode_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_func_str_utf8_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_func_str_utf8_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_func_glob_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_func_glob_LDADD   = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/test_func_glob.c
+++ b/lib/filterx/tests/test_func_glob.c
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/filterx-lib.h"
+
+#include "filterx/func-glob.h"
+#include "filterx/object-string.h"
+#include "filterx/object-primitive.h"
+#include "filterx/object-list.h"
+#include "filterx/expr-function.h"
+#include "filterx/expr-literal.h"
+#include "filterx/filterx-sequence.h"
+#include "filterx/filterx-private.h"
+
+#include "apphook.h"
+#include "scratch-buffers.h"
+
+static FilterXExpr *
+_create_glob_match_expr(const gchar *filename, const gchar *patterns[], gsize num_patterns)
+{
+  FilterXObject *list = filterx_list_new();
+  for (gsize i = 0; i < num_patterns; i++)
+    {
+      FilterXObject *pattern = filterx_string_new(patterns[i], -1);
+      filterx_sequence_append(list, &pattern);
+      filterx_object_unref(pattern);
+    }
+
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(filename, -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(list)));
+
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_simple_function_new("glob_match", filterx_function_args_new(args, NULL),
+                                                filterx_simple_function_glob_match, &error);
+  cr_assert_null(error);
+  return fn;
+}
+
+static gboolean
+_eval_glob_match(const gchar *filename, const gchar *patterns[], gsize num_patterns)
+{
+  FilterXExpr *fn = _create_glob_match_expr(filename, patterns, num_patterns);
+  FilterXObject *res = init_and_eval_expr(fn);
+
+  cr_assert_not_null(res);
+
+  gboolean result;
+  cr_assert(filterx_boolean_unwrap(res, &result));
+
+  filterx_object_unref(res);
+  filterx_expr_unref(fn);
+  return result;
+}
+
+Test(filterx_func_glob_match, single_pattern_matches)
+{
+  const gchar *patterns[] = { "*.log" };
+  cr_assert(_eval_glob_match("filename.log", patterns, G_N_ELEMENTS(patterns)));
+}
+
+Test(filterx_func_glob_match, single_pattern_does_not_match)
+{
+  const gchar *patterns[] = { "*.log" };
+  cr_assert_not(_eval_glob_match("filename.txt", patterns, G_N_ELEMENTS(patterns)));
+}
+
+Test(filterx_func_glob_match, question_mark_wildcard)
+{
+  const gchar *patterns[] = { "file.???" };
+  cr_assert(_eval_glob_match("file.txt", patterns, G_N_ELEMENTS(patterns)));
+  cr_assert_not(_eval_glob_match("file.py", patterns, G_N_ELEMENTS(patterns)));
+}
+
+Test(filterx_func_glob_match, path_pattern)
+{
+  const gchar *patterns[] = { "/var/log/*" };
+  cr_assert(_eval_glob_match("/var/log/syslog", patterns, G_N_ELEMENTS(patterns)));
+  cr_assert_not(_eval_glob_match("/var/run/syslog", patterns, G_N_ELEMENTS(patterns)));
+}
+
+Test(filterx_func_glob_match, multiple_patterns_first_matches)
+{
+  const gchar *patterns[] = { "*.log", "*.txt" };
+  cr_assert(_eval_glob_match("filename.log", patterns, G_N_ELEMENTS(patterns)));
+}
+
+Test(filterx_func_glob_match, multiple_patterns_second_matches)
+{
+  const gchar *patterns[] = { "*.log", "*.txt" };
+  cr_assert(_eval_glob_match("filename.txt", patterns, G_N_ELEMENTS(patterns)));
+}
+
+Test(filterx_func_glob_match, multiple_patterns_none_match)
+{
+  const gchar *patterns[] = { "*.log", "*.txt" };
+  cr_assert_not(_eval_glob_match("filename.cfg", patterns, G_N_ELEMENTS(patterns)));
+}
+
+Test(filterx_func_glob_match, empty_pattern_list_never_matches)
+{
+  cr_assert_not(_eval_glob_match("filename.log", NULL, 0));
+}
+
+Test(filterx_func_glob_match, rejects_no_arguments)
+{
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_simple_function_new("glob_match", filterx_function_args_new(NULL, NULL),
+                                                filterx_simple_function_glob_match, &error);
+  cr_assert_null(error);
+
+  FilterXObject *res = init_and_eval_expr(fn);
+  cr_assert_null(res);
+
+  filterx_expr_unref(fn);
+}
+
+Test(filterx_func_glob_match, rejects_filename_only)
+{
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_string_new("filename.log", -1))));
+
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_simple_function_new("glob_match", filterx_function_args_new(args, NULL),
+                                                filterx_simple_function_glob_match, &error);
+  cr_assert_null(error);
+
+  FilterXObject *res = init_and_eval_expr(fn);
+  cr_assert_null(res);
+
+  filterx_expr_unref(fn);
+}
+
+Test(filterx_func_glob_match, rejects_non_string_filename)
+{
+  FilterXObject *list = filterx_list_new();
+  FilterXObject *pattern = filterx_string_new("*.log", -1);
+  filterx_sequence_append(list, &pattern);
+  filterx_object_unref(pattern);
+
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_integer_new(42))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(list)));
+
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_simple_function_new("glob_match", filterx_function_args_new(args, NULL),
+                                                filterx_simple_function_glob_match, &error);
+  cr_assert_null(error);
+
+  FilterXObject *res = init_and_eval_expr(fn);
+  cr_assert_null(res);
+
+  filterx_expr_unref(fn);
+}
+
+Test(filterx_func_glob_match, rejects_non_string_pattern)
+{
+  FilterXObject *list = filterx_list_new();
+  FilterXObject *pattern = filterx_integer_new(42);
+  filterx_sequence_append(list, &pattern);
+  filterx_object_unref(pattern);
+
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_string_new("filename.log", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(list)));
+
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_simple_function_new("glob_match", filterx_function_args_new(args, NULL),
+                                                filterx_simple_function_glob_match, &error);
+  cr_assert_null(error);
+
+  FilterXObject *res = init_and_eval_expr(fn);
+  cr_assert_null(res);
+
+  filterx_expr_unref(fn);
+}
+
+Test(filterx_func_glob_match, rejects_non_list_or_string_patterns_arg)
+{
+  GList *args = NULL;
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_string_new("filename.log", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_integer_new(42))));
+
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_simple_function_new("glob_match", filterx_function_args_new(args, NULL),
+                                                filterx_simple_function_glob_match, &error);
+  cr_assert_null(error);
+
+  FilterXObject *res = init_and_eval_expr(fn);
+  cr_assert_null(res);
+
+  filterx_expr_unref(fn);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  init_libtest_filterx();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  deinit_libtest_filterx();
+  app_shutdown();
+}
+
+TestSuite(filterx_func_glob_match, .init = setup, .fini = teardown);

--- a/news/feature-1039.md
+++ b/news/feature-1039.md
@@ -1,0 +1,7 @@
+Filterx `glob_match()` function: this function will match a filename against
+a single-, or a list of glob-style patterns.
+
+Example:
+
+    glob_match(filename, "*.zip");
+    glob_match(filename, ["*.zip", "*.7z"]);

--- a/tests/light/functional_tests/filterx/test_filterx_funcs.py
+++ b/tests/light/functional_tests/filterx/test_filterx_funcs.py
@@ -1301,3 +1301,64 @@ def test_hex(config, syslog_ng):
             "roundtrip": base64.b64encode(b"szilvafa").decode(),
         }, separators=(",", ":"),
     )
+
+
+def test_glob_match_returns_true_on_match(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    result = json();
+    result.wildcard_ext = glob_match("filename.log", ["*.log"]);
+    result.wildcard_path = glob_match("/var/log/syslog", ["/var/log/*"]);
+    result.question_mark = glob_match("file.txt", ["file.???"]);
+    $MSG = result;
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == '{"wildcard_ext":true,"wildcard_path":true,"question_mark":true}'
+
+
+def test_glob_match_works_with_a_string_pattern(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    result = json();
+    result.match = glob_match("filename.log", "*.log");
+    result.nomatch = glob_match("filename.log", "*.txt");
+    $MSG = result;
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == '{"match":true,"nomatch":false}'
+
+
+def test_glob_match_returns_false_when_no_pattern_matches(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    result = json();
+    result.no_match = glob_match("filename.txt", ["*.log"]);
+    $MSG = result;
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == '{"no_match":false}'
+
+
+def test_glob_match_multiple_patterns(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    result = json();
+    result.first_matches = glob_match("filename.log", ["*.log", "*.txt"]);
+    result.second_matches = glob_match("filename.txt", ["*.log", "*.txt"]);
+    result.none_matches = glob_match("filename.cfg", ["*.log", "*.txt"]);
+    $MSG = result;
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    assert file_final.read_log() == '{"first_matches":true,"second_matches":true,"none_matches":false}'


### PR DESCRIPTION
This PR implements the glob_match() function, which I needed on a filterx use-case.

Usage:

```
glob_match($filename, ["*.zip.exe", "*.pdf.exe"])
```

the fist parameter is a string and must be a filename, the second one is either a list of patterns or a single pattern (as a string).
