### PR TITLE
fixing pr-1038 - Add Service type and service annotation to the helm chart

### DIFF
--- a/charts/axosyslog/README.md
+++ b/charts/axosyslog/README.md
@@ -96,8 +96,10 @@ The chart deploys two complementary components that can run side by side:
 | resources | object | `{}` | Default CPU/memory resource requests and limits for all components (overridden per component via collector.resources / aggregator.resources) |
 | secretMounts | list | `[]` | Default secrets to mount as files (overridden per component) |
 | securityContext | object | `{}` | Default container-level security context for all components (overridden per component via collector.securityContext / aggregator.securityContext) |
-| service.create | bool | `true` | Create a Service for the aggregator StatefulSet |
-| service.extraPorts | list | `[]` | Additional ports to expose on the aggregator Service |
+| service.annotations | object | `{}` | Annotations to apply to the service |
+| service.create | bool | `true` | Whether to create the service |
+| service.extraPorts | list | `[]` | Additional ports to expose on the service |
+| service.type | string | `"NodePort"` | Type of the service to create (`NodePort`, `LoadBalancer`, `ClusterIP`, or `ExternalName`) |
 | serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount |
 | serviceAccount.create | bool | `true` | Create a ServiceAccount for the pods |
 | terminationGracePeriodSeconds | int | `30` | Time in seconds given to pods to terminate gracefully |

--- a/charts/axosyslog/templates/service.yaml
+++ b/charts/axosyslog/templates/service.yaml
@@ -6,10 +6,14 @@ metadata:
   namespace: {{ include "axosyslog.namespace" . }}
   labels:
     {{- include "axosyslog.aggregator.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   selector:
     {{- include "axosyslog.aggregator.selectorLabels" . | nindent 4 }}
-  type: NodePort
+  type: {{ .Values.service.type }}
   ports:
 {{ if .Values.service.extraPorts }}
 {{ toYaml ( .Values.service.extraPorts ) | nindent 4 }}
@@ -19,31 +23,41 @@ spec:
 {{- if .syslog.enabled }}
     - name: rfc3164-udp
       protocol: UDP
-      nodePort: {{ .syslog.rfc3164UdpPort | default 30514 }}
+      {{- if and .syslog.rfc3164UdpPort (or (eq $.Values.service.type "NodePort") (eq $.Values.service.type "LoadBalancer")) }}
+      nodePort: {{ .syslog.rfc3164UdpPort }}
+      {{- end }}
       port: 514
       targetPort: rfc3164-udp
     - name: rfc3164-tcp
       protocol: TCP
-      nodePort: {{ .syslog.rfc3164TcpPort | default 30514 }}
+      {{- if and .syslog.rfc3164TcpPort (or (eq $.Values.service.type "NodePort") (eq $.Values.service.type "LoadBalancer")) }}
+      nodePort: {{ .syslog.rfc3164TcpPort }}
+      {{- end }}
       port: 514
       targetPort: rfc3164-tcp
     {{- if .syslog.tls }}
     - name: rfc5424-tls
       protocol: TCP
-      nodePort: {{ .syslog.rfc5424TlsPort | default 30614 }}
+      {{- if and .syslog.rfc5424TlsPort (or (eq $.Values.service.type "NodePort") (eq $.Values.service.type "LoadBalancer")) }}
+      nodePort: {{ .syslog.rfc5424TlsPort }}
+      {{- end }}
       port: 6514
       targetPort: rfc5424-tls
     {{- end }}
     - name: rfc5424-tcp
       protocol: TCP
-      nodePort: {{ .syslog.rfc5424TcpPort | default 30601 }}
+      {{- if and .syslog.rfc5424TcpPort (or (eq $.Values.service.type "NodePort") (eq $.Values.service.type "LoadBalancer")) }}
+      nodePort: {{ .syslog.rfc5424TcpPort }}
+      {{- end }}
       port: 601
       targetPort: rfc5424-tcp
 {{- end }}
 {{- if .axosyslogOtlp.enabled }}
     - name: otlp
       protocol: TCP
-      nodePort: {{ .axosyslogOtlp.port | default 30317 }}
+      {{- if and .axosyslogOtlp.port (or (eq $.Values.service.type "NodePort") (eq $.Values.service.type "LoadBalancer")) }}
+      nodePort: {{ .axosyslogOtlp.port }}
+      {{- end }}
       port: 4317
       targetPort: otlp
 {{- end }}

--- a/charts/axosyslog/values.yaml
+++ b/charts/axosyslog/values.yaml
@@ -242,9 +242,13 @@ openShift:
     annotations: {}
 
 service:
-  # -- Create a Service for the aggregator StatefulSet
+  # -- Whether to create the service
   create: true
-  # -- Additional ports to expose on the aggregator Service
+  # -- Type of the service to create (`NodePort`, `LoadBalancer`, `ClusterIP`, or `ExternalName`)
+  type: NodePort
+  # -- Annotations to apply to the service
+  annotations: {}
+  # -- Additional ports to expose on the service
   extraPorts: []
   #  - protocol: TCP
   #    port: 514


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
This PR is to combine these two Pull requests https://github.com/axoflow/axosyslog/pull/1038 and https://github.com/axoflow/axosyslog/pull/1058

The pull request is to make the service type configurable rather than a static NodePort. 
Also, to add a service annotation.
-->
