### PR TITLE
Reduce GSockAddr->refcnt related cache ping pong

### DIFF
--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -159,6 +159,20 @@ g_sockaddr_get_address(GSockAddr *self, guint8 *buffer, gsize buffer_size, gsize
     }
 }
 
+void
+g_sockaddr_unshare(GSockAddr **pa)
+{
+  GSockAddr *a = *pa;
+
+  if (g_atomic_counter_get(&a->super.refcnt) == 1)
+    return;
+  gsize len = g_sockaddr_len(a);
+  GSockAddr *new = g_malloc(len);
+  memcpy(new, a, len);
+  g_atomic_counter_set(&new->super.refcnt, 1);
+  *pa = new;
+}
+
 /* AF_INET socket address */
 /*+
 

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -89,6 +89,7 @@ guint8 *g_sockaddr_get_address(GSockAddr *self, guint8 *buffer, gsize buffer_siz
 gsize g_sockaddr_len(GSockAddr *a);
 
 GSockAddr *g_sockaddr_new(struct sockaddr *sa, int salen);
+void g_sockaddr_unshare(GSockAddr **pa);
 
 static inline struct sockaddr *
 g_sockaddr_get_sa(GSockAddr *self)

--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -751,6 +751,16 @@ log_proto_buffered_server_fetch_from_buffer(LogProtoBufferedServer *self, const 
 
   if (aux)
     log_transport_aux_data_copy(aux, &self->buffer_aux);
+
+  if (state->pending_buffer_pos == state->pending_buffer_end)
+    {
+      /* NOTE: if our buffer is empty, let's clear our aux storage, we will
+       * read a new one anyway and this means we are not holding a reference
+       * to the sockaddr members */
+
+      log_transport_aux_data_reinit(&self->buffer_aux);
+    }
+
 exit:
   log_proto_buffered_server_put_state(self);
   return success;

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -471,6 +471,11 @@ _set_addresses(LogReader *self, LogMessage *msg, LogTransportAuxData *aux)
 set:
   log_msg_set_saddr(msg, source_addr);
   log_msg_set_daddr(msg, aux->local_addr ? : self->local_addr);
+
+  g_sockaddr_unref(aux->peer_addr);
+  aux->peer_addr = NULL;
+  g_sockaddr_unref(aux->local_addr);
+  aux->local_addr = NULL;
 }
 
 static gboolean

--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -352,6 +352,8 @@ _queue_thread(LogScheduler *self, LogSchedulerThreadState *thread_state, LogMess
 
   guint partition_index = _get_partition_index(self, thread_state, msg);
 
+  g_sockaddr_unshare(&msg->saddr);
+  g_sockaddr_unshare(&msg->daddr);
   LogMessageQueueNode *node;
   node = log_msg_alloc_queue_node(msg, path_options);
   thread_state->partitions[partition_index].len++;


### PR DESCRIPTION
This PR attempts to reduce the cache contention on GSockAddr instances in case we share those across parallelize workers.

In those cases each LogMessage will point to the same pair of saddr/daddr instances and we will be banging their refcnt from all of the threads in parallel.

This PR was originally combined with a refactor, which I have now split out to #1086 I am still addressing the review comments here, but in general the two can be reviewed/merged separately.
