### PR TITLE
logsource: move "window_size" out of the LogSource read-mostly data

### DIFF
--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -67,16 +67,16 @@ struct _LogSource
   LogPipe super;
   LogSourceOptions *options;
   gboolean threaded;
+  gboolean window_initialized;
   gchar *name;
   gchar *stats_id;
-  WindowSizeCounter window_size;
   DynamicWindow dynamic_window;
-  gboolean window_initialized;
   gsize initial_window_size;
   /* full_window_size = static + dynamic */
   gsize full_window_size;
   atomic_gssize window_size_to_be_reclaimed;
   atomic_gssize pending_reclamation;
+  WindowSizeCounter window_size;
 
   struct
   {


### PR DESCRIPTION
`window_size` is a member that gets written atomically all the time by competing threads, move that to the next cache line along with other atomics. This removes false sharing between window_size and dynamic_window, actually the check whether dynamic window is enabled became expensive because of this false sharing.

