### PR TITLE
filterx-assign: fix error handling of nullv assignment

### DIFF
--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -70,6 +70,10 @@ _nullv_assign_eval(FilterXExpr *s)
 
   FilterXObject *result = _assign(self, value);
   filterx_object_unref(value);
+
+  if (!result)
+    filterx_eval_push_error_static_info("Failed to assign value", s, "assign() method failed");
+
   return result;
 }
 

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -342,6 +342,7 @@ filterx_eval_exec(FilterXEvalContext *context, FilterXExpr *expr)
   FilterXObject *res = filterx_expr_eval(expr);
   if (!res)
     {
+      g_assert(context->error_count);
       /* Open coded as this function is context specific. */
       if (debug_flag)
         {


### PR DESCRIPTION
For example:

```
log = otel_logrecord();
dpath(log.input) =?? "hello";
```
(input is not a valid otel logrecord field)