### PR TITLE
plugin: keep modules resident during discovery scan

### DIFF
--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -587,7 +587,10 @@ plugin_discover_loadable_modules(PluginContext *context)
                 plugin_extract_candidate_plugins(context, module_name, module_info);
               g_free(module_name);
               if (mod)
-                g_module_close(mod);
+                {
+                  g_module_make_resident(mod);
+                  g_module_close(mod);
+                }
               else
                 mod = NULL;
             }
@@ -719,7 +722,10 @@ plugin_list_modules(FILE *out, gboolean verbose)
                 }
               g_free(module_name);
               if (mod)
-                g_module_close(mod);
+                {
+                  g_module_make_resident(mod);
+                  g_module_close(mod);
+                }
             }
         }
       g_dir_close(dir);


### PR DESCRIPTION
`plugin_discover_loadable_modules()` and `plugin_list_modules()` dlopen every `.so` in the module dir to read its `module_info`, then `dlclose` it. That's safe for syslog-ng's own registration model because no module init function runs during the scan, but it's not safe for C++ static initializers in third-party libraries.

Protobuf's generated `.pb.cc` files contain static initializers that call `InternalAddGeneratedFile()` with a raw pointer into the calling `.so`'s `.rodata`. The `DescriptorPool` is a process-wide singleton in `libprotobuf` and stores that pointer without copying. If the module gets `dlclose`'d and its `rodata` unmaps, the pool's entry dangles. The next module that registers its descriptors walks the pool's tree to find the insert position, the comparator `memcmp`s an existing entry's filename, and crashes on the unmapped page.

This was not a problem for a while, because we moved all the protobuf descriptors into the `libgrpc-protos.so` file, which is not a plugin, so it does not get unloaded during plugin disco.

I am planning to add Arrow Flight, which brings its own descriptors, and the plugin links to them. when the plugin gets unloaded, the descriptors get unloaded too, and the next plugin that registers its own descriptors crashes when it tries to compare against the dangling pointer.

The production load path in `plugin_load_module()` has called `g_module_make_resident()` since the
plugin framework was added in 2010, because plugins register function pointers and struct pointers into long-lived registries, unloading the `.so` would dangle those too. We can apply the same treatment to the discovery paths: every
successfully-opened module stays mapped for the rest of the process's lifetime. `dlopen` on the same module later just bumps the refcount, no static initializers re-run.

Assisted-by: Claude:claude-opus-4-7[1m]

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
