### PR TITLE
Logproto spoof source

### DIFF
--- a/lib/logproto/logproto-framed-client.c
+++ b/lib/logproto/logproto-framed-client.c
@@ -79,15 +79,9 @@ log_proto_framed_client_new(LogTransport *transport, const LogProtoClientOptions
 {
   LogProtoFramedClient *self = g_new0(LogProtoFramedClient, 1);
 
-  log_proto_text_client_init(&self->super, transport, options);
+  log_proto_text_client_init(&self->super, transport, options, FALSE);
   self->super.super.post = log_proto_framed_client_post;
   self->super.state = LPFCS_FRAME_SEND;
-
-  /* the framed client writes the frame header and message through the partial
-   * path, never the batch, so opt out of batching and drop the unused buffer */
-  g_free(self->super.batch.iov);
-  self->super.batch.iov = NULL;
-  self->super.batch.size = 1;
 
   return &self->super.super;
 }

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -364,7 +364,8 @@ _calculate_batch_size(const LogProtoClientOptions *options)
 }
 
 void
-log_proto_text_client_init(LogProtoTextClient *self, LogTransport *transport, const LogProtoClientOptions *options)
+log_proto_text_client_init(LogProtoTextClient *self, LogTransport *transport,
+                           const LogProtoClientOptions *options, gboolean batching_supported)
 {
   log_proto_client_init(&self->super, transport, options);
   self->super.poll_prepare = log_proto_text_client_poll_prepare;
@@ -374,8 +375,11 @@ log_proto_text_client_init(LogProtoTextClient *self, LogTransport *transport, co
   self->super.free_fn = log_proto_text_client_free;
   self->next_state = -1;
 
-  self->batch.size = _calculate_batch_size(options);
-  self->batch.iov = g_new0(struct iovec, self->batch.size);
+  if (batching_supported)
+    {
+      self->batch.size = _calculate_batch_size(options);
+      self->batch.iov = g_new0(struct iovec, self->batch.size);
+    }
 }
 
 LogProtoClient *
@@ -383,7 +387,7 @@ log_proto_text_client_new(LogTransport *transport, const LogProtoClientOptions *
 {
   LogProtoTextClient *self = g_new0(LogProtoTextClient, 1);
 
-  log_proto_text_client_init(self, transport, options);
+  log_proto_text_client_init(self, transport, options, TRUE);
   return &self->super;
 }
 
@@ -392,7 +396,7 @@ log_proto_unidirectional_text_client_new(LogTransport *transport, const LogProto
 {
   LogProtoTextClient *self = g_new0(LogProtoTextClient, 1);
 
-  log_proto_text_client_init(self, transport, options);
+  log_proto_text_client_init(self, transport, options, TRUE);
   self->super.poll_prepare = log_proto_unidirectional_text_client_poll_prepare;
   self->super.process_in = _prohibit_in;
 

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -305,8 +305,8 @@ _can_queue_to_batch(LogProtoTextClient *self)
  * of partially sent data if needed. The return value indicates whether we
  * successfully sent this message, or if it should be resent by the caller.
  **/
-static LogProtoStatus
-log_proto_text_client_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg, gsize msg_len, gboolean *consumed)
+LogProtoStatus
+log_proto_text_client_post_method(LogProtoClient *s, LogMessage *logmsg, guchar *msg, gsize msg_len, gboolean *consumed)
 {
   LogProtoTextClient *self = (LogProtoTextClient *) s;
 
@@ -371,7 +371,7 @@ log_proto_text_client_init(LogProtoTextClient *self, LogTransport *transport,
   self->super.poll_prepare = log_proto_text_client_poll_prepare;
   self->super.flush = log_proto_text_client_flush;
   self->super.process_in = log_proto_text_client_process_input;
-  self->super.post = log_proto_text_client_post;
+  self->super.post = log_proto_text_client_post_method;
   self->super.free_fn = log_proto_text_client_free;
   self->next_state = -1;
 

--- a/lib/logproto/logproto-text-client.h
+++ b/lib/logproto/logproto-text-client.h
@@ -47,7 +47,8 @@ typedef struct _LogProtoTextClient
 LogProtoStatus log_proto_text_client_submit_write(LogProtoClient *s, guchar *msg, gsize msg_len,
                                                   GDestroyNotify msg_free, gint next_state);
 void log_proto_text_client_init(LogProtoTextClient *self, LogTransport *transport,
-                                const LogProtoClientOptions *options);
+                                const LogProtoClientOptions *options,
+                                gboolean batching_supported);
 LogProtoClient *log_proto_text_client_new(LogTransport *transport, const LogProtoClientOptions *options);
 
 LogProtoClient *log_proto_unidirectional_text_client_new(LogTransport *transport, const LogProtoClientOptions *options);

--- a/lib/logproto/logproto-text-client.h
+++ b/lib/logproto/logproto-text-client.h
@@ -46,6 +46,8 @@ typedef struct _LogProtoTextClient
 
 LogProtoStatus log_proto_text_client_submit_write(LogProtoClient *s, guchar *msg, gsize msg_len,
                                                   GDestroyNotify msg_free, gint next_state);
+LogProtoStatus log_proto_text_client_post_method(LogProtoClient *s, LogMessage *logmsg, guchar *msg, gsize msg_len,
+                                                 gboolean *consumed);
 void log_proto_text_client_init(LogProtoTextClient *self, LogTransport *transport,
                                 const LogProtoClientOptions *options,
                                 gboolean batching_supported);

--- a/modules/afsocket/CMakeLists.txt
+++ b/modules/afsocket/CMakeLists.txt
@@ -41,6 +41,8 @@ set(AFSOCKET_SOURCES
     systemd-syslog-source.h
     systemd-syslog-source.c
     afsocket-systemd-override.h
+    logproto-spoof-source-client.h
+    logproto-spoof-source-client.c
 )
 
 find_package(ZLIB REQUIRED)

--- a/modules/afsocket/Makefile.am
+++ b/modules/afsocket/Makefile.am
@@ -16,6 +16,8 @@ modules_afsocket_libafsocket_la_SOURCES	=	\
 	modules/afsocket/afinet-source.h		\
 	modules/afsocket/afinet-dest.c			\
 	modules/afsocket/afinet-dest.h			\
+	modules/afsocket/logproto-spoof-source-client.c	\
+	modules/afsocket/logproto-spoof-source-client.h	\
 	modules/afsocket/afinet-dest-failover.c		\
 	modules/afsocket/afinet-dest-failover.h		\
 	modules/afsocket/socket-options-inet.c		\

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -30,6 +30,9 @@
 #include "afsocket-signals.h"
 #include "transport/transport-tls.h"
 #include "transport/transport-stack.h"
+#if SYSLOG_NG_ENABLE_SPOOF_SOURCE
+#include "logproto-spoof-source-client.h"
+#endif
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -38,23 +41,6 @@
 #include <netinet/in.h>
 #include <stdlib.h>
 #include <string.h>
-
-#ifdef _GNU_SOURCE
-#  define _GNU_SOURCE_DEFINED 1
-#  undef _GNU_SOURCE
-#endif
-
-#if SYSLOG_NG_ENABLE_SPOOF_SOURCE
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wundef"
-#include <libnet.h>
-#pragma GCC diagnostic pop
-#endif
-
-#if _GNU_SOURCE_DEFINED
-#  undef _GNU_SOURCE
-#  define _GNU_SOURCE 1
-#endif
 
 static const gint MAX_UDP_PAYLOAD_SIZE = 65507;
 
@@ -392,15 +378,6 @@ afinet_dd_get_dest_name(const AFSocketDestDriver *s)
   return buf;
 }
 
-static inline void
-_libnet_destroy_when_spoof_source_enabled(AFInetDestDriver *self)
-{
-#if SYSLOG_NG_ENABLE_SPOOF_SOURCE
-  if (self->lnet_ctx)
-    libnet_destroy(self->lnet_ctx);
-#endif
-}
-
 static gboolean
 afinet_dd_deinit(LogPipe *s)
 {
@@ -409,15 +386,13 @@ afinet_dd_deinit(LogPipe *s)
   if (_is_failover_used(self))
     afinet_dd_failover_deinit(self->failover);
 
-  _libnet_destroy_when_spoof_source_enabled(self);
-
   return afsocket_dd_deinit(s);
 }
 
 static gboolean
 afinet_dd_init(LogPipe *s)
 {
-  AFInetDestDriver *self G_GNUC_UNUSED = (AFInetDestDriver *) s;
+  AFInetDestDriver *self = (AFInetDestDriver *) s;
 
 #if SYSLOG_NG_ENABLE_SPOOF_SOURCE
   if (self->spoof_source)
@@ -426,27 +401,6 @@ afinet_dd_init(LogPipe *s)
 
   if (!afsocket_dd_init(s))
     return FALSE;
-
-#if SYSLOG_NG_ENABLE_SPOOF_SOURCE
-  if (self->super.transport_mapper->sock_type == SOCK_DGRAM)
-    {
-      if (self->spoof_source && !self->lnet_ctx)
-        {
-          gchar error[LIBNET_ERRBUF_SIZE];
-          cap_t saved_caps;
-
-          saved_caps = g_process_cap_save();
-          g_process_enable_cap("cap_net_raw");
-          self->lnet_ctx = libnet_init(self->super.bind_addr->sa.sa_family == AF_INET ? LIBNET_RAW4 : LIBNET_RAW6, NULL, error);
-          g_process_cap_restore(saved_caps);
-          if (!self->lnet_ctx)
-            {
-              msg_error("Error initializing raw socket, spoof-source support disabled",
-                        evt_tag_str("error", error));
-            }
-        }
-    }
-#endif
 
   if (self->super.transport_mapper->sock_type == SOCK_DGRAM)
     {
@@ -474,198 +428,34 @@ afinet_dd_init(LogPipe *s)
 }
 
 #if SYSLOG_NG_ENABLE_SPOOF_SOURCE
-static gboolean
-afinet_dd_construct_ipv4_packet(AFInetDestDriver *self, LogMessage *msg, GString *msg_line)
+static LogProtoClient *
+afinet_dd_construct_proto(AFSocketDestDriver *s, gint fd)
 {
-  libnet_ptag_t ip, udp;
-  struct sockaddr_in *src, *dst;
-
-  if (msg->saddr->sa.sa_family != AF_INET)
-    return FALSE;
-
-  src = (struct sockaddr_in *) &msg->saddr->sa;
-  dst = (struct sockaddr_in *) &self->super.dest_addr->sa;
-
-  libnet_clear_packet(self->lnet_ctx);
-
-  udp = libnet_build_udp(ntohs(src->sin_port),
-                         ntohs(dst->sin_port),
-                         LIBNET_UDP_H + msg_line->len,
-                         0,
-                         (guchar *) msg_line->str,
-                         msg_line->len,
-                         self->lnet_ctx,
-                         0);
-  if (udp == -1)
-    return FALSE;
-
-  ip = libnet_build_ipv4(LIBNET_IPV4_H + msg_line->len + LIBNET_UDP_H,
-                         IPTOS_LOWDELAY,         /* IP tos */
-                         0,                      /* IP ID */
-                         0,                      /* frag stuff */
-                         64,                     /* TTL */
-                         IPPROTO_UDP,            /* transport protocol */
-                         0,
-                         src->sin_addr.s_addr,   /* source IP */
-                         dst->sin_addr.s_addr,   /* destination IP */
-                         NULL,                   /* payload (none) */
-                         0,                      /* payload length */
-                         self->lnet_ctx,
-                         0);
-  if (ip == -1)
-    return FALSE;
-
-  return TRUE;
-}
-
-#if SYSLOG_NG_ENABLE_IPV6
-static gboolean
-afinet_dd_construct_ipv6_packet(AFInetDestDriver *self, LogMessage *msg, GString *msg_line)
-{
-  libnet_ptag_t ip, udp;
-  struct sockaddr_in *src4;
-  struct sockaddr_in6 src, *dst;
-  struct libnet_in6_addr ln_src, ln_dst;
-
-  switch (msg->saddr->sa.sa_family)
-    {
-    case AF_INET:
-      src4 = (struct sockaddr_in *) &msg->saddr->sa;
-      memset(&src, 0, sizeof(src));
-      src.sin6_family = AF_INET6;
-      src.sin6_port = src4->sin_port;
-      ((guint32 *) &src.sin6_addr)[0] = 0;
-      ((guint32 *) &src.sin6_addr)[1] = 0;
-      ((guint32 *) &src.sin6_addr)[2] = htonl(0xffff);
-      ((guint32 *) &src.sin6_addr)[3] = src4->sin_addr.s_addr;
-      break;
-    case AF_INET6:
-      src = *((struct sockaddr_in6 *) &msg->saddr->sa);
-      break;
-    default:
-      g_assert_not_reached();
-      break;
-    }
-
-  dst = (struct sockaddr_in6 *) &self->super.dest_addr->sa;
-
-  libnet_clear_packet(self->lnet_ctx);
-
-  udp = libnet_build_udp(ntohs(src.sin6_port),
-                         ntohs(dst->sin6_port),
-                         LIBNET_UDP_H + msg_line->len,
-                         0,
-                         (guchar *) msg_line->str,
-                         msg_line->len,
-                         self->lnet_ctx,
-                         0);
-  if (udp == -1)
-    return FALSE;
-
-  memcpy(&ln_src, &src.sin6_addr, sizeof(ln_src));
-  memcpy(&ln_dst, &dst->sin6_addr, sizeof(ln_dst));
-  ip = libnet_build_ipv6(0, 0,
-                         LIBNET_UDP_H + msg_line->len,
-                         IPPROTO_UDP,            /* IPv6 next header */
-                         64,                     /* hop limit */
-                         ln_src, ln_dst,
-                         NULL, 0,                /* payload and its length */
-                         self->lnet_ctx,
-                         0);
-
-  if (ip == -1)
-    return FALSE;
-
-  return TRUE;
-}
-#endif
-
-static inline gboolean
-afinet_dd_construct_ip_packet(AFInetDestDriver *self, LogMessage *msg, GString *msg_line)
-{
-  switch (self->super.dest_addr->sa.sa_family)
-    {
-    case AF_INET:
-      return afinet_dd_construct_ipv4_packet(self, msg, msg_line);
-#if SYSLOG_NG_ENABLE_IPV6
-    case AF_INET6:
-      return afinet_dd_construct_ipv6_packet(self, msg, msg_line);
-#endif
-    default:
-      g_assert_not_reached();
-    }
-
-  return FALSE;
-}
-
-static gboolean
-afinet_dd_spoof_write_message(AFInetDestDriver *self, LogMessage *msg, const LogPathOptions *path_options)
-{
-  g_assert(self->super.transport_mapper->sock_type == SOCK_DGRAM);
-
-  g_mutex_lock(&self->lnet_lock);
-
-  if (!self->lnet_buffer)
-    self->lnet_buffer = g_string_sized_new(self->spoof_source_max_msglen);
-
-  log_writer_format_log(self->super.writer, msg, self->lnet_buffer);
-
-  if (self->lnet_buffer->len > self->spoof_source_max_msglen)
-    g_string_truncate(self->lnet_buffer, self->spoof_source_max_msglen);
-
-  gboolean success = afinet_dd_construct_ip_packet(self, msg, self->lnet_buffer);
-
-  if (!success)
-    goto finish;
-
-  success = libnet_write(self->lnet_ctx) >= 0;
-
-  if (!success)
-    {
-      msg_error("Error sending raw frame", evt_tag_str("error", libnet_geterror(self->lnet_ctx)));
-      goto finish;
-    }
-
-  /* we have finished processing msg */
-  log_msg_ack(msg, path_options, AT_PROCESSED);
-  log_msg_unref(msg);
-
-finish:
-  g_mutex_unlock(&self->lnet_lock);
-  return success;
-}
-
-static inline gboolean
-_is_message_spoofable(LogMessage *msg)
-{
-  return msg->saddr && (msg->saddr->sa.sa_family == AF_INET || msg->saddr->sa.sa_family == AF_INET6);
-}
-
-static inline gboolean
-_is_spoof_source_enabled(AFInetDestDriver *self)
-{
-  return self->spoof_source && self->lnet_ctx;
-}
-
-#endif
-
-static void
-afinet_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
-{
-#if SYSLOG_NG_ENABLE_SPOOF_SOURCE
   AFInetDestDriver *self = (AFInetDestDriver *) s;
 
-  /* NOTE: This code should probably be moved to the LogProto layer so that
-   * spoofed packets are also going through the LogWriter queue */
-
-  if (_is_spoof_source_enabled(self) && _is_message_spoofable(msg) && log_writer_opened(self->super.writer))
+  if (self->spoof_source && self->super.transport_mapper->sock_type == SOCK_DGRAM)
     {
-      if (afinet_dd_spoof_write_message(self, msg, path_options))
-        return;
+      LogProtoClient *proto = log_proto_spoof_source_client_new(
+                                self->super.bind_addr->sa.sa_family,
+                                &self->super.writer_options.proto_options.super,
+                                self->super.dest_addr,
+                                self->spoof_source_max_msglen
+                              );
+
+      if (proto)
+        {
+          if (!transport_mapper_setup_stack(self->super.transport_mapper, &proto->transport_stack, fd))
+            {
+              log_proto_client_free(proto);
+              return afsocket_dd_construct_proto_method(s, fd);
+            }
+          return proto;
+        }
     }
-#endif
-  log_dest_driver_queue_method(s, msg, path_options);
+
+  return afsocket_dd_construct_proto_method(s, fd);
 }
+#endif
 
 void
 afinet_dd_free(LogPipe *s)
@@ -675,15 +465,9 @@ afinet_dd_free(LogPipe *s)
   g_free(self->primary);
   afinet_dd_failover_free(self->failover);
 
-
   g_free(self->bind_ip);
   g_free(self->bind_port);
   g_free(self->dest_port);
-#if SYSLOG_NG_ENABLE_SPOOF_SOURCE
-  if (self->lnet_buffer)
-    g_string_free(self->lnet_buffer, TRUE);
-  g_mutex_clear(&self->lnet_lock);
-#endif
   afsocket_dd_free(s);
 }
 
@@ -772,20 +556,18 @@ afinet_dd_new_instance(TransportMapper *transport_mapper, gchar *hostname, const
   afsocket_dd_init_instance(&self->super, socket_options_inet_new(), transport_mapper, driver_name, cfg);
   self->super.super.super.super.init = afinet_dd_init;
   self->super.super.super.super.deinit = afinet_dd_deinit;
-  self->super.super.super.super.queue = afinet_dd_queue;
   self->super.super.super.super.free_fn = afinet_dd_free;
   self->super.setup_addresses = afinet_dd_setup_addresses;
   self->super.get_dest_name = afinet_dd_get_dest_name;
   self->super.should_restore_connection = afinet_dd_should_restore_connection;
   self->super.restore_connection = afinet_dd_restore_connection;
   self->super.save_connection = afinet_dd_save_connection;
-
-  self->primary = g_strdup(hostname);
-
 #if SYSLOG_NG_ENABLE_SPOOF_SOURCE
-  g_mutex_init(&self->lnet_lock);
+  self->super.construct_proto = afinet_dd_construct_proto;
   self->spoof_source_max_msglen = 1024;
 #endif
+
+  self->primary = g_strdup(hostname);
   return self;
 }
 

--- a/modules/afsocket/afinet-dest.h
+++ b/modules/afsocket/afinet-dest.h
@@ -29,24 +29,11 @@
 #include "afinet-dest-failover.h"
 #include "transport/tls-context.h"
 
-#if SYSLOG_NG_ENABLE_SPOOF_SOURCE
-
-/* this forward declaration avoids having to include libnet, which requires
- * ugly playing with macros, see that for yourself in the implementation
- * file */
-struct libnet_context;
-#endif
-
-
-
 typedef struct _AFInetDestDriver
 {
   AFSocketDestDriver super;
 #if SYSLOG_NG_ENABLE_SPOOF_SOURCE
   gboolean spoof_source;
-  struct libnet_context *lnet_ctx;
-  GMutex lnet_lock;
-  GString *lnet_buffer;
   guint spoof_source_max_msglen;
 #endif
   gchar *primary;

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -249,11 +249,25 @@ _update_legacy_connection_persist_name(AFSocketDestDriver *self)
   return persist_state_move_entry(cfg->state, legacy_persist_name, current_persist_name);
 }
 
+LogProtoClient *
+afsocket_dd_construct_proto_method(AFSocketDestDriver *self, gint fd)
+{
+  LogProtoClient *proto = log_proto_client_factory_construct(self->proto_factory, NULL,
+                                                             &self->writer_options.proto_options.super);
+
+  if (!transport_mapper_setup_stack(self->transport_mapper, &proto->transport_stack, fd))
+    {
+      log_proto_client_free(proto);
+      return NULL;
+    }
+
+  return proto;
+}
+
 static gboolean
 afsocket_dd_connected(AFSocketDestDriver *self)
 {
   GlobalConfig *cfg = log_pipe_get_config(&self->super.super.super);
-  LogProtoClient *proto;
   gchar buf1[256], buf2[256];
 
   main_loop_assert_main_thread();
@@ -264,13 +278,9 @@ afsocket_dd_connected(AFSocketDestDriver *self)
              evt_tag_str("server", g_sockaddr_format(self->dest_addr, buf2, sizeof(buf2), GSA_FULL)),
              evt_tag_str("local", g_sockaddr_format(self->bind_addr, buf1, sizeof(buf1), GSA_FULL)));
 
-  proto = log_proto_client_factory_construct(self->proto_factory, NULL, &self->writer_options.proto_options.super);
-
-  if (!transport_mapper_setup_stack(self->transport_mapper, &proto->transport_stack, self->fd))
-    {
-      log_proto_client_free(proto);
-      return FALSE;
-    }
+  LogProtoClient *proto = self->construct_proto(self, self->fd);
+  if (!proto)
+    return FALSE;
 
   log_proto_client_restart_with_state(proto, cfg->state, afsocket_dd_format_connections_name(self));
   log_writer_reopen(self->writer, proto);
@@ -826,6 +836,7 @@ afsocket_dd_init_instance(AFSocketDestDriver *self,
   self->super.super.super.generate_persist_name = afsocket_dd_format_name;
   self->setup_addresses = afsocket_dd_setup_addresses_method;
   self->construct_writer = afsocket_dd_construct_writer_method;
+  self->construct_proto = afsocket_dd_construct_proto_method;
   self->should_restore_connection = afsocket_dd_should_restore_connection_method;
   self->restore_connection = afsocket_dd_restore_connection_method;
   self->save_connection = afsocket_dd_save_connection_method;

--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -61,6 +61,7 @@ struct _AFSocketDestDriver
   } metrics;
 
   LogWriter *(*construct_writer)(AFSocketDestDriver *self);
+  LogProtoClient *(*construct_proto)(AFSocketDestDriver *self, gint fd);
   gboolean (*setup_addresses)(AFSocketDestDriver *s);
   const gchar *(*get_dest_name)(const AFSocketDestDriver *s);
 
@@ -100,6 +101,7 @@ afsocket_dd_get_dest_name(const AFSocketDestDriver *s)
 }
 
 LogWriter *afsocket_dd_construct_writer_method(AFSocketDestDriver *self);
+LogProtoClient *afsocket_dd_construct_proto_method(AFSocketDestDriver *self, gint fd);
 gboolean afsocket_dd_setup_addresses_method(AFSocketDestDriver *self);
 void afsocket_dd_set_keep_alive(LogDriver *self, gint enable);
 void afsocket_dd_init_instance(AFSocketDestDriver *self, SocketOptions *socket_options,

--- a/modules/afsocket/logproto-spoof-source-client.c
+++ b/modules/afsocket/logproto-spoof-source-client.c
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2002-2012 Balabit
+ * Copyright (c) 1998-2012 Balázs Scheidler
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "logproto-spoof-source-client.h"
+#include "logproto/logproto-text-client.h"
+#include "logmsg/logmsg.h"
+#include "messages.h"
+#include "gprocess.h"
+
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#if SYSLOG_NG_ENABLE_SPOOF_SOURCE
+
+#ifdef _GNU_SOURCE
+#  define _GNU_SOURCE_DEFINED 1
+#  undef _GNU_SOURCE
+#endif
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundef"
+#include <libnet.h>
+#pragma GCC diagnostic pop
+
+#ifdef _GNU_SOURCE_DEFINED
+#  undef _GNU_SOURCE
+#  define _GNU_SOURCE 1
+#endif
+
+typedef struct _LogProtoSpoofSourceClient
+{
+  LogProtoTextClient super;
+  libnet_t *lnet_ctx;
+  GSockAddr *dest_addr;
+  guint max_msglen;
+} LogProtoSpoofSourceClient;
+
+static inline gboolean
+_is_message_spoofable(LogMessage *msg)
+{
+  return msg->saddr && (msg->saddr->sa.sa_family == AF_INET || msg->saddr->sa.sa_family == AF_INET6);
+}
+
+static gboolean
+_construct_ipv4_packet(LogProtoSpoofSourceClient *self, LogMessage *msg, const guchar *payload, gsize payload_len)
+{
+  libnet_ptag_t ip, udp;
+  struct sockaddr_in *src, *dst;
+
+  if (msg->saddr->sa.sa_family != AF_INET)
+    return FALSE;
+
+  src = (struct sockaddr_in *) &msg->saddr->sa;
+  dst = (struct sockaddr_in *) &self->dest_addr->sa;
+
+  libnet_clear_packet(self->lnet_ctx);
+
+  udp = libnet_build_udp(ntohs(src->sin_port),
+                         ntohs(dst->sin_port),
+                         LIBNET_UDP_H + payload_len,
+                         0,
+                         (guchar *) payload,
+                         payload_len,
+                         self->lnet_ctx,
+                         0);
+  if (udp == -1)
+    return FALSE;
+
+  ip = libnet_build_ipv4(LIBNET_IPV4_H + payload_len + LIBNET_UDP_H,
+                         IPTOS_LOWDELAY,
+                         0,
+                         0,
+                         64,
+                         IPPROTO_UDP,
+                         0,
+                         src->sin_addr.s_addr,
+                         dst->sin_addr.s_addr,
+                         NULL,
+                         0,
+                         self->lnet_ctx,
+                         0);
+  return ip != -1;
+}
+
+#if SYSLOG_NG_ENABLE_IPV6
+static gboolean
+_construct_ipv6_packet(LogProtoSpoofSourceClient *self, LogMessage *msg, const guchar *payload, gsize payload_len)
+{
+  libnet_ptag_t ip, udp;
+  struct sockaddr_in *src4;
+  struct sockaddr_in6 src, *dst;
+  struct libnet_in6_addr ln_src, ln_dst;
+
+  switch (msg->saddr->sa.sa_family)
+    {
+    case AF_INET:
+      src4 = (struct sockaddr_in *) &msg->saddr->sa;
+      memset(&src, 0, sizeof(src));
+      src.sin6_family = AF_INET6;
+      src.sin6_port = src4->sin_port;
+      ((guint32 *) &src.sin6_addr)[0] = 0;
+      ((guint32 *) &src.sin6_addr)[1] = 0;
+      ((guint32 *) &src.sin6_addr)[2] = htonl(0xffff);
+      ((guint32 *) &src.sin6_addr)[3] = src4->sin_addr.s_addr;
+      break;
+    case AF_INET6:
+      src = *((struct sockaddr_in6 *) &msg->saddr->sa);
+      break;
+    default:
+      g_assert_not_reached();
+      break;
+    }
+
+  dst = (struct sockaddr_in6 *) &self->dest_addr->sa;
+
+  libnet_clear_packet(self->lnet_ctx);
+
+  udp = libnet_build_udp(ntohs(src.sin6_port),
+                         ntohs(dst->sin6_port),
+                         LIBNET_UDP_H + payload_len,
+                         0,
+                         (guchar *) payload,
+                         payload_len,
+                         self->lnet_ctx,
+                         0);
+  if (udp == -1)
+    return FALSE;
+
+  memcpy(&ln_src, &src.sin6_addr, sizeof(ln_src));
+  memcpy(&ln_dst, &dst->sin6_addr, sizeof(ln_dst));
+  ip = libnet_build_ipv6(0, 0,
+                         LIBNET_UDP_H + payload_len,
+                         IPPROTO_UDP,
+                         64,
+                         ln_src, ln_dst,
+                         NULL, 0,
+                         self->lnet_ctx,
+                         0);
+  return ip != -1;
+}
+#endif
+
+static gboolean
+_construct_packet(LogProtoSpoofSourceClient *self, LogMessage *msg, const guchar *payload, gsize payload_len)
+{
+  switch (self->dest_addr->sa.sa_family)
+    {
+    case AF_INET:
+      return _construct_ipv4_packet(self, msg, payload, payload_len);
+#if SYSLOG_NG_ENABLE_IPV6
+    case AF_INET6:
+      return _construct_ipv6_packet(self, msg, payload, payload_len);
+#endif
+    default:
+      g_assert_not_reached();
+    }
+  return FALSE;
+}
+
+static gboolean
+log_proto_spoof_source_client_poll_prepare(LogProtoClient *s, GIOCondition *cond, GIOCondition *idle_cond,
+                                           gint *timeout)
+{
+  LogProtoSpoofSourceClient *self = (LogProtoSpoofSourceClient *) s;
+
+  *cond = G_IO_OUT;
+  *idle_cond = 0;
+  return self->super.partial != NULL;
+}
+
+static LogProtoStatus
+log_proto_spoof_source_client_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg, gsize msg_len,
+                                   gboolean *consumed)
+{
+  LogProtoSpoofSourceClient *self = (LogProtoSpoofSourceClient *) s;
+
+  if (!_is_message_spoofable(logmsg))
+    return log_proto_text_client_post_method(s, logmsg, msg, msg_len, consumed);
+
+  *consumed = FALSE;
+
+  gsize effective_len = MIN(msg_len, (gsize) self->max_msglen);
+  gboolean success = _construct_packet(self, logmsg, msg, effective_len)
+                     && (libnet_write(self->lnet_ctx) >= 0);
+
+  if (!success)
+    {
+      msg_warning_once("Error sending raw frame, falling back to normal UDP",
+                       evt_tag_str("error", libnet_geterror(self->lnet_ctx)));
+      return log_proto_text_client_post_method(s, logmsg, msg, msg_len, consumed);
+    }
+
+  *consumed = TRUE;
+  log_proto_client_msg_ack(s, 1);
+  g_free(msg);
+  return LPS_SUCCESS;
+}
+
+static void
+log_proto_spoof_source_client_free(LogProtoClient *s)
+{
+  LogProtoSpoofSourceClient *self = (LogProtoSpoofSourceClient *) s;
+
+  if (self->lnet_ctx)
+    libnet_destroy(self->lnet_ctx);
+  if (self->dest_addr)
+    g_sockaddr_unref(self->dest_addr);
+  if (self->super.partial_free)
+    self->super.partial_free(self->super.partial);
+  self->super.partial = NULL;
+  log_proto_client_free_method(s);
+}
+
+LogProtoClient *
+log_proto_spoof_source_client_new(gint address_family,
+                                  const LogProtoClientOptions *options,
+                                  GSockAddr *dest_addr,
+                                  guint max_msglen)
+{
+  LogProtoSpoofSourceClient *self = g_new0(LogProtoSpoofSourceClient, 1);
+
+  log_proto_text_client_init(&self->super, NULL, options, FALSE);
+  self->super.super.poll_prepare = log_proto_spoof_source_client_poll_prepare;
+  self->super.super.post = log_proto_spoof_source_client_post;
+  self->super.super.free_fn = log_proto_spoof_source_client_free;
+
+  gchar error[LIBNET_ERRBUF_SIZE];
+  cap_t saved_caps = g_process_cap_save();
+  g_process_enable_cap("cap_net_raw");
+  self->lnet_ctx = libnet_init(address_family == AF_INET ? LIBNET_RAW4 : LIBNET_RAW6, NULL, error);
+  g_process_cap_restore(saved_caps);
+
+  if (!self->lnet_ctx)
+    {
+      msg_error("Error initializing raw socket, spoof-source support disabled",
+                evt_tag_str("error", error));
+      log_proto_client_free(&self->super.super);
+      return NULL;
+    }
+
+  self->dest_addr = g_sockaddr_ref(dest_addr);
+  self->max_msglen = max_msglen;
+
+  return &self->super.super;
+}
+
+#endif

--- a/modules/afsocket/logproto-spoof-source-client.h
+++ b/modules/afsocket/logproto-spoof-source-client.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2012 Balabit
+ * Copyright (c) 1998-2012 Balázs Scheidler
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef LOGPROTO_SPOOF_SOURCE_CLIENT_H_INCLUDED
+#define LOGPROTO_SPOOF_SOURCE_CLIENT_H_INCLUDED
+
+#include "logproto/logproto-client.h"
+#include "gsockaddr.h"
+
+LogProtoClient *log_proto_spoof_source_client_new(gint address_family,
+                                                  const LogProtoClientOptions *options,
+                                                  GSockAddr *dest_addr,
+                                                  guint max_msglen);
+
+#endif

--- a/news/feature-1064.md
+++ b/news/feature-1064.md
@@ -1,0 +1,5 @@
+`network()` and `syslog()` destinations: improve performance of the
+spoof-soure(yes) feature by drastically improving scalability in this case.
+The sending of packets is now running in a destination thread (instead of
+piggybacking it to the source thread), which also allowed to eliminate the
+per-destination lock protecting the send operation.


### PR DESCRIPTION
This PR moves the implementation of the spoof-source() feature so it becomes a LogProtoClient, e.g. it stops bypassing the LogWriter machinery. This has a number of benefits:

1) receiving and sending of message become separate threads, allowing more scale
2) the mutex protecting the libnet context is eliminated (another scalability improvement)
3) the queue metrics light up (until now, spoofed messages are not counted in stats)
4) the code is much nicer

The majority of the PR has been  generated by claude as indicated in the commits. I reviewed it and tested it with ipv4. I also compared the ipv4/ipv6 packet construction against the old implementation and they match up.