### PR TITLE
Logmsg memory allocation fix

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -552,11 +552,11 @@ log_msg_rename_value(LogMessage *self, NVHandle from, NVHandle to)
 }
 
 static inline void
-_unshare_payload_if_needed(LogMessage *self, gsize extra_space)
+_unshare_payload_if_needed(LogMessage *self, guint32 memory_needed)
 {
   if (!log_msg_chk_flag(self, LF_STATE_OWN_PAYLOAD))
     {
-      self->payload = nv_table_clone(self->payload, extra_space);
+      self->payload = nv_table_clone(self->payload, memory_needed);
       log_msg_set_flag(self, LF_STATE_OWN_PAYLOAD);
       log_msg_update_allocation(self, nv_table_get_size(self->payload));
     }
@@ -630,9 +630,10 @@ log_msg_set_value_with_type(LogMessage *self, NVHandle handle,
   /* we need a loop here as a single realloc may not be enough. Might help
    * if we pass how much bytes we need though. */
 
-  while (!nv_table_add_value(self->payload, handle, name, name_len, value, value_len, type, &new_entry))
+  guint32 memory_needed = 0;
+  while (!nv_table_add_value(self->payload, handle, name, name_len, value, value_len, type, &new_entry, &memory_needed))
     {
-      if (!_grow_payload(self, "set_value", name_len + value_len + 2))
+      if (!_grow_payload(self, "set_value", memory_needed))
         break;
     }
 
@@ -665,9 +666,10 @@ log_msg_unset_value(LogMessage *self, NVHandle handle)
 
   _unshare_payload_if_needed(self, 0);
 
-  while (!nv_table_unset_value(self->payload, handle))
+  guint32 memory_needed = 0;
+  while (!nv_table_unset_value(self->payload, handle, &memory_needed))
     {
-      if (!_grow_payload(self, "unset_value", 0))
+      if (!_grow_payload(self, "unset_value", memory_needed))
         break;
     }
 
@@ -721,9 +723,10 @@ log_msg_set_value_indirect_with_type(LogMessage *self, NVHandle handle,
     .len = len,
   };
 
-  while (!nv_table_add_value_indirect(self->payload, handle, name, name_len, &referenced_slice, type, &new_entry))
+  guint32 memory_needed = 0;
+  while (!nv_table_add_value_indirect(self->payload, handle, name, name_len, &referenced_slice, type, &new_entry, &memory_needed))
     {
-      if (!_grow_payload(self, "set_value_indirect", name_len + 1))
+      if (!_grow_payload(self, "set_value_indirect", memory_needed))
         break;
     }
 

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -567,18 +567,29 @@ _grow_payload(LogMessage *self, const gchar *operation, gsize extra_space)
 {
   /* error allocating string in payload, reallocate */
   guint32 old_size = nv_table_get_size(self->payload);
+  guint32 avail_size = nv_table_get_available(self->payload);
   if (!nv_table_realloc(&self->payload, extra_space))
     {
       /* can't grow the payload, it has reached the maximum size */
       msg_info("Cannot grow message payload, maximum size has been reached",
                evt_tag_str("operation", operation),
                evt_tag_int("size", old_size),
+               evt_tag_int("avail_size", avail_size),
                evt_tag_int("extra_space", extra_space),
                evt_tag_int("maximum_payload", NV_TABLE_MAX_BYTES),
                evt_tag_printf("msg", "%p", self));
       return FALSE;
     }
   guint32 new_size = nv_table_get_size(self->payload);
+  msg_trace("Message payload reallocated",
+           evt_tag_str("operation", operation),
+           evt_tag_int("old_size", old_size),
+           evt_tag_int("old_avail_size", avail_size),
+           evt_tag_int("new_size", new_size),
+           evt_tag_int("avail_size", nv_table_get_available(self->payload)),
+           evt_tag_int("extra_space", extra_space),
+           evt_tag_int("maximum_payload", NV_TABLE_MAX_BYTES),
+           evt_tag_printf("msg", "%p", self));
   log_msg_update_allocation(self, (new_size - old_size));
   stats_counter_inc(count_payload_reallocs);
   return TRUE;

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -181,10 +181,15 @@ nv_table_get_next_size(NVTable *self, gsize additional_space)
     return self->size;
 
   gsize new_size = self->size + (additional_space - avail_size);
-  if (new_size > 4096)
+  if (new_size > 8192)
     {
       /* align to page boundary */
       new_size = (new_size + 0xFFF) & ~0xFFF;
+    }
+  else if (new_size > 4096)
+    {
+      /* align to page boundary */
+      new_size = (new_size + 0x7FF) & ~0x7FF;
     }
   else if (new_size > 1024)
     {

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -406,39 +406,37 @@ _make_entry_direct(NVHandle handle, NVEntry *entry, NVIndexEntry *index_entry, g
 {
   NVTable *self = (NVTable *) (((gpointer *) user_data)[0]);
   NVHandle ref_handle = GPOINTER_TO_UINT(((gpointer *) user_data)[1]);
+  guint32 *memory_needed = (((gpointer *) user_data)[2]);
 
   if (entry->indirect && entry->vindirect.handle == ref_handle)
     {
       const gchar *value;
       gssize value_len;
+      guint32 mem = 0;
 
       value = nv_table_resolve_indirect(self, entry, &value_len);
-      if (!nv_table_add_value(self, handle, entry->vindirect.name, entry->name_len, value, value_len, entry->type, NULL))
+      if (!nv_table_add_value(self, handle, entry->vindirect.name, entry->name_len, value, value_len, entry->type, NULL, &mem))
         {
           /* nvtable full, but we can't realloc it ourselves,
            * propagate this back as a failure of
            * nv_table_add_value() */
-
-          return TRUE;
+          *memory_needed += mem;
         }
     }
   return FALSE;
 }
 
 static inline gboolean
-nv_table_break_references_to_entry(NVTable *self, NVHandle handle, NVEntry *entry)
+nv_table_break_references_to_entry(NVTable *self, NVHandle handle, NVEntry *entry, guint32 *memory_needed)
 {
   if (G_UNLIKELY(entry && !entry->indirect && entry->referenced))
     {
-      gpointer data[2] = { self, GUINT_TO_POINTER((glong) handle) };
+      guint32 mem = 0;
+      gpointer data[3] = { self, GUINT_TO_POINTER((glong) handle), &mem };
 
-      if (nv_table_foreach_entry(self, _make_entry_direct, data))
-        {
-          /* we had to stop iteration, which means that we were unable
-           * to allocate enough space for making indirect entries
-           * direct */
-          return FALSE;
-        }
+      nv_table_foreach_entry(self, _make_entry_direct, data);
+      *memory_needed += mem;
+      return mem == 0;
     }
   return TRUE;
 }
@@ -488,19 +486,26 @@ nv_table_add_value(NVTable *self, NVHandle handle,
                    const gchar *name, gsize name_len,
                    const gchar *value, gsize value_len,
                    NVType type,
-                   gboolean *new_entry)
+                   gboolean *new_entry,
+                   guint32 *memory_needed)
 {
   NVEntry *entry;
   guint32 ofs;
   NVIndexEntry *index_entry, *index_slot;
+  guint32 mem = 0;
 
   if (value_len > NV_TABLE_MAX_BYTES)
     value_len = NV_TABLE_MAX_BYTES;
   if (new_entry)
     *new_entry = FALSE;
+
+  mem += NV_TABLE_BOUND(NV_ENTRY_DIRECT_SIZE(name_len, value_len)) + sizeof(NVIndexEntry);
   entry = nv_table_get_entry(self, handle, &index_entry, &index_slot);
-  if (!nv_table_break_references_to_entry(self, handle, entry))
-    return FALSE;
+  if (!nv_table_break_references_to_entry(self, handle, entry, &mem))
+    {
+      *memory_needed += mem;
+      return FALSE;
+    }
 
   if (entry && entry->alloc_len >= NV_ENTRY_DIRECT_SIZE(entry->name_len, value_len))
     {
@@ -513,7 +518,10 @@ nv_table_add_value(NVTable *self, NVHandle handle,
   /* check if there's enough free space: size of the struct plus the
    * size needed for a dynamic table slot */
   if (!_alloc_index_entry(self, handle, &index_entry, index_slot))
-    return FALSE;
+    {
+      *memory_needed += mem;
+      return FALSE;
+    }
 
   if (nv_table_is_handle_static(self, handle))
     name_len = 0;
@@ -521,6 +529,7 @@ nv_table_add_value(NVTable *self, NVHandle handle,
   entry = nv_table_alloc_value(self, NV_ENTRY_DIRECT_SIZE(name_len, value_len));
   if (G_UNLIKELY(!entry))
     {
+      *memory_needed += mem;
       return FALSE;
     }
   entry->type = type;
@@ -541,16 +550,20 @@ nv_table_add_value(NVTable *self, NVHandle handle,
 }
 
 gboolean
-nv_table_unset_value(NVTable *self, NVHandle handle)
+nv_table_unset_value(NVTable *self, NVHandle handle, guint32 *memory_needed)
 {
   NVIndexEntry *index_entry;
   NVEntry *entry = nv_table_get_entry(self, handle, &index_entry, NULL);
+  guint32 mem = 0;
 
   if (!entry)
     return TRUE;
 
-  if (!nv_table_break_references_to_entry(self, handle, entry))
-    return FALSE;
+  if (!nv_table_break_references_to_entry(self, handle, entry, &mem))
+    {
+      *memory_needed += mem;
+      return FALSE;
+    }
 
   entry->unset = TRUE;
 
@@ -600,7 +613,8 @@ nv_table_set_indirect_entry(NVTable *self, NVHandle handle, NVEntry *entry, cons
 
 static gboolean
 nv_table_copy_referenced_value(NVTable *self, NVEntry *ref_entry, NVHandle handle, const gchar *name,
-                               gsize name_len, NVReferencedSlice *ref_slice, NVType type, gboolean *new_entry)
+                               gsize name_len, NVReferencedSlice *ref_slice, NVType type,
+                               gboolean *new_entry, guint32 *memory_needed)
 {
 
   gssize ref_length;
@@ -616,28 +630,29 @@ nv_table_copy_referenced_value(NVTable *self, NVEntry *ref_entry, NVHandle handl
       ref_slice->len = MIN(ref_slice->ofs + ref_slice->len, ref_length) - ref_slice->ofs;
     }
 
-  return nv_table_add_value(self, handle, name, name_len, ref_value + ref_slice->ofs, ref_slice->len, type, new_entry);
+  return nv_table_add_value(self, handle, name, name_len, ref_value + ref_slice->ofs, ref_slice->len, type, new_entry, memory_needed);
 }
 
 gboolean
 nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, gsize name_len,
-                            NVReferencedSlice *referenced_slice, NVType type, gboolean *new_entry)
+                            NVReferencedSlice *referenced_slice, NVType type, gboolean *new_entry, guint32 *memory_needed)
 {
   NVEntry *entry, *ref_entry;
   NVIndexEntry *index_entry, *index_slot;
-  guint32 ofs;
+  guint32 ofs, mem = 0;
 
   if (new_entry)
     *new_entry = FALSE;
-  ref_entry = nv_table_get_entry(self, referenced_slice->handle, NULL, NULL);
 
+  ref_entry = nv_table_get_entry(self, referenced_slice->handle, NULL, NULL);
   if ((ref_entry && ref_entry->indirect) || handle == referenced_slice->handle)
     {
       /* NOTE: uh-oh, the to-be-referenced value is already an indirect
        * reference, this is not supported, copy the stuff */
-      return nv_table_copy_referenced_value(self, ref_entry, handle, name, name_len, referenced_slice, type, new_entry);
+      return nv_table_copy_referenced_value(self, ref_entry, handle, name, name_len, referenced_slice, type, new_entry, memory_needed);
     }
 
+  mem += NV_TABLE_BOUND(NV_ENTRY_INDIRECT_SIZE(name_len)) + sizeof(NVIndexEntry);
   entry = nv_table_get_entry(self, handle, &index_entry, &index_slot);
   if ((!entry && !new_entry && referenced_slice->len == 0) || !ref_entry)
     {
@@ -649,8 +664,11 @@ nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, g
       return TRUE;
     }
 
-  if (!nv_table_break_references_to_entry(self, handle, entry))
-    return FALSE;
+  if (!nv_table_break_references_to_entry(self, handle, entry, &mem))
+    {
+      *memory_needed += mem;
+      return FALSE;
+    }
 
   if (entry && (entry->alloc_len >= NV_ENTRY_INDIRECT_SIZE(name_len)))
     {
@@ -665,10 +683,14 @@ nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, g
     }
 
   if (!_alloc_index_entry(self, handle, &index_entry, index_slot))
-    return FALSE;
+    {
+      *memory_needed += mem;
+      return FALSE;
+    }
   entry = nv_table_alloc_value(self, NV_ENTRY_INDIRECT_SIZE(name_len));
   if (!entry)
     {
+      *memory_needed += mem;
       return FALSE;
     }
 
@@ -780,11 +802,11 @@ nv_table_init_borrowed(gpointer space, gsize space_len, gint num_static_entries)
 
 /* returns TRUE if successfully realloced, FALSE means that we're unable to grow */
 gboolean
-nv_table_realloc(NVTable **pself, gsize additional_space)
+nv_table_realloc(NVTable **pself, guint32 memory_needed)
 {
   NVTable *self = *pself;
   gsize old_size = self->size;
-  gsize new_size = nv_table_get_next_size(self, additional_space + sizeof(NVEntry));
+  gsize new_size = nv_table_get_next_size(self, memory_needed);
 
   if (new_size == old_size)
     return FALSE;
@@ -843,12 +865,12 @@ nv_table_unref(NVTable *self)
  *
  **/
 NVTable *
-nv_table_clone(NVTable *self, gsize additional_space)
+nv_table_clone(NVTable *self, guint32 memory_needed)
 {
   NVTable *new;
   gsize new_size;
 
-  new_size = nv_table_get_next_size(self, additional_space + sizeof(NVEntry));
+  new_size = nv_table_get_next_size(self, NV_TABLE_BOUND(memory_needed) + sizeof(NVEntry) + sizeof(NVIndexEntry));
   new = g_malloc(new_size);
   memcpy(new, self, sizeof(NVTable) + self->num_static_entries * sizeof(self->static_entries[0]) + self->index_size *
          sizeof(NVIndexEntry));
@@ -895,10 +917,11 @@ _compact_foreach_entry(NVHandle handle, NVEntry *entry, NVIndexEntry *index_entr
     {
       value = nv_table_resolve_direct(old, entry, &value_len);
 
+      guint32 memory_needed = 0;
       gboolean value_successfully_added =
         nv_table_add_value(new, handle,
                            name, name_len, value, value_len,
-                           entry->type, NULL);
+                           entry->type, NULL, &memory_needed);
       g_assert(value_successfully_added);
     }
   else
@@ -910,11 +933,12 @@ _compact_foreach_entry(NVHandle handle, NVEntry *entry, NVIndexEntry *index_entr
         .len = entry->vindirect.len
       };
 
+      guint32 memory_needed = 0;
       gboolean value_successfully_added =
         nv_table_add_value_indirect(new, handle,
                                     name, name_len,
                                     &referenced_slice,
-                                    entry->type, NULL);
+                                    entry->type, NULL, &memory_needed);
       g_assert(value_successfully_added);
     }
 

--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -299,21 +299,25 @@ struct _NVTable
 gboolean nv_table_add_value(NVTable *self, NVHandle handle,
                             const gchar *name, gsize name_len,
                             const gchar *value, gsize value_len,
-                            NVType type, gboolean *new_entry);
-gboolean nv_table_unset_value(NVTable *self, NVHandle handle);
+                            NVType type,
+                            gboolean *new_entry,
+                            guint32 *memory_needed);
+gboolean nv_table_unset_value(NVTable *self, NVHandle handle, guint32 *memory_needed);
 gboolean nv_table_add_value_indirect(NVTable *self, NVHandle handle,
                                      const gchar *name, gsize name_len,
                                      NVReferencedSlice *referenced_slice,
-                                     NVType type, gboolean *new_entry);
+                                     NVType type,
+                                     gboolean *new_entry,
+                                     guint32 *memory_needed);
 
 gboolean nv_table_foreach(NVTable *self, NVRegistry *registry, NVTableForeachFunc func, gpointer user_data);
 gboolean nv_table_foreach_entry(NVTable *self, NVTableForeachEntryFunc func, gpointer user_data);
 
 NVTable *nv_table_new(gint num_static_values, gint index_size_hint, gint init_length);
 NVTable *nv_table_init_borrowed(gpointer space, gsize space_len, gint num_static_entries);
-gboolean nv_table_realloc(NVTable **pself, gsize additional_space);
+gboolean nv_table_realloc(NVTable **pself, guint32 memory_needed);
 NVTable *nv_table_compact(NVTable *self);
-NVTable *nv_table_clone(NVTable *self, gsize additional_space);
+NVTable *nv_table_clone(NVTable *self, guint32 memory_needed);
 NVTable *nv_table_ref(NVTable *self);
 void nv_table_unref(NVTable *self);
 

--- a/lib/logmsg/tests/test_nvtable.c
+++ b/lib/logmsg/tests/test_nvtable.c
@@ -173,6 +173,7 @@ Test(nvtable, test_nvtable_direct)
   gboolean success;
   gint i;
   guint16 used;
+  guint32 memory_needed = 0;
 
   for (i = 0; i < sizeof(value); i++)
     value[i] = 'A' + (i % 26);
@@ -188,15 +189,17 @@ Test(nvtable, test_nvtable_direct)
 
       /* one that fits */
       tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-      success = nv_table_add_value(tab, handle, name, strlen(name), value, 128, 0, NULL);
+      success = nv_table_add_value(tab, handle, name, strlen(name), value, 128, 0, NULL, &memory_needed);
       cr_assert(success);
       assert_nvtable(tab, handle, value, 128);
       nv_table_unref(tab);
 
       /* one that is too large */
+      memory_needed = 0;
       tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-      success = nv_table_add_value(tab, handle, name, strlen(name), value, 512, 0, NULL);
+      success = nv_table_add_value(tab, handle, name, strlen(name), value, 512, 0, NULL, &memory_needed);
       cr_assert_not(success);
+      cr_assert_gt(memory_needed, 512);
       nv_table_unref(tab);
 
       /*************************************************************/
@@ -205,11 +208,11 @@ Test(nvtable, test_nvtable_direct)
 
       /* one that fits, but realloced size wouldn't fit */
       tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 192);
-      success = nv_table_add_value(tab, handle, name, strlen(name), value, 128, 0, NULL);
+      success = nv_table_add_value(tab, handle, name, strlen(name), value, 128, 0, NULL, &memory_needed);
       cr_assert(success);
       used = tab->used;
 
-      success = nv_table_add_value(tab, handle, name, strlen(name), value, 64, 0, NULL);
+      success = nv_table_add_value(tab, handle, name, strlen(name), value, 64, 0, NULL, &memory_needed);
       cr_assert(success);
       cr_assert_eq(tab->used, used);
       assert_nvtable(tab, handle, value, 64);
@@ -217,11 +220,11 @@ Test(nvtable, test_nvtable_direct)
 
       /* one that is too large for the given entry, but still fits in the NVTable */
       tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-      success = nv_table_add_value(tab, handle, name, strlen(name), value, 64, 0, NULL);
+      success = nv_table_add_value(tab, handle, name, strlen(name), value, 64, 0, NULL, &memory_needed);
       cr_assert(success);
       used = tab->used;
 
-      success = nv_table_add_value(tab, handle, name, strlen(name), value, 128, 0, NULL);
+      success = nv_table_add_value(tab, handle, name, strlen(name), value, 128, 0, NULL, &memory_needed);
       cr_assert(success);
       cr_assert_gt(tab->used, used);
       assert_nvtable(tab, handle, value, 128);
@@ -229,11 +232,13 @@ Test(nvtable, test_nvtable_direct)
 
       /* one that is too large for the given entry, and also for the NVTable */
       tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-      success = nv_table_add_value(tab, handle, name, strlen(name), value, 64, 0, NULL);
+      success = nv_table_add_value(tab, handle, name, strlen(name), value, 64, 0, NULL, &memory_needed);
       cr_assert(success);
 
-      success = nv_table_add_value(tab, handle, name, strlen(name), value, 512, 0, NULL);
+      memory_needed = 0;
+      success = nv_table_add_value(tab, handle, name, strlen(name), value, 512, 0, NULL, &memory_needed);
       cr_assert_not(success);
+      cr_assert_gt(memory_needed, 512);
       assert_nvtable(tab, handle, value, 64);
       nv_table_unref(tab);
 
@@ -247,18 +252,18 @@ Test(nvtable, test_nvtable_direct)
 
           /* setup code: add static and a dynamic-indirect entry */
           tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 192);
-          success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+          success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
           cr_assert(success);
           success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                                 &(NVReferencedSlice)
           {
             STATIC_HANDLE, 1, 126
-          }, 0, NULL);
+          }, 0, NULL, &memory_needed);
           cr_assert(success);
           used = tab->used;
 
           /* store a direct entry over the indirect one */
-          success = nv_table_add_value(tab, handle, name, strlen(name), value, 1, 0, NULL);
+          success = nv_table_add_value(tab, handle, name, strlen(name), value, 1, 0, NULL, &memory_needed);
           cr_assert(success);
           cr_assert_eq(tab->used, used);
           assert_nvtable(tab, STATIC_HANDLE, value, 128);
@@ -268,19 +273,19 @@ Test(nvtable, test_nvtable_direct)
 
           /* setup code: add static and a dynamic-indirect entry */
           tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-          success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 64, 0, NULL);
+          success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 64, 0, NULL, &memory_needed);
           cr_assert(success);
           success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                                 &(NVReferencedSlice)
           {
             STATIC_HANDLE, 1, 63
-          }, 0, NULL);
+          }, 0, NULL, &memory_needed);
           cr_assert(success);
 
           used = tab->used;
 
           /* store a direct entry over the indirect one, we don't fit in the allocated space */
-          success = nv_table_add_value(tab, handle, name, strlen(name), value, 128, 0, NULL);
+          success = nv_table_add_value(tab, handle, name, strlen(name), value, 128, 0, NULL, &memory_needed);
           cr_assert(success);
           cr_assert_gt(tab->used, used);
           assert_nvtable(tab, STATIC_HANDLE, value, 64);
@@ -290,18 +295,18 @@ Test(nvtable, test_nvtable_direct)
 
           /* setup code: add static and a dynamic-indirect entry */
           tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-          success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 64, 0, NULL);
+          success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 64, 0, NULL, &memory_needed);
           cr_assert(success);
           success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                                 &(NVReferencedSlice)
           {
             STATIC_HANDLE, 1, 62
-          }, 0, NULL);
+          }, 0, NULL, &memory_needed);
           cr_assert(success);
           used = tab->used;
 
           /* store a direct entry over the indirect one, we don't fit in the allocated space */
-          success = nv_table_add_value(tab, handle, name, strlen(name), value, 256, 0, NULL);
+          success = nv_table_add_value(tab, handle, name, strlen(name), value, 256, 0, NULL, &memory_needed);
           cr_assert_not(success);
           assert_nvtable(tab, STATIC_HANDLE, value, 64);
           assert_nvtable(tab, handle, value + 1, 62);
@@ -349,6 +354,7 @@ Test(nvtable, test_nvtable_indirect)
   NVHandle handle;
   gchar value[1024], name[16];
   gboolean success;
+  guint32 memory_needed;
   gint i;
   guint16 used;
 
@@ -371,14 +377,14 @@ Test(nvtable, test_nvtable_indirect)
 
   /* one that fits */
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 192);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
 
   success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
   assert_nvtable(tab, STATIC_HANDLE, value, 128);
   assert_nvtable(tab, handle, value + 1, 126);
@@ -390,14 +396,14 @@ Test(nvtable, test_nvtable_indirect)
      to make it possible to store one direct entry */
 
   tab = nv_table_new(STATIC_VALUES, 0, 138+3);  // direct: +3
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
 
   success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert_not(success);
 
   nv_table_unref(tab);
@@ -407,13 +413,13 @@ Test(nvtable, test_nvtable_indirect)
   /*************************************************************/
 
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 192);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
   success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
   used = tab->used;
 
@@ -421,7 +427,7 @@ Test(nvtable, test_nvtable_indirect)
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 62
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
 
   cr_assert(success);
   cr_assert_eq(used, tab->used);
@@ -438,9 +444,9 @@ Test(nvtable, test_nvtable_indirect)
 
   /* setup code: add static and a dynamic-direct entry */
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
-  success = nv_table_add_value(tab, handle, name, strlen(name), value, 64, 0, NULL);
+  success = nv_table_add_value(tab, handle, name, strlen(name), value, 64, 0, NULL, &memory_needed);
   cr_assert(success);
   used = tab->used;
 
@@ -448,7 +454,7 @@ Test(nvtable, test_nvtable_indirect)
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
   cr_assert_eq(tab->used, used);
   assert_nvtable(tab, STATIC_HANDLE, value, 128);
@@ -460,9 +466,9 @@ Test(nvtable, test_nvtable_indirect)
 
   /* setup code: add static and a dynamic-direct entry */
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
-  success = nv_table_add_value(tab, handle, name, strlen(name), value, 1, 0, NULL);
+  success = nv_table_add_value(tab, handle, name, strlen(name), value, 1, 0, NULL, &memory_needed);
   cr_assert(success);
   used = tab->used;
 
@@ -470,7 +476,7 @@ Test(nvtable, test_nvtable_indirect)
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
   cr_assert_gt(tab->used, used);
   assert_nvtable(tab, STATIC_HANDLE, value, 128);
@@ -482,16 +488,16 @@ Test(nvtable, test_nvtable_indirect)
 
   /* setup code: add static and a dynamic-direct entry */
   tab = nv_table_new(STATIC_VALUES, 1, 154+3+4);  // direct: +3, indirect: +4
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
-  success = nv_table_add_value(tab, handle, name, strlen(name), value, 1, 0, NULL);
+  success = nv_table_add_value(tab, handle, name, strlen(name), value, 1, 0, NULL, &memory_needed);
   cr_assert(success);
 
   success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert_not(success);
   assert_nvtable(tab, STATIC_HANDLE, value, 128);
   assert_nvtable(tab, handle, value, 1);
@@ -511,20 +517,20 @@ Test(nvtable, test_nvtable_indirect)
 
   /* one that fits */
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
   success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
 
   success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                         &(NVReferencedSlice)
   {
     DYN_HANDLE, 1, 122
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
   assert_nvtable(tab, STATIC_HANDLE, value, 128);
   assert_nvtable(tab, DYN_HANDLE, value + 1, 126);
@@ -533,20 +539,20 @@ Test(nvtable, test_nvtable_indirect)
 
   /* one that is too large */
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 192);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
   success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
 
   success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                         &(NVReferencedSlice)
   {
     DYN_HANDLE, 1, 122
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert_not(success);
   assert_nvtable(tab, STATIC_HANDLE, value, 128);
   assert_nvtable(tab, DYN_HANDLE, value + 1, 126);
@@ -560,19 +566,19 @@ Test(nvtable, test_nvtable_indirect)
 
   /* we fit to the space of the old */
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
   success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
   success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
   used = tab->used;
 
@@ -580,7 +586,7 @@ Test(nvtable, test_nvtable_indirect)
                                         &(NVReferencedSlice)
   {
     DYN_HANDLE, 1, 1
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
 
   cr_assert_eq(tab->used, used);
@@ -592,19 +598,19 @@ Test(nvtable, test_nvtable_indirect)
   /* the new entry will not fit to the space allocated to the old */
 
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
   success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
   success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
   used = tab->used;
 
@@ -612,7 +618,7 @@ Test(nvtable, test_nvtable_indirect)
                                         &(NVReferencedSlice)
   {
     DYN_HANDLE, 1, 16
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
 
   cr_assert_gt(tab->used, used);
@@ -624,19 +630,19 @@ Test(nvtable, test_nvtable_indirect)
   /* one that is too large */
 
   tab = nv_table_new(STATIC_VALUES, 4, 256);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
   success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
   success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
   used = tab->used;
 
@@ -644,7 +650,7 @@ Test(nvtable, test_nvtable_indirect)
                                         &(NVReferencedSlice)
   {
     DYN_HANDLE, 1, 124
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert_not(success);
 
   cr_assert_eq(tab->used, used);
@@ -660,15 +666,15 @@ Test(nvtable, test_nvtable_indirect)
 
   /* we fit to the space of the old */
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
   success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
-  success = nv_table_add_value(tab, handle, name, strlen(name), value, 64, 0, NULL);
+  success = nv_table_add_value(tab, handle, name, strlen(name), value, 64, 0, NULL, &memory_needed);
   cr_assert(success);
   used = tab->used;
 
@@ -676,7 +682,7 @@ Test(nvtable, test_nvtable_indirect)
                                         &(NVReferencedSlice)
   {
     DYN_HANDLE, 1, 16
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
 
   cr_assert_eq(tab->used, used);
@@ -689,15 +695,15 @@ Test(nvtable, test_nvtable_indirect)
   /* the new entry will not fit to the space allocated to the old */
 
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
   success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
-  success = nv_table_add_value(tab, handle, name, strlen(name), value, 16, 0, NULL);
+  success = nv_table_add_value(tab, handle, name, strlen(name), value, 16, 0, NULL, &memory_needed);
   cr_assert(success);
   used = tab->used;
 
@@ -705,7 +711,7 @@ Test(nvtable, test_nvtable_indirect)
                                         &(NVReferencedSlice)
   {
     DYN_HANDLE, 1, 32
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
 
   cr_assert_gt(tab->used, used);
@@ -717,15 +723,15 @@ Test(nvtable, test_nvtable_indirect)
   /* one that is too large */
 
   tab = nv_table_new(STATIC_VALUES, 4, 256);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
   success = nv_table_add_value_indirect(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
-  success = nv_table_add_value(tab, handle, name, strlen(name), value, 16, 0, NULL);
+  success = nv_table_add_value(tab, handle, name, strlen(name), value, 16, 0, NULL, &memory_needed);
   cr_assert(success);
   used = tab->used;
 
@@ -733,7 +739,7 @@ Test(nvtable, test_nvtable_indirect)
                                         &(NVReferencedSlice)
   {
     DYN_HANDLE, 1, 124
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert_not(success);
 
   cr_assert_eq(tab->used, used);
@@ -753,7 +759,7 @@ Test(nvtable, test_nvtable_indirect)
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
   cr_assert_eq(used, tab->used);
   assert_nvtable(tab, STATIC_HANDLE, "", 0);
@@ -778,6 +784,7 @@ Test(nvtable, test_nvtable_others)
   NVHandle handle;
   gchar value[1024], name[16];
   gboolean success;
+  guint32 memory_needed;
   gint i;
 
   for (i = 0; i < sizeof(value); i++)
@@ -789,16 +796,16 @@ Test(nvtable, test_nvtable_others)
 
   /* one that fits */
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 256);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
 
   success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value + 32, 32, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value + 32, 32, 0, NULL, &memory_needed);
   cr_assert(success);
 
   assert_nvtable(tab, STATIC_HANDLE, value + 32, 32);
@@ -807,16 +814,16 @@ Test(nvtable, test_nvtable_others)
 
   /* one that doesn't fit */
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 192);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value, 128, 0, NULL, &memory_needed);
   cr_assert(success);
 
   success = nv_table_add_value_indirect(tab, handle, name, strlen(name),
                                         &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 126
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
   cr_assert(success);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value + 32, 32, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, 4, value + 32, 32, 0, NULL, &memory_needed);
   cr_assert_not(success);
 
   assert_nvtable(tab, STATIC_HANDLE, value, 128);
@@ -830,6 +837,7 @@ Test(nvtable, test_nvtable_lookup)
   NVHandle handle;
   gchar name[16];
   gboolean success;
+  guint32 memory_needed;
   gint i;
   NVHandle handles[100];
   gint x;
@@ -848,7 +856,7 @@ Test(nvtable, test_nvtable_lookup)
             }
           while (handle == 0);
           g_snprintf(name, sizeof(name), "VAL%d", handle);
-          success = nv_table_add_value(tab, handle, name, strlen(name), name, strlen(name), 0, NULL);
+          success = nv_table_add_value(tab, handle, name, strlen(name), name, strlen(name), 0, NULL, &memory_needed);
           g_assert(success);
           handles[i] = handle;
         }
@@ -870,9 +878,10 @@ Test(nvtable, test_nvtable_clone_grows_the_cloned_structure)
 {
   NVTable *tab, *tab_clone;
   gboolean success;
+  guint32 memory_needed;
 
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 64);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(STATIC_NAME), "value", 5, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(STATIC_NAME), "value", 5, 0, NULL, &memory_needed);
   cr_assert(success);
   assert_nvtable(tab, STATIC_HANDLE, "value", 5);
 
@@ -887,9 +896,10 @@ Test(nvtable, test_nvtable_clone_cannot_grow_nvtable_larger_than_nvtable_max_byt
 {
   NVTable *tab, *tab_clone;
   gboolean success;
+  guint32 memory_needed;
 
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 1024);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(STATIC_NAME), "value", 5, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(STATIC_NAME), "value", 5, 0, NULL, &memory_needed);
   cr_assert(success);
   assert_nvtable(tab, STATIC_HANDLE, "value", 5);
 
@@ -905,9 +915,10 @@ Test(nvtable, test_nvtable_realloc_extends_nvtable_size)
 {
   NVTable *tab;
   gboolean success;
+  guint32 memory_needed;
 
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 1024);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(STATIC_NAME), "value", 5, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(STATIC_NAME), "value", 5, 0, NULL, &memory_needed);
   cr_assert(success);
   assert_nvtable(tab, STATIC_HANDLE, "value", 5);
 
@@ -922,9 +933,10 @@ Test(nvtable, test_nvtable_realloc_sets_size_to_nv_table_max_bytes_at_most)
 {
   NVTable *tab;
   gboolean success;
+  guint32 memory_needed;
 
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, NV_TABLE_MAX_BYTES - 8192);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(STATIC_NAME), "value", 5, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(STATIC_NAME), "value", 5, 0, NULL, &memory_needed);
   cr_assert(success);
   assert_nvtable(tab, STATIC_HANDLE, "value", 5);
 
@@ -942,9 +954,10 @@ Test(nvtable, test_nvtable_realloc_fails_if_new_allocation_fits)
 {
   NVTable *tab;
   gboolean success;
+  guint32 memory_needed;
 
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, NV_TABLE_MAX_BYTES);
-  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(STATIC_NAME), "value", 5, 0, NULL);
+  success = nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(STATIC_NAME), "value", 5, 0, NULL, &memory_needed);
   cr_assert(success);
   assert_nvtable(tab, STATIC_HANDLE, "value", 5);
 
@@ -959,12 +972,13 @@ Test(nvtable, test_nvtable_realloc_leaves_original_intact_if_there_are_multiple_
 {
   NVTable *tab_ref1, *tab_ref2;
   gboolean success;
+  guint32 memory_needed;
   gsize old_size;
 
   tab_ref1 = nv_table_new(STATIC_VALUES, STATIC_VALUES, 1024);
   tab_ref2 = nv_table_ref(tab_ref1);
 
-  success = nv_table_add_value(tab_ref1, STATIC_HANDLE, STATIC_NAME, strlen(STATIC_NAME), "value", 5, 0, NULL);
+  success = nv_table_add_value(tab_ref1, STATIC_HANDLE, STATIC_NAME, strlen(STATIC_NAME), "value", 5, 0, NULL, &memory_needed);
   cr_assert(success);
   assert_nvtable(tab_ref1, STATIC_HANDLE, "value", 5);
   assert_nvtable(tab_ref2, STATIC_HANDLE, "value", 5);
@@ -987,6 +1001,7 @@ Test(nvtable, test_nvtable_unset_values)
   gssize size = 9999;
   const gchar *value;
   gboolean success;
+  guint32 memory_needed;
 
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 1024);
   value = nv_table_get_value(tab, DYN_HANDLE, &size, NULL);
@@ -998,7 +1013,7 @@ Test(nvtable, test_nvtable_unset_values)
   cr_assert_null(value);
   cr_assert_eq(size, 0);
 
-  success = nv_table_add_value(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), "foo", 3, 0, NULL);
+  success = nv_table_add_value(tab, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), "foo", 3, 0, NULL, &memory_needed);
   cr_assert(success);
   size = 1;
   value = nv_table_get_value(tab, DYN_HANDLE, &size, NULL);
@@ -1006,7 +1021,7 @@ Test(nvtable, test_nvtable_unset_values)
   cr_assert_arr_eq(value, "foo", 3);
   cr_assert_eq(size, 3);
 
-  nv_table_unset_value(tab, DYN_HANDLE);
+  nv_table_unset_value(tab, DYN_HANDLE, &memory_needed);
   size = 1;
   value = nv_table_get_value(tab, DYN_HANDLE, &size, NULL);
   cr_assert_null(value);
@@ -1021,21 +1036,22 @@ Test(nvtable, test_nvtable_unset_copies_indirect_references)
   gssize size = 9999;
   const gchar *value;
   const gchar *indirect_nv_name = "indirect-name";
+  guint32 memory_needed;
 
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 1024);
-  nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(DYN_NAME), "static-foo", 10, 0, NULL);
+  nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(DYN_NAME), "static-foo", 10, 0, NULL, &memory_needed);
   nv_table_add_value_indirect(tab, DYN_HANDLE, indirect_nv_name, strlen(indirect_nv_name),
                               &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 5
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
 
   value = nv_table_get_value(tab, DYN_HANDLE, &size, NULL);
   cr_assert_not_null(value);
   cr_assert(strncmp(value, "tatic", 5) == 0);
   cr_assert_eq(size, 5);
 
-  nv_table_unset_value(tab, STATIC_HANDLE);
+  nv_table_unset_value(tab, STATIC_HANDLE, &memory_needed);
 
   value = nv_table_get_value(tab, DYN_HANDLE, &size, NULL);
   cr_assert_not_null(value);
@@ -1051,21 +1067,22 @@ Test(nvtable, test_nvtable_indirect_references_unset_and_then_set_again_are_pres
   gssize size = 9999;
   const gchar *value;
   const gchar *indirect_nv_name = "indirect-name";
+  guint32 memory_needed;
 
   tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 1024);
-  nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(DYN_NAME), "static-foo", 10, 0, NULL);
+  nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(DYN_NAME), "static-foo", 10, 0, NULL, &memory_needed);
   nv_table_add_value_indirect(tab, DYN_HANDLE, indirect_nv_name, strlen(indirect_nv_name),
                               &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 5
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
 
   value = nv_table_get_value(tab, DYN_HANDLE, &size, NULL);
   cr_assert_not_null(value);
   cr_assert(strncmp(value, "tatic", 5) == 0);
   cr_assert_eq(size, 5);
 
-  nv_table_unset_value(tab, DYN_HANDLE);
+  nv_table_unset_value(tab, DYN_HANDLE, &memory_needed);
 
   value = nv_table_get_value(tab, DYN_HANDLE, &size, NULL);
   cr_assert_null(value);
@@ -1074,7 +1091,7 @@ Test(nvtable, test_nvtable_indirect_references_unset_and_then_set_again_are_pres
                               &(NVReferencedSlice)
   {
     STATIC_HANDLE, 2, 4
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
 
   value = nv_table_get_value(tab, DYN_HANDLE, &size, NULL);
   cr_assert_not_null(value);
@@ -1090,15 +1107,16 @@ Test(nvtable, test_nvtable_compact_copies_name_value_pairs)
   gssize size = 9999;
   const gchar *value;
   const gchar *indirect_nv_name = "indirect-name";
+  guint32 memory_needed;
 
   tab1 = nv_table_new(STATIC_VALUES, STATIC_VALUES, 1024);
-  nv_table_add_value(tab1, STATIC_HANDLE, STATIC_NAME, strlen(DYN_NAME), "static-foo", 10, 0, NULL);
-  nv_table_add_value(tab1, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), "dyn-foo", 7, 0, NULL);
+  nv_table_add_value(tab1, STATIC_HANDLE, STATIC_NAME, strlen(DYN_NAME), "static-foo", 10, 0, NULL, &memory_needed);
+  nv_table_add_value(tab1, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), "dyn-foo", 7, 0, NULL, &memory_needed);
   nv_table_add_value_indirect(tab1, DYN_HANDLE+1, indirect_nv_name, strlen(indirect_nv_name),
                               &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 5
-  }, 0, NULL);
+  }, 0, NULL, &memory_needed);
 
   tab2 = nv_table_compact(tab1);
   nv_table_unref(tab1);
@@ -1127,16 +1145,17 @@ Test(nvtable, test_nvtable_compact_skips_unset_values)
   gssize size = 9999;
   const gchar *value;
   const gchar *indirect_nv_name = "indirect-name";
+  guint32 memory_needed;
 
   tab1 = nv_table_new(STATIC_VALUES, STATIC_VALUES, 1024);
-  nv_table_add_value(tab1, STATIC_HANDLE, STATIC_NAME, strlen(DYN_NAME), "static-foo", 10, 0, NULL);
-  nv_table_add_value(tab1, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), "dyn-foo", 7, 0, NULL);
+  nv_table_add_value(tab1, STATIC_HANDLE, STATIC_NAME, strlen(DYN_NAME), "static-foo", 10, 0, NULL, &memory_needed);
+  nv_table_add_value(tab1, DYN_HANDLE, DYN_NAME, strlen(DYN_NAME), "dyn-foo", 7, 0, NULL, &memory_needed);
   nv_table_add_value_indirect(tab1, DYN_HANDLE+1, indirect_nv_name, strlen(indirect_nv_name),
                               &(NVReferencedSlice)
   {
     STATIC_HANDLE, 1, 5
-  }, 0, NULL);
-  nv_table_unset_value(tab1, DYN_HANDLE);
+  }, 0, NULL, &memory_needed);
+  nv_table_unset_value(tab1, DYN_HANDLE, &memory_needed);
 
   /* this should get rid off the unset value, thus used should be smaller */
   tab2 = nv_table_compact(tab1);


### PR DESCRIPTION
This should fix a log message reallocation problem as reported on the Splunk slack and introduced by this commit:

https://splunkcommunity.slack.com/archives/CNV918JCQ/p1778702893800799

3092ece9b4cd61b71dc8f4e72229276685a5f27f

The problem is that LogMessage layer does not always know perfectly how much more memory is needed by the NVTable,
so the estimation was not always successful. In those cases, an error message was displayed, such as this:

```
- - syslog-ng 175 - [meta sequenceId="69053"]Cannot grow message payload, maximum size has been reached; operation='set_value', size='2048', extra_space='738', maximum_payload='268435456', msg='0x7ff8d0e5bb00'
```

