### PR TITLE
modules/xml: fix double unref

### DIFF
--- a/modules/xml/filterx-parse-xml.c
+++ b/modules/xml/filterx-parse-xml.c
@@ -578,7 +578,6 @@ _extract_raw_xml(FilterXFunctionParseXml *self, FilterXObject *xml_obj, gsize *l
       filterx_eval_push_error_info_printf("Failed to evaluate parse_xml()", &self->super.super,
                                           "Input must be a string, got: %s",
                                           filterx_object_get_type_name(xml_obj));
-      filterx_object_unref(xml_obj);
       return NULL;
     }
 

--- a/news/bugfix-1041.md
+++ b/news/bugfix-1041.md
@@ -1,0 +1,3 @@
+modules/xml: fix crash
+
+Fix parse_xml() filterx function's crash in case of invalid XML


### PR DESCRIPTION
The exit tag already calls filterx_object_unref() on the object, no need to do it in the helper method

- [x] NEWS file
