### PR TITLE
contributing: add section for AI-assisted contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,9 @@ For brief development guidelines and architecture overview, see
     2. [Feature requests](#feature-requests)
     3. [Testing](#testing)
 2. [Pull requests](#pull-requests)
-3. [Additional resources](#additional-resources)
+3. [AI-assisted contributions](#ai-assisted-contributions)
+4. [Licensing](#licensing)
+5. [Additional resources](#additional-resources)
 
 ## Issues
 
@@ -173,6 +175,22 @@ and will assign themselves. We try to add feedback as soon as possible.
 
 If you get stuck with a regression test, feel free to ask for help. Sometimes it is difficult to understand the test logs.
 
+## AI-assisted contributions
+
+When a contribution is made with significant assistance from an LLM (AI), or involves AI-generated code, it should be
+indicated in the commit message for tracking purposes.
+
+The contribution should include an `Assisted-by: NAME:MODEL` tag, for example:
+```
+Assisted-by: Claude:claude-opus-4-7
+```
+
+AI agents MUST NOT add Signed-off-by tags. The person submitting the pull request is responsible for
+
+- Reviewing all AI-generated code
+- Ensuring compliance with licensing requirements
+- Adding their own Signed-off-by tag to certify the [DCO](DCO.md)
+- Taking full responsibility for the contribution
 
 ## Licensing
 


### PR DESCRIPTION
A proposal for requiring attribution when submitting AI-assisted contributions.

Based on https://github.com/torvalds/linux/blob/2e68039281932e6dc37718a1ea7cbb8e2cda42e6/Documentation/process/coding-assistants.rst#ai-coding-assistants

----

Tracking such contributions can be useful for many reasons, my personal reason, for example, is about the review process.
It would be a very long monologue to share my experience with reviewing generated code, so I try to summarize everything as briefly as possible:

LLM-generated code always looks like it was written by someone with deep, years-long experience in AxoSyslog development, but the errors and bugs hidden inside are similar to those made by inexperienced contributors who are new to the project. This dissonance is hard to spot, so the suggested commit message attribution would help me to continue giving thorough reviews. TLDR: if I see such attribution, I know to take the slow path and spend some extra time on the review of the PR.