### PR TITLE
Permissive mode for app-parser/app-transform and a bugfix

### DIFF
--- a/modules/appmodel/app-object-generator.c
+++ b/modules/appmodel/app-object-generator.c
@@ -43,7 +43,7 @@ app_object_generator_is_application_excluded(AppObjectGenerator *self, const gch
   return cfg_is_literal_in_list_of_literals(self->excluded_apps, app_name);
 }
 
-static gboolean
+static void
 _parse_auto_parse_arg(AppObjectGenerator *self, CfgArgs *args, const gchar *reference)
 {
   const gchar *v = cfg_args_get(args, "auto-parse");
@@ -52,7 +52,6 @@ _parse_auto_parse_arg(AppObjectGenerator *self, CfgArgs *args, const gchar *refe
     self->is_parsing_enabled = cfg_process_yesno(v);
   else
     self->is_parsing_enabled = TRUE;
-  return TRUE;
 }
 
 static gboolean
@@ -78,8 +77,8 @@ app_object_generator_parse_arguments_method(AppObjectGenerator *self, CfgArgs *a
 {
   g_assert(args != NULL);
 
-  if (!_parse_auto_parse_arg(self, args, reference))
-    return FALSE;
+  _parse_auto_parse_arg(self, args, reference);
+
   if (!_parse_auto_parse_exclude_arg(self, args, reference))
     return FALSE;
   if (!_parse_auto_parse_include_arg(self, args, reference))

--- a/modules/appmodel/app-parser-generator.c
+++ b/modules/appmodel/app-parser-generator.c
@@ -53,7 +53,7 @@ _parse_topic_arg(AppParserGenerator *self, CfgArgs *args, const gchar *reference
   return TRUE;
 }
 
-static gboolean
+static void
 _parse_allow_overlaps(AppParserGenerator *self, CfgArgs *args, const gchar *reference)
 {
   const gchar *v = cfg_args_get(args, "allow-overlaps");
@@ -61,10 +61,9 @@ _parse_allow_overlaps(AppParserGenerator *self, CfgArgs *args, const gchar *refe
     self->allow_overlaps = cfg_process_yesno(v);
   else
     self->allow_overlaps = FALSE;
-  return TRUE;
 }
 
-static gboolean
+static void
 _parse_permissive(AppParserGenerator *self, CfgArgs *args, const gchar *reference)
 {
   const gchar *v = cfg_args_get(args, "permissive");
@@ -72,14 +71,12 @@ _parse_permissive(AppParserGenerator *self, CfgArgs *args, const gchar *referenc
     self->permissive = cfg_process_yesno(v);
   else
     self->permissive = FALSE;
-  return TRUE;
 }
 
-static gboolean
+static void
 _parse_filterx_app_variable(AppParserGenerator *self, CfgArgs *args, const gchar *reference)
 {
   self->filterx_app_variable = cfg_args_get(args, "filterx-app-variable");
-  return TRUE;
 }
 
 static gboolean
@@ -91,14 +88,9 @@ app_parser_generator_parse_arguments(AppObjectGenerator *s, CfgArgs *args, const
   if (!_parse_topic_arg(self, args, reference))
     return FALSE;
 
-  if (!_parse_allow_overlaps(self, args, reference))
-    return FALSE;
-
-  if (!_parse_permissive(self, args, reference))
-    return FALSE;
-
-  if (!_parse_filterx_app_variable(self, args, reference))
-    return FALSE;
+  _parse_allow_overlaps(self, args, reference);
+  _parse_permissive(self, args, reference);
+  _parse_filterx_app_variable(self, args, reference);
 
   if (!app_object_generator_parse_arguments_method(&self->super, args, reference))
     return FALSE;

--- a/modules/appmodel/app-parser-generator.c
+++ b/modules/appmodel/app-parser-generator.c
@@ -35,6 +35,9 @@ typedef struct _AppParserGenerator
   GString *block;
   gboolean first_app_generated;
   gboolean allow_overlaps;
+
+  /* never drops messages (0 matches, FilterX errors, filtering) */
+  gboolean permissive;
 } AppParserGenerator;
 
 static gboolean
@@ -62,6 +65,17 @@ _parse_allow_overlaps(AppParserGenerator *self, CfgArgs *args, const gchar *refe
 }
 
 static gboolean
+_parse_permissive(AppParserGenerator *self, CfgArgs *args, const gchar *reference)
+{
+  const gchar *v = cfg_args_get(args, "permissive");
+  if (v)
+    self->permissive = cfg_process_yesno(v);
+  else
+    self->permissive = FALSE;
+  return TRUE;
+}
+
+static gboolean
 _parse_filterx_app_variable(AppParserGenerator *self, CfgArgs *args, const gchar *reference)
 {
   self->filterx_app_variable = cfg_args_get(args, "filterx-app-variable");
@@ -78,6 +92,9 @@ app_parser_generator_parse_arguments(AppObjectGenerator *s, CfgArgs *args, const
     return FALSE;
 
   if (!_parse_allow_overlaps(self, args, reference))
+    return FALSE;
+
+  if (!_parse_permissive(self, args, reference))
     return FALSE;
 
   if (!_parse_filterx_app_variable(self, args, reference))
@@ -224,7 +241,7 @@ _generate_framing(AppParserGenerator *self, GlobalConfig *cfg)
                   "\nchannel {\n");
 
   self->first_app_generated = FALSE;
-  if (!self->allow_overlaps)
+  if (!self->allow_overlaps && !self->permissive)
     {
       _generate_applications(self, cfg);
       if (self->first_app_generated)

--- a/modules/appmodel/app-transform-generator.c
+++ b/modules/appmodel/app-transform-generator.c
@@ -32,6 +32,9 @@ typedef struct _AppTransformGenerator
   const gchar *filterx_app_variable;
   GList *included_transforms;
   GList *excluded_transforms;
+
+  /* never drops messages (undefined filterx_app_variable, FilterX errors, filtering) */
+  gboolean permissive;
 } AppTransformGenerator;
 
 static gboolean
@@ -40,6 +43,17 @@ _parse_transforms_arg(AppTransformGenerator *self, CfgArgs *args, const gchar *r
   self->topic = cfg_args_get(args, "topic");
   if (!self->topic)
     self->topic = "default";
+  return TRUE;
+}
+
+static gboolean
+_parse_permissive(AppTransformGenerator *self, CfgArgs *args, const gchar *reference)
+{
+  const gchar *v = cfg_args_get(args, "permissive");
+  if (v)
+    self->permissive = cfg_process_yesno(v);
+  else
+    self->permissive = TRUE;
   return TRUE;
 }
 
@@ -81,6 +95,9 @@ app_transform_generator_parse_arguments(AppObjectGenerator *s, CfgArgs *args, co
   g_assert(args != NULL);
 
   if (!_parse_transforms_arg(self, args, reference))
+    return FALSE;
+
+  if (!_parse_permissive(self, args, reference))
     return FALSE;
 
   if (!_parse_filterx_app_variable(self, args, reference))
@@ -287,11 +304,11 @@ app_transform_generate_config(AppObjectGenerator *s, GlobalConfig *cfg, GString 
   appmodel_iter_transformations(cfg, _generate_filterx_only_app_transform_cases, user_data);
   gboolean has_filterx = block->len > 0;
 
-  if (has_non_filterx && !has_filterx)
-    {
-      g_string_append(result, ";\n");
-    }
-  else if (has_non_filterx && has_filterx)
+
+  if (!has_non_filterx && !has_filterx)
+    goto exit;
+
+  if (has_non_filterx && has_filterx)
     {
       g_string_append_printf(result,
                              "    elif {\n"
@@ -300,7 +317,7 @@ app_transform_generate_config(AppObjectGenerator *s, GlobalConfig *cfg, GString 
                              "%s\n"
                              "            };\n"
                              "        };\n"
-                             "    };\n",
+                             "    }",
                              self->filterx_app_variable,
                              block->str);
     }
@@ -313,11 +330,22 @@ app_transform_generate_config(AppObjectGenerator *s, GlobalConfig *cfg, GString 
                              "%s\n"
                              "            };\n"
                              "        };\n"
-                             "    };\n",
+                             "    }",
                              self->filterx_app_variable,
                              block->str);
     }
 
+  if (self->permissive)
+    g_string_append(result, ";\n");
+  else
+    {
+      g_string_append(result, "\n"
+                      "    else {\n"
+                      "        filterx { false; };\n"
+                      "    };\n");
+    }
+
+exit:
   g_string_append(result, "};\n");
   g_string_free(block, TRUE);
 }

--- a/modules/appmodel/app-transform-generator.c
+++ b/modules/appmodel/app-transform-generator.c
@@ -294,7 +294,7 @@ app_transform_generate_config(AppObjectGenerator *s, GlobalConfig *cfg, GString 
   else if (has_non_filterx && has_filterx)
     {
       g_string_append_printf(result,
-                             "    else {\n"
+                             "    elif {\n"
                              "        filterx {\n"
                              "            switch (%s) {\n"
                              "%s\n"
@@ -307,9 +307,11 @@ app_transform_generate_config(AppObjectGenerator *s, GlobalConfig *cfg, GString 
   else if (!has_non_filterx && has_filterx)
     {
       g_string_append_printf(result,
-                             "    filterx {\n"
-                             "        switch (%s) {\n"
+                             "    if {\n"
+                             "        filterx {\n"
+                             "            switch (%s) {\n"
                              "%s\n"
+                             "            };\n"
                              "        };\n"
                              "    };\n",
                              self->filterx_app_variable,

--- a/modules/appmodel/app-transform-generator.c
+++ b/modules/appmodel/app-transform-generator.c
@@ -37,16 +37,15 @@ typedef struct _AppTransformGenerator
   gboolean permissive;
 } AppTransformGenerator;
 
-static gboolean
+static void
 _parse_transforms_arg(AppTransformGenerator *self, CfgArgs *args, const gchar *reference)
 {
   self->topic = cfg_args_get(args, "topic");
   if (!self->topic)
     self->topic = "default";
-  return TRUE;
 }
 
-static gboolean
+static void
 _parse_permissive(AppTransformGenerator *self, CfgArgs *args, const gchar *reference)
 {
   const gchar *v = cfg_args_get(args, "permissive");
@@ -54,7 +53,6 @@ _parse_permissive(AppTransformGenerator *self, CfgArgs *args, const gchar *refer
     self->permissive = cfg_process_yesno(v);
   else
     self->permissive = TRUE;
-  return TRUE;
 }
 
 static gboolean
@@ -94,11 +92,8 @@ app_transform_generator_parse_arguments(AppObjectGenerator *s, CfgArgs *args, co
   AppTransformGenerator *self = (AppTransformGenerator *) s;
   g_assert(args != NULL);
 
-  if (!_parse_transforms_arg(self, args, reference))
-    return FALSE;
-
-  if (!_parse_permissive(self, args, reference))
-    return FALSE;
+  _parse_transforms_arg(self, args, reference);
+  _parse_permissive(self, args, reference);
 
   if (!_parse_filterx_app_variable(self, args, reference))
     return FALSE;


### PR DESCRIPTION
When one wants to use the app-parser() but allow all messages to pass
through even with 0 matches, the parser has to be wrapped in an if
block.

```
if {
  parser {
    app-parser(topic(t) filterx-app-variable(meta.app));
  };
};
```

With the new permissive(yes) mode, this is no longer necessary,
and the generated config is simpler (we basically added an if block
to remove the effect of the inner else block), therefore the built
pipeline is also less complex.

```diff
-if {
 parser {
   channel {
     if {
         filterx {
           1;
         };
     }
     elif {
         filterx {
           2;
         };
-      }
-      else {
-          filterx { false; };
-      };
     };
   };
 };
```

`permissive(yes)` also allows FilterX errors to happen inside the topic
codes, so there will be no message loss.

The default for app-parser is `permissive(no)`.

----

Transformations are by default permissive, meaning that a missing `filterx-app-variable`, an error, or accidental filtering rule would not cause messages being dropped.

This was true for transformations containing at least one non-filterx block. For filterx-only configs, this permissive behavior was violated, so I fixed it.

`permissive(yes/no)` can be set for transformations too, but the default here is `yes`.  
