### PR TITLE
FilterXObject: move fx_ref_cnt in FilterXObject instances to a separate cacheline

### DIFF
--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -184,7 +184,6 @@ G_STATIC_ASSERT(__FILTERX_OBJECT_REFCOUNT_MAX == G_MAXINT32);
 struct _FilterXObject
 {
   guint32 ref_cnt;
-  GAtomicCounter fx_ref_cnt;
 
   /* NOTE:
    *
@@ -208,6 +207,34 @@ struct _FilterXObject
   volatile guint32 hash;
   FilterXType *type;
 };
+
+typedef struct _FilterXMutableObject
+{
+  union
+  {
+    FilterXObject super;
+
+    /* align it to cacheline boundary and also this is where derived classes
+     * can fit their instance data.  */
+    gchar __padd[64];
+  };
+  union
+  {
+    GAtomicCounter fx_ref_cnt;
+    gchar __padd2[64];
+  };
+} FilterXMutableObject;
+
+/* these are designed */
+#define FILTERX_MUTABLE_OBJECT_HEADER \
+  union \
+  { \
+    struct \
+
+#define FILTERX_MUTABLE_OBJECT_TAILER \
+    ; \
+    FilterXMutableObject __mutable; \
+  }
 
 static inline void
 filterx_object_init_instance(FilterXObject *self, FilterXType *type)
@@ -648,7 +675,6 @@ filterx_object_set_dirty(FilterXObject *self, gboolean value)
 #define FILTERX_OBJECT_STACK_INIT(_type) \
   { \
     .ref_cnt = FILTERX_OBJECT_REFCOUNT_STACK, \
-    .fx_ref_cnt = { .counter = 0 }, \
     .weak_referenced = FALSE, \
     .is_dirty = FALSE, \
     .hash = 0, \

--- a/lib/filterx/filterx-ref.c
+++ b/lib/filterx/filterx-ref.c
@@ -136,7 +136,7 @@
  *      but will clone the xref if it is already wrapped.
  *
  * The number of copies for objects are tracked by the
- * `FilterXObject->fx_ref_cnt` member, which counts the number of
+ * `FilterXMutableObject->fx_ref_cnt` member, which counts the number of
  * active xrefs to an object.
  *
  * When the reference count for an xref drops to zero, it automatically
@@ -276,19 +276,25 @@ _filterx_ref_clone(FilterXObject *s)
   return _filterx_ref_new(filterx_object_ref(self->value));
 }
 
+static GAtomicCounter *
+_get_fx_ref_cnt(FilterXRef *self)
+{
+  return &((FilterXMutableObject *) self->value)->fx_ref_cnt;
+}
+
 static inline void
 _filterx_ref_clone_value_if_shared(FilterXRef *self, FilterXRef *child_of_interest)
 {
-  if (g_atomic_counter_get(&self->value->fx_ref_cnt) <= 1)
+  if (g_atomic_counter_get(_get_fx_ref_cnt(self)) <= 1)
     return;
 
   FilterXObject *cloned = filterx_object_clone_container(self->value, &self->super, &child_of_interest->super, FALSE);
 
-  g_atomic_counter_dec_and_test(&self->value->fx_ref_cnt);
+  g_atomic_counter_dec_and_test(_get_fx_ref_cnt(self));
   filterx_object_unref(self->value);
 
   self->value = cloned;
-  g_atomic_counter_inc(&self->value->fx_ref_cnt);
+  g_atomic_counter_inc(_get_fx_ref_cnt(self));
 }
 
 gboolean
@@ -356,7 +362,7 @@ _filterx_ref_free(FilterXObject *s)
 {
   FilterXRef *self = (FilterXRef *) s;
 
-  g_atomic_counter_dec_and_test(&self->value->fx_ref_cnt);
+  g_atomic_counter_dec_and_test(_get_fx_ref_cnt(self));
   filterx_object_unref(self->value);
 
   filterx_object_free_method(s);
@@ -441,7 +447,7 @@ _filterx_ref_replace_shared_xref_with_a_floating_one(FilterXObject *s, FilterXOb
   FilterXRef *container = (FilterXRef *) c;
 
   if (filterx_weakref_is_set_to(&self->parent_container, &container->super) &&
-      g_atomic_counter_get(&container->value->fx_ref_cnt) <= 1)
+      g_atomic_counter_get(_get_fx_ref_cnt(container)) <= 1)
     return s;
 
   FilterXObject *result = filterx_ref_float(_filterx_ref_new(filterx_object_ref(self->value)));
@@ -569,7 +575,7 @@ filterx_ref_dup(FilterXObject *s)
   filterx_object_init_instance(&dup->super, &FILTERX_TYPE_NAME(ref));
 
   dup->value = filterx_object_clone_container(value, &dup->super, NULL, TRUE);
-  g_atomic_counter_inc(&dup->value->fx_ref_cnt);
+  g_atomic_counter_inc(_get_fx_ref_cnt(dup));
 
   return &dup->super;
 }
@@ -589,7 +595,7 @@ _filterx_ref_new(FilterXObject *value)
   filterx_object_init_instance(&self->super, &FILTERX_TYPE_NAME(ref));
 
   self->value = value;
-  g_atomic_counter_inc(&self->value->fx_ref_cnt);
+  g_atomic_counter_inc(_get_fx_ref_cnt(self));
 
   return &self->super;
 }

--- a/lib/filterx/object-dict.c
+++ b/lib/filterx/object-dict.c
@@ -540,8 +540,12 @@ _table_resize_if_needed(FilterXDictTable *old_table)
 
 typedef struct _FilterXDictObject
 {
-  FilterXMapping super;
-  FilterXDictTable *table;
+  FILTERX_MUTABLE_OBJECT_HEADER
+  {
+    FilterXMapping super;
+    FilterXDictTable *table;
+  }
+  FILTERX_MUTABLE_OBJECT_TAILER;
 } FilterXDictObject;
 
 static gboolean

--- a/lib/filterx/object-list.h
+++ b/lib/filterx/object-list.h
@@ -28,9 +28,15 @@
 
 typedef struct _FilterXListObject
 {
-  FilterXSequence super;
-  GPtrArray *array;
+  FILTERX_MUTABLE_OBJECT_HEADER
+  {
+      FilterXSequence super;
+      GPtrArray *array;
+  }
+  FILTERX_MUTABLE_OBJECT_TAILER;
 } FilterXListObject;
+
+G_STATIC_ASSERT(sizeof(FilterXListObject) == sizeof(FilterXMutableObject));
 
 FILTERX_DECLARE_TYPE(list);
 

--- a/lib/filterx/object-metrics-labels.c
+++ b/lib/filterx/object-metrics-labels.c
@@ -38,12 +38,18 @@
 
 typedef struct _FilterXObjectMetricsLabels
 {
-  FilterXMapping super;
-  GArray *labels;
-  GPtrArray *objects;
-  gboolean sorted;
-  gboolean deduped;
+  FILTERX_MUTABLE_OBJECT_HEADER
+  {
+      FilterXMapping super;
+      GArray *labels;
+      GPtrArray *objects;
+      gboolean sorted;
+      gboolean deduped;
+  }
+  FILTERX_MUTABLE_OBJECT_TAILER;
 } FilterXObjectMetricsLabels;
+
+G_STATIC_ASSERT(sizeof(FilterXObjectMetricsLabels) == sizeof(FilterXMutableObject));
 
 static gboolean
 _truthy(FilterXObject *s)

--- a/modules/grpc/otel/filterx/object-otel-array.hpp
+++ b/modules/grpc/otel/filterx/object-otel-array.hpp
@@ -98,8 +98,12 @@ extern ArrayFieldConverter array_field_converter;
 
 struct FilterXOtelArray_
 {
-  FilterXSequence super;
-  syslogng::grpc::otel::filterx::Array *cpp;
+  FILTERX_MUTABLE_OBJECT_HEADER
+  {
+    FilterXSequence super;
+    syslogng::grpc::otel::filterx::Array *cpp;
+  }
+  FILTERX_MUTABLE_OBJECT_TAILER;
 };
 
 #include "compat/cpp-end.h"

--- a/modules/grpc/otel/filterx/object-otel-kvlist.hpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.hpp
@@ -105,8 +105,12 @@ extern KVListFieldConverter kvlist_field_converter;
 
 struct FilterXOtelKVList_
 {
-  FilterXMapping super;
-  syslogng::grpc::otel::filterx::KVList *cpp;
+  FILTERX_MUTABLE_OBJECT_HEADER
+  {
+    FilterXMapping super;
+    syslogng::grpc::otel::filterx::KVList *cpp;
+  }
+  FILTERX_MUTABLE_OBJECT_TAILER;
 };
 
 #include "compat/cpp-end.h"

--- a/modules/grpc/otel/filterx/object-otel-logrecord.hpp
+++ b/modules/grpc/otel/filterx/object-otel-logrecord.hpp
@@ -76,8 +76,12 @@ protected:
 
 struct FilterXOtelLogRecord_
 {
-  FilterXMapping super;
-  syslogng::grpc::otel::filterx::LogRecord *cpp;
+  FILTERX_MUTABLE_OBJECT_HEADER
+  {
+    FilterXMapping super;
+    syslogng::grpc::otel::filterx::LogRecord *cpp;
+  }
+  FILTERX_MUTABLE_OBJECT_TAILER;
 };
 
 #include "compat/cpp-end.h"

--- a/modules/grpc/otel/filterx/object-otel-resource.hpp
+++ b/modules/grpc/otel/filterx/object-otel-resource.hpp
@@ -80,8 +80,12 @@ protected:
 
 struct FilterXOtelResource_
 {
-  FilterXMapping super;
-  syslogng::grpc::otel::filterx::Resource *cpp;
+  FILTERX_MUTABLE_OBJECT_HEADER
+  {
+    FilterXMapping super;
+    syslogng::grpc::otel::filterx::Resource *cpp;
+  }
+  FILTERX_MUTABLE_OBJECT_TAILER;
 };
 
 #include "compat/cpp-end.h"

--- a/modules/grpc/otel/filterx/object-otel-scope.hpp
+++ b/modules/grpc/otel/filterx/object-otel-scope.hpp
@@ -80,8 +80,12 @@ protected:
 
 struct FilterXOtelScope_
 {
-  FilterXMapping super;
-  syslogng::grpc::otel::filterx::Scope *cpp;
+  FILTERX_MUTABLE_OBJECT_HEADER
+  {
+    FilterXMapping super;
+    syslogng::grpc::otel::filterx::Scope *cpp;
+  }
+  FILTERX_MUTABLE_OBJECT_TAILER;
 };
 
 #include "compat/cpp-end.h"

--- a/modules/grpc/pubsub/filterx/object-pubsub-message.cpp
+++ b/modules/grpc/pubsub/filterx/object-pubsub-message.cpp
@@ -370,7 +370,6 @@ filterx_pubsub_message_new_from_args(FilterXExpr *s, FilterXObject *args[], gsiz
 FILTERX_SIMPLE_FUNCTION(pubsub_message, filterx_pubsub_message_new_from_args);
 
 FILTERX_DEFINE_TYPE(pubsub_message, FILTERX_TYPE_NAME(object),
-                    .is_mutable = TRUE,
                     .marshal = _marshal,
                     .clone = _filterx_pubsub_message_clone,
                     .truthy = _truthy,


### PR DESCRIPTION
This field changes in otherwise read-only objects, causing cache ping-pong between CPU cores. By moving it to a separate cache-line, this is eliminated:

CPU1: fx_ref_cnt is modified in an atomic manner (making the object exclusive in this CPU's cache

CPU2: read any other fields in the FilterXObject header, cacheline is in modified state, which means it needs to be loaded into the current CPUs cache.

Since all literal dicts and cache_json_file objects are shared, multiple CPUs are regularly changing the refcnt.  By moving it elsewhere, _only_ atomic operations will cause the c2c traffic.
