### PR TITLE
Logscheduler batching improvements

### DIFF
--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -359,6 +359,10 @@ _queue_thread(LogScheduler *self, LogSchedulerThreadState *thread_state, LogMess
   log_msg_unref(msg);
 
   stats_counter_inc(self->partitions[partition_index].metrics.assigned_events_total);
+  if (self->options->batch_size && thread_state->partitions[partition_index].len >= self->options->batch_size)
+    {
+      _move_batch_to_partition(self, thread_state, partition_index);
+    }
 }
 
 

--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -623,7 +623,7 @@ void
 log_scheduler_options_defaults(LogSchedulerOptions *options)
 {
   options->num_partitions = -1;
-  options->batch_size = 0;
+  options->batch_size = -1;
   options->partition_key = NULL;
   options->log_fetch_limit = 1000;
 }
@@ -644,6 +644,8 @@ log_scheduler_options_init(LogSchedulerOptions *options, GlobalConfig *cfg)
                   evt_tag_int("used_workers", LOGSCHEDULER_MAX_PARTITIONS));
       options->num_partitions = LOGSCHEDULER_MAX_PARTITIONS;
     }
+  if (options->batch_size == -1)
+    options->batch_size = 100;
 
   return TRUE;
 }

--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -277,7 +277,12 @@ _partition_clear(LogSchedulerPartition *partition)
 static guint
 _get_partition_index(LogScheduler *self, LogSchedulerThreadState *thread_state, LogMessage *msg)
 {
-  if (self->options->batch_size)
+  if (self->options->partition_key)
+    {
+      LogTemplateEvalOptions options = DEFAULT_TEMPLATE_EVAL_OPTIONS;
+      return log_template_hash(self->options->partition_key, msg, &options) % self->options->num_partitions;
+    }
+  else if (self->options->batch_size > 1)
     {
       gint partition_index = thread_state->last_partition;
 
@@ -288,16 +293,12 @@ _get_partition_index(LogScheduler *self, LogSchedulerThreadState *thread_state, 
 
       return partition_index;
     }
-
-  if (self->options->partition_key)
+  else
     {
-      LogTemplateEvalOptions options = DEFAULT_TEMPLATE_EVAL_OPTIONS;
-      return log_template_hash(self->options->partition_key, msg, &options) % self->options->num_partitions;
+      gint partition_index = thread_state->last_partition;
+      thread_state->last_partition = (thread_state->last_partition + 1) % self->options->num_partitions;
+      return partition_index;
     }
-
-  gint partition_index = thread_state->last_partition;
-  thread_state->last_partition = (thread_state->last_partition + 1) % self->options->num_partitions;
-  return partition_index;
 }
 
 /* runs in the source thread */
@@ -642,12 +643,6 @@ log_scheduler_options_init(LogSchedulerOptions *options, GlobalConfig *cfg)
                   evt_tag_int("specified_workers", options->num_partitions),
                   evt_tag_int("used_workers", LOGSCHEDULER_MAX_PARTITIONS));
       options->num_partitions = LOGSCHEDULER_MAX_PARTITIONS;
-    }
-
-  if (options->partition_key && options->batch_size)
-    {
-      msg_error("parallelize() options worker-partition-key() and batch-size() cannot be used together");
-      return FALSE;
     }
 
   return TRUE;

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -121,26 +121,65 @@ _flow_control_rate_adjust(LogSource *self)
               clock_gettime(CLOCK_MONOTONIC, &now);
               if (now.tv_sec > self->last_ack_rate_time.tv_sec + 6)
                 {
-                  /* last check was too far apart, this means the rate is quite slow. turn off sleeping. */
+                  /* last check was too far apart (at least 7 seconds), this
+                   * means the rate is quite slow (less than 2340/sec).
+                   * disable sleeping, we are far from being overloaded.
+                   */
+
                   self->window_full_sleep_nsec = 0;
                   self->last_ack_rate_time = now;
                 }
               else
                 {
-                  /* ok, we seem to have a close enough measurement, this means
-                   * we do have a high rate.  Calculate how much we should sleep
-                   * in case the window gets full */
+
+                  /* ok, we seem to be running at more than 2340 eps (e.g.
+                   * 0.42msec/message), this means we do have a high rate.
+                   * Since going back to the main loop is expensive, let's
+                   * see how much time we should wait for a slot to clear
+                   * from our window.
+                   */
 
                   diff = timespec_diff_nsec(&now, &self->last_ack_rate_time);
                   self->window_full_sleep_nsec = (diff / (cur_ack_count - last_ack_count));
                   if (self->window_full_sleep_nsec > 1e6)
                     {
-                      /* in case we'd be waiting for 1msec for another free slot in the window, let's go to background instead */
+                      /* in case we'd be waiting for more than 1msec for
+                       * another free slot in the window, let's go to
+                       * background instead.  I don't expect this to ever
+                       * happen, as we already calculated our message rate
+                       * to be above 2340 eps, e.g.  less than 0.42msec /
+                       * message.  With that said, I am pretty sure this
+                       * could even be a g_assert_not_reached(), but just
+                       * doing nothing is safer.
+                       */
+
                       self->window_full_sleep_nsec = 0;
                     }
                   else
                     {
-                      /* otherwise let's wait for about 8 message to be emptied before going back to the loop, but clamp the maximum time to 0.1msec */
+                      /* At this point we concluded that the destination
+                       * draining the next message from the window is a
+                       * short time period.  Instead of going back to sleep
+                       * and then woken up, let's try to keep this source
+                       * running.  This avoids the costs associated with the
+                       * mainloop, and also, the latency associated with
+                       * sleeping and waking up.  The first reduces CPU
+                       * usage, the second increases parallelism.
+                       *
+                       * The algorithm here is to wait for about 16 messages
+                       * to be emptied before going back to the main loop.
+                       * The time is clamped to 1msec as we can't sleep for
+                       * too long: that could potentially cause other
+                       * sources to starve.
+                       *
+                       * NOTE: The limits in the algorithm above were
+                       * increased to 16 messages/1msec, when we recognized
+                       * that expensive parsing may take longer per message
+                       * than we anticipated when the original algorithm was
+                       * created (e.g.  message rates at the order of ~10k
+                       * eps instead of ~100k eps).
+                       */
+
                       self->window_full_sleep_nsec <<= 4;
                       if (self->window_full_sleep_nsec > 1e6)
                         self->window_full_sleep_nsec = 1e6;

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -141,9 +141,9 @@ _flow_control_rate_adjust(LogSource *self)
                   else
                     {
                       /* otherwise let's wait for about 8 message to be emptied before going back to the loop, but clamp the maximum time to 0.1msec */
-                      self->window_full_sleep_nsec <<= 3;
-                      if (self->window_full_sleep_nsec > 1e5)
-                        self->window_full_sleep_nsec = 1e5;
+                      self->window_full_sleep_nsec <<= 4;
+                      if (self->window_full_sleep_nsec > 1e6)
+                        self->window_full_sleep_nsec = 1e6;
                     }
                   self->last_ack_count = cur_ack_count;
                   self->last_ack_rate_time = now;

--- a/lib/timeutils/misc.c
+++ b/lib/timeutils/misc.c
@@ -66,39 +66,33 @@ check_nanosleep(void)
 }
 
 void
-timespec_add_msec(struct timespec *ts, glong msec)
+timespec_add_nsec(struct timespec *ts, gint64 nsec)
 {
-  ts->tv_sec += msec / 1000;
-  msec = msec % 1000;
-  ts->tv_nsec += (glong) (msec * 1000000);
+  ts->tv_sec += nsec / 1000000000L;
+  nsec = nsec % 1000000000L;
+  ts->tv_nsec += nsec;
   if (ts->tv_nsec >= 1000000000)
     {
-      ts->tv_nsec -= (glong) 1000000000;
+      ts->tv_nsec -= 1000000000L;
       ts->tv_sec++;
     }
   else if (ts->tv_nsec < 0)
     {
-      ts->tv_nsec += (glong) 1000000000;
+      ts->tv_nsec += 1000000000L;
       ts->tv_sec--;
     }
 }
 
 void
+timespec_add_msec(struct timespec *ts, gint64 msec)
+{
+  timespec_add_nsec(ts, MSEC_TO_NSEC(msec));
+}
+
+void
 timespec_add_usec(struct timespec *ts, gint64 usec)
 {
-  ts->tv_sec += usec / 1000000;
-  usec = usec % 1000000;
-  ts->tv_nsec += (glong) (usec * 1000);
-  if (ts->tv_nsec >= 1000000000)
-    {
-      ts->tv_nsec -= (glong) 1000000000;
-      ts->tv_sec++;
-    }
-  else if (ts->tv_nsec < 0)
-    {
-      ts->tv_nsec += (glong) 1000000000;
-      ts->tv_sec--;
-    }
+  timespec_add_nsec(ts, USEC_TO_NSEC(usec));
 }
 
 glong

--- a/lib/timeutils/misc.h
+++ b/lib/timeutils/misc.h
@@ -41,7 +41,8 @@
 
 gboolean check_nanosleep(void);
 
-void timespec_add_msec(struct timespec *ts, glong msec);
+void timespec_add_nsec(struct timespec *ts, gint64 nsec);
+void timespec_add_msec(struct timespec *ts, gint64 msec);
 void timespec_add_usec(struct timespec *ts, gint64 usec);
 glong timespec_diff_msec(const struct timespec *t1, const struct timespec *t2);
 gint64 timespec_diff_usec(const struct timespec *t1, const struct timespec *t2);

--- a/news/news-1078.md
+++ b/news/news-1078.md
@@ -1,0 +1,3 @@
+`parallelize()`: improve throughput by avoiding batches that are too large.
+Also set the default batch-size() parameter to 100, both in case of
+partition based and round robin batching.


### PR DESCRIPTION
This improved parallelize performance by ~9.3% on c5.2xlarge

This PR significantly reduces window-full scenarios, thereby reducing the times we need to suspend and wakeup the source. This in turn reduces the pressure on the main thread's ivykis loop and related machinery (iv_event_post).