### PR TITLE
FilterX JIT compiler - codegen for 10 expressions

### DIFF
--- a/lib/filterx/expr-arithmetic-operators.c
+++ b/lib/filterx/expr-arithmetic-operators.c
@@ -338,6 +338,102 @@ _eval_uminus(FilterXExpr *s)
   return _do_uminus(filterx_expr_eval_typed(self->operand), &self->super);
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+__attribute__((used))
+FilterXObject *
+fx_jit_arithmetic_sub(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
+{
+  return _do_substraction(lhs, rhs, expr);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_arithmetic_mul(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
+{
+  return _do_multiplication(lhs, rhs, expr);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_arithmetic_div(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
+{
+  return _do_division(lhs, rhs, expr);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_arithmetic_mod(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
+{
+  return _do_modulo(lhs, rhs, expr);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_arithmetic_uminus(FilterXObject *operand, FilterXExpr *expr)
+{
+  return _do_uminus(operand, expr);
+}
+
+static FilterXIRValue
+_compile_binary_arithmetic(FilterXExpr *s, FilterXJIT *jit, const gchar *fn_name)
+{
+  FilterXArithmeticOperator *self = (FilterXArithmeticOperator *) s;
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  FilterXIRValue lhs = self->literal_lhs
+                       ? fx_jit_emit_object_ref(jit, fx_jit_emit_const_ptr(jit, self->literal_lhs))
+                       : filterx_expr_compile_or_eval_typed(self->super.lhs, jit);
+  FilterXIRValue rhs = self->literal_rhs
+                       ? fx_jit_emit_object_ref(jit, fx_jit_emit_const_ptr(jit, self->literal_rhs))
+                       : filterx_expr_compile_or_eval(self->super.rhs, jit);
+
+  FilterXIRValue args[] = { lhs, rhs, fx_jit_emit_const_ptr(jit, self) };
+  FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
+  return fx_jit_emit_extern_call(jit, fn_name, ffi->ptr_ty, param_tys, args, 3);
+}
+
+static FilterXIRValue
+_compile_substraction(FilterXExpr *s, FilterXJIT *jit)
+{
+  return _compile_binary_arithmetic(s, jit, "fx_jit_arithmetic_sub");
+}
+
+static FilterXIRValue
+_compile_multiplication(FilterXExpr *s, FilterXJIT *jit)
+{
+  return _compile_binary_arithmetic(s, jit, "fx_jit_arithmetic_mul");
+}
+
+static FilterXIRValue
+_compile_division(FilterXExpr *s, FilterXJIT *jit)
+{
+  return _compile_binary_arithmetic(s, jit, "fx_jit_arithmetic_div");
+}
+
+static FilterXIRValue
+_compile_modulo(FilterXExpr *s, FilterXJIT *jit)
+{
+  return _compile_binary_arithmetic(s, jit, "fx_jit_arithmetic_mod");
+}
+
+static FilterXIRValue
+_compile_uminus(FilterXExpr *s, FilterXJIT *jit)
+{
+  FilterXUnaryOp *self = (FilterXUnaryOp *) s;
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  FilterXIRValue operand = filterx_expr_compile_or_eval_typed(self->operand, jit);
+  FilterXIRValue args[] = { operand, fx_jit_emit_const_ptr(jit, s) };
+  FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty };
+  return fx_jit_emit_extern_call(jit, "fx_jit_arithmetic_uminus", ffi->ptr_ty, param_tys, args, 2);
+}
+
+#endif
+
 FilterXExpr *
 filterx_arithmetic_operator_substraction_new(FilterXExpr *lhs, FilterXExpr *rhs)
 {
@@ -346,6 +442,9 @@ filterx_arithmetic_operator_substraction_new(FilterXExpr *lhs, FilterXExpr *rhs)
   self->super.super.optimize = _optimize_substraction;
   self->super.super.eval = _eval_substraction;
   self->super.super.free_fn = _free_arithmetic_common;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.super.compile = _compile_substraction;
+#endif
 
   return &self->super.super;
 }
@@ -358,6 +457,9 @@ filterx_arithmetic_operator_division_new(FilterXExpr *lhs, FilterXExpr *rhs)
   self->super.super.optimize = _optimize_division;
   self->super.super.eval = _eval_division;
   self->super.super.free_fn = _free_arithmetic_common;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.super.compile = _compile_division;
+#endif
 
   return &self->super.super;
 }
@@ -370,6 +472,9 @@ filterx_arithmetic_operator_modulo_new(FilterXExpr *lhs, FilterXExpr *rhs)
   self->super.super.optimize = _optimize_modulo;
   self->super.super.eval = _eval_modulo;
   self->super.super.free_fn = _free_arithmetic_common;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.super.compile = _compile_modulo;
+#endif
 
   return &self->super.super;
 }
@@ -382,6 +487,9 @@ filterx_arithmetic_operator_multiplication_new(FilterXExpr *lhs, FilterXExpr *rh
   self->super.super.optimize = _optimize_multiplication;
   self->super.super.eval = _eval_multiplication;
   self->super.super.free_fn = _free_arithmetic_common;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.super.compile = _compile_multiplication;
+#endif
 
   return &self->super.super;
 }
@@ -393,6 +501,9 @@ filterx_arithmetic_operator_uminus_new(FilterXExpr *operand)
   filterx_unary_op_init_instance(self, "uminus", FXE_READ, operand);
 
   self->super.eval = _eval_uminus;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.compile = _compile_uminus;
+#endif
 
   return &self->super;
 }

--- a/lib/filterx/expr-arithmetic-operators.c
+++ b/lib/filterx/expr-arithmetic-operators.c
@@ -135,18 +135,6 @@ _optimize_substraction(FilterXExpr *s)
   return NULL;
 }
 
-FilterXExpr *
-filterx_arithmetic_operator_substraction_new(FilterXExpr *lhs, FilterXExpr *rhs)
-{
-  FilterXArithmeticOperator *self = g_new0(FilterXArithmeticOperator, 1);
-  filterx_binary_op_init_instance(&self->super, "subs", FXE_READ, lhs, rhs);
-  self->super.super.optimize = _optimize_substraction;
-  self->super.super.eval = _eval_substraction;
-  self->super.super.free_fn = _free_arithmetic_common;
-
-  return &self->super.super;
-}
-
 static FilterXObject *
 _eval_multiplication(FilterXExpr *s)
 {
@@ -178,18 +166,6 @@ _optimize_multiplication(FilterXExpr *s)
   if (self->literal_lhs && self->literal_rhs)
     return filterx_literal_new(_eval_multiplication(&self->super.super));
   return NULL;
-}
-
-FilterXExpr *
-filterx_arithmetic_operator_multiplication_new(FilterXExpr *lhs, FilterXExpr *rhs)
-{
-  FilterXArithmeticOperator *self = g_new0(FilterXArithmeticOperator, 1);
-  filterx_binary_op_init_instance(&self->super, "mult", FXE_READ, lhs, rhs);
-  self->super.super.optimize = _optimize_multiplication;
-  self->super.super.eval = _eval_multiplication;
-  self->super.super.free_fn = _free_arithmetic_common;
-
-  return &self->super.super;
 }
 
 static FilterXObject *
@@ -225,17 +201,7 @@ _optimize_division(FilterXExpr *s)
   return NULL;
 }
 
-FilterXExpr *
-filterx_arithmetic_operator_division_new(FilterXExpr *lhs, FilterXExpr *rhs)
-{
-  FilterXArithmeticOperator *self = g_new0(FilterXArithmeticOperator, 1);
-  filterx_binary_op_init_instance(&self->super, "subs", FXE_READ, lhs, rhs);
-  self->super.super.optimize = _optimize_division;
-  self->super.super.eval = _eval_division;
-  self->super.super.free_fn = _free_arithmetic_common;
 
-  return &self->super.super;
-}
 
 static FilterXObject *
 _eval_modulo(FilterXExpr *s)
@@ -297,18 +263,6 @@ _optimize_modulo(FilterXExpr *s)
   return NULL;
 }
 
-FilterXExpr *
-filterx_arithmetic_operator_modulo_new(FilterXExpr *lhs, FilterXExpr *rhs)
-{
-  FilterXArithmeticOperator *self = g_new0(FilterXArithmeticOperator, 1);
-  filterx_binary_op_init_instance(&self->super, "mod", FXE_READ, lhs, rhs);
-  self->super.super.optimize = _optimize_modulo;
-  self->super.super.eval = _eval_modulo;
-  self->super.super.free_fn = _free_arithmetic_common;
-
-  return &self->super.super;
-}
-
 static FilterXObject *
 _eval_uminus(FilterXExpr *s)
 {
@@ -344,6 +298,54 @@ _eval_uminus(FilterXExpr *s)
 
   gn_set_double(&result, -gn_as_double(&operand), -1);
   return filterx_double_new(gn_as_double(&result));
+}
+
+FilterXExpr *
+filterx_arithmetic_operator_substraction_new(FilterXExpr *lhs, FilterXExpr *rhs)
+{
+  FilterXArithmeticOperator *self = g_new0(FilterXArithmeticOperator, 1);
+  filterx_binary_op_init_instance(&self->super, "subs", FXE_READ, lhs, rhs);
+  self->super.super.optimize = _optimize_substraction;
+  self->super.super.eval = _eval_substraction;
+  self->super.super.free_fn = _free_arithmetic_common;
+
+  return &self->super.super;
+}
+
+FilterXExpr *
+filterx_arithmetic_operator_division_new(FilterXExpr *lhs, FilterXExpr *rhs)
+{
+  FilterXArithmeticOperator *self = g_new0(FilterXArithmeticOperator, 1);
+  filterx_binary_op_init_instance(&self->super, "subs", FXE_READ, lhs, rhs);
+  self->super.super.optimize = _optimize_division;
+  self->super.super.eval = _eval_division;
+  self->super.super.free_fn = _free_arithmetic_common;
+
+  return &self->super.super;
+}
+
+FilterXExpr *
+filterx_arithmetic_operator_modulo_new(FilterXExpr *lhs, FilterXExpr *rhs)
+{
+  FilterXArithmeticOperator *self = g_new0(FilterXArithmeticOperator, 1);
+  filterx_binary_op_init_instance(&self->super, "mod", FXE_READ, lhs, rhs);
+  self->super.super.optimize = _optimize_modulo;
+  self->super.super.eval = _eval_modulo;
+  self->super.super.free_fn = _free_arithmetic_common;
+
+  return &self->super.super;
+}
+
+FilterXExpr *
+filterx_arithmetic_operator_multiplication_new(FilterXExpr *lhs, FilterXExpr *rhs)
+{
+  FilterXArithmeticOperator *self = g_new0(FilterXArithmeticOperator, 1);
+  filterx_binary_op_init_instance(&self->super, "mult", FXE_READ, lhs, rhs);
+  self->super.super.optimize = _optimize_multiplication;
+  self->super.super.eval = _eval_multiplication;
+  self->super.super.free_fn = _free_arithmetic_common;
+
+  return &self->super.super;
 }
 
 FilterXExpr *

--- a/lib/filterx/expr-arithmetic-operators.c
+++ b/lib/filterx/expr-arithmetic-operators.c
@@ -36,50 +36,58 @@ typedef struct FilterXArithmeticOperator_
   FilterXObject *literal_rhs;
 } FilterXArithmeticOperator;
 
+
+/* consumes operand objects */
 static gboolean
-_eval_arithmetic_operators_common(FilterXArithmeticOperator *self, GenericNumber *lhs_number,
-                                  GenericNumber *rhs_number, GenericNumber *result)
+_extract_operands_into_generic_numbers(FilterXObject *lhs_object, FilterXObject *rhs_object,
+                 GenericNumber *lhs_number, GenericNumber *rhs_number, FilterXExpr *expr)
 {
-  FilterXObject *lhs_object = self->literal_lhs ? filterx_object_ref(self->literal_lhs)
-                              : filterx_expr_eval_typed(self->super.lhs);
+  gboolean ok = FALSE;
+
   if (!lhs_object)
     {
-      filterx_eval_push_error_static_info("Failed to evaluate arithmetic operator", &self->super.super,
+      filterx_eval_push_error_static_info("Failed to evaluate arithmetic operator", expr,
                                           "Failed to evaluate left hand side");
-      return FALSE;
+      goto exit;
     }
-
   if (!filterx_object_extract_generic_number(lhs_object, lhs_number))
     {
-      filterx_eval_push_error_info_printf("Failed to evaluate arithmetic operator", &self->super.super,
+      filterx_eval_push_error_info_printf("Failed to evaluate arithmetic operator", expr,
                                           "Left hand side must be a double or integer, got: %s",
                                           filterx_object_get_type_name(lhs_object));
-      filterx_object_unref(lhs_object);
-      return FALSE;
+      goto exit;
     }
-  filterx_object_unref(lhs_object);
-
-  FilterXObject *rhs_object = self->literal_rhs ? filterx_object_ref(self->literal_rhs)
-                              : filterx_expr_eval(self->super.rhs);
-
   if (!rhs_object)
     {
-      filterx_eval_push_error_static_info("Failed to evaluate arithmetic operator", &self->super.super,
+      filterx_eval_push_error_static_info("Failed to evaluate arithmetic operator", expr,
                                           "Failed to evaluate right hand side");
-      return FALSE;
+      goto exit;
     }
-
   if (!filterx_object_extract_generic_number(rhs_object, rhs_number))
     {
-      filterx_eval_push_error_info_printf("Failed to evaluate arithmetic operator", &self->super.super,
+      filterx_eval_push_error_info_printf("Failed to evaluate arithmetic operator", expr,
                                           "right hand side must be a double or integer, got: %s",
                                           filterx_object_get_type_name(rhs_object));
-      filterx_object_unref(lhs_object);
-      return FALSE;
+      goto exit;
     }
-  filterx_object_unref(rhs_object);
+  ok = TRUE;
 
-  return TRUE;
+exit:
+  filterx_object_unref(lhs_object);
+  filterx_object_unref(rhs_object);
+  return ok;
+}
+
+static inline FilterXObject *
+_eval_lhs(FilterXArithmeticOperator *self)
+{
+  return self->literal_lhs ? filterx_object_ref(self->literal_lhs) : filterx_expr_eval_typed(self->super.lhs);
+}
+
+static inline FilterXObject *
+_eval_rhs(FilterXArithmeticOperator *self)
+{
+  return self->literal_rhs ? filterx_object_ref(self->literal_rhs) : filterx_expr_eval(self->super.rhs);
 }
 
 static void
@@ -103,17 +111,17 @@ _free_arithmetic_common(FilterXExpr *s)
 }
 
 static FilterXObject *
-_eval_substraction(FilterXExpr *s)
+_do_substraction(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
 {
-  FilterXArithmeticOperator *self = (FilterXArithmeticOperator *) s;
   GenericNumber lhs_number, rhs_number, result;
 
-  if(!_eval_arithmetic_operators_common(self, &lhs_number, &rhs_number, &result))
+  if (!_extract_operands_into_generic_numbers(lhs, rhs, &lhs_number, &rhs_number, expr))
     return NULL;
 
   if (lhs_number.type == GN_NAN || rhs_number.type == GN_NAN)
     return NULL;
-  else if (lhs_number.type == GN_INT64 && rhs_number.type == GN_INT64)
+
+  if (lhs_number.type == GN_INT64 && rhs_number.type == GN_INT64)
     {
       gn_set_int64(&result, gn_as_int64(&lhs_number) - gn_as_int64(&rhs_number));
       return filterx_integer_new(gn_as_int64(&result));
@@ -121,6 +129,13 @@ _eval_substraction(FilterXExpr *s)
 
   gn_set_double(&result, gn_as_double(&lhs_number) - gn_as_double(&rhs_number), -1);
   return filterx_double_new(gn_as_double(&result));
+}
+
+static FilterXObject *
+_eval_substraction(FilterXExpr *s)
+{
+  FilterXArithmeticOperator *self = (FilterXArithmeticOperator *) s;
+  return _do_substraction(_eval_lhs(self), _eval_rhs(self), s);
 }
 
 static FilterXExpr *
@@ -136,17 +151,17 @@ _optimize_substraction(FilterXExpr *s)
 }
 
 static FilterXObject *
-_eval_multiplication(FilterXExpr *s)
+_do_multiplication(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
 {
-  FilterXArithmeticOperator *self = (FilterXArithmeticOperator *) s;
   GenericNumber lhs_number, rhs_number, result;
 
-  if(!_eval_arithmetic_operators_common(self, &lhs_number, &rhs_number, &result))
+  if (!_extract_operands_into_generic_numbers(lhs, rhs, &lhs_number, &rhs_number, expr))
     return NULL;
 
   if (lhs_number.type == GN_NAN || rhs_number.type == GN_NAN)
     return NULL;
-  else if (lhs_number.type == GN_INT64 && rhs_number.type == GN_INT64)
+
+  if (lhs_number.type == GN_INT64 && rhs_number.type == GN_INT64)
     {
       gn_set_int64(&result, gn_as_int64(&lhs_number) * gn_as_int64(&rhs_number));
       return filterx_integer_new(gn_as_int64(&result));
@@ -154,6 +169,13 @@ _eval_multiplication(FilterXExpr *s)
 
   gn_set_double(&result, gn_as_double(&lhs_number) * gn_as_double(&rhs_number), -1);
   return filterx_double_new(gn_as_double(&result));
+}
+
+static FilterXObject *
+_eval_multiplication(FilterXExpr *s)
+{
+  FilterXArithmeticOperator *self = (FilterXArithmeticOperator *) s;
+  return _do_multiplication(_eval_lhs(self), _eval_rhs(self), s);
 }
 
 static FilterXExpr *
@@ -169,17 +191,17 @@ _optimize_multiplication(FilterXExpr *s)
 }
 
 static FilterXObject *
-_eval_division(FilterXExpr *s)
+_do_division(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
 {
-  FilterXArithmeticOperator *self = (FilterXArithmeticOperator *) s;
   GenericNumber lhs_number, rhs_number, result;
 
-  if(!_eval_arithmetic_operators_common(self, &lhs_number, &rhs_number, &result))
+  if (!_extract_operands_into_generic_numbers(lhs, rhs, &lhs_number, &rhs_number, expr))
     return NULL;
 
   if (lhs_number.type == GN_NAN || rhs_number.type == GN_NAN)
     return NULL;
-  else if (lhs_number.type == GN_INT64 && rhs_number.type == GN_INT64)
+
+  if (lhs_number.type == GN_INT64 && rhs_number.type == GN_INT64)
     {
       gn_set_int64(&result, gn_as_int64(&lhs_number) / gn_as_int64(&rhs_number));
       return filterx_integer_new(gn_as_int64(&result));
@@ -187,6 +209,13 @@ _eval_division(FilterXExpr *s)
 
   gn_set_double(&result, gn_as_double(&lhs_number) / gn_as_double(&rhs_number), -1);
   return filterx_double_new(gn_as_double(&result));
+}
+
+static FilterXObject *
+_eval_division(FilterXExpr *s)
+{
+  FilterXArithmeticOperator *self = (FilterXArithmeticOperator *) s;
+  return _do_division(_eval_lhs(self), _eval_rhs(self), s);
 }
 
 static FilterXExpr *
@@ -201,54 +230,54 @@ _optimize_division(FilterXExpr *s)
   return NULL;
 }
 
+static FilterXObject *
+_do_modulo(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
+{
+  gint64 lhs_number, rhs_number;
+  FilterXObject *result = NULL;
 
+  if (!lhs)
+    {
+      filterx_eval_push_error_static_info("Failed to evaluate modulo operator", expr,
+                                          "Failed to evaluate left hand side");
+      goto exit;
+    }
+
+  if (!filterx_object_extract_integer(lhs, &lhs_number))
+    {
+      filterx_eval_push_error_info_printf("Failed to evaluate modulo operator", expr,
+                                          "Left hand side must be an integer, got: %s",
+                                          filterx_object_get_type_name(lhs));
+      goto exit;
+    }
+
+  if (!rhs)
+    {
+      filterx_eval_push_error_static_info("Failed to evaluate modulo operator", expr,
+                                          "Failed to evaluate right hand side");
+      goto exit;
+    }
+
+  if (!filterx_object_extract_integer(rhs, &rhs_number))
+    {
+      filterx_eval_push_error_info_printf("Failed to evaluate modulo operator", expr,
+                                          "Right hand side must be an integer, got: %s",
+                                          filterx_object_get_type_name(rhs));
+      goto exit;
+    }
+  result = filterx_integer_new(lhs_number % rhs_number);
+
+exit:
+  filterx_object_unref(lhs);
+  filterx_object_unref(rhs);
+  return result;
+}
 
 static FilterXObject *
 _eval_modulo(FilterXExpr *s)
 {
   FilterXArithmeticOperator *self = (FilterXArithmeticOperator *) s;
-  gint64 lhs_number, rhs_number;
-
-  FilterXObject *lhs_object = self->literal_lhs ? filterx_object_ref(self->literal_lhs)
-                              : filterx_expr_eval_typed(self->super.lhs);
-  if (!lhs_object)
-    {
-      filterx_eval_push_error_static_info("Failed to evaluate modulo operator", &self->super.super,
-                                          "Failed to evaluate left hand side");
-      return NULL;
-    }
-
-  if(!filterx_object_extract_integer(lhs_object, &lhs_number))
-    {
-      filterx_eval_push_error_info_printf("Failed to evaluate modulo operator", &self->super.super,
-                                          "Left hand side must be an integer, got: %s",
-                                          filterx_object_get_type_name(lhs_object));
-      filterx_object_unref(lhs_object);
-      return NULL;
-    }
-  filterx_object_unref(lhs_object);
-
-  FilterXObject *rhs_object = self->literal_rhs ? filterx_object_ref(self->literal_rhs)
-                              : filterx_expr_eval(self->super.rhs);
-
-  if (!rhs_object)
-    {
-      filterx_eval_push_error_static_info("Failed to evaluate modulo operator", &self->super.super,
-                                          "Failed to evaluate right hand side");
-      return NULL;
-    }
-
-  if(!filterx_object_extract_integer(rhs_object, &rhs_number))
-    {
-      filterx_eval_push_error_info_printf("Failed to evaluate modulo operator", &self->super.super,
-                                          "Right hand side must be an integer, got: %s",
-                                          filterx_object_get_type_name(rhs_object));
-      filterx_object_unref(rhs_object);
-      return NULL;
-    }
-  filterx_object_unref(rhs_object);
-
-  return filterx_integer_new(lhs_number % rhs_number);
+  return _do_modulo(_eval_lhs(self), _eval_rhs(self), s);
 }
 
 static FilterXExpr *
@@ -264,40 +293,49 @@ _optimize_modulo(FilterXExpr *s)
 }
 
 static FilterXObject *
-_eval_uminus(FilterXExpr *s)
+_do_uminus(FilterXObject *operand_obj, FilterXExpr *expr)
 {
-  FilterXUnaryOp *self = (FilterXUnaryOp *) s;
   GenericNumber operand, result;
+  FilterXObject *out = NULL;
 
-  FilterXObject *operand_obj = filterx_expr_eval_typed(self->operand);
   if (!operand_obj)
     {
-      filterx_eval_push_error_static_info("Failed to evaluate arithmetic operator", &self->super,
+      filterx_eval_push_error_static_info("Failed to evaluate arithmetic operator", expr,
                                           "Failed to evaluate operand");
-      return FALSE;
+      goto exit;
     }
 
   if (!filterx_object_extract_generic_number(operand_obj, &operand))
     {
-      filterx_eval_push_error_info_printf("Failed to evaluate arithmetic operator", &self->super,
+      filterx_eval_push_error_info_printf("Failed to evaluate arithmetic operator", expr,
                                           "Operand must be a double or integer, got: %s",
                                           filterx_object_get_type_name(operand_obj));
-      filterx_object_unref(operand_obj);
-      return FALSE;
+      goto exit;
     }
-  filterx_object_unref(operand_obj);
 
   if (operand.type == GN_NAN)
-    return NULL;
+    goto exit;
 
   if (operand.type == GN_INT64)
     {
       gn_set_int64(&result, -gn_as_int64(&operand));
-      return filterx_integer_new(gn_as_int64(&result));
+      out = filterx_integer_new(gn_as_int64(&result));
+      goto exit;
     }
 
   gn_set_double(&result, -gn_as_double(&operand), -1);
-  return filterx_double_new(gn_as_double(&result));
+  out = filterx_double_new(gn_as_double(&result));
+
+exit:
+  filterx_object_unref(operand_obj);
+  return out;
+}
+
+static FilterXObject *
+_eval_uminus(FilterXExpr *s)
+{
+  FilterXUnaryOp *self = (FilterXUnaryOp *) s;
+  return _do_uminus(filterx_expr_eval_typed(self->operand), &self->super);
 }
 
 FilterXExpr *

--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -92,6 +92,51 @@ _nullv_assign_eval(FilterXExpr *s)
   return _do_nullv_assign(self, filterx_expr_eval(self->super.rhs));
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_assign(FilterXExpr *s, FilterXObject *value)
+{
+  return _do_assign((FilterXAssign *) s, value);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_nullv_assign(FilterXExpr *s, FilterXObject *value)
+{
+  return _do_nullv_assign((FilterXAssign *) s, value);
+}
+
+static FilterXIRValue
+_compile_assignment(FilterXExpr *s, FilterXJIT *jit, const gchar *fn_name)
+{
+  FilterXAssign *self = (FilterXAssign *) s;
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  FilterXIRValue value = filterx_expr_compile_or_eval(self->super.rhs, jit);
+  FilterXIRValue args[] = { fx_jit_emit_const_ptr(jit, self), value };
+  FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty };
+  return fx_jit_emit_extern_call(jit, fn_name, ffi->ptr_ty, param_tys, args, 2);
+}
+
+static FilterXIRValue
+_assign_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  return _compile_assignment(s, jit, "fx_jit_do_assign");
+}
+
+static FilterXIRValue
+_nullv_assign_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  return _compile_assignment(s, jit, "fx_jit_do_nullv_assign");
+}
+
+#endif
+
 static void
 filterx_assign_init_instance(FilterXAssign *self, const gchar *type,
                              FilterXExpr *lhs, FilterXExpr *rhs)
@@ -108,6 +153,9 @@ filterx_assign_new(FilterXExpr *lhs, FilterXExpr *rhs)
 
   filterx_assign_init_instance(self, "assign", lhs, rhs);
   self->super.super.eval = _assign_eval;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.super.compile = _assign_compile;
+#endif
   return &self->super.super;
 }
 
@@ -118,5 +166,8 @@ filterx_nullv_assign_new(FilterXExpr *lhs, FilterXExpr *rhs)
 
   filterx_assign_init_instance(self, "nullv-assign", lhs, rhs);
   self->super.super.eval = _nullv_assign_eval;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.super.compile = _nullv_assign_compile;
+#endif
   return &self->super.super;
 }

--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -32,17 +32,37 @@ typedef struct FilterXAssign
   FilterXBinaryOp super;
 } FilterXAssign;
 
-static inline FilterXObject *
-_assign(FilterXAssign *self, FilterXObject *value)
+static FilterXObject *
+_do_assign(FilterXAssign *self, FilterXObject *value)
 {
-  FilterXObject *cloned = filterx_object_cow_fork2(filterx_object_ref(value), NULL);
+  FilterXObject *cloned = NULL;
+
+  if (!value)
+    {
+      filterx_eval_push_error_static_info("Failed to assign value", &self->super.super,
+                                          "Failed to evaluate right hand side");
+      return NULL;
+    }
+
+  /* cow_fork2 consumes the ref on value */
+  cloned = filterx_object_cow_fork2(value, NULL);
+
   if (!filterx_expr_assign(self->super.lhs, &cloned))
     {
+      filterx_eval_push_error_static_info("Failed to assign value", &self->super.super,
+                                          "assign() method failed");
       filterx_object_unref(cloned);
       return NULL;
     }
 
   return cloned;
+}
+
+static FilterXObject *
+_assign_eval(FilterXExpr *s)
+{
+  FilterXAssign *self = (FilterXAssign *) s;
+  return _do_assign(self, filterx_expr_eval(self->super.rhs));
 }
 
 static inline FilterXObject *
@@ -54,49 +74,22 @@ _suppress_error(void)
 }
 
 static FilterXObject *
-_nullv_assign_eval(FilterXExpr *s)
+_do_nullv_assign(FilterXAssign *self, FilterXObject *value)
 {
-  FilterXAssign *self = (FilterXAssign *) s;
+  if (!value)
+    return _suppress_error();
 
-  FilterXObject *value = filterx_expr_eval(self->super.rhs);
+  if (filterx_object_extract_null(value))
+    return value;
 
-  if (!value || filterx_object_extract_null(value))
-    {
-      if (!value)
-        return _suppress_error();
-
-      return value;
-    }
-
-  FilterXObject *result = _assign(self, value);
-  filterx_object_unref(value);
-
-  if (!result)
-    filterx_eval_push_error_static_info("Failed to assign value", s, "assign() method failed");
-
-  return result;
+  return _do_assign(self, value);
 }
 
 static FilterXObject *
-_assign_eval(FilterXExpr *s)
+_nullv_assign_eval(FilterXExpr *s)
 {
   FilterXAssign *self = (FilterXAssign *) s;
-
-  FilterXObject *value = filterx_expr_eval(self->super.rhs);
-
-  if (!value)
-    {
-      filterx_eval_push_error_static_info("Failed to assign value", s, "Failed to evaluate right hand side");
-      return NULL;
-    }
-
-  FilterXObject *result = _assign(self, value);
-  filterx_object_unref(value);
-
-  if (!result)
-    filterx_eval_push_error_static_info("Failed to assign value", s, "assign() method failed");
-
-  return result;
+  return _do_nullv_assign(self, filterx_expr_eval(self->super.rhs));
 }
 
 static void

--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -182,6 +182,91 @@ _conditional_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return TRUE;
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+__attribute__((used))
+gboolean
+fx_jit_condition_is_truthy(FilterXConditional *self, FilterXObject *condition_value)
+{
+  return _condition_is_truthy(self, condition_value);
+}
+
+static inline FilterXIRValue
+_emit_condition_is_truthy(FilterXJIT *jit, FilterXConditional *self, FilterXIRValue condition_value)
+{
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+  return fx_jit_emit_extern_call(jit, "fx_jit_condition_is_truthy", ffi->i32_ty,
+                                 (LLVMTypeRef[]){ ffi->ptr_ty, ffi->ptr_ty },
+                                 (FilterXIRValue[]){ fx_jit_emit_const_ptr(jit, self), condition_value }, 2);
+}
+
+static FilterXIRValue
+_compile_conditional(FilterXExpr *s, FilterXJIT *jit)
+{
+  FilterXConditional *self = (FilterXConditional *) s;
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+  FilterXIRBuilder ir = filterx_jit_get_ir_builder(jit);
+  FilterXIRValue block = filterx_jit_ir_get_current_block(jit);
+
+  FilterXIRValue result_slot = LLVMBuildAlloca(ir, ffi->ptr_ty, "result");
+  LLVMBuildStore(ir, LLVMConstNull(ffi->ptr_ty), result_slot);
+
+  FilterXIRSequence cond_null = filterx_jit_ir_create_sequence(jit, "conditional_null", block);
+  FilterXIRSequence cond_check = filterx_jit_ir_create_sequence(jit, "conditional_check", block);
+  FilterXIRSequence true_branch = filterx_jit_ir_create_sequence(jit, "conditional_true", block);
+  FilterXIRSequence false_branch = filterx_jit_ir_create_sequence(jit, "conditional_false", block);
+  FilterXIRSequence finish = filterx_jit_ir_create_sequence(jit, "conditional_finish", block);
+
+  FilterXIRValue condition_value = filterx_expr_compile_or_eval(self->condition, jit);
+
+  /* if (!condition_value) { push_error; goto finish; } */
+  FilterXIRValue is_null = LLVMBuildIsNull(ir, condition_value, "is_null");
+  LLVMBuildCondBr(ir, is_null, cond_null, cond_check);
+  filterx_jit_ir_add_sequence_to_block(jit, cond_null, block);
+  filterx_jit_ir_set_insert_point_to_sequence_tail(jit, cond_null);
+  fx_jit_emit_eval_push_error_static_info(jit, "Failed to evaluate conditional", s, "Failed to evaluate condition");
+  LLVMBuildBr(ir, finish);
+
+  /* if (_condition_is_truthy(self, condition_value)) */
+  filterx_jit_ir_add_sequence_to_block(jit, cond_check, block);
+  filterx_jit_ir_set_insert_point_to_sequence_tail(jit, cond_check);
+  FilterXIRValue truthy = _emit_condition_is_truthy(jit, self, condition_value);
+  FilterXIRValue is_truthy = LLVMBuildICmp(ir, LLVMIntNE, truthy, LLVMConstInt(ffi->i32_ty, 0, FALSE), "is_truthy");
+  LLVMBuildCondBr(ir, is_truthy, true_branch, false_branch);
+
+  /* true_branch */
+  filterx_jit_ir_add_sequence_to_block(jit, true_branch, block);
+  filterx_jit_ir_set_insert_point_to_sequence_tail(jit, true_branch);
+  if (self->true_branch)
+    {
+      fx_jit_emit_object_unref(jit, condition_value);
+      LLVMBuildStore(ir, filterx_expr_compile_or_eval(self->true_branch, jit), result_slot);
+    }
+  else
+    LLVMBuildStore(ir, condition_value, result_slot);
+  LLVMBuildBr(ir, finish);
+
+  /* false_branch */
+  filterx_jit_ir_add_sequence_to_block(jit, false_branch, block);
+  filterx_jit_ir_set_insert_point_to_sequence_tail(jit, false_branch);
+  fx_jit_emit_object_unref(jit, condition_value);
+  if (self->false_branch)
+    LLVMBuildStore(ir, filterx_expr_compile_or_eval(self->false_branch, jit), result_slot);
+  else
+    LLVMBuildStore(ir, fx_jit_emit_boolean_new(jit, TRUE), result_slot);
+  LLVMBuildBr(ir, finish);
+
+  /* finish */
+  filterx_jit_ir_add_sequence_to_block(jit, finish, block);
+  filterx_jit_ir_set_insert_point_to_sequence_tail(jit, finish);
+  return LLVMBuildLoad2(ir, ffi->ptr_ty, result_slot, "result");
+}
+
+#endif
+
 FilterXExpr *
 filterx_conditional_new(FilterXExpr *condition)
 {
@@ -191,6 +276,9 @@ filterx_conditional_new(FilterXExpr *condition)
   self->super.optimize = _optimize;
   self->super.walk_children = _conditional_walk;
   self->super.free_fn = _free;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.compile = _compile_conditional;
+#endif
   self->super.suppress_from_trace = TRUE;
   self->condition = condition;
   return &self->super;

--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -49,18 +49,10 @@ _free(FilterXExpr *s)
   filterx_expr_free_method(s);
 }
 
-static FilterXObject *
-_eval_conditional(FilterXExpr *s)
+static gboolean
+_condition_is_truthy(FilterXConditional *self, FilterXObject *condition_value)
 {
-  FilterXConditional *self = (FilterXConditional *) s;
-  FilterXObject *condition_value = filterx_expr_eval(self->condition);
-  FilterXObject *result = NULL;
-
-  if (!condition_value)
-    {
-      filterx_eval_push_error_static_info("Failed to evaluate conditional", s, "Failed to evaluate condition");
-      return NULL;
-    }
+  gboolean truthy = filterx_object_truthy(condition_value);
 
   if (trace_flag)
     {
@@ -74,15 +66,32 @@ _eval_conditional(FilterXExpr *s)
             g_assert_not_reached();
         }
 
-      msg_trace(filterx_object_truthy(condition_value) ? "FILTERX CONDT" : "FILTERX CONDF",
+      msg_trace(truthy ? "FILTERX CONDT" : "FILTERX CONDF",
                 filterx_expr_format_location_tag(self->condition),
                 evt_tag_mem("value", buf->str, buf->len),
-                evt_tag_int("truthy", filterx_object_truthy(condition_value)),
+                evt_tag_int("truthy", truthy),
                 evt_tag_str("type", filterx_object_get_type_name(condition_value)));
+
       scratch_buffers_reclaim_marked(mark);
     }
 
-  if (filterx_object_truthy(condition_value))
+  return truthy;
+}
+
+static FilterXObject *
+_eval_conditional(FilterXExpr *s)
+{
+  FilterXConditional *self = (FilterXConditional *) s;
+  FilterXObject *condition_value = filterx_expr_eval(self->condition);
+  FilterXObject *result = NULL;
+
+  if (!condition_value)
+    {
+      filterx_eval_push_error_static_info("Failed to evaluate conditional", s, "Failed to evaluate condition");
+      return NULL;
+    }
+
+  if (_condition_is_truthy(self, condition_value))
     {
       if (self->true_branch)
         result = filterx_expr_eval(self->true_branch);

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -170,6 +170,76 @@ _simple_function_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return TRUE;
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_simple_function(FilterXSimpleFunctionProto fn, FilterXExpr *expr,
+                          FilterXObject **args, gsize args_len)
+{
+  FilterXObject *res = NULL;
+  gboolean all_ok = TRUE;
+
+  for (gsize i = 0; i < args_len; i++)
+    {
+      if (!args[i])
+        {
+          all_ok = FALSE;
+          break;
+        }
+    }
+
+  if (all_ok)
+    res = fn(expr, args, args_len);
+
+  for (gsize i = 0; i < args_len; i++)
+    filterx_object_unref(args[i]);
+
+  return res;
+}
+
+static FilterXIRValue
+_simple_function_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  FilterXSimpleFunction *self = (FilterXSimpleFunction *) s;
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+  FilterXIRBuilder ir = filterx_jit_get_ir_builder(jit);
+
+  gsize args_len = self->args->len;
+  LLVMValueRef args_ptr;
+
+  if (args_len > 0)
+    {
+      args_ptr = LLVMBuildArrayAlloca(ir, ffi->ptr_ty, LLVMConstInt(ffi->i64_ty, args_len, FALSE), "simple_args");
+      for (gsize i = 0; i < args_len; i++)
+        {
+          FilterXExpr *arg_expr = g_ptr_array_index(self->args, i);
+          LLVMValueRef arg_val = filterx_expr_compile_or_eval_typed(arg_expr, jit);
+          LLVMValueRef idx = LLVMConstInt(ffi->i64_ty, i, FALSE);
+          LLVMValueRef slot = LLVMBuildGEP2(ir, ffi->ptr_ty, args_ptr, &idx, 1, "");
+          LLVMBuildStore(ir, arg_val, slot);
+        }
+    }
+  else
+    {
+      args_ptr = LLVMConstNull(ffi->ptr_ty);
+    }
+
+  FilterXIRValue call_args[] = {
+    fx_jit_emit_const_ptr(jit, self->function_proto),
+    fx_jit_emit_const_ptr(jit, s),
+    args_ptr,
+    LLVMConstInt(ffi->i64_ty, args_len, FALSE),
+  };
+  FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty, ffi->i64_ty };
+  return fx_jit_emit_extern_call(jit, "fx_jit_do_simple_function", ffi->ptr_ty, param_tys, call_args, 4);
+}
+
+#endif
+
 FilterXExpr *
 filterx_simple_function_new(const gchar *function_name, FilterXFunctionArgs *args,
                             FilterXSimpleFunctionProto function_proto, GError **error)
@@ -180,6 +250,9 @@ filterx_simple_function_new(const gchar *function_name, FilterXFunctionArgs *arg
   self->super.super.eval = _simple_eval;
   self->super.super.walk_children = _simple_function_walk;
   self->super.super.free_fn = _simple_free;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.super.compile = _simple_function_compile;
+#endif
   self->function_proto = function_proto;
 
   self->args = g_ptr_array_new_full(filterx_function_args_len(args), (GDestroyNotify) filterx_expr_unref);

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -33,28 +33,28 @@ typedef struct _FilterXGetAttr
 } FilterXGetAttr;
 
 static FilterXObject *
-_eval_getattr(FilterXExpr *s)
+_do_getattr(FilterXObject *variable, FilterXObject *attr, FilterXExpr *expr)
 {
-  FilterXGetAttr *self = (FilterXGetAttr *) s;
-
-  FilterXObject *variable = filterx_expr_eval_typed(self->operand);
-
   if (!variable)
     {
-      filterx_eval_push_error_static_info("Failed to get-attribute from object", s, "Failed to evaluate expression");
+      filterx_eval_push_error_static_info("Failed to get-attribute from object", expr,
+                                          "Failed to evaluate expression");
       return NULL;
     }
 
-  FilterXObject *attr = filterx_object_getattr(variable, self->attr);
-  if (!attr)
-    {
-      filterx_eval_push_error_static_info("Failed to get-attribute from object", s, "Failed to evaluate key");
-      goto exit;
-    }
+  FilterXObject *result = filterx_object_getattr(variable, attr);
+  if (!result)
+    filterx_eval_push_error_static_info("Failed to get-attribute from object", expr, "Failed to evaluate key");
 
-exit:
   filterx_object_unref(variable);
-  return attr;
+  return result;
+}
+
+static FilterXObject *
+_eval_getattr(FilterXExpr *s)
+{
+  FilterXGetAttr *self = (FilterXGetAttr *) s;
+  return _do_getattr(filterx_expr_eval_typed(self->operand), self->attr, s);
 }
 
 static gboolean

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -146,6 +146,36 @@ _getattr_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return TRUE;
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_getattr(FilterXObject *variable, FilterXObject *attr, FilterXExpr *expr)
+{
+  return _do_getattr(variable, attr, expr);
+}
+
+static FilterXIRValue
+_getattr_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  FilterXGetAttr *self = (FilterXGetAttr *) s;
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  FilterXIRValue variable = filterx_expr_compile_or_eval_typed(self->operand, jit);
+  FilterXIRValue args[] = {
+    variable,
+    fx_jit_emit_const_ptr(jit, self->attr),
+    fx_jit_emit_const_ptr(jit, self),
+  };
+  FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
+  return fx_jit_emit_extern_call(jit, "fx_jit_do_getattr", ffi->ptr_ty, param_tys, args, 3);
+}
+
+#endif
+
 /* NOTE: takes the object reference */
 FilterXExpr *
 filterx_getattr_new(FilterXExpr *operand, FilterXObject *attr_name)
@@ -159,6 +189,9 @@ filterx_getattr_new(FilterXExpr *operand, FilterXObject *attr_name)
   self->super.is_set = _isset;
   self->super.walk_children = _getattr_walk;
   self->super.free_fn = _free;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.compile = _getattr_compile;
+#endif
   self->operand = operand;
 
   g_assert(filterx_object_is_type(attr_name, &FILTERX_TYPE_NAME(string)));

--- a/lib/filterx/expr-literal.c
+++ b/lib/filterx/expr-literal.c
@@ -58,6 +58,21 @@ _literal_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return TRUE;
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+static FilterXIRValue
+_literal_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  FilterXLiteral *self = (FilterXLiteral *) s;
+
+  return fx_jit_emit_object_ref(jit, fx_jit_emit_const_ptr(jit, self->object));
+}
+
+#endif
+
 /* NOTE: takes the object reference */
 void
 filterx_literal_init_instance(FilterXLiteral *s, FilterXObject *object)
@@ -68,6 +83,9 @@ filterx_literal_init_instance(FilterXLiteral *s, FilterXObject *object)
   self->super.eval = _eval_literal;
   self->super.walk_children = _literal_walk;
   self->super.free_fn = _free;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.compile = _literal_compile;
+#endif
   self->object = object;
 }
 

--- a/lib/filterx/expr-plus.c
+++ b/lib/filterx/expr-plus.c
@@ -95,6 +95,38 @@ _filterx_operator_plus_free(FilterXExpr *s)
   filterx_binary_op_free_method(s);
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_plus(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
+{
+  return _do_plus(lhs, rhs, expr);
+}
+
+static FilterXIRValue
+_compile_plus(FilterXExpr *s, FilterXJIT *jit)
+{
+  FilterXOperatorPlus *self = (FilterXOperatorPlus *) s;
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  FilterXIRValue lhs = self->literal_lhs
+                       ? fx_jit_emit_object_ref(jit, fx_jit_emit_const_ptr(jit, self->literal_lhs))
+                       : filterx_expr_compile_or_eval_typed(self->super.lhs, jit);
+  FilterXIRValue rhs = self->literal_rhs
+                       ? fx_jit_emit_object_ref(jit, fx_jit_emit_const_ptr(jit, self->literal_rhs))
+                       : filterx_expr_compile_or_eval(self->super.rhs, jit);
+
+  FilterXIRValue args[] = { lhs, rhs, fx_jit_emit_const_ptr(jit, self) };
+  FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
+  return fx_jit_emit_extern_call(jit, "fx_jit_do_plus", ffi->ptr_ty, param_tys, args, 3);
+}
+
+#endif
+
 FilterXExpr *
 filterx_operator_plus_new(FilterXExpr *lhs, FilterXExpr *rhs)
 {
@@ -103,6 +135,9 @@ filterx_operator_plus_new(FilterXExpr *lhs, FilterXExpr *rhs)
   self->super.super.optimize = _optimize;
   self->super.super.eval = _eval_plus;
   self->super.super.free_fn = _filterx_operator_plus_free;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.super.compile = _compile_plus;
+#endif
 
   return &self->super.super;
 }

--- a/lib/filterx/expr-plus.c
+++ b/lib/filterx/expr-plus.c
@@ -33,35 +33,40 @@ typedef struct FilterXOperatorPlus
 } FilterXOperatorPlus;
 
 static FilterXObject *
+_do_plus(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
+{
+  FilterXObject *result = NULL;
+
+  if (!lhs)
+    {
+      filterx_eval_push_error_static_info("Failed to add values", expr, "Failed to evaluate left hand side");
+      goto exit;
+    }
+  if (!rhs)
+    {
+      filterx_eval_push_error_static_info("Failed to add values", expr, "Failed to evaluate right hand side");
+      goto exit;
+    }
+
+  result = filterx_object_add(lhs, rhs);
+  if (!result)
+    filterx_eval_push_error_static_info("Failed to add values", expr, "add() method failed");
+
+exit:
+  filterx_object_unref(lhs);
+  filterx_object_unref(rhs);
+  return result;
+}
+
+static FilterXObject *
 _eval_plus(FilterXExpr *s)
 {
   FilterXOperatorPlus *self = (FilterXOperatorPlus *) s;
-
-  FilterXObject *lhs_object = self->literal_lhs ? filterx_object_ref(self->literal_lhs)
-                              : filterx_expr_eval_typed(self->super.lhs);
-  if (!lhs_object)
-    {
-      filterx_eval_push_error_static_info("Failed to add values", s, "Failed to evaluate left hand side");
-      return NULL;
-    }
-
-  FilterXObject *rhs_object = self->literal_rhs ? filterx_object_ref(self->literal_rhs)
-                              : filterx_expr_eval(self->super.rhs);
-  if (!rhs_object)
-    {
-      filterx_eval_push_error_static_info("Failed to add values", s, "Failed to evaluate right hand side");
-      filterx_object_unref(lhs_object);
-      return NULL;
-    }
-
-  FilterXObject *res = filterx_object_add(lhs_object, rhs_object);
-  filterx_object_unref(lhs_object);
-  filterx_object_unref(rhs_object);
-
-  if (!res)
-    filterx_eval_push_error_static_info("Failed to add values", s, "add() method failed");
-
-  return res;
+  FilterXObject *lhs = self->literal_lhs ? filterx_object_ref(self->literal_lhs)
+                       : filterx_expr_eval_typed(self->super.lhs);
+  FilterXObject *rhs = self->literal_rhs ? filterx_object_ref(self->literal_rhs)
+                       : filterx_expr_eval(self->super.rhs);
+  return _do_plus(lhs, rhs, s);
 }
 
 static FilterXExpr *

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -38,34 +38,38 @@ typedef struct _FilterXSetAttr
   FilterXExpr *new_value;
 } FilterXSetAttr;
 
-static inline FilterXObject *
-_setattr(FilterXSetAttr *self, FilterXObject *new_value)
+/* cloned must be cow_fork2-ed by the caller *before* lhs is evaluated, so
+ * that the lhs traversal sees the rhs as shared and clones along the path
+ * accordingly (e.g. for `d.x.y = d`). Both lhs and cloned are owned by us. */
+static FilterXObject *
+_do_setattr(FilterXSetAttr *self, FilterXObject *lhs, FilterXObject *cloned)
 {
-  /* NOTE: we need to fork the rhs first, so that the lhs will notice it is
-   * shared and can clone accordingly.  This is needed to make sure
-   * something like `d.sub = d` works.
-   */
+  if (!cloned)
+    {
+      filterx_eval_push_error_static_info("Failed to set-attribute to object", &self->super,
+                                          "Failed to evaluate right hand side");
+      goto error;
+    }
 
-  FilterXObject *cloned = filterx_object_cow_fork2(filterx_object_ref(new_value), NULL);
-
-  FilterXObject *object = filterx_expr_eval_typed(self->object);
-  if (!object)
+  if (!lhs)
     {
       filterx_eval_push_error_static_info("Failed to set-attribute to object", &self->super,
                                           "Failed to evaluate expression");
       goto error;
     }
 
-  if (!filterx_object_setattr(object, self->attr, &cloned))
+  if (!filterx_object_setattr(lhs, self->attr, &cloned))
     {
-      filterx_eval_push_error_static_info("Failed to set-attribute to object", &self->super, "setattr() method failed");
+      filterx_eval_push_error_static_info("Failed to set-attribute to object", &self->super,
+                                          "setattr() method failed");
       goto error;
     }
 
-  filterx_object_unref(object);
+  filterx_object_unref(lhs);
   return cloned;
+
 error:
-  filterx_object_unref(object);
+  filterx_object_unref(lhs);
   filterx_object_unref(cloned);
   return NULL;
 }
@@ -79,42 +83,53 @@ _suppress_error(void)
 }
 
 static FilterXObject *
-_nullv_setattr_eval(FilterXExpr *s)
+_do_nullv_setattr(FilterXSetAttr *self, FilterXObject *lhs, FilterXObject *cloned)
 {
-  FilterXSetAttr *self = (FilterXSetAttr *) s;
-  FilterXObject *result = NULL;
-
-  FilterXObject *new_value = filterx_expr_eval(self->new_value);
-  if (!new_value || filterx_object_extract_null(new_value))
+  if (!cloned)
     {
-      if (!new_value)
-        return _suppress_error();
-
-      return new_value;
+      filterx_object_unref(lhs);
+      return _suppress_error();
     }
 
-  result = _setattr(self, new_value);
-  filterx_object_unref(new_value);
-  return result;
+  if (filterx_object_extract_null(cloned))
+    {
+      filterx_object_unref(lhs);
+      return cloned;
+    }
+
+  return _do_setattr(self, lhs, cloned);
 }
 
 static FilterXObject *
 _setattr_eval(FilterXExpr *s)
 {
   FilterXSetAttr *self = (FilterXSetAttr *) s;
-  FilterXObject *result = NULL;
 
-  FilterXObject *new_value = filterx_expr_eval(self->new_value);
-  if (!new_value)
-    {
-      filterx_eval_push_error_static_info("Failed to set-attribute to object", &self->super,
-                                          "Failed to evaluate right hand side");
-      return NULL;
-    }
+  /* NOTE: we need to fork the rhs first, so that the lhs will notice it is
+   * shared and can clone accordingly.  This is needed to make sure
+   * something like `d.sub = d` works.
+   */
 
-  result = _setattr(self, new_value);
-  filterx_object_unref(new_value);
-  return result;
+  FilterXObject *rhs = filterx_expr_eval(self->new_value);
+  FilterXObject *cloned = rhs ? filterx_object_cow_fork2(rhs, NULL) : NULL;
+  FilterXObject *lhs = cloned ? filterx_expr_eval_typed(self->object) : NULL;
+  return _do_setattr(self, lhs, cloned);
+}
+
+static FilterXObject *
+_nullv_setattr_eval(FilterXExpr *s)
+{
+  FilterXSetAttr *self = (FilterXSetAttr *) s;
+
+  /* NOTE: we need to fork the rhs first, so that the lhs will notice it is
+   * shared and can clone accordingly.  This is needed to make sure
+   * something like `d.sub = d` works.
+   */
+
+  FilterXObject *rhs = filterx_expr_eval(self->new_value);
+  FilterXObject *cloned = rhs ? filterx_object_cow_fork2(rhs, NULL) : NULL;
+  FilterXObject *lhs = cloned ? filterx_expr_eval_typed(self->object) : NULL;
+  return _do_nullv_setattr(self, lhs, cloned);
 }
 
 static void

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -159,6 +159,58 @@ _setattr_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return TRUE;
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_setattr(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned)
+{
+  return _do_setattr((FilterXSetAttr *) s, lhs, cloned);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_nullv_setattr(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned)
+{
+  return _do_nullv_setattr((FilterXSetAttr *) s, lhs, cloned);
+}
+
+static inline FilterXIRValue
+_emit_setattr_call(FilterXSetAttr *self, FilterXJIT *jit, const gchar *fn_name)
+{
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  /* NOTE: we need to fork the rhs first, so that the lhs will notice it is
+   * shared and can clone accordingly.  This is needed to make sure
+   * something like `d.sub = d` works.
+   */
+
+  FilterXIRValue rhs = filterx_expr_compile_or_eval(self->new_value, jit);
+  FilterXIRValue cloned = fx_jit_emit_object_cow_fork2(jit, rhs);
+  FilterXIRValue lhs = filterx_expr_compile_or_eval_typed(self->object, jit);
+
+  FilterXIRValue args[] = { fx_jit_emit_const_ptr(jit, self), lhs, cloned };
+  FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
+  return fx_jit_emit_extern_call(jit, fn_name, ffi->ptr_ty, param_tys, args, 3);
+}
+
+static FilterXIRValue
+_setattr_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  return _emit_setattr_call((FilterXSetAttr *) s, jit, "fx_jit_do_setattr");
+}
+
+static FilterXIRValue
+_nullv_setattr_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  return _emit_setattr_call((FilterXSetAttr *) s, jit, "fx_jit_do_nullv_setattr");
+}
+
+#endif
+
 /* Takes reference of object and new_value */
 FilterXExpr *
 filterx_setattr_new(FilterXExpr *object, FilterXObject *attr_name, FilterXExpr *new_value)
@@ -169,6 +221,9 @@ filterx_setattr_new(FilterXExpr *object, FilterXObject *attr_name, FilterXExpr *
   self->super.eval = _setattr_eval;
   self->super.walk_children = _setattr_walk;
   self->super.free_fn = _free;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.compile = _setattr_compile;
+#endif
   self->object = object;
 
   g_assert(filterx_object_is_type(attr_name, &FILTERX_TYPE_NAME(string)));
@@ -186,7 +241,12 @@ FilterXExpr *
 filterx_nullv_setattr_new(FilterXExpr *object, FilterXObject *attr_name, FilterXExpr *new_value)
 {
   FilterXExpr *self = filterx_setattr_new(object, attr_name, new_value);
+
   self->type = "nullv_setattr";
   self->eval = _nullv_setattr_eval;
+#if SYSLOG_NG_ENABLE_JIT
+  self->compile = _nullv_setattr_compile;
+#endif
+
   return self;
 }

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -206,6 +206,33 @@ _variable_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return TRUE;
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+__attribute__((used))
+FilterXObject *
+fx_jit_eval_variable(FilterXExpr *s)
+{
+  return _eval_variable(s);
+}
+
+static FilterXIRValue
+_variable_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  /* TODO: move variable management into LLVM */
+
+  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  FilterXIRValue args[] = { fx_jit_emit_const_ptr(jit, self) };
+  FilterXIRType param_tys[] = { ffi->ptr_ty };
+  return fx_jit_emit_extern_call(jit, "fx_jit_eval_variable", ffi->ptr_ty, param_tys, args, 1);
+}
+
+#endif
+
 static FilterXExpr *
 filterx_variable_expr_new(const gchar *name, FilterXVariableType variable_type)
 {
@@ -215,6 +242,9 @@ filterx_variable_expr_new(const gchar *name, FilterXVariableType variable_type)
   self->super.walk_children = _variable_walk;
   self->super.free_fn = _free;
   self->super.eval = _eval_variable;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.compile = _variable_compile;
+#endif
   self->super._update_repr = _update_repr;
   self->super.assign = _assign;
   self->super.is_set = _isset;


### PR DESCRIPTION
LLVM IR code generation for 10 expressions.

This is just an initial implementation, as an example, where most `compile()` methods delegate directly to the corresponding C functions without significant IR logic.

The IR generation was done by `claude-opus-4-7`, but I spent a sad amount of time cleaning up its work: refactored them to reduce the boilerplate, rewrote parts of it so that it can easily be matched and verified against the interpreted code.

Even with this primitive initial version, I measured 15-20% perf improvement in a multi-threaded setup.
The biggest performance gain should come once we move the FilterX variable management into LLVM.

Depends on #1048
First commit to review: `filterx-compound: extract _process_compound_result()`