### PR TITLE
light: override no tests collected return code

### DIFF
--- a/tests/light/functional_tests/conftest.py
+++ b/tests/light/functional_tests/conftest.py
@@ -21,4 +21,11 @@
 #
 #############################################################################
 # flake8: noqa: F401, F403
+import pytest
 from axosyslog_light.fixtures import *
+
+
+def pytest_sessionfinish(session, exitstatus):
+    # Return with 0 return code in case no tests were collected
+    if ( exitstatus == pytest.ExitCode.NO_TESTS_COLLECTED):
+        session.exitstatus = 0


### PR DESCRIPTION
Since we have introduced timing sensitive tests we do a 2 round test run. The second test run might not run any tests and PyTest returns with 5 as a return code. This commit overrides this behaviour, enabling the following command to be chained for example: `make light-check EXTRA_ARGS="-k transport_error_metric"`

https://docs.pytest.org/en/stable/reference/exit-codes.html#exit-codes https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_sessionfinish

No NEWS file needed.
