### PR TITLE
Logscheduler batching related metrics

### DIFF
--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -304,12 +304,13 @@ _get_partition_index(LogScheduler *self, LogSchedulerThreadState *thread_state, 
 static inline void
 _move_batch_to_partition(LogScheduler *self, LogSchedulerThreadState *thread_state, gint partition_index)
 {
-  if (iv_list_empty(&thread_state->batch_by_partition[partition_index]))
+  if (iv_list_empty(&thread_state->partitions[partition_index].elements))
     return;
 
   /* form the new batch, hand over the accumulated elements in batch_by_partition */
-  LogSchedulerBatch *batch = _batch_new(&thread_state->batch_by_partition[partition_index]);
-  INIT_IV_LIST_HEAD(&thread_state->batch_by_partition[partition_index]);
+  LogSchedulerBatch *batch = _batch_new(&thread_state->partitions[partition_index].elements);
+  INIT_IV_LIST_HEAD(&thread_state->partitions[partition_index].elements);
+  thread_state->partitions[partition_index].len = 0;
 
   /* add the new batch to the target partition */
   LogSchedulerPartition *partition = &self->partitions[partition_index];
@@ -347,7 +348,8 @@ _queue_thread(LogScheduler *self, LogSchedulerThreadState *thread_state, LogMess
 
   LogMessageQueueNode *node;
   node = log_msg_alloc_queue_node(msg, path_options);
-  iv_list_add_tail(&node->list, &thread_state->batch_by_partition[partition_index]);
+  thread_state->partitions[partition_index].len++;
+  iv_list_add_tail(&node->list, &thread_state->partitions[partition_index].elements);
   log_msg_unref(msg);
 
   stats_counter_inc(self->partitions[partition_index].metrics.assigned_events_total);
@@ -364,7 +366,10 @@ _thread_state_init(LogScheduler *self, LogSchedulerThreadState *state, gint inde
   state->last_partition = index % self->options->num_partitions;
 
   for (gint i = 0; i < self->options->num_partitions; i++)
-    INIT_IV_LIST_HEAD(&state->batch_by_partition[i]);
+    {
+      INIT_IV_LIST_HEAD(&state->partitions[i].elements);
+      state->partitions[i].len = 0;
+    }
 }
 
 static void

--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -330,6 +330,9 @@ _flush_batches(gpointer s)
 
   LogSchedulerThreadState *thread_state = &self->input_thread_states[thread_index];
 
+  stats_aggregator_add_data_point(thread_state->metrics.input_batch_size, thread_state->input_batch_size);
+  thread_state->input_batch_size = 0;
+
   for (gint partition_index = 0; partition_index < self->options->num_partitions; partition_index++)
     _move_batch_to_partition(self, thread_state, partition_index);
 
@@ -351,6 +354,7 @@ _queue_thread(LogScheduler *self, LogSchedulerThreadState *thread_state, LogMess
   LogMessageQueueNode *node;
   node = log_msg_alloc_queue_node(msg, path_options);
   thread_state->partitions[partition_index].len++;
+  thread_state->input_batch_size++;
   iv_list_add_tail(&node->list, &thread_state->partitions[partition_index].elements);
   log_msg_unref(msg);
 
@@ -373,6 +377,7 @@ _thread_state_init(LogScheduler *self, LogSchedulerThreadState *state, gint inde
       state->partitions[i].len = 0;
     }
   state->metrics.batch_size = self->batch_size;
+  state->metrics.input_batch_size = self->input_batch_size;
 }
 
 static void
@@ -457,6 +462,13 @@ _register_aggregated_stats(LogScheduler *self)
   stats_register_aggregator_hist(STATS_LEVEL4, &sc_key, round_to_log2(1), 14,
                                  &self->batch_size);
   stats_aggregator_unlock();
+
+  stats_cluster_hist_key_set(&sc_key, METRIC(parallelized_input_batch_size), labels2, G_N_ELEMENTS(labels2));
+
+  stats_aggregator_lock();
+  stats_register_aggregator_hist(STATS_LEVEL4, &sc_key, round_to_log2(1), 14,
+                                 &self->input_batch_size);
+  stats_aggregator_unlock();
 }
 
 static inline void
@@ -477,6 +489,12 @@ _unregister_aggregated_stats(LogScheduler *self)
 
   stats_aggregator_lock();
   stats_unregister_aggregator(&self->batch_size);
+  stats_aggregator_unlock();
+
+  stats_cluster_hist_key_set(&sc_key, METRIC(parallelized_input_batch_size), labels2, G_N_ELEMENTS(labels2));
+
+  stats_aggregator_lock();
+  stats_unregister_aggregator(&self->input_batch_size);
   stats_aggregator_unlock();
 }
 

--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -307,6 +307,8 @@ _move_batch_to_partition(LogScheduler *self, LogSchedulerThreadState *thread_sta
   if (iv_list_empty(&thread_state->partitions[partition_index].elements))
     return;
 
+  stats_aggregator_add_data_point(thread_state->metrics.batch_size, thread_state->partitions[partition_index].len);
+
   /* form the new batch, hand over the accumulated elements in batch_by_partition */
   LogSchedulerBatch *batch = _batch_new(&thread_state->partitions[partition_index].elements);
   INIT_IV_LIST_HEAD(&thread_state->partitions[partition_index].elements);
@@ -370,6 +372,7 @@ _thread_state_init(LogScheduler *self, LogSchedulerThreadState *state, gint inde
       INIT_IV_LIST_HEAD(&state->partitions[i].elements);
       state->partitions[i].len = 0;
     }
+  state->metrics.batch_size = self->batch_size;
 }
 
 static void
@@ -446,6 +449,14 @@ _register_aggregated_stats(LogScheduler *self)
   stats_register_aggregator_hist(STATS_LEVEL2, &sc_key, round_to_log2(1), 14,
                                  &self->processing_latency);
   stats_aggregator_unlock();
+
+  StatsClusterLabel labels2[] = { stats_cluster_label("parallelize", self->id) };
+  stats_cluster_hist_key_set(&sc_key, METRIC(parallelized_batch_size), labels2, G_N_ELEMENTS(labels2));
+
+  stats_aggregator_lock();
+  stats_register_aggregator_hist(STATS_LEVEL4, &sc_key, round_to_log2(1), 14,
+                                 &self->batch_size);
+  stats_aggregator_unlock();
 }
 
 static inline void
@@ -459,6 +470,13 @@ _unregister_aggregated_stats(LogScheduler *self)
 
   stats_aggregator_lock();
   stats_unregister_aggregator(&self->processing_latency);
+  stats_aggregator_unlock();
+
+  StatsClusterLabel labels2[] = { stats_cluster_label("parallelize", self->id) };
+  stats_cluster_hist_key_set(&sc_key, METRIC(parallelized_batch_size), labels2, G_N_ELEMENTS(labels2));
+
+  stats_aggregator_lock();
+  stats_unregister_aggregator(&self->batch_size);
   stats_aggregator_unlock();
 }
 

--- a/lib/logscheduler.h
+++ b/lib/logscheduler.h
@@ -69,9 +69,11 @@ typedef struct _LogSchedulerThreadState
 
   gint last_partition;
   gint current_batch_size;
+  gint input_batch_size;
   struct
   {
     StatsAggregator *batch_size;
+    StatsAggregator *input_batch_size;
   } metrics;
 } LogSchedulerThreadState;
 
@@ -93,6 +95,7 @@ typedef struct _LogScheduler
   StatsCounterItem *parallelize_failed_events_total;
   StatsAggregator *processing_latency;
   StatsAggregator *batch_size;
+  StatsAggregator *input_batch_size;
   LogSchedulerThreadState input_thread_states[];
 } LogScheduler;
 

--- a/lib/logscheduler.h
+++ b/lib/logscheduler.h
@@ -69,6 +69,10 @@ typedef struct _LogSchedulerThreadState
 
   gint last_partition;
   gint current_batch_size;
+  struct
+  {
+    StatsAggregator *batch_size;
+  } metrics;
 } LogSchedulerThreadState;
 
 typedef struct _LogSchedulerOptions
@@ -88,6 +92,7 @@ typedef struct _LogScheduler
   LogSchedulerPartition partitions[LOGSCHEDULER_MAX_PARTITIONS];
   StatsCounterItem *parallelize_failed_events_total;
   StatsAggregator *processing_latency;
+  StatsAggregator *batch_size;
   LogSchedulerThreadState input_thread_states[];
 } LogScheduler;
 

--- a/lib/logscheduler.h
+++ b/lib/logscheduler.h
@@ -61,7 +61,11 @@ typedef struct _LogSchedulerPartition
 typedef struct _LogSchedulerThreadState
 {
   WorkerBatchCallback batch_callback;
-  struct iv_list_head batch_by_partition[LOGSCHEDULER_MAX_PARTITIONS];
+  struct
+  {
+    struct iv_list_head elements;
+    guint32 len;
+  } partitions[LOGSCHEDULER_MAX_PARTITIONS];
 
   gint last_partition;
   gint current_batch_size;

--- a/lib/metrics/metric-names.h
+++ b/lib/metrics/metric-names.h
@@ -78,6 +78,7 @@
   M(parallelize_failed_events_total) \
   M(parallelized_assigned_events_total) \
   M(parallelized_processed_events_total) \
+  M(parallelized_batch_size) \
   M(parsed_events_total) \
   M(route_egress_total) \
   M(route_ingress_total) \

--- a/lib/metrics/metric-names.h
+++ b/lib/metrics/metric-names.h
@@ -79,6 +79,7 @@
   M(parallelized_assigned_events_total) \
   M(parallelized_processed_events_total) \
   M(parallelized_batch_size) \
+  M(parallelized_input_batch_size) \
   M(parsed_events_total) \
   M(route_egress_total) \
   M(route_ingress_total) \

--- a/news/feature-1077.md
+++ b/news/feature-1077.md
@@ -1,0 +1,3 @@
+`parallelize()`: add `syslogng_parallelized_batch_size` and
+`syslogng_parallelized_input_batch_size` histograms to the prometheus style
+stats output, at stats(level(4)).


### PR DESCRIPTION
This PR adds two prometheus style histograms to logscheduler to give an insight into how logscheduler batches messages.

These are available at stats-level(4)

```
syslogng_parallelized_batch_size_sum{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5"} 1000000
syslogng_parallelized_batch_size_count{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5"} 13962
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="1"} 4686
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="2"} 2857
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="4"} 2757
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="8"} 1401
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="16"} 180
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="32"} 31
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="64"} 17
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="128"} 60
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="256"} 49
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="512"} 1924
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="1024"} 0
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="2048"} 0
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="4096"} 0
syslogng_parallelized_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="+Inf"} 0
syslogng_parallelized_input_batch_size_sum{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5"} 1000000
syslogng_parallelized_input_batch_size_count{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5"} 11979
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="1"} 4545
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="2"} 2784
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="4"} 2729
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="8"} 1429
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="16"} 185
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="32"} 29
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="64"} 11
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="128"} 10
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="256"} 4
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="512"} 0
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="1024"} 5
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="2048"} 9
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="4096"} 239
syslogng_parallelized_input_batch_size_bucket{parallelize="/install/etc/callgrind-syslog-ng.conf:30:5",le="+Inf"} 0
```