### PR TITLE
Fix/filterx inplace add floating

### DIFF
--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -688,7 +688,7 @@ filterx_object_cow_prepare(FilterXObject **pself)
 
 
 /* Perform a lazy copy (e.g.  copy-on-write) of @self and return the new
- * copy. This function does nothing for inmutable data types.
+ * copy. This function does nothing for immutable data types.
  *
  * For copy-on-write to work, all references to @self need to be done
  * through refs, but our @self argument may still point to a bare, but

--- a/lib/filterx/filterx-ref.c
+++ b/lib/filterx/filterx-ref.c
@@ -519,7 +519,13 @@ _filterx_ref_len(FilterXObject *s, guint64 *len)
 static FilterXObject *
 _filterx_ref_add_method(FilterXObject *s, FilterXObject *object)
 {
-  FilterXObject *cloned = filterx_ref_float_unchecked(_filterx_ref_clone(s));
+  /* filterx_object_copy() handles both non-floating and floating inputs:
+   * for non-floating it clones,
+   * for floating it grounds s in place (clearing parent_container) and returns it.
+   * Either way we then float the result: it is a fresh
+   * temporary with no parent_container, so the CoW inside add_inplace does
+   * not propagate up into a shared source hierarchy. */
+  FilterXObject *cloned = filterx_ref_float_unchecked(filterx_object_copy(s));
   FilterXObject *value = filterx_ref_add_inplace(cloned, object);
   if (!value)
     {

--- a/lib/filterx/filterx-ref.c
+++ b/lib/filterx/filterx-ref.c
@@ -127,7 +127,7 @@
  *      newly created object.
  *
  *   2) filterx_object_cow_fork() and fork2() are to be used when the filterx
- *      language is using a copying construct (e.g.  assigmnent, setattr or
+ *      language is using a copying construct (e.g.  assignment, setattr or
  *      set_subscript).  These functions return both "copies" of the object:
  *      old and new.  They also handle filterx_object_cow_prepare() if an
  *      object is not yet wrapped.

--- a/tests/light/functional_tests/filterx/test_filterx_cow.py
+++ b/tests/light/functional_tests/filterx/test_filterx_cow.py
@@ -573,3 +573,20 @@ def test_list_mutable_elements_appended_from_another_list_cause_clone_when_whang
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
     assert file_true.read_log() == """[1,2,3,4,5,6,{"foo":"foovalue","bar":"barvalue"}]--[4,5,6,{"bar":"barvalue"}]"""
+
+
+def test_plus_on_child_of_shared_hierarchy(config, syslog_ng):
+    (file_true, file_false, _) = create_config(
+        config, [
+            """
+                d = {'child':['foo','bar']};
+                result = d.child + ['foobar'];
+                $MSG = string(result) + '--' + string(d);
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == """["foo","bar","foobar"]--{"child":["foo","bar"]}"""


### PR DESCRIPTION
https://github.com/axoflow/axosyslog/pull/863 have introduced a regression, this PR aims to fix it.

I added a test case that triggers the assertion, will push the fix later once the CI has finished running.
Crash triggered: https://github.com/axoflow/axosyslog/actions/runs/24563624521/job/71818144770?pr=1040#step:13:2884

```
 filterx{
    d1 = {'child':['foo','bar']};
    $MSG = d1.child + ['foobar']; # floating ref to other dict's child node
  };
```

main:
```
[2026-04-17T14:06:06.042441] FILTERX ESTEP; expr='crasher.conf:8:5|     d1 = {\'child\':[\'foo\',\'bar\']}', value='{"child":["foo","bar"]}', truthy='1', type='ref/dict'
**
ERROR:../lib/filterx/filterx-ref.c:275:_filterx_ref_clone: assertion failed: (s->floating_ref == FALSE)
Bail out! ERROR:../lib/filterx/filterx-ref.c:275:_filterx_ref_clone: assertion failed: (s->floating_ref == FALSE)
```

After this PR:
```
[2026-04-17T14:10:22.673578] FILTERX ESTEP; expr='crasher.conf:8:5|     d1 = {\'child\':[\'foo\',\'bar\']}', value='{"child":["foo","bar"]}', truthy='1', type='ref/dict'
[2026-04-17T14:10:22.673578] FILTERX ESTEP; expr='crasher.conf:9:5|     $MSG = d1.child + [\'foobar\']', value='["foo","bar","foobar"]', truthy='1', type='ref/list'
[2026-04-17T14:10:22.673578] <<<<<< filterx rule evaluation result; result='matched', rule='#anon-filter0', location='crasher.conf:6:10', dirty='1', msg='0x6480df0fa1a0', rcptid='29'
[2026-04-17T14:10:22.673578] Filterx sync: changed variable in scope, overwriting in message; variable='MESSAGE'
[2026-04-17T14:10:22.673578] Setting value; name='MESSAGE', value='foo,bar,foobar', type='list', msg='0x6480df0fa1a0', rcptid='29'
[2026-04-17T14:10:22.673578] Initializing destination file writer; template='/dev/stdout', filename='/dev/stdout', symlink_as='(null)'
[2026-04-17T14:10:22.673578] affile_open_file; path='/dev/stdout', fd='13'
[2026-04-17T14:10:22.673578] Window size adjustment; old_window_size='99', window_size_increment='1', suspended_before_increment='FALSE', last_ack_type_is_suspended='FALSE'
[2026-04-17T14:10:22.673578] Emptying FilterX allocator; areas='1', area='0', used='176'
[2026-04-17T14:10:22.673578] <<<<<< Source side message processing finish; location='crasher.conf:4:10', msg='0x6480df0fa1a0', rcptid='29'
[2026-04-17T14:10:22.713289] Outgoing message; message='Apr 17 14:10:22 orion-T14G3 foo,bar,foobar\x0a'
Apr 17 14:10:22 orion-T14G3 foo,bar,foobar
```

