### PR TITLE
Retire logmsg refcache

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -51,42 +51,6 @@
 #include <ctype.h>
 #include <syslog.h>
 
-/*
- * Reference/ACK counting for LogMessage structures
- *
- * Each LogMessage structure is allocated when received by a LogSource
- * instance, and then freed once all destinations finish with it.  Since a
- * LogMessage is processed by different threads, reference counting must be
- * atomic.
- *
- * A similar counter is used to track when a given message is considered to
- * be delivered.  In case flow-control is in use, the number of
- * to-be-expected ACKs are counted in an atomic variable.
- *
- * Since we use the same atomic variable to store two things, updating that
- * counter becomes somewhat more complicated, therefore a g_atomic_int_add()
- * doesn't suffice.  We're using a CAS loop (compare-and-exchange) to do our
- * stuff, but that shouldn't have that much of an overhead.
- */
-
-#define LOGMSG_REFCACHE_SUSPEND_SHIFT                 31 /* number of bits to shift to get the SUSPEND flag */
-#define LOGMSG_REFCACHE_SUSPEND_MASK          0x80000000 /* bit mask to extract the SUSPEND flag */
-#define LOGMSG_REFCACHE_ABORT_SHIFT                   30 /* number of bits to shift to get the ABORT flag */
-#define LOGMSG_REFCACHE_ABORT_MASK            0x40000000 /* bit mask to extract the ABORT flag */
-#define LOGMSG_REFCACHE_ACK_SHIFT                     15 /* number of bits to shift to get the ACK counter */
-#define LOGMSG_REFCACHE_ACK_MASK              0x3FFF8000 /* bit mask to extract the ACK counter */
-#define LOGMSG_REFCACHE_REF_SHIFT                      0 /* number of bits to shift to get the REF counter */
-#define LOGMSG_REFCACHE_REF_MASK              0x00007FFF /* bit mask to extract the ACK counter */
-
-#define LOGMSG_REFCACHE_REF_TO_VALUE(x)    (((x) << LOGMSG_REFCACHE_REF_SHIFT)   & LOGMSG_REFCACHE_REF_MASK)
-#define LOGMSG_REFCACHE_ACK_TO_VALUE(x)    (((x) << LOGMSG_REFCACHE_ACK_SHIFT)   & LOGMSG_REFCACHE_ACK_MASK)
-#define LOGMSG_REFCACHE_ABORT_TO_VALUE(x)  (((x) << LOGMSG_REFCACHE_ABORT_SHIFT) & LOGMSG_REFCACHE_ABORT_MASK)
-#define LOGMSG_REFCACHE_SUSPEND_TO_VALUE(x)  (((x) << LOGMSG_REFCACHE_SUSPEND_SHIFT) & LOGMSG_REFCACHE_SUSPEND_MASK)
-
-#define LOGMSG_REFCACHE_VALUE_TO_REF(x)    (((x) & LOGMSG_REFCACHE_REF_MASK)   >> LOGMSG_REFCACHE_REF_SHIFT)
-#define LOGMSG_REFCACHE_VALUE_TO_ACK(x)    (((x) & LOGMSG_REFCACHE_ACK_MASK)   >> LOGMSG_REFCACHE_ACK_SHIFT)
-#define LOGMSG_REFCACHE_VALUE_TO_ABORT(x)  (((x) & LOGMSG_REFCACHE_ABORT_MASK) >> LOGMSG_REFCACHE_ABORT_SHIFT)
-#define LOGMSG_REFCACHE_VALUE_TO_SUSPEND(x)  (((x) & LOGMSG_REFCACHE_SUSPEND_MASK) >> LOGMSG_REFCACHE_SUSPEND_SHIFT)
 
 /**********************************************************************
  * LogMessage
@@ -1519,7 +1483,7 @@ log_msg_new_mark(void)
  *
  * Frees a LogMessage instance.
  **/
-static void
+void
 _log_msg_free(LogMessage *self)
 {
   if (log_msg_chk_flag(self, LF_STATE_OWN_PAYLOAD) && self->payload)
@@ -1560,7 +1524,7 @@ log_msg_drop(LogMessage *msg, const LogPathOptions *path_options, AckType ack_ty
     }
 }
 
-static AckType
+static inline AckType
 _ack_and_ref_and_abort_and_suspend_to_acktype(gint value)
 {
   AckType type = AT_PROCESSED;
@@ -1571,84 +1535,6 @@ _ack_and_ref_and_abort_and_suspend_to_acktype(gint value)
     type = AT_ABORTED;
 
   return type;
-}
-
-
-/***************************************************************************************
- * In order to read & understand this code, reading the comment on the top
- * of this file about ref/ack handling is strongly recommended.
- ***************************************************************************************/
-
-/* Function to update the combined ACK (with the abort flag) and REF counter. */
-static inline gint
-log_msg_update_ack_and_ref_and_abort_and_suspended(LogMessage *self, gint add_ref, gint add_ack, gint add_abort,
-                                                   gint add_suspend)
-{
-  gint old_value, new_value;
-  do
-    {
-      new_value = old_value = (volatile gint) self->ack_and_ref_and_abort_and_suspended;
-      new_value = (new_value & ~LOGMSG_REFCACHE_REF_MASK)   + LOGMSG_REFCACHE_REF_TO_VALUE(  (LOGMSG_REFCACHE_VALUE_TO_REF(
-                    old_value)   + add_ref));
-      new_value = (new_value & ~LOGMSG_REFCACHE_ACK_MASK)   + LOGMSG_REFCACHE_ACK_TO_VALUE(  (LOGMSG_REFCACHE_VALUE_TO_ACK(
-                    old_value)   + add_ack));
-      new_value = (new_value & ~LOGMSG_REFCACHE_ABORT_MASK) + LOGMSG_REFCACHE_ABORT_TO_VALUE((LOGMSG_REFCACHE_VALUE_TO_ABORT(
-                    old_value) | add_abort));
-      new_value = (new_value & ~LOGMSG_REFCACHE_SUSPEND_MASK) + LOGMSG_REFCACHE_SUSPEND_TO_VALUE((
-                    LOGMSG_REFCACHE_VALUE_TO_SUSPEND(old_value) | add_suspend));
-    }
-  while (!g_atomic_int_compare_and_exchange(&self->ack_and_ref_and_abort_and_suspended, old_value, new_value));
-
-  return old_value;
-}
-
-/* Function to update the combined ACK (without abort) and REF counter. */
-static inline gint
-log_msg_update_ack_and_ref(LogMessage *self, gint add_ref, gint add_ack)
-{
-  return log_msg_update_ack_and_ref_and_abort_and_suspended(self, add_ref, add_ack, 0, 0);
-}
-
-/**
- * log_msg_ref:
- * @self: LogMessage instance
- *
- * Increment reference count of @self and return the new reference.
- **/
-LogMessage *
-log_msg_ref(LogMessage *self)
-{
-  if (!self)
-    return NULL;
-
-  gint old_value;
-
-  old_value = log_msg_update_ack_and_ref(self, 1, 0);
-  g_assert(LOGMSG_REFCACHE_VALUE_TO_REF(old_value) >= 1);
-  return self;
-}
-
-/**
- * log_msg_unref:
- * @self: LogMessage instance
- *
- * Decrement reference count and free self if the reference count becomes 0.
- **/
-void
-log_msg_unref(LogMessage *self)
-{
-  if (!self)
-    return;
-
-  gint old_value;
-
-  old_value = log_msg_update_ack_and_ref(self, -1, 0);
-  g_assert(LOGMSG_REFCACHE_VALUE_TO_REF(old_value) >= 1);
-
-  if (LOGMSG_REFCACHE_VALUE_TO_REF(old_value) == 1)
-    {
-      _log_msg_free(self);
-    }
 }
 
 /**
@@ -1665,7 +1551,6 @@ log_msg_add_ack(LogMessage *self, const LogPathOptions *path_options)
       log_msg_update_ack_and_ref(self, 0, 1);
     }
 }
-
 
 /**
  * log_msg_ack:

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -63,89 +63,11 @@
  * be delivered.  In case flow-control is in use, the number of
  * to-be-expected ACKs are counted in an atomic variable.
  *
- * Code is written in a way, that it is explicitly mentioned whether a
- * function expects a reference (called "consuming" the ref), or whether it
- * gets a 'borrowed' reference (more common).  Also, a function that returns
- * a LogMessage instance generally returns a reference too.
- *
- * Because of these rules, quite a number of refs/unrefs are being made
- * during the processing of a message, even though they wouldn't cause the
- * structure to be freed.  Considering that ref/unref operations are
- * expensive atomic operations, these have a considerable overhead.
- *
- * The solution we employ in this module, is that we try to exploit the
- * fact, that each thread is usually working on a single LogMessage
- * instance, and once it is done with it, it fetches the next one, and so
- * on.  In the LogReader/LogWriter cases, this usage pattern is quite
- * normal.
- *
- * Also, a quite similar usage pattern can be applied to the ACK counter
- * (the one which tracks how much flow-controlled destinations need to
- * confirm the deliver of the message).
- *
- * The solution implemented here is outlined below (and the same rules are
- * used for ACKs and REFs):
- *
- *    - ACKs and REFs are put into the same 32 bit integer value, one half
- *      is used for the ref counter, the other is used for the ACK counter
- *      (see the macros LOGMSG_REFCACHE_ below)
- *
- *    - The processing of a given message in a given thread is enclosed by
- *      calls to log_msg_refcache_start() / log_msg_refcache_stop()
- *
- *    - The calls to these functions is optional, if they are not called,
- *      then normal atomic reference counting is performed
- *
- *    - When refcache_start() is called, the atomic reference count is not
- *      changed by log_msg_ref()/unref(). Rather, a per-thread variable is
- *      used to count the _difference_ to the "would-be" value of the ref counter.
- *
- *    - When refcache_stop() is called, the atomic reference counter is
- *      updated as a single atomic operation. This means, that if a thread
- *      calls refcache_start() early enough, then the ref/unref operations
- *      performed by the given thread can be completely atomic-op free.
- *
- *    - There's one catch: if the producer thread (e.g. LogReader), doesn't
- *      add references to a consumer thread (e.g.  LogWriter), and the
- *      consumer doesn't use the refcache infrastructure, then the counters
- *      could become negative (simply because the reader's real number of
- *      references is not represented in the refcounter).  This is solved by
- *      adding a large-enough number (so called BIAS) to the ref counter in
- *      refcache_start(), which ensures that all possible writers will see a
- *      positive value.  This is then subtracted in refcache_stop() the
- *      same way as the other references.
- *
  * Since we use the same atomic variable to store two things, updating that
  * counter becomes somewhat more complicated, therefore a g_atomic_int_add()
  * doesn't suffice.  We're using a CAS loop (compare-and-exchange) to do our
  * stuff, but that shouldn't have that much of an overhead.
  */
-
-TLS_BLOCK_START
-{
-  /* message that is being processed by the current thread. Its ack/ref changes are cached */
-  LogMessage *logmsg_current;
-  /* whether the consumer is flow-controlled, (the producer always is) */
-  gboolean logmsg_cached_ack_needed;
-
-  /* has to be signed as these can become negative */
-  /* number of cached refs by the current thread */
-  gint logmsg_cached_refs;
-  /* number of cached acks by the current thread */
-  gint logmsg_cached_acks;
-  /* abort flag in the current thread for acks */
-  gboolean logmsg_cached_abort;
-  /* suspend flag in the current thread for acks */
-  gboolean logmsg_cached_suspend;
-}
-TLS_BLOCK_END;
-
-#define logmsg_current              __tls_deref(logmsg_current)
-#define logmsg_cached_refs          __tls_deref(logmsg_cached_refs)
-#define logmsg_cached_acks          __tls_deref(logmsg_cached_acks)
-#define logmsg_cached_ack_needed    __tls_deref(logmsg_cached_ack_needed)
-#define logmsg_cached_abort         __tls_deref(logmsg_cached_abort)
-#define logmsg_cached_suspend       __tls_deref(logmsg_cached_suspend)
 
 #define LOGMSG_REFCACHE_SUSPEND_SHIFT                 31 /* number of bits to shift to get the SUSPEND flag */
 #define LOGMSG_REFCACHE_SUSPEND_MASK          0x80000000 /* bit mask to extract the SUSPEND flag */
@@ -155,7 +77,6 @@ TLS_BLOCK_END;
 #define LOGMSG_REFCACHE_ACK_MASK              0x3FFF8000 /* bit mask to extract the ACK counter */
 #define LOGMSG_REFCACHE_REF_SHIFT                      0 /* number of bits to shift to get the REF counter */
 #define LOGMSG_REFCACHE_REF_MASK              0x00007FFF /* bit mask to extract the ACK counter */
-#define LOGMSG_REFCACHE_BIAS                  0x00002000 /* the BIAS we add to the ref counter in refcache_start */
 
 #define LOGMSG_REFCACHE_REF_TO_VALUE(x)    (((x) << LOGMSG_REFCACHE_REF_SHIFT)   & LOGMSG_REFCACHE_REF_MASK)
 #define LOGMSG_REFCACHE_ACK_TO_VALUE(x)    (((x) << LOGMSG_REFCACHE_ACK_SHIFT)   & LOGMSG_REFCACHE_ACK_MASK)
@@ -1599,7 +1520,7 @@ log_msg_new_mark(void)
  * Frees a LogMessage instance.
  **/
 static void
-log_msg_free(LogMessage *self)
+_log_msg_free(LogMessage *self)
 {
   if (log_msg_chk_flag(self, LF_STATE_OWN_PAYLOAD) && self->payload)
     nv_table_unref(self->payload);
@@ -1632,8 +1553,11 @@ log_msg_free(LogMessage *self)
 void
 log_msg_drop(LogMessage *msg, const LogPathOptions *path_options, AckType ack_type)
 {
-  log_msg_ack(msg, path_options, ack_type);
-  log_msg_unref(msg);
+  if (msg)
+    {
+      log_msg_ack(msg, path_options, ack_type);
+      log_msg_unref(msg);
+    }
 }
 
 static AckType
@@ -1694,18 +1618,11 @@ log_msg_update_ack_and_ref(LogMessage *self, gint add_ref, gint add_ack)
 LogMessage *
 log_msg_ref(LogMessage *self)
 {
+  if (!self)
+    return NULL;
+
   gint old_value;
 
-  if (G_LIKELY(logmsg_current == self))
-    {
-      /* fastpath, @self is the current message, ref/unref processing is
-       * delayed until log_msg_refcache_stop() is called */
-
-      logmsg_cached_refs++;
-      return self;
-    }
-
-  /* slow path, refcache is not used, do the ordinary way */
   old_value = log_msg_update_ack_and_ref(self, 1, 0);
   g_assert(LOGMSG_REFCACHE_VALUE_TO_REF(old_value) >= 1);
   return self;
@@ -1720,23 +1637,17 @@ log_msg_ref(LogMessage *self)
 void
 log_msg_unref(LogMessage *self)
 {
+  if (!self)
+    return;
+
   gint old_value;
-
-  if (G_LIKELY(logmsg_current == self))
-    {
-      /* fastpath, @self is the current message, ref/unref processing is
-       * delayed until log_msg_refcache_stop() is called */
-
-      logmsg_cached_refs--;
-      return;
-    }
 
   old_value = log_msg_update_ack_and_ref(self, -1, 0);
   g_assert(LOGMSG_REFCACHE_VALUE_TO_REF(old_value) >= 1);
 
   if (LOGMSG_REFCACHE_VALUE_TO_REF(old_value) == 1)
     {
-      log_msg_free(self);
+      _log_msg_free(self);
     }
 }
 
@@ -1751,15 +1662,6 @@ log_msg_add_ack(LogMessage *self, const LogPathOptions *path_options)
 {
   if (path_options->ack_needed)
     {
-      if (G_LIKELY(logmsg_current == self))
-        {
-          /* fastpath, @self is the current message, add_ack/ack processing is
-           * delayed until log_msg_refcache_stop() is called */
-
-          logmsg_cached_acks++;
-          logmsg_cached_ack_needed = TRUE;
-          return;
-        }
       log_msg_update_ack_and_ref(self, 0, 1);
     }
 }
@@ -1781,16 +1683,6 @@ log_msg_ack(LogMessage *self, const LogPathOptions *path_options, AckType ack_ty
 
   if (path_options->ack_needed)
     {
-      if (G_LIKELY(logmsg_current == self))
-        {
-          /* fastpath, @self is the current message, add_ack/ack processing is
-           * delayed until log_msg_refcache_stop() is called */
-
-          logmsg_cached_acks--;
-          logmsg_cached_abort |= IS_ACK_ABORTED(ack_type);
-          logmsg_cached_suspend |= IS_ACK_SUSPENDED(ack_type);
-          return;
-        }
       old_value = log_msg_update_ack_and_ref_and_abort_and_suspended(self, 0, -1, IS_ACK_ABORTED(ack_type),
                   IS_ACK_SUSPENDED(ack_type));
       if (LOGMSG_REFCACHE_VALUE_TO_ACK(old_value) == 1)
@@ -1825,182 +1717,6 @@ log_msg_break_ack(LogMessage *msg, const LogPathOptions *path_options, LogPathOp
   local_path_options->ack_needed = FALSE;
 
   return local_path_options;
-}
-
-
-/*
- * Start caching ref/unref/ack/add-ack operations in the current thread for
- * the message specified by @self.  See the comment at the top of this file
- * for more information.
- *
- * This function is to be called by the producer thread (e.g. the one
- * that generates new messages). You should use
- * log_msg_refcache_start_consumer() in consumer threads instead.
- *
- * This function cannot be called for the same message from multiple
- * threads.
- *
- */
-void
-log_msg_refcache_start_producer(LogMessage *self)
-{
-  g_assert(logmsg_current == NULL);
-
-  logmsg_current = self;
-  /* we're the producer of said message, and thus we want to inhibit
-   * freeing/acking it due to our cached refs, add a bias large enough
-   * to cover any possible unrefs/acks of the consumer side */
-
-  /* we don't need to be thread-safe here, as a producer has just created this message and no parallel access is yet possible */
-
-  self->ack_and_ref_and_abort_and_suspended = (self->ack_and_ref_and_abort_and_suspended & ~LOGMSG_REFCACHE_REF_MASK) +
-                                              LOGMSG_REFCACHE_REF_TO_VALUE((LOGMSG_REFCACHE_VALUE_TO_REF(self->ack_and_ref_and_abort_and_suspended) +
-                                                LOGMSG_REFCACHE_BIAS));
-  self->ack_and_ref_and_abort_and_suspended = (self->ack_and_ref_and_abort_and_suspended & ~LOGMSG_REFCACHE_ACK_MASK) +
-                                              LOGMSG_REFCACHE_ACK_TO_VALUE((LOGMSG_REFCACHE_VALUE_TO_ACK(self->ack_and_ref_and_abort_and_suspended) +
-                                                LOGMSG_REFCACHE_BIAS));
-
-  logmsg_cached_refs = -LOGMSG_REFCACHE_BIAS;
-  logmsg_cached_acks = -LOGMSG_REFCACHE_BIAS;
-  logmsg_cached_abort = FALSE;
-  logmsg_cached_suspend = FALSE;
-  logmsg_cached_ack_needed = TRUE;
-}
-
-/*
- * Start caching ref/unref/ack/add-ack operations in the current thread for
- * the message specified by @self.  See the comment at the top of this file
- * for more information.
- *
- * This function is to be called by the consumer threads (e.g. the
- * ones that consume messages).
- *
- * This function can be called from multiple consumer threads at the
- * same time, even for the same message.
- *
- */
-void
-log_msg_refcache_start_consumer(LogMessage *self, const LogPathOptions *path_options)
-{
-  g_assert(logmsg_current == NULL);
-
-  logmsg_current = self;
-  logmsg_cached_ack_needed = path_options->ack_needed;
-  logmsg_cached_refs = 0;
-  logmsg_cached_acks = 0;
-  logmsg_cached_abort = FALSE;
-  logmsg_cached_suspend = FALSE;
-}
-
-/*
- * Stop caching ref/unref/ack/add-ack operations in the current thread for
- * the message specified by the log_msg_refcache_start() function.
- *
- * See the comment at the top of this file for more information.
- */
-void
-log_msg_refcache_stop(void)
-{
-  gint old_value;
-  gint current_cached_acks;
-  gboolean current_cached_abort;
-  gboolean current_cached_suspend;
-
-  g_assert(logmsg_current != NULL);
-
-  /* validate that we didn't overflow the counters:
-   *
-   * Both counters must be:
-   *
-   * - at least 1 smaller than the bias, rationale:
-   *
-   *      - if we are caching "bias" number of refs, it may happen
-   *        that there are bias number of unrefs, potentially running
-   *        in consumer threads
-   *
-   *      - if the potential unrefs is larger than the bias value, it may
-   *        happen that the producer sets the bias (trying to avoid
-   *        the freeing of the LogMessage), but still it gets freed.
-   *
-   * - not smaller than the "-bias" value, rationale:
-   *      - if we are caching "bias" number of unrefs the same can happen
-   *        as with the ref case.
-   *
-   */
-  g_assert((logmsg_cached_acks < LOGMSG_REFCACHE_BIAS - 1) && (logmsg_cached_acks >= -LOGMSG_REFCACHE_BIAS));
-  g_assert((logmsg_cached_refs < LOGMSG_REFCACHE_BIAS - 1) && (logmsg_cached_refs >= -LOGMSG_REFCACHE_BIAS));
-
-  /*
-   * We fold the differences in ack/ref counts in three stages:
-   *
-   *   1) we take a ref of logmsg_current, this is needed so that the
-   *      message is not freed until we return from refcache_stop()
-   *
-   *   2) we add in all the diffs that were accumulated between
-   *      refcache_start and refcache_stop. This gets us a final value of the
-   *      ack counter, ref must be >= as we took a ref ourselves.
-   *
-   *   3) we call the ack handler if needed, this might change ref counters
-   *      recursively (but not ack counters as that already atomically
-   *      dropped to zero)
-   *
-   *   4) drop the ref we took in step 1) above
-   *
-   *   4) then we fold in the net ref results of the ack callback and
-   *      refcache_stop() combined. This either causes the LogMessage to be
-   *      freed (when we were the last), or it stays around because of other
-   *      refs.
-   */
-
-  /* 1) take ref */
-  log_msg_ref(logmsg_current);
-
-  /* 2) fold in ref/ack counter diffs into the atomic value */
-
-  current_cached_acks = logmsg_cached_acks;
-  logmsg_cached_acks = 0;
-
-  current_cached_abort = logmsg_cached_abort;
-  logmsg_cached_abort = FALSE;
-
-  current_cached_suspend = logmsg_cached_suspend;
-  logmsg_cached_suspend = FALSE;
-
-  old_value = log_msg_update_ack_and_ref_and_abort_and_suspended(logmsg_current, 0, current_cached_acks,
-              current_cached_abort, current_cached_suspend);
-
-  gboolean acks_changed = current_cached_acks != 0;
-  if (acks_changed && (LOGMSG_REFCACHE_VALUE_TO_ACK(old_value) == -current_cached_acks) && logmsg_cached_ack_needed)
-    {
-      AckType ack_type_cumulated = _ack_and_ref_and_abort_and_suspend_to_acktype(old_value);
-
-      if (current_cached_suspend)
-        ack_type_cumulated = AT_SUSPENDED;
-      else if (current_cached_abort)
-        ack_type_cumulated = AT_ABORTED;
-
-      /* 3) call the ack handler */
-
-      logmsg_current->ack_func(logmsg_current, ack_type_cumulated);
-
-      /* the ack callback may not change the ack counters, it already
-       * dropped to zero atomically, changing that again is an error */
-
-      g_assert(logmsg_cached_acks == 0);
-    }
-
-  /* 4) drop our own ref */
-  log_msg_unref(logmsg_current);
-
-  /* 5) fold the combined result of our own ref/unref and ack handler's results */
-  gint current_cached_refs = logmsg_cached_refs;
-  old_value = log_msg_update_ack_and_ref(logmsg_current, current_cached_refs, 0);
-
-  gboolean refs_changed = current_cached_refs != 0;
-  if (refs_changed && LOGMSG_REFCACHE_VALUE_TO_REF(old_value) == -current_cached_refs)
-    log_msg_free(logmsg_current);
-  logmsg_cached_refs = 0;
-  logmsg_current = NULL;
 }
 
 void

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -628,10 +628,6 @@ void log_msg_drop(LogMessage *msg, const LogPathOptions *path_options, AckType a
 const LogPathOptions *log_msg_break_ack(LogMessage *msg, const LogPathOptions *path_options,
                                         LogPathOptions *local_path_options);
 
-void log_msg_refcache_start_producer(LogMessage *self);
-void log_msg_refcache_start_consumer(LogMessage *self, const LogPathOptions *path_options);
-void log_msg_refcache_stop(void);
-
 void log_msg_registry_init(void);
 void log_msg_registry_deinit(void);
 void log_msg_global_init(void);

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -331,8 +331,116 @@ extern const char logmsg_sd_prefix[];
 extern const gint logmsg_sd_prefix_len;
 extern gint logmsg_node_max;
 
-LogMessage *log_msg_ref(LogMessage *m);
-void log_msg_unref(LogMessage *m);
+/*
+ * Reference/ACK counting for LogMessage structures
+ *
+ * Each LogMessage structure is allocated when received by a LogSource
+ * instance, and then freed once all destinations finish with it.  Since a
+ * LogMessage is processed by different threads, reference counting must be
+ * atomic.
+ *
+ * A similar counter is used to track when a given message is considered to
+ * be delivered.  In case flow-control is in use, the number of
+ * to-be-expected ACKs are counted in an atomic variable.
+ *
+ * Since we use the same atomic variable to store two things, updating that
+ * counter becomes somewhat more complicated, therefore a g_atomic_int_add()
+ * doesn't suffice.  We're using a CAS loop (compare-and-exchange) to do our
+ * stuff, but that shouldn't have that much of an overhead.
+ */
+
+#define LOGMSG_REFCACHE_SUSPEND_SHIFT                 31 /* number of bits to shift to get the SUSPEND flag */
+#define LOGMSG_REFCACHE_SUSPEND_MASK          0x80000000 /* bit mask to extract the SUSPEND flag */
+#define LOGMSG_REFCACHE_ABORT_SHIFT                   30 /* number of bits to shift to get the ABORT flag */
+#define LOGMSG_REFCACHE_ABORT_MASK            0x40000000 /* bit mask to extract the ABORT flag */
+#define LOGMSG_REFCACHE_ACK_SHIFT                     15 /* number of bits to shift to get the ACK counter */
+#define LOGMSG_REFCACHE_ACK_MASK              0x3FFF8000 /* bit mask to extract the ACK counter */
+#define LOGMSG_REFCACHE_REF_SHIFT                      0 /* number of bits to shift to get the REF counter */
+#define LOGMSG_REFCACHE_REF_MASK              0x00007FFF /* bit mask to extract the ACK counter */
+
+#define LOGMSG_REFCACHE_REF_TO_VALUE(x)    (((x) << LOGMSG_REFCACHE_REF_SHIFT)   & LOGMSG_REFCACHE_REF_MASK)
+#define LOGMSG_REFCACHE_ACK_TO_VALUE(x)    (((x) << LOGMSG_REFCACHE_ACK_SHIFT)   & LOGMSG_REFCACHE_ACK_MASK)
+#define LOGMSG_REFCACHE_ABORT_TO_VALUE(x)  (((x) << LOGMSG_REFCACHE_ABORT_SHIFT) & LOGMSG_REFCACHE_ABORT_MASK)
+#define LOGMSG_REFCACHE_SUSPEND_TO_VALUE(x)  (((x) << LOGMSG_REFCACHE_SUSPEND_SHIFT) & LOGMSG_REFCACHE_SUSPEND_MASK)
+
+#define LOGMSG_REFCACHE_VALUE_TO_REF(x)    (((x) & LOGMSG_REFCACHE_REF_MASK)   >> LOGMSG_REFCACHE_REF_SHIFT)
+#define LOGMSG_REFCACHE_VALUE_TO_ACK(x)    (((x) & LOGMSG_REFCACHE_ACK_MASK)   >> LOGMSG_REFCACHE_ACK_SHIFT)
+#define LOGMSG_REFCACHE_VALUE_TO_ABORT(x)  (((x) & LOGMSG_REFCACHE_ABORT_MASK) >> LOGMSG_REFCACHE_ABORT_SHIFT)
+#define LOGMSG_REFCACHE_VALUE_TO_SUSPEND(x)  (((x) & LOGMSG_REFCACHE_SUSPEND_MASK) >> LOGMSG_REFCACHE_SUSPEND_SHIFT)
+
+/* Function to update the combined ACK (with the abort flag) and REF counter. */
+static inline gint
+log_msg_update_ack_and_ref_and_abort_and_suspended(LogMessage *self, gint add_ref, gint add_ack, gint add_abort,
+                                                   gint add_suspend)
+{
+  gint old_value, new_value;
+  do
+    {
+      new_value = old_value = self->ack_and_ref_and_abort_and_suspended;
+      new_value = (new_value & ~LOGMSG_REFCACHE_REF_MASK)   + LOGMSG_REFCACHE_REF_TO_VALUE(  (LOGMSG_REFCACHE_VALUE_TO_REF(
+                    old_value)   + add_ref));
+      new_value = (new_value & ~LOGMSG_REFCACHE_ACK_MASK)   + LOGMSG_REFCACHE_ACK_TO_VALUE(  (LOGMSG_REFCACHE_VALUE_TO_ACK(
+                    old_value)   + add_ack));
+      new_value = (new_value & ~LOGMSG_REFCACHE_ABORT_MASK) + LOGMSG_REFCACHE_ABORT_TO_VALUE((LOGMSG_REFCACHE_VALUE_TO_ABORT(
+                    old_value) | add_abort));
+      new_value = (new_value & ~LOGMSG_REFCACHE_SUSPEND_MASK) + LOGMSG_REFCACHE_SUSPEND_TO_VALUE((
+                    LOGMSG_REFCACHE_VALUE_TO_SUSPEND(old_value) | add_suspend));
+    }
+  while (!g_atomic_int_compare_and_exchange(&self->ack_and_ref_and_abort_and_suspended, old_value, new_value));
+
+  return old_value;
+}
+
+/* Function to update the combined ACK (without abort) and REF counter. */
+static inline gint
+log_msg_update_ack_and_ref(LogMessage *self, gint add_ref, gint add_ack)
+{
+  return log_msg_update_ack_and_ref_and_abort_and_suspended(self, add_ref, add_ack, 0, 0);
+}
+
+/**
+ * log_msg_ref:
+ * @self: LogMessage instance
+ *
+ * Increment reference count of @self and return the new reference.
+ **/
+static inline LogMessage *
+log_msg_ref(LogMessage *self)
+{
+  if (!self)
+    return NULL;
+
+  gint old_value;
+
+  old_value = log_msg_update_ack_and_ref(self, 1, 0);
+  g_assert(LOGMSG_REFCACHE_VALUE_TO_REF(old_value) >= 1);
+  return self;
+}
+
+void _log_msg_free(LogMessage *self);
+
+/**
+ * log_msg_unref:
+ * @self: LogMessage instance
+ *
+ * Decrement reference count and free self if the reference count becomes 0.
+ **/
+static inline void
+log_msg_unref(LogMessage *self)
+{
+  if (!self)
+    return;
+
+  gint old_value;
+
+  old_value = log_msg_update_ack_and_ref(self, -1, 0);
+  g_assert(LOGMSG_REFCACHE_VALUE_TO_REF(old_value) >= 1);
+
+  if (LOGMSG_REFCACHE_VALUE_TO_REF(old_value) == 1)
+    {
+      _log_msg_free(self);
+    }
+}
 
 typedef gpointer LogMessagePin;
 

--- a/lib/logmsg/tests/test_logmsg_ack.c
+++ b/lib/logmsg/tests/test_logmsg_ack.c
@@ -40,7 +40,6 @@ _init(AckRecord *self)
 {
   self->acked = FALSE;
 
-  log_msg_refcache_start_producer(self->original);
   log_msg_add_ack(self->original, &self->path_options);
   log_msg_ref(self->original);
   log_msg_write_protect(self->original);
@@ -50,7 +49,6 @@ static void
 _deinit(AckRecord *self)
 {
   log_msg_drop(self->original, &self->path_options, AT_PROCESSED);
-  log_msg_refcache_stop();
 }
 
 static void

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -507,12 +507,9 @@ log_reader_handle_line(LogReader *self, const guchar *line, gsize length, LogTra
           m->timestamps[LM_TS_RECVD].ut_usec = aux->timestamp.tv_nsec / 1000;
         }
     }
-  log_msg_refcache_start_producer(m);
-
   log_transport_aux_data_foreach(aux, _add_aux_nvpair, m);
 
   log_source_post(&self->super, m);
-  log_msg_refcache_stop();
   return log_source_free_to_send(&self->super);
 }
 

--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -132,9 +132,7 @@ _work(gpointer s, gpointer arg)
 
           log_msg_free_queue_node(node);
 
-          log_msg_refcache_start_consumer(msg, &path_options);
           _reinject_message(partition->front_pipe, msg, &path_options, partition->metrics.processing_latency);
-          log_msg_refcache_stop();
 
           msgs_processed++;
           stats_counter_inc(partition->metrics.processed_events_total);

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -577,7 +577,7 @@ _get_pid_string(void)
 }
 
 static inline void
-_update_processing_latency(LogSource *self, LogMessage *msg)
+_update_processing_latency(LogSource *self, UnixTime *recvd_stamp)
 {
   if (!self->metrics.processing_latency)
     return;
@@ -585,7 +585,7 @@ _update_processing_latency(LogSource *self, LogMessage *msg)
   UnixTime now;
   unix_time_set_precise_now(&now);
 
-  gint64 processing_latency = unix_time_diff_in_msec(&now, &msg->timestamps[LM_TS_RECVD]);
+  gint64 processing_latency = unix_time_diff_in_msec(&now, recvd_stamp);
   stats_aggregator_add_data_point(self->metrics.processing_latency, processing_latency);
 }
 
@@ -633,8 +633,9 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
   stats_counter_inc(self->metrics.recvd_messages);
   stats_counter_set_time(self->metrics.last_message_seen, msg->timestamps[LM_TS_RECVD].ut_sec);
   stats_byte_counter_add(&self->metrics.recvd_bytes, msg->recvd_rawmsg_size);
+  UnixTime recvd_stamp = msg->timestamps[LM_TS_RECVD];
   log_pipe_forward_msg(s, msg, path_options);
-  _update_processing_latency(self, msg);
+  _update_processing_latency(self, &recvd_stamp);
 
   if (accurate_nanosleep && self->threaded && self->window_full_sleep_nsec > 0 && !log_source_free_to_send(self))
     {

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -541,7 +541,6 @@ _perform_inserts(LogThreadedDestWorker *self)
         }
 
       msg_set_context(msg);
-      log_msg_refcache_start_consumer(msg, &path_options);
 
       self->batch_size++;
       result = log_threaded_dest_worker_insert(self, msg);
@@ -556,7 +555,6 @@ _perform_inserts(LogThreadedDestWorker *self)
 
       log_msg_unref(msg);
       msg_set_context(NULL);
-      log_msg_refcache_stop();
 
 flush_error:
       scratch_buffers_reclaim_marked(mark);

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1188,7 +1188,6 @@ log_writer_write_message(LogWriter *self, LogMessage *msg, LogPathOptions *path_
 
   *write_error = FALSE;
 
-  log_msg_refcache_start_consumer(msg, path_options);
   msg_set_context(msg);
 
   log_writer_format_log(self, msg, self->line_buffer);
@@ -1245,7 +1244,6 @@ log_writer_write_message(LogWriter *self, LogMessage *msg, LogPathOptions *path_
       stats_byte_counter_add(&self->metrics.written_bytes, msg_len);
       log_msg_unref(msg);
       msg_set_context(NULL);
-      log_msg_refcache_stop();
 
       return TRUE;
     }
@@ -1258,7 +1256,6 @@ log_writer_write_message(LogWriter *self, LogMessage *msg, LogPathOptions *path_
 
       log_msg_unref(msg);
       msg_set_context(NULL);
-      log_msg_refcache_stop();
 
       return FALSE;
     }

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -42,7 +42,7 @@ add_dummy_template_to_configuration(void)
 }
 
 static void
-_log_msg_free(gpointer data, gpointer user_data)
+_free_msg(gpointer data, gpointer user_data)
 {
   log_msg_unref((LogMessage *) data);
 }
@@ -67,7 +67,7 @@ create_log_messages_with_values(const gchar *name, const gchar **values)
 static void
 free_log_message_array(GPtrArray *messages)
 {
-  g_ptr_array_foreach(messages, _log_msg_free, NULL);
+  g_ptr_array_foreach(messages, _free_msg, NULL);
   g_ptr_array_free(messages, TRUE);
 }
 


### PR DESCRIPTION
This PR gets rid of the LogMessage refcache. 

The refcount for LogMessage instances are mostly changed by the same CPU with a single handover from the source to the destination worker. With that said, in most cases this is  going to be exclusive in the cache. 

It is complex, does not help performance much if at all. This PR improves the CPU cycle count, although only a small improvement. 

Let's get rid of refcache, prime example of premature optimization on my part.

RIP.

