### PR TITLE
Add FilterX JIT toggle to Light tests

### DIFF
--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -186,7 +186,8 @@ version(void)
          "Enable-Spoof-Source: %s\n"
          "Enable-TCP-Wrapper: %s\n"
          "Enable-Linux-Caps: %s\n"
-         "Enable-Systemd: %s\n",
+         "Enable-Systemd: %s\n"
+         "Enable-Filterx-Jit: %s\n",
          ON_OFF_STR(SYSLOG_NG_ENABLE_DEBUG),
          ON_OFF_STR(SYSLOG_NG_ENABLE_GPROF),
          ON_OFF_STR(SYSLOG_NG_ENABLE_MEMTRACE),
@@ -195,7 +196,8 @@ version(void)
          ON_OFF_STR(SYSLOG_NG_ENABLE_SPOOF_SOURCE),
          ON_OFF_STR(SYSLOG_NG_ENABLE_TCP_WRAPPER),
          ON_OFF_STR(SYSLOG_NG_ENABLE_LINUX_CAPS),
-         ON_OFF_STR(SYSLOG_NG_ENABLE_SYSTEMD));
+         ON_OFF_STR(SYSLOG_NG_ENABLE_SYSTEMD),
+         ON_OFF_STR(SYSLOG_NG_ENABLE_JIT));
 
   g_free(installer_version);
 }

--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "axosyslog-light"
-version = "1.16.0"
+version = "1.17.0"
 description = "Lightweight End-to-End Test Framework for AxoSyslog."
 authors = ["Andras Mitzki <andras.mitzki@axoflow.com>", "Attila Szakacs <attila.szakacs@axoflow.com>"]
 readme = "README.md"

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -105,6 +105,8 @@ def pytest_addoption(parser):
         help="Path for report files folder. Default form: 'reports/<current_date>'",
     )
 
+    parser.addoption("--disable-filterx-jit", action="store_true", help="Disable JIT compilation in filterx expressions.")
+
 
 _test_results = []
 
@@ -146,7 +148,9 @@ def testcase_parameters(request):
 
 @pytest.fixture
 def config(request, syslog_ng, teardown) -> SyslogNgConfig:
-    return syslog_ng.create_config(request.getfixturevalue("config_version"), teardown)
+    cfg = syslog_ng.create_config(request.getfixturevalue("config_version"), teardown)
+    cfg.filterx_jit_enabled = request.getfixturevalue("jit_available") and not request.config.getoption("--disable-filterx-jit")
+    return cfg
 
 
 @pytest.fixture
@@ -229,6 +233,11 @@ def version(syslog_ng):
 @pytest.fixture
 def config_version(syslog_ng):
     return syslog_ng.get_config_version()
+
+
+@pytest.fixture
+def jit_available(syslog_ng):
+    return syslog_ng.get_jit_availability()
 
 
 @pytest.fixture

--- a/tests/light/src/axosyslog_light/syslog_ng/syslog_ng.py
+++ b/tests/light/src/axosyslog_light/syslog_ng/syslog_ng.py
@@ -153,6 +153,9 @@ class SyslogNg(object):
     def get_version(self) -> str:
         return self._get_version_info("Installer-Version:")
 
+    def get_jit_availability(self) -> str:
+        return self._get_version_info("Enable-Filterx-Jit:")
+
     def is_process_running(self) -> bool:
         return self._process and self._process.poll() is None
 

--- a/tests/light/src/axosyslog_light/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/syslog_ng_config.py
@@ -93,6 +93,7 @@ class SyslogNgConfig(object):
         self._prometheus_stats_handler = prometheus_stats_handler
         self.__implicit_statement_groups: typing.Dict[int, StatementGroup] = {}
         self.teardown = teardown
+        self.filterx_jit_enabled = None
 
     stringify = staticmethod(stringify)
 
@@ -115,6 +116,13 @@ class SyslogNgConfig(object):
             rendered_config = self._raw_config
         else:
             rendered_config = ConfigRenderer(self._syslog_ng_config).get_rendered_config()
+
+        if len(rendered_config) > 0:
+            if self.filterx_jit_enabled:
+                rendered_config += "\noptions { filterx-jit(yes); };\n"
+            else:
+                rendered_config += "\noptions { filterx-jit(no); };\n"
+
         logger.info("Generated syslog-ng config\n{}\n".format(rendered_config))
 
         syslog_ng_config_file = File(config_path)


### PR DESCRIPTION
During the incubation phase of the FilterX JIT feature we should test interpreted and JIT code paths alongside each other.

The test framework implies that the appropriate keyword is known to the axosyslog instance (ie. FilterX JIT merged)
The test framework works well without compiled in JIT functionality, in that case the JIT is never enabled in the config.
The change adds the appropriate JIT enable/disable flags to the raw and rendered logs.