### PR TITLE
Filterx: add tuple datatype

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -83,6 +83,7 @@ set(FILTERX_HEADERS
     filterx/object-dict.h
     filterx/object-extractor.h
     filterx/object-list.h
+    filterx/object-tuple.h
     filterx/object-message-value.h
     filterx/object-metrics-labels.h
     filterx/object-null.h
@@ -172,6 +173,7 @@ set(FILTERX_SOURCES
     filterx/object-ip.c
     filterx/object-dict.c
     filterx/object-list.c
+    filterx/object-tuple.c
     filterx/object-message-value.c
     filterx/object-metrics-labels.c
     filterx/object-null.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -84,6 +84,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/object-ip.h \
 	lib/filterx/object-dict.h \
 	lib/filterx/object-list.h \
+	lib/filterx/object-tuple.h \
 	lib/filterx/object-extractor.h \
 	lib/filterx/object-message-value.h \
 	lib/filterx/object-metrics-labels.h \
@@ -178,6 +179,7 @@ lib_filterx_libfilterx_la_SOURCES = \
 	lib/filterx/object-dict.c \
 	lib/filterx/object-ip.c \
 	lib/filterx/object-list.c \
+	lib/filterx/object-tuple.c \
 	lib/filterx/object-message-value.c \
 	lib/filterx/object-metrics-labels.c \
 	lib/filterx/object-null.c \

--- a/lib/filterx/expr-literal-container.c
+++ b/lib/filterx/expr-literal-container.c
@@ -113,13 +113,16 @@ filterx_literal_container_len(FilterXExpr *s)
 }
 
 static inline FilterXObject *
-_literal_container_eval_expr(FilterXExpr *expr, gboolean early_eval)
+_literal_container_eval_expr(FilterXExpr *expr, gboolean early_eval, gboolean support_sparse_container)
 {
   if (early_eval)
     {
       if (filterx_expr_is_literal(expr))
         return filterx_literal_get_value(expr);
-      return filterx_null_new();
+      if (support_sparse_container)
+        return filterx_null_new();
+      else
+        return NULL;
     }
   else
     return filterx_expr_eval(expr);
@@ -225,13 +228,13 @@ _literal_dict_eval_elem(FilterXLiteralContainer *self, FilterXLiteralElement *el
   FilterXObject *value = NULL;
   gboolean success = FALSE;
 
-  key = _literal_container_eval_expr(elem->key, early_eval);
+  key = _literal_container_eval_expr(elem->key, early_eval, TRUE);
   if (!key)
     {
       goto exit;
     }
 
-  value = _literal_container_eval_expr(elem->value, early_eval);
+  value = _literal_container_eval_expr(elem->value, early_eval, TRUE);
   if (!value && !elem->nullv)
     {
       goto exit;
@@ -421,7 +424,7 @@ _literal_list_eval_elem(FilterXLiteralContainer *self, FilterXLiteralElement *el
   FilterXObject *value = NULL;
   gboolean success = FALSE;
 
-  value = _literal_container_eval_expr(elem->value, early_eval);
+  value = _literal_container_eval_expr(elem->value, early_eval, FALSE);
   if (!value)
     {
       goto exit;
@@ -530,12 +533,9 @@ _literal_tuple_eval_elem(FilterXLiteralContainer *self, FilterXLiteralElement *e
 {
   FilterXObject *value = NULL;
 
-  value = _literal_container_eval_expr(elem->value, early_eval);
+  value = _literal_container_eval_expr(elem->value, early_eval, FALSE);
   if (!value)
-    {
-      filterx_eval_push_error_static_info("Failed create literal container", &self->super, "Failed to evaluate value");
-      return FALSE;
-    }
+    return FALSE;
 
   value = filterx_object_cow_fork2(value, NULL);
   filterx_tuple_set_subscript(result, filterx_tuple_get_length(result), value);

--- a/lib/filterx/expr-literal-container.c
+++ b/lib/filterx/expr-literal-container.c
@@ -25,6 +25,7 @@
 #include "filterx/object-primitive.h"
 #include "filterx/object-dict.h"
 #include "filterx/object-list.h"
+#include "filterx/object-tuple.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/filterx-object.h"
 #include "filterx/object-null.h"
@@ -521,5 +522,106 @@ filterx_literal_list_new(GList *elements)
   return &self->super;
 }
 
+/* Literal tuple objects */
+
+static inline gboolean
+_literal_tuple_eval_elem(FilterXLiteralContainer *self, FilterXLiteralElement *elem, FilterXObject *result,
+                         gboolean early_eval)
+{
+  FilterXObject *value = NULL;
+
+  value = _literal_container_eval_expr(elem->value, early_eval);
+  if (!value)
+    {
+      filterx_eval_push_error_static_info("Failed create literal container", &self->super, "Failed to evaluate value");
+      return FALSE;
+    }
+
+  value = filterx_object_cow_fork2(value, NULL);
+  filterx_tuple_set_subscript(result, filterx_tuple_get_length(result), value);
+  filterx_object_unref(value);
+  return TRUE;
+}
+
+/*
+ * This is an inline version with two variants,
+ *
+ * "fastpath" == TRUE means we * are doing this at eval time by which point
+ *                    we already did a filterx_ptuple_seal()
+ *
+ * "fastpath" == FALSE means we are still doing this at compilation time and
+ *               seal is yet to be called.
+ */
+static inline FilterXObject *
+_literal_tuple_eval_adaptive(FilterXExpr *s, gboolean early_eval)
+{
+  FilterXLiteralContainer *self = (FilterXLiteralContainer *) s;
+
+  gsize len = filterx_pointer_list_get_length(&self->elements);
+  FilterXObject *result = filterx_tuple_new(len);
+
+  for (gsize i = 0; i < len; i++)
+    {
+      FilterXLiteralElement *elem;
+
+      if (early_eval)
+        elem = (FilterXLiteralElement *) filterx_pointer_list_index(&self->elements, i);
+      else
+        elem = (FilterXLiteralElement *) filterx_pointer_list_index_fast(&self->elements, i);
+
+      if (!_literal_tuple_eval_elem(self, elem, result, early_eval))
+        goto error;
+    }
+
+  return result;
+error:
+  filterx_object_unref(result);
+  return NULL;
+}
+
+/* evaluate during optimize while the expressions are yet to be initialized */
+static FilterXObject *
+_literal_tuple_eval_early(FilterXLiteralContainer *self)
+{
+  return _literal_tuple_eval_adaptive(&self->super, TRUE);
+}
+
+static FilterXObject *
+_literal_tuple_eval(FilterXExpr *s)
+{
+  return _literal_tuple_eval_adaptive(s, FALSE);
+}
+
+gboolean
+filterx_literal_tuple_foreach(FilterXExpr *s, FilterXLiteralListForeachFunc func, gpointer user_data)
+{
+  FilterXLiteralContainer *self = (FilterXLiteralContainer *) s;
+
+  gsize len = filterx_pointer_list_get_length(&self->elements);
+  for (gsize i = 0; i < len; i++)
+    {
+      FilterXLiteralElement *elem = (FilterXLiteralElement *) filterx_pointer_list_index(&self->elements, i);
+
+      if (!func(i, elem->value, user_data))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+FilterXExpr *
+filterx_literal_tuple_new(GList *elements)
+{
+  FilterXLiteralContainer *self = g_new0(FilterXLiteralContainer, 1);
+
+  _literal_container_init_instance(self, FILTERX_EXPR_TYPE_NAME(literal_tuple));
+  self->super.eval = _literal_tuple_eval;
+  self->eval_early = _literal_tuple_eval_early;
+  filterx_pointer_list_add_list(&self->elements, elements);
+
+  return &self->super;
+}
+
 FILTERX_EXPR_DEFINE_TYPE(literal_list);
 FILTERX_EXPR_DEFINE_TYPE(literal_dict);
+FILTERX_EXPR_DEFINE_TYPE(literal_tuple);

--- a/lib/filterx/expr-literal-container.h
+++ b/lib/filterx/expr-literal-container.h
@@ -57,6 +57,12 @@ gboolean filterx_literal_list_foreach(FilterXExpr *s, FilterXLiteralListForeachF
 
 FilterXExpr *filterx_literal_list_new(GList *elements);
 
+/* Literal Tuple */
+
+FILTERX_EXPR_DECLARE_TYPE(literal_tuple);
+
+FilterXExpr *filterx_literal_tuple_new(GList *elements);
+
 /* inline functions */
 
 static inline gboolean
@@ -72,9 +78,15 @@ filterx_expr_is_literal_list(FilterXExpr *expr)
 }
 
 static inline gboolean
+filterx_expr_is_literal_tuple(FilterXExpr *expr)
+{
+  return expr && expr->type == FILTERX_EXPR_TYPE_NAME(literal_tuple);
+}
+
+static inline gboolean
 filterx_expr_is_literal_container(FilterXExpr *s)
 {
-  return filterx_expr_is_literal_list(s) || filterx_expr_is_literal_dict(s);
+  return filterx_expr_is_literal_list(s) || filterx_expr_is_literal_dict(s) || filterx_expr_is_literal_tuple(s);
 }
 
 #endif

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -395,6 +395,7 @@ filterx_eval_begin_context(FilterXEvalContext *context,
   context->previous_context = previous_context;
 
   context->eval_control_modifier = FXC_UNSET;
+  context->allocations_shared = FALSE;
   filterx_eval_set_context(context);
 }
 
@@ -435,6 +436,7 @@ filterx_eval_begin_restricted_context(FilterXEvalContext *context, FilterXEnviro
   context->eval_control_modifier = FXC_UNSET;
   context->previous_context = filterx_eval_get_context();
   context->env = env;
+  context->allocations_shared = TRUE;
   filterx_eval_set_context(context);
 }
 
@@ -477,7 +479,7 @@ filterx_eval_freeze_object(FilterXObject **object)
 
   if (context && context->env)
     {
-      if (filterx_eval_context_is_production(context))
+      if (!filterx_eval_context_allocations_are_shared(context))
         g_assert_not_reached();
       /* only compile contexts have an env. We can only freeze objects during compile time. */
       filterx_env_freeze_object(context->env, object);

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -479,8 +479,7 @@ filterx_eval_freeze_object(FilterXObject **object)
 
   if (context && context->env)
     {
-      if (!filterx_eval_context_allocations_are_shared(context))
-        g_assert_not_reached();
+      g_assert(!(*object)->allocator_used);
       /* only compile contexts have an env. We can only freeze objects during compile time. */
       filterx_env_freeze_object(context->env, object);
     }

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -75,7 +75,7 @@ struct _FilterXEvalContext
   FilterXEvalControl eval_control_modifier;
   FilterXEvalContext *previous_context;
 
-  guint8 failure_info_collect_falsy:1;
+  guint8 failure_info_collect_falsy:1, allocations_shared:1;
   GArray *failure_info;
   gint weak_refs_offset;
   FilterXEnvironment *env;
@@ -198,11 +198,11 @@ filterx_eval_store_weak_ref(FilterXObject *object)
   } while(0)
 
 static inline gboolean
-filterx_eval_context_is_production(FilterXEvalContext *context)
+filterx_eval_context_allocations_are_shared(FilterXEvalContext *context)
 {
   if (!context)
     return FALSE;
-  return context->scope != NULL;
+  return context->allocations_shared;
 }
 
 static inline FilterXObject *
@@ -221,7 +221,7 @@ filterx_eval_malloc_object(gsize object_size, gsize alloc_size)
       result = (FilterXObject *) filterx_allocator_malloc(context->allocator, alloc_size, object_size);
       result->allocator_used = TRUE;
     }
-  result->early_allocation = !filterx_eval_context_is_production(context);
+  result->early_allocation = filterx_eval_context_allocations_are_shared(context);
 
   return result;
 }

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -28,6 +28,7 @@
 #include "filterx/object-string.h"
 #include "filterx/object-dict.h"
 #include "filterx/object-list.h"
+#include "filterx/object-tuple.h"
 #include "filterx/object-datetime.h"
 #include "filterx/object-subnet.h"
 #include "filterx/object-ip.h"
@@ -96,6 +97,7 @@ _simple_init(void)
   filterx_builtin_simple_functions_init_private(&filterx_builtin_simple_functions);
   g_assert(filterx_builtin_simple_function_register("dict", filterx_dict_new_from_args));
   g_assert(filterx_builtin_simple_function_register("list", filterx_list_new_from_args));
+  g_assert(filterx_builtin_simple_function_register("tuple", filterx_tuple_new_from_args));
   g_assert(filterx_builtin_simple_function_register("json", filterx_dict_new_from_args));
   g_assert(filterx_builtin_simple_function_register("json_array", filterx_list_new_from_args));
   g_assert(filterx_builtin_simple_function_register("format_json", filterx_format_json_call));
@@ -271,6 +273,7 @@ filterx_global_init(void)
   filterx_type_init(&FILTERX_TYPE_NAME(mapping));
   filterx_type_init(&FILTERX_TYPE_NAME(dict));
   filterx_type_init(&FILTERX_TYPE_NAME(list));
+  filterx_type_init(&FILTERX_TYPE_NAME(tuple));
 
   filterx_type_init(&FILTERX_TYPE_NAME(null));
   filterx_type_init(&FILTERX_TYPE_NAME(integer));

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -166,6 +166,10 @@ _assign_location(FilterXExpr *expr, CfgLexer *lexer, CFG_LTYPE *lloc)
 %type <ptr> list_literal
 %type <ptr> list_element
 %type <ptr> list_elements
+%type <ptr> tuple_literal
+%type <ptr> tuple_elements
+%type <ptr> tuple_list
+%type <ptr> tuple_element
 %type <ptr> dpath_element
 %type <ptr> dpath_elements
 %type <ptr> regexp_match
@@ -379,6 +383,7 @@ literal
 	: literal_object			{ FilterXObject *literal = $1; $$ = filterx_literal_new(literal); }
 	| dict_literal
 	| list_literal
+	| tuple_literal
 	;
 
 literal_object
@@ -472,6 +477,28 @@ list_elements
 	;
 
 list_element
+	: expr					{ $$ = filterx_literal_element_new(NULL, $1); }
+	;
+
+tuple_literal
+	: '(' tuple_elements ')'
+          {
+            $$ = filterx_literal_tuple_new($2);
+          }
+	;
+
+tuple_elements
+	: tuple_list				{ $$ = $1; }
+	| 					{ $$ = NULL; }
+	;
+
+tuple_list
+	: tuple_element ',' tuple_list		{ $$ = g_list_prepend($3, $1); }
+	| tuple_element ',' tuple_element	{ $$ = g_list_prepend(g_list_append(NULL, $3), $1); }
+	| tuple_element ',' 			{ $$ = g_list_prepend(NULL, $1); }
+	;
+
+tuple_element
 	: expr					{ $$ = filterx_literal_element_new(NULL, $1); }
 	;
 

--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -129,7 +129,7 @@ void
 _filterx_object_assert_object_is_not_shared(FilterXObject *self)
 {
   FilterXEvalContext *context = filterx_eval_get_context();
-  if (filterx_eval_context_is_production(context))
+  if (!filterx_eval_context_allocations_are_shared(context))
     {
       g_assert(!self->early_allocation);
       self->early_allocation_checked = TRUE;

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -200,6 +200,8 @@ struct _FilterXObject
    *
    *     early_allocation_checked -- the early_allocation check was already done
    *
+   *     is_nvtable_backed -- are we borrowing the value from an NVTable value
+   *
    *     flags             -- to be used by descendant types
    *
    */

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -202,11 +202,13 @@ struct _FilterXObject
    *
    *     is_nvtable_backed -- are we borrowing the value from an NVTable value
    *
+   *     is_hashable       -- the object can be used as a key in the mapping
+   *
    *     flags             -- to be used by descendant types
    *
    */
   guint weak_referenced:1, is_dirty:1, allocator_used:1, floating_ref:1, early_allocation:1, early_allocation_checked:1,
-        is_nvtable_backed:1, flags:5;
+        is_nvtable_backed:1, is_hashable:1, flags:5;
   volatile guint32 hash;
   FilterXType *type;
 };
@@ -244,6 +246,8 @@ filterx_object_init_instance(FilterXObject *self, FilterXType *type)
 {
   self->ref_cnt = 1;
   self->type = type;
+  if (type->hash && type->equal)
+    self->is_hashable = TRUE;
 }
 
 static inline gboolean
@@ -603,7 +607,7 @@ filterx_object_iter(FilterXObject *self, FilterXObjectIterFunc func, gpointer us
 static inline gboolean
 filterx_object_hashable(FilterXObject *self)
 {
-  return self->type->hash && self->type->equal;
+  return self->is_hashable;
 }
 
 static inline guint
@@ -686,11 +690,12 @@ filterx_object_set_dirty(FilterXObject *self, gboolean value)
   self->is_dirty = value;
 }
 
-#define FILTERX_OBJECT_STACK_INIT(_type) \
+#define FILTERX_OBJECT_STACK_INIT(_type, _hashable) \
   { \
     .ref_cnt = FILTERX_OBJECT_REFCOUNT_STACK, \
     .weak_referenced = FALSE, \
     .is_dirty = FALSE, \
+    .is_hashable = _hashable, \
     .hash = 0, \
     .type = &FILTERX_TYPE_NAME(_type) \
   }

--- a/lib/filterx/filterx-sequence.c
+++ b/lib/filterx/filterx-sequence.c
@@ -113,8 +113,8 @@ _format_json(FilterXObject *value, GString *json)
   return TRUE;
 }
 
-static FilterXObject *
-_add(FilterXObject *self, FilterXObject *other)
+FilterXObject *
+filterx_sequence_generic_add_method(FilterXObject *self, FilterXObject *other)
 {
   FilterXObject *cloned = filterx_object_copy(self);
 
@@ -127,8 +127,8 @@ error:
   return NULL;
 }
 
-static FilterXObject *
-_add_inplace(FilterXObject *self, FilterXObject *container, FilterXObject *other)
+FilterXObject *
+filterx_sequence_generic_add_inplace_method(FilterXObject *self, FilterXObject *container, FilterXObject *other)
 {
   if (!filterx_sequence_merge(container, other))
     return NULL;
@@ -140,6 +140,4 @@ FILTERX_DEFINE_TYPE(sequence, FILTERX_TYPE_NAME(object),
                     .is_mutable = TRUE,
                     .is_abstract = TRUE,
                     .format_json = _format_json,
-                    .add = _add,
-                    .add_inplace = _add_inplace,
                    );

--- a/lib/filterx/filterx-sequence.h
+++ b/lib/filterx/filterx-sequence.h
@@ -104,10 +104,6 @@ filterx_sequence_normalize_index(FilterXObject *index_object,
 static inline void
 filterx_sequence_init_instance(FilterXSequence *self, FilterXType *type)
 {
-#if SYSLOG_NG_ENABLE_DEBUG
-  g_assert(type->is_mutable);
-#endif
-
   filterx_object_init_instance(&self->super, type);
 }
 

--- a/lib/filterx/filterx-sequence.h
+++ b/lib/filterx/filterx-sequence.h
@@ -107,4 +107,8 @@ filterx_sequence_init_instance(FilterXSequence *self, FilterXType *type)
   filterx_object_init_instance(&self->super, type);
 }
 
+FilterXObject *filterx_sequence_generic_add_method(FilterXObject *self, FilterXObject *other);
+FilterXObject *filterx_sequence_generic_add_inplace_method(FilterXObject *self, FilterXObject *container,
+                                                           FilterXObject *other);
+
 #endif

--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -432,7 +432,11 @@ _target_iterator(gsize index, FilterXExpr *value, gpointer user_data)
       else if (filterx_expr_is_literal_dict(value))
         set_flag(&self->flags, FILTERX_FUNC_UNSET_EMPTIES_FLAG_REPLACE_EMPTY_DICT, TRUE);
       else
-        g_assert_not_reached();
+        {
+          g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                      FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS" argument must be a list or a dict! " FILTERX_FUNC_UNSET_EMPTIES_USAGE);
+          return FALSE;
+        }
       return TRUE;
     }
   else

--- a/lib/filterx/object-list.c
+++ b/lib/filterx/object-list.c
@@ -424,4 +424,6 @@ FILTERX_DEFINE_TYPE(list, FILTERX_TYPE_NAME(sequence),
                     .len = _filterx_list_len,
                     .freeze = _filterx_list_freeze,
                     .dedup = _filterx_list_dedup,
+                    .add = filterx_sequence_generic_add_method,
+                    .add_inplace = filterx_sequence_generic_add_inplace_method,
                    );

--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -45,6 +45,23 @@ _truthy(FilterXObject *s)
   return !gn_is_zero(&self->value);
 }
 
+static guint
+_hash(FilterXObject *s)
+{
+  FilterXPrimitive *self = (FilterXPrimitive *) s;
+
+  return gn_as_int64(&self->value);
+}
+
+static gboolean
+_equal(FilterXObject *s, FilterXObject *o)
+{
+  FilterXPrimitive *self = (FilterXPrimitive *) s;
+  FilterXPrimitive *other = (FilterXPrimitive *) o;
+
+  return gn_compare(&self->value, &other->value) == 0;
+}
+
 static FilterXPrimitive *
 filterx_primitive_new(FilterXType *type)
 {
@@ -452,6 +469,8 @@ FILTERX_DEFINE_TYPE(primitive, FILTERX_TYPE_NAME(object),
                     .is_abstract = TRUE,
                     .truthy = _truthy,
                     .repr = _repr,
+                    .equal = _equal,
+                    .hash = _hash,
                    );
 
 FILTERX_DEFINE_TYPE(integer, FILTERX_TYPE_NAME(primitive),

--- a/lib/filterx/object-primitive.h
+++ b/lib/filterx/object-primitive.h
@@ -131,7 +131,7 @@ void filterx_primitive_global_deinit(void);
 
 #define FILTERX_INTEGER_STACK_INIT(v) \
   { \
-    .super = FILTERX_OBJECT_STACK_INIT(integer), \
+    .super = FILTERX_OBJECT_STACK_INIT(integer, TRUE), \
     .value = { \
       .value = { \
         .raw_int64 = v, \

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -267,7 +267,7 @@ void filterx_string_global_deinit(void);
 
 #define FILTERX_STRING_STACK_INIT(cstr, cstr_len) \
   { \
-    .super = FILTERX_OBJECT_STACK_INIT(string), \
+    .super = FILTERX_OBJECT_STACK_INIT(string, TRUE), \
     .str = (cstr), \
     .str_len = (((gssize) cstr_len) == -1 ? (guint32) strlen(cstr) : (guint32) (cstr_len)), \
   }

--- a/lib/filterx/object-tuple.c
+++ b/lib/filterx/object-tuple.c
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/object-tuple.h"
+#include "filterx/object-string.h"
+#include "filterx/json-repr.h"
+#include "filterx/filterx-eval.h"
+
+typedef gboolean (*FilterXTupleForeachFunc)(gsize index, FilterXObject **, gpointer);
+
+static gboolean
+filterx_tuple_foreach(FilterXTuple *self, FilterXTupleForeachFunc func, gpointer user_data)
+{
+  for (gsize i = 0; i < self->array->len; i++)
+    {
+      FilterXObject **el = (FilterXObject **) &g_ptr_array_index(self->array, i);
+      if (!func(i, el, user_data))
+        return FALSE;
+    }
+  return TRUE;
+}
+
+static gboolean
+_filterx_tuple_truthy(FilterXObject *s)
+{
+  return TRUE;
+}
+
+static gboolean
+_filterx_tuple_repr(FilterXObject *s, GString *repr)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+  g_string_append_c(repr, '(');
+
+  for (gsize i = 0; i < self->array->len; i++)
+    {
+      FilterXObject *elt = (FilterXObject *) g_ptr_array_index(self->array, i);
+      if (!filterx_object_repr_append(elt, repr))
+        return FALSE;
+      if (i == 0 || i < self->array->len - 1)
+        g_string_append_c(repr, ',');
+    }
+
+  g_string_append_c(repr, ')');
+  return TRUE;
+}
+
+static gboolean
+_filterx_tuple_marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
+{
+  if (!filterx_object_to_json(s, repr))
+    return FALSE;
+  *t = LM_VT_JSON;
+  return TRUE;
+}
+
+static FilterXObject *
+_filterx_tuple_get_subscript(FilterXObject *s, FilterXObject *key)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+
+  guint64 normalized_index;
+  const gchar *error;
+  if (!filterx_sequence_normalize_index(key, self->array->len, &normalized_index, FALSE, &error))
+    {
+      filterx_eval_push_error(error, key);
+      return NULL;
+    }
+
+  return filterx_object_ref(g_ptr_array_index(self->array, normalized_index));
+}
+
+static gboolean
+_filterx_tuple_len(FilterXObject *s, guint64 *len)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+
+  *len = self->array->len;
+  return TRUE;
+}
+
+static gboolean
+_filterx_tuple_is_key_set(FilterXObject *s, FilterXObject *key)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+
+  guint64 normalized_index;
+  const gchar *error;
+  return filterx_sequence_normalize_index(key, self->array->len, &normalized_index, FALSE, &error);
+}
+
+static gboolean
+_filterx_tuple_iter(FilterXObject *s, FilterXObjectIterFunc func, gpointer user_data)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+
+  for (gsize i = 0; i < self->array->len; i++)
+    {
+      FilterXObject *value = g_ptr_array_index(self->array, i);
+      FILTERX_INTEGER_DECLARE_ON_STACK(index_obj, i);
+      gboolean result = func(index_obj, value, user_data);
+      FILTERX_INTEGER_CLEAR_FROM_STACK(index_obj);
+      if (!result)
+        return FALSE;
+    }
+  return TRUE;
+}
+
+static gboolean
+_filterx_tuple_equal(FilterXObject *s, FilterXObject *o)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+  FilterXTuple *other = (FilterXTuple *) o;
+
+  if (self->array->len != other->array->len)
+    return FALSE;
+
+  for (gsize i = 0; i < self->array->len; i++)
+    {
+      FilterXObject *v1 = g_ptr_array_index(self->array, i);
+      FilterXObject *v2 = g_ptr_array_index(other->array, i);
+      if (!filterx_object_equal(v1, v2))
+        return FALSE;
+    }
+  return TRUE;
+}
+
+
+/*
+ * This is a slightly simplified version of the xxHash non-cryptographic hash:
+ *
+ * For the xxHash specification, see
+ * https://github.com/Cyan4973/xxHash/blob/master/doc/xxhash_spec.md
+ */
+
+#define _TUPLE_HASH_XXPRIME_1 ((guint)2654435761UL)
+#define _TUPLE_HASH_XXPRIME_2 ((guint)2246822519UL)
+#define _TUPLE_HASH_XXPRIME_5 ((guint)374761393UL)
+#define _TUPLE_HASH_XXROTATE(x) ((x << 13) | (x >> 19))  /* Rotate left 13 bits */
+
+static guint
+_filterx_tuple_hash(FilterXObject *s)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+
+  guint acc = _TUPLE_HASH_XXPRIME_5;
+  gsize len = self->array->len;
+
+  for (gsize i = 0; i < len; i++)
+    {
+      FilterXObject *value = g_ptr_array_index(self->array, i);
+      guint hash = filterx_object_hash(value);
+      acc += hash * _TUPLE_HASH_XXPRIME_2;
+      acc = _TUPLE_HASH_XXROTATE(acc);
+      acc *= _TUPLE_HASH_XXPRIME_1;
+    }
+  acc += len ^ _TUPLE_HASH_XXPRIME_5;
+  return acc;
+}
+
+static void
+_filterx_tuple_append_ref(FilterXTuple *self, FilterXObject *el)
+{
+  filterx_tuple_set_subscript(&self->super.super, self->array->len, el);
+  filterx_object_unref(el);
+}
+
+/* since copy-on-write is not used with tuples, whenever we get a clone()
+ * call, it will be triggered by filterx_object_dup().  In the case of
+ * filterx_object_copy(), we will just take a ref because a tuple is not mutable
+ */
+static FilterXObject *
+_filterx_tuple_clone(FilterXObject *s)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+  FilterXTuple *clone = (FilterXTuple *) filterx_tuple_new(self->array->len);
+
+  for (gsize i = 0; i < self->array->len; i++)
+    {
+      FilterXObject *el = g_ptr_array_index(self->array, i);
+
+      el = filterx_object_dup(el);
+      _filterx_tuple_append_ref(clone, el);
+    }
+  return &clone->super.super;
+}
+
+static gboolean
+_dedup_tuple_item(gsize index, FilterXObject **value, gpointer user_data)
+{
+  FilterXObjectDeduplicator *dedup = (FilterXObjectDeduplicator *) user_data;
+
+  filterx_object_dedup(value, dedup);
+
+  return TRUE;
+}
+
+static void
+_filterx_tuple_dedup(FilterXObject **pself, FilterXObjectDeduplicator *dedup)
+{
+  FilterXTuple *self = (FilterXTuple *) *pself;
+
+  g_assert(filterx_tuple_foreach(self, _dedup_tuple_item, dedup));
+  g_assert(*pself == &self->super.super);
+}
+
+static gboolean
+_freeze_tuple_item(gsize index, FilterXObject **value, gpointer user_data)
+{
+  FilterXObjectFreezer *freezer = (FilterXObjectFreezer *) user_data;
+
+  filterx_object_freeze(*value, freezer);
+
+  return TRUE;
+}
+
+static FilterXObject *
+_filterx_tuple_add_sequence(FilterXTuple *self, FilterXObject *sequence)
+{
+  guint64 sequence_len;
+
+  if (!filterx_object_is_type_or_ref(sequence, &FILTERX_TYPE_NAME(sequence)))
+    {
+      filterx_eval_push_error_info_printf("Failed to concatenate tuples",
+                                          "rhs must be a sequence, got: %s",
+                                          filterx_object_get_type_name(sequence));
+      return NULL;
+    }
+
+  g_assert(filterx_object_len(sequence, &sequence_len));
+  FilterXTuple *clone = (FilterXTuple *) filterx_tuple_new(self->array->len + sequence_len);
+
+  for (gsize i = 0; i < self->array->len; i++)
+    {
+      FilterXObject *el = g_ptr_array_index(self->array, i);
+
+      el = filterx_object_dup(el);
+      _filterx_tuple_append_ref(clone, el);
+    }
+  for (guint64 i = 0; i < sequence_len; i++)
+    {
+      FilterXObject *elt = filterx_sequence_get_subscript(sequence, i);
+      _filterx_tuple_append_ref(clone, filterx_object_copy(elt));
+      filterx_object_unref(elt);
+    }
+  return &clone->super.super;
+}
+
+FilterXObject *
+_filterx_tuple_add(FilterXObject *s, FilterXObject *o)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+  if (o->type != s->type)
+    {
+      return _filterx_tuple_add_sequence(self, o);
+    }
+
+  FilterXTuple *other = (FilterXTuple *) o;
+  gsize new_len = self->array->len + other->array->len;
+  FilterXTuple *clone = (FilterXTuple *) filterx_tuple_new(new_len);
+
+  for (gsize i = 0; i < new_len; i++)
+    {
+      FilterXObject *el;
+
+      if (i < self->array->len)
+        el = g_ptr_array_index(self->array, i);
+      else
+        el = g_ptr_array_index(other->array, i - self->array->len);
+
+      el = filterx_object_dup(el);
+      _filterx_tuple_append_ref(clone, el);
+    }
+  return &clone->super.super;
+}
+
+static void
+_filterx_tuple_freeze(FilterXObject *s, FilterXObjectFreezer *freezer)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+
+  filterx_object_freezer_keep(freezer, s);
+  g_assert(filterx_tuple_foreach(self, _freeze_tuple_item, freezer));
+}
+
+static void
+_filterx_tuple_free(FilterXObject *s)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+
+  g_ptr_array_unref(self->array);
+  filterx_object_free_method(s);
+}
+
+FilterXObject *
+filterx_tuple_new(gsize len)
+{
+  FilterXTuple *self = filterx_new_object(FilterXTuple);
+  filterx_sequence_init_instance(&self->super, &FILTERX_TYPE_NAME(tuple));
+
+  self->array = g_ptr_array_new_full(len, (GDestroyNotify) filterx_object_unref);
+  return &self->super.super;
+}
+
+FilterXObject *
+filterx_tuple_new_from_sequence(FilterXObject *sequence)
+{
+  guint64 len;
+
+  g_assert(filterx_object_len(sequence, &len));
+
+  FilterXTuple *self = (FilterXTuple *) filterx_tuple_new(len);
+  for (guint64 i = 0; i < len; i++)
+    {
+      FilterXObject *elt = filterx_sequence_get_subscript(sequence, i);
+      _filterx_tuple_append_ref(self, filterx_object_copy(elt));
+      filterx_object_unref(elt);
+    }
+
+  return &self->super.super;
+}
+
+FilterXObject *
+filterx_tuple_new_from_args(FilterXExpr *s, FilterXObject *args[], gsize args_len)
+{
+  if (args_len == 0)
+    return filterx_tuple_new(0);
+
+  if (args_len != 1)
+    {
+      filterx_eval_push_error("Too many arguments", NULL);
+      return NULL;
+    }
+
+  FilterXObject *arg = args[0];
+  FilterXObject *arg_unwrapped = filterx_ref_unwrap_ro(arg);
+  if (filterx_object_is_type(arg_unwrapped, &FILTERX_TYPE_NAME(tuple)))
+    return filterx_object_ref(arg);
+
+  if (filterx_object_is_type(arg_unwrapped, &FILTERX_TYPE_NAME(sequence)))
+    {
+      return filterx_tuple_new_from_sequence(arg_unwrapped);
+    }
+
+  const gchar *repr;
+  gsize repr_len;
+  repr = filterx_string_get_value_ref(arg, &repr_len);
+  if (repr)
+    {
+      GError *error = NULL;
+      FilterXObject *jso = filterx_object_from_json(repr, repr_len, &error);
+      if (!jso)
+        {
+          filterx_eval_push_error_info_printf("Failed to create tuple",
+                                              "Argument must be a valid JSON string: %s",
+                                              error->message);
+          g_clear_error(&error);
+          return NULL;
+        }
+      FilterXObject *result = filterx_tuple_new_from_args(s, &jso, 1);
+      filterx_object_unref(jso);
+      return result;
+    }
+
+  filterx_eval_push_error_info_printf("Failed to create tuple",
+                                      "Argument must be a sequence or a string, got: %s",
+                                      filterx_object_get_type_name(arg));
+  return NULL;
+}
+
+FILTERX_DEFINE_TYPE(tuple, FILTERX_TYPE_NAME(sequence),
+                    .truthy = _filterx_tuple_truthy,
+                    .free_fn = _filterx_tuple_free,
+                    .marshal = _filterx_tuple_marshal,
+                    .repr = _filterx_tuple_repr,
+                    .clone = _filterx_tuple_clone,
+                    .get_subscript = _filterx_tuple_get_subscript,
+                    .is_key_set = _filterx_tuple_is_key_set,
+                    .iter = _filterx_tuple_iter,
+                    .equal = _filterx_tuple_equal,
+                    .hash = _filterx_tuple_hash,
+                    .freeze = _filterx_tuple_freeze,
+                    .dedup = _filterx_tuple_dedup,
+                    .len = _filterx_tuple_len,
+                    .add = _filterx_tuple_add,
+                   );

--- a/lib/filterx/object-tuple.h
+++ b/lib/filterx/object-tuple.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_OBJECT_TUPLE_H
+#define FILTERX_OBJECT_TUPLE_H
+
+#include "filterx/filterx-sequence.h"
+
+/* read only tuple of values */
+typedef struct _FilterXTuple
+{
+  FilterXSequence super;
+  GPtrArray *array;
+} FilterXTuple;
+
+FILTERX_DECLARE_TYPE(tuple);
+
+FilterXObject *filterx_tuple_new(gsize len);
+FilterXObject *filterx_tuple_new_from_args(FilterXExpr *s, FilterXObject *args[], gsize args_len);
+
+
+/* these are low-level, fast interfaces which bypass a lot of validations */
+
+/* NOTE: index must be valid! */
+static inline FilterXObject *
+filterx_tuple_peek_subscript(FilterXObject *s, gint64 index)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+  return g_ptr_array_index(self->array, index);
+}
+
+static inline gsize
+filterx_tuple_get_length(FilterXObject *s)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+
+  return self->array->len;
+}
+
+/* NOTE: index must be valid! */
+static inline void
+filterx_tuple_set_subscript(FilterXObject *s, gint64 index, FilterXObject *new_value)
+{
+  FilterXTuple *self = (FilterXTuple *) s;
+
+  if (!filterx_object_hashable(new_value))
+    self->super.super.is_hashable = FALSE;
+  if (self->array->len == index)
+    g_ptr_array_set_size(self->array, index + 1);
+  FilterXObject **slot = (FilterXObject **) &g_ptr_array_index(self->array, index);
+  filterx_object_unref(*slot);
+  *slot = filterx_object_ref(new_value);
+}
+
+
+#endif

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -42,3 +42,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_expr_arithmetic_operators DEPENDS js
 add_unit_test(LIBTEST CRITERION TARGET test_func_set_pri DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_json_repr DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_filterx_plist DEPENDS syslogformat json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_object_tuple DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -3,6 +3,7 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_object_message	\
 		lib/filterx/tests/test_object_datetime	\
 		lib/filterx/tests/test_object_dict	\
+		lib/filterx/tests/test_object_tuple	\
 		lib/filterx/tests/test_object_null	\
 		lib/filterx/tests/test_object_string	\
 		lib/filterx/tests/test_object_protobuf	\
@@ -61,6 +62,9 @@ lib_filterx_tests_test_object_datetime_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_object_dict_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_object_dict_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_object_tuple_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_object_tuple_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_object_null_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_object_null_LDADD   = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/test_object_cow.c
+++ b/lib/filterx/tests/test_object_cow.c
@@ -30,9 +30,6 @@
 #include "apphook.h"
 #include "cfg.h"
 
-FilterXEvalContext compile_context;
-
-
 Test(filterx_cow, test_filterx_cow_wrap_adds_an_xref_wrapper)
 {
   FilterXObject *d = filterx_dict_new();
@@ -214,13 +211,13 @@ setup(void)
   app_startup();
 
   configuration = cfg_new_snippet();
-  filterx_eval_begin_compile(&compile_context, configuration);
+  init_libtest_filterx();
 }
 
 static void
 teardown(void)
 {
-  filterx_eval_end_compile(&compile_context);
+  deinit_libtest_filterx();
   cfg_free(configuration);
   scratch_buffers_explicit_gc();
   app_shutdown();

--- a/lib/filterx/tests/test_object_string.c
+++ b/lib/filterx/tests/test_object_string.c
@@ -47,15 +47,12 @@ Test(filterx_string, test_filterx_object_string_maps_to_the_right_json_value)
 
 Test(filterx_string, test_frozen_string_deduplication)
 {
-  FilterXEvalContext context;
-  filterx_eval_begin_compile(&context, configuration);
   FilterXObject *str = filterx_string_new_frozen("abcd");
   FilterXObject *str2 = filterx_string_new_frozen("abcd");
   FilterXObject *str3 = filterx_string_new_frozen("abcde");
 
   cr_assert_eq(str, str2);
   cr_assert_neq(str, str3);
-  filterx_eval_end_compile(&context);
 }
 
 Test(filterx_string, test_string_taking_allocated_storage)
@@ -229,14 +226,10 @@ Test(filterx_string, test_filterx_string_cache_json_escaping_need)
 
 Test(filterx_string, test_filterx_string_frozen_json_escaping_need)
 {
-  FilterXEvalContext context;
-
-  filterx_eval_begin_compile(&context, configuration);
   FilterXObject *fobj = filterx_string_new_frozen("foo\"bar");
   cr_assert(filterx_string_is_json_escaping_needed(fobj));
   assert_object_json_equals(fobj, "\"foo\\\"bar\"");
   cr_assert(filterx_string_is_json_escaping_needed(fobj));
-  filterx_eval_end_compile(&context);
 }
 
 Test(filterx_string, test_filterx_string_typecast_null_args)

--- a/lib/filterx/tests/test_object_tuple.c
+++ b/lib/filterx/tests/test_object_tuple.c
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/object-tuple.h"
+#include "filterx/object-list.h"
+#include "filterx/object-string.h"
+#include "filterx/object-primitive.h"
+#include "filterx/object-message-value.h"
+#include "filterx/filterx-eval.h"
+#include "filterx/expr-function.h"
+#include "filterx/json-repr.h"
+#include "filterx/filterx-config.h"
+#include "scratch-buffers.h"
+#include "apphook.h"
+#include "cfg.h"
+
+#include <criterion/criterion.h>
+#include "libtest/filterx-lib.h"
+
+static FilterXObject *
+_exec_func(FilterXSimpleFunctionProto func, FilterXObject *arg)
+{
+  if (!arg)
+    return func(NULL, NULL, 0);
+
+  FilterXObject *args[] = { arg };
+  FilterXObject *result = func(NULL, args, G_N_ELEMENTS(args));
+  filterx_object_unref(arg);
+  return result;
+}
+
+static FilterXObject *
+_exec_tuple_func(FilterXObject *arg)
+{
+  return _exec_func(filterx_tuple_new_from_args, arg);
+}
+
+Test(filterx_tuple, test_tuple_function)
+{
+  FilterXObject *fobj;
+
+  fobj = _exec_tuple_func(NULL);
+  cr_assert(filterx_object_is_type_or_ref(fobj, &FILTERX_TYPE_NAME(tuple)));
+  assert_object_json_equals(fobj, "[]");
+  filterx_object_unref(fobj);
+
+  fobj = _exec_tuple_func(filterx_string_new("[1, 2]", -1));
+  cr_assert(filterx_object_is_type_or_ref(fobj, &FILTERX_TYPE_NAME(tuple)));
+  assert_object_json_equals(fobj, "[1,2]");
+  filterx_object_unref(fobj);
+
+  /* no need to handle MessageValue arguments, those will be unmarshalled at
+   * evaluation before passing them to the list() function */
+  fobj = _exec_tuple_func(filterx_message_value_new("[1, 2]", -1, LM_VT_JSON));
+  cr_assert(fobj == NULL);
+
+  fobj = _exec_tuple_func(filterx_object_from_json("[1, 2]", -1, NULL));
+  cr_assert(filterx_object_is_type_or_ref(fobj, &FILTERX_TYPE_NAME(tuple)));
+  assert_object_json_equals(fobj, "[1,2]");
+  filterx_object_unref(fobj);
+
+  fobj = _exec_tuple_func(filterx_object_from_json("{\"foo\":\"bar\"}", -1, NULL));
+  cr_assert(fobj == NULL);
+
+  fobj = _exec_tuple_func(filterx_string_new("{\"foo\":\"bar\"}", -1));
+  cr_assert(fobj == NULL);
+}
+
+Test(filterx_tuple, test_tuple_dedup)
+{
+  FilterXObject *tuple = _exec_tuple_func(filterx_string_new("[\"a\", \"b\", \"a\"]", -1));
+  FilterXObject *orig_tuple = tuple;
+
+  filterx_config_dedup_object(configuration, &tuple);
+
+  cr_assert_eq(tuple, orig_tuple);
+
+  FilterXObject *val_0 = filterx_sequence_get_subscript(tuple, 0);
+  FilterXObject *val_1 = filterx_sequence_get_subscript(tuple, 1);
+  FilterXObject *val_2 = filterx_sequence_get_subscript(tuple, 2);
+
+  cr_assert_eq(val_0, val_2);
+  cr_assert_neq(val_0, val_1);
+
+  filterx_object_unref(val_2);
+  filterx_object_unref(val_1);
+  filterx_object_unref(val_0);
+  filterx_object_unref(tuple);
+}
+
+Test(filterx_tuple, filterx_tuple_array_repr_one_element)
+{
+  FilterXObject *obj = _exec_tuple_func(filterx_string_new("[\"foo\"]", -1));
+  GString *repr = scratch_buffers_alloc();
+  g_string_assign(repr, "foo");
+  cr_assert(filterx_object_repr(obj, repr));
+  cr_assert_str_eq(repr->str, "(\"foo\",)");
+  filterx_object_unref(obj);
+}
+
+Test(filterx_tuple, filterx_tuple_array_repr_append)
+{
+  FilterXObject *obj = _exec_tuple_func(filterx_string_new("[\"foo\", \"bar\"]", -1));
+  GString *repr = scratch_buffers_alloc();
+  g_string_assign(repr, "foo");
+  cr_assert(filterx_object_repr(obj, repr));
+  cr_assert_str_eq(repr->str, "(\"foo\",\"bar\")");
+  cr_assert(filterx_object_repr_append(obj, repr));
+  cr_assert_str_eq(repr->str, "(\"foo\",\"bar\")(\"foo\",\"bar\")");
+  filterx_object_unref(obj);
+}
+
+Test(filterx_tuple, test_tuple_function_from_tuple)
+{
+  FilterXObject *t1 = _exec_tuple_func(filterx_string_new("[1, 2]", -1));
+  cr_assert_not_null(t1);
+
+  FilterXObject *t2 = _exec_tuple_func(filterx_object_ref(t1));
+  cr_assert_eq(t1, t2);
+
+  filterx_object_unref(t2);
+  filterx_object_unref(t1);
+}
+
+Test(filterx_tuple, test_tuple_repr_empty)
+{
+  FilterXObject *obj = filterx_tuple_new(0);
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(obj, repr));
+  cr_assert_str_eq(repr->str, "()");
+  filterx_object_unref(obj);
+}
+
+Test(filterx_tuple, test_tuple_marshal)
+{
+  FilterXObject *obj = _exec_tuple_func(filterx_string_new("[\"a\", \"b\"]", -1));
+  assert_marshaled_object(obj, "[\"a\",\"b\"]", LM_VT_JSON);
+  filterx_object_unref(obj);
+}
+
+Test(filterx_tuple, test_tuple_len)
+{
+  guint64 len;
+
+  FilterXObject *obj = filterx_tuple_new(0);
+  cr_assert(filterx_object_len(obj, &len));
+  cr_assert_eq(len, 0);
+  filterx_object_unref(obj);
+
+  obj = _exec_tuple_func(filterx_string_new("[1, 2, 3]", -1));
+  cr_assert(filterx_object_len(obj, &len));
+  cr_assert_eq(len, 3);
+  filterx_object_unref(obj);
+}
+
+Test(filterx_tuple, test_tuple_subscript)
+{
+  FilterXObject *obj = _exec_tuple_func(filterx_string_new("[1, 2, 3]", -1));
+
+  FilterXObject *key = filterx_integer_new(0);
+  FilterXObject *val = filterx_object_get_subscript(obj, key);
+  cr_assert_not_null(val);
+  assert_object_json_equals(val, "1");
+  filterx_object_unref(val);
+  filterx_object_unref(key);
+
+  key = filterx_integer_new(2);
+  val = filterx_object_get_subscript(obj, key);
+  cr_assert_not_null(val);
+  assert_object_json_equals(val, "3");
+  filterx_object_unref(val);
+  filterx_object_unref(key);
+
+  key = filterx_integer_new(-1);
+  val = filterx_object_get_subscript(obj, key);
+  cr_assert_not_null(val);
+  assert_object_json_equals(val, "3");
+  filterx_object_unref(val);
+  filterx_object_unref(key);
+
+  key = filterx_integer_new(-3);
+  val = filterx_object_get_subscript(obj, key);
+  cr_assert_not_null(val);
+  assert_object_json_equals(val, "1");
+  filterx_object_unref(val);
+  filterx_object_unref(key);
+
+  key = filterx_integer_new(10);
+  val = filterx_object_get_subscript(obj, key);
+  cr_assert_null(val);
+  filterx_object_unref(key);
+
+  filterx_object_unref(obj);
+}
+
+Test(filterx_tuple, test_tuple_is_key_set)
+{
+  FilterXObject *obj = _exec_tuple_func(filterx_string_new("[1, 2, 3]", -1));
+
+  FilterXObject *key = filterx_integer_new(0);
+  cr_assert(filterx_object_is_key_set(obj, key));
+  filterx_object_unref(key);
+
+  key = filterx_integer_new(-1);
+  cr_assert(filterx_object_is_key_set(obj, key));
+  filterx_object_unref(key);
+
+  key = filterx_integer_new(10);
+  cr_assert_not(filterx_object_is_key_set(obj, key));
+  filterx_object_unref(key);
+
+  filterx_object_unref(obj);
+}
+
+Test(filterx_tuple, test_tuple_equal)
+{
+  FilterXObject *t1 = _exec_tuple_func(filterx_string_new("[1, 2, 3]", -1));
+  FilterXObject *t2 = _exec_tuple_func(filterx_string_new("[1, 2, 3]", -1));
+  FilterXObject *t3 = _exec_tuple_func(filterx_string_new("[1, 2]", -1));
+  FilterXObject *t4 = _exec_tuple_func(filterx_string_new("[1, 2, 4]", -1));
+
+  cr_assert(filterx_object_equal(t1, t2));
+  cr_assert_not(filterx_object_equal(t1, t3));
+  cr_assert_not(filterx_object_equal(t1, t4));
+
+  filterx_object_unref(t4);
+  filterx_object_unref(t3);
+  filterx_object_unref(t2);
+  filterx_object_unref(t1);
+}
+
+Test(filterx_tuple, test_tuple_hash)
+{
+  FilterXObject *t1 = _exec_tuple_func(filterx_string_new("[1, 2, 3]", -1));
+  FilterXObject *t2 = _exec_tuple_func(filterx_string_new("[1, 2, 3]", -1));
+  FilterXObject *t3 = _exec_tuple_func(filterx_string_new("[1, 2]", -1));
+
+  cr_assert_eq(filterx_object_hash(t1), filterx_object_hash(t2));
+  cr_assert_neq(filterx_object_hash(t1), filterx_object_hash(t3));
+
+  filterx_object_unref(t3);
+  filterx_object_unref(t2);
+  filterx_object_unref(t1);
+}
+
+Test(filterx_tuple, test_tuple_add)
+{
+  FilterXObject *t1 = _exec_tuple_func(filterx_string_new("[1, 2, 3]", -1));
+  FilterXObject *t2 = _exec_tuple_func(filterx_string_new("[1, 2, 3]", -1));
+
+  FilterXObject *tsum = filterx_object_add(t1, t2);
+  assert_object_repr_equals(tsum, "(1,2,3,1,2,3)");
+
+  filterx_object_unref(tsum);
+  filterx_object_unref(t2);
+  filterx_object_unref(t1);
+}
+
+Test(filterx_tuple, test_tuple_unhashable)
+{
+  FilterXObject *t = _exec_tuple_func(filterx_string_new("[1, 2, []]", -1));
+
+  cr_assert(!filterx_object_hashable(t));
+  filterx_object_unref(t);
+}
+
+Test(filterx_tuple, test_tuple_clone)
+{
+  FilterXObject *orig = _exec_tuple_func(filterx_string_new("[1, 2, 3]", -1));
+  FilterXObject *clone = filterx_object_copy(orig);
+
+  cr_assert_not_null(clone);
+  cr_assert_eq(orig, clone);
+  assert_object_json_equals(clone, "[1,2,3]");
+
+  guint64 len;
+  cr_assert(filterx_object_len(clone, &len));
+  cr_assert_eq(len, 3);
+
+  filterx_object_unref(clone);
+  filterx_object_unref(orig);
+}
+
+typedef struct
+{
+  gint count;
+  FilterXObject *keys[8];
+  FilterXObject *values[8];
+} TupleIterCtx;
+
+static gboolean
+_collect_iter(FilterXObject *key, FilterXObject *value, gpointer user_data)
+{
+  TupleIterCtx *ctx = (TupleIterCtx *) user_data;
+  ctx->keys[ctx->count] = filterx_object_ref(key);
+  ctx->values[ctx->count] = filterx_object_ref(value);
+  ctx->count++;
+  return TRUE;
+}
+
+Test(filterx_tuple, test_tuple_iter)
+{
+  FilterXObject *obj = _exec_tuple_func(filterx_string_new("[\"a\", \"b\", \"c\"]", -1));
+  TupleIterCtx ctx = {0};
+
+  cr_assert(filterx_object_iter(obj, _collect_iter, &ctx));
+  cr_assert_eq(ctx.count, 3);
+
+  assert_object_json_equals(ctx.values[0], "\"a\"");
+  assert_object_json_equals(ctx.values[1], "\"b\"");
+  assert_object_json_equals(ctx.values[2], "\"c\"");
+
+  for (gint i = 0; i < ctx.count; i++)
+    {
+      filterx_object_unref(ctx.keys[i]);
+      filterx_object_unref(ctx.values[i]);
+    }
+  filterx_object_unref(obj);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  init_libtest_filterx();
+  configuration = cfg_new_snippet();
+}
+
+static void
+teardown(void)
+{
+  cfg_free(configuration);
+  scratch_buffers_explicit_gc();
+  deinit_libtest_filterx();
+  app_shutdown();
+}
+
+TestSuite(filterx_tuple, .init = setup, .fini = teardown);

--- a/libtest/filterx-lib.c
+++ b/libtest/filterx-lib.c
@@ -310,7 +310,7 @@ static struct
   FilterXScope *scope;
   FilterXEnvironment test_env;
   FilterXEvalContext context;
-} filterx_env;
+} filterx_world;
 
 void
 init_libtest_filterx(void)
@@ -335,22 +335,22 @@ init_libtest_filterx(void)
    * Objects are never allocated from the thread-specific allocator,
    * everything is on the heap.
    */
-  filterx_env.msg = create_sample_message();
-  filterx_env.scope = filterx_scope_new(NULL, NULL);
-  filterx_env_init(&filterx_env.test_env);
-  filterx_eval_begin_context(&filterx_env.context, NULL, filterx_env.scope, filterx_env.msg);
-  filterx_env.context.env = &filterx_env.test_env;
-  filterx_env.context.allocator = NULL;
+  filterx_world.msg = create_sample_message();
+  filterx_world.scope = filterx_scope_new(NULL, NULL);
+  filterx_env_init(&filterx_world.test_env);
+  filterx_eval_begin_context(&filterx_world.context, NULL, filterx_world.scope, filterx_world.msg);
+  filterx_world.context.env = &filterx_world.test_env;
+  filterx_world.context.allocator = NULL;
 }
 
 void
 set_libtest_filterx_scope(FilterXScope *scope)
 {
-  FilterXScope *old_scope = filterx_env.scope;
+  FilterXScope *old_scope = filterx_world.scope;
 
-  filterx_scope_set_message(scope, filterx_env.msg);
-  filterx_env.context.scope = scope;
-  filterx_env.scope = scope;
+  filterx_scope_set_message(scope, filterx_world.msg);
+  filterx_world.context.scope = scope;
+  filterx_world.scope = scope;
 
   if (old_scope)
     filterx_scope_free(old_scope);
@@ -359,11 +359,11 @@ set_libtest_filterx_scope(FilterXScope *scope)
 void
 deinit_libtest_filterx(void)
 {
-  log_msg_unref(filterx_env.msg);
-  filterx_scope_free(filterx_env.scope);
+  log_msg_unref(filterx_world.msg);
+  filterx_scope_free(filterx_world.scope);
   filterx_eval_clear_errors();
-  filterx_eval_end_context(&filterx_env.context);
-  filterx_env_clear(&filterx_env.test_env);
+  filterx_eval_end_context(&filterx_world.context);
+  filterx_env_clear(&filterx_world.test_env);
 }
 
 FILTERX_DEFINE_TYPE(test_dict, FILTERX_TYPE_NAME(object), .is_abstract = TRUE);

--- a/libtest/filterx-lib.c
+++ b/libtest/filterx-lib.c
@@ -308,6 +308,7 @@ static struct
 {
   LogMessage *msg;
   FilterXScope *scope;
+  FilterXEnvironment test_env;
   FilterXEvalContext context;
 } filterx_env;
 
@@ -322,9 +323,24 @@ init_libtest_filterx(void)
   FILTERX_TYPE_NAME(test_dict) = FILTERX_TYPE_NAME(dict);
   FILTERX_TYPE_NAME(test_list) = FILTERX_TYPE_NAME(list);
 
+  /* We are setting up a context that allows us to exercise most things.
+   *
+   *   1) compile-time things (freeze, dedup): allocator is unset, e.g.  all
+   *      objects will be heap allocated.  FilterXEnvironment is populated,
+   *      e.g.  dedup storage, weak refs, etc are available.
+   *
+   *   2) production-time things (eval, error state): msg and scope are both
+   *      set.
+   *
+   * Objects are never allocated from the thread-specific allocator,
+   * everything is on the heap.
+   */
   filterx_env.msg = create_sample_message();
   filterx_env.scope = filterx_scope_new(NULL, NULL);
+  filterx_env_init(&filterx_env.test_env);
   filterx_eval_begin_context(&filterx_env.context, NULL, filterx_env.scope, filterx_env.msg);
+  filterx_env.context.env = &filterx_env.test_env;
+  filterx_env.context.allocator = NULL;
 }
 
 void
@@ -347,6 +363,7 @@ deinit_libtest_filterx(void)
   filterx_scope_free(filterx_env.scope);
   filterx_eval_clear_errors();
   filterx_eval_end_context(&filterx_env.context);
+  filterx_env_clear(&filterx_env.test_env);
 }
 
 FILTERX_DEFINE_TYPE(test_dict, FILTERX_TYPE_NAME(object), .is_abstract = TRUE);

--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -499,5 +499,7 @@ FILTERX_DEFINE_TYPE(otel_array, FILTERX_TYPE_NAME(sequence),
                     .len = _len,
                     .iter = _iter,
                     .repr = _repr,
+                    .add = filterx_sequence_generic_add_method,
+                    .add_inplace = filterx_sequence_generic_add_inplace_method,
                     .free_fn = _free,
                    );

--- a/news/feature-1047.md
+++ b/news/feature-1047.md
@@ -1,0 +1,7 @@
+`tuple()`: this is a read-only, list-like data type, that can only be
+initialized once, and then remains read-only until the end of its lifecycle.
+Patterned after the Python type of the same name.
+
+  t = ();        # empty tuple
+  t = ("foo",);  # singleton
+  t = (1,2,3);   # a tuple of 3 elements

--- a/tests/light/functional_tests/filterx/test_filterx_cow.py
+++ b/tests/light/functional_tests/filterx/test_filterx_cow.py
@@ -590,3 +590,60 @@ def test_plus_on_child_of_shared_hierarchy(config, syslog_ng):
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
     assert file_true.read_log() == """["foo","bar","foobar"]--{"child":["foo","bar"]}"""
+
+
+def test_list_mutable_elements_from_tuple_cause_clone_when_whanged_through_tuple(config, syslog_ng):
+    (file_true, file_false, _) = create_config(
+        config, [
+            """
+                d = {'foo':'foovalue','bar':'barvalue'};
+                t = tuple([1,2,3,d]);
+                l = list(t);
+                unset(t[3].foo);
+                $MSG = string(t) + '--' + string(l);
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == """(1,2,3,{"bar":"barvalue"})--[1,2,3,{"foo":"foovalue","bar":"barvalue"}]"""
+
+
+def test_list_mutable_elements_from_tuple_cause_clone_when_whanged_through_list(config, syslog_ng):
+    (file_true, file_false, _) = create_config(
+        config, [
+            """
+                d = {'foo':'foovalue','bar':'barvalue'};
+                t = tuple([1,2,3,d]);
+                l = list(t);
+                l[3];
+                unset(l[3].foo);
+                $MSG = string(t) + '--' + string(l);
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == """(1,2,3,{"foo":"foovalue","bar":"barvalue"})--[1,2,3,{"bar":"barvalue"}]"""
+
+
+def test_tuple_changing_mutable_elements_cause_clone(config, syslog_ng):
+    (file_true, file_false, _) = create_config(
+        config, [
+            """
+                d = {'foo':'foovalue','bar':'barvalue'};
+                t = tuple([1,2,3,[4,5,6,d]]);
+                unset(d.foo);
+                $MSG = string(t) + '--' + string(d);
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == """(1,2,3,[4,5,6,{"foo":"foovalue","bar":"barvalue"}])--{"bar":"barvalue"}"""

--- a/tests/light/functional_tests/filterx/test_filterx_types.py
+++ b/tests/light/functional_tests/filterx/test_filterx_types.py
@@ -110,6 +110,34 @@ def test_type_list(config, syslog_ng):
     assert msg["json"] == """{"foo":"foovalue","bar":"barvalue","int":5,"null":null,"double":3.1400000000000001,"datetime":"1139650496.123000"}"""
 
 
+def test_type_tuple(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    variable = {};
+    variable.just_an_expr = ("alma");
+    variable.singleton = ("alma",);
+    variable.pair = ("alma","korte");
+    variable.triplet = ("alma","korte","barack");
+    variable.four = ("alma","korte","barack","dio");
+    variable.five = ("alma","korte","barack","dio","szilva");
+    variable.six = ("alma","korte","barack","dio","szilva","mango");
+    variable.trailing_comma = ("alma","korte","barack",);
+
+    $MSG = {};
+    $MSG.repr = repr(variable);
+    $MSG.string = string(variable);
+    $MSG.json = format_json(variable);
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    msg = json.loads(file_final.read_log())
+    assert msg["repr"] == """{"just_an_expr":"alma","singleton":("alma",),"pair":("alma","korte"),"triplet":("alma","korte","barack"),"four":("alma","korte","barack","dio"),"five":("alma","korte","barack","dio","szilva"),"six":("alma","korte","barack","dio","szilva","mango"),"trailing_comma":("alma","korte","barack")}"""
+    assert msg["string"] == msg["repr"]
+    assert msg["json"] == """{"just_an_expr":"alma","singleton":["alma"],"pair":["alma","korte"],"triplet":["alma","korte","barack"],"four":["alma","korte","barack","dio"],"five":["alma","korte","barack","dio","szilva"],"six":["alma","korte","barack","dio","szilva","mango"],"trailing_comma":["alma","korte","barack"]}"""
+
+
 def test_type_bytes(config, syslog_ng):
     (file_final,) = create_config(
         config, r"""


### PR DESCRIPTION
Intended to be very similar to Python's own implementation.
    
Examples:
```
      t = ();  # empty tuple
      t = (1,); # singleton
      t = (1,2); # pair
```

*  The tuple can contain mutable items, but the tuple itself can't be changed. 
* A tuple is hashable (as long as all its items are hashable), so with the combination of #1046, we can use tuples as hash keys, which was my intended use-case.

NOTE: I used AI to get a review of the production code (that I wrote myself) and to generate 75% of the unit tests.
NOTE/2: this depends on a lot of previous PRs, hence the long history. These are the dependent PRs: #925, #1046, #1033
