### PR TITLE
GSockaddr refactor to make smaller

### DIFF
--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -38,6 +38,13 @@
 #include <netdb.h>
 
 
+static void
+g_sockaddr_base_init(GSockAddrBase *a, gint salen)
+{
+  g_atomic_counter_set(&a->refcnt, 1);
+  a->salen = salen;
+}
+
 /* general GSockAddr functions */
 
 /**
@@ -167,7 +174,7 @@ GSockAddr *
 g_sockaddr_ref(GSockAddr *a)
 {
   if (a)
-    g_atomic_counter_inc(&a->refcnt);
+    g_atomic_counter_inc(&a->super.refcnt);
   return a;
 }
 
@@ -189,7 +196,7 @@ g_sockaddr_unref(GSockAddr *a)
   /* FIXME: maybe add a callback to funcs table */
   if (a)
     {
-      if (g_atomic_counter_dec_and_test(&a->refcnt))
+      if (g_atomic_counter_dec_and_test(&a->super.refcnt))
         {
           g_slice_free1(g_sockaddr_len(a), a);
         }
@@ -205,8 +212,7 @@ g_sockaddr_unref(GSockAddr *a)
   +*/
 typedef struct _GSockAddrInet
 {
-  GAtomicCounter refcnt;
-  int salen;
+  GSockAddrBase super;
   struct sockaddr_in sin;
 } GSockAddrInet;
 
@@ -308,9 +314,8 @@ g_sockaddr_inet_new(const gchar *ip, guint16 port)
   if (inet_aton(ip, &ina))
     {
       self = g_new0(GSockAddrInet, 1);
+      g_sockaddr_base_init(&self->super, sizeof(struct sockaddr_in));
 
-      g_atomic_counter_set(&self->refcnt, 1);
-      self->salen = sizeof(struct sockaddr_in);
       self->sin.sin_family = AF_INET;
       self->sin.sin_port = htons(port);
       self->sin.sin_addr = ina;
@@ -335,9 +340,8 @@ g_sockaddr_inet_new2(struct sockaddr_in *sin)
 {
   GSockAddrInet *self = g_new0(GSockAddrInet, 1);
 
-  g_atomic_counter_set(&self->refcnt, 1);
+  g_sockaddr_base_init(&self->super, sizeof(struct sockaddr_in));
   g_assert(sin->sin_family == AF_INET);
-  self->salen = sizeof(struct sockaddr_in);
   self->sin = *sin;
 
   return (GSockAddr *) self;
@@ -353,8 +357,7 @@ g_sockaddr_inet_new2(struct sockaddr_in *sin)
   +*/
 typedef struct _GSockAddrInet6
 {
-  GAtomicCounter refcnt;
-  int salen;
+  GSockAddrBase super;
   struct sockaddr_in6 sin6;
 } GSockAddrInet6;
 
@@ -462,9 +465,8 @@ g_sockaddr_inet6_new(const gchar *ip, guint16 port)
   if (inet_pton(AF_INET6, ip, &sin6_addr))
     {
       addr = g_new0(GSockAddrInet6, 1);
+      g_sockaddr_base_init(&addr->super, sizeof(struct sockaddr_in6));
 
-      g_atomic_counter_set(&addr->refcnt, 1);
-      addr->salen = sizeof(struct sockaddr_in6);
       addr->sin6.sin6_family = AF_INET6;
       addr->sin6.sin6_addr = sin6_addr;
       addr->sin6.sin6_port = htons(port);
@@ -491,9 +493,9 @@ g_sockaddr_inet6_new2(struct sockaddr_in6 *sin6)
 {
   GSockAddrInet6 *addr = g_new0(GSockAddrInet6, 1);
 
-  g_atomic_counter_set(&addr->refcnt, 1);
+  g_sockaddr_base_init(&addr->super, sizeof(struct sockaddr_in6));
+
   g_assert(sin6->sin6_family == AF_INET6);
-  addr->salen = sizeof(struct sockaddr_in6);
   addr->sin6 = *sin6;
 
   return (GSockAddr *) addr;
@@ -533,8 +535,7 @@ g_sockaddr_inet_or_inet6_check(GSockAddr *a)
   +*/
 typedef struct _GSockAddrUnix
 {
-  GAtomicCounter refcnt;
-  int salen;
+  GSockAddrBase super;
   struct sockaddr_un saun;
 } GSockAddrUnix;
 
@@ -573,19 +574,18 @@ g_sockaddr_unix_new(const gchar *name)
 {
   GSockAddrUnix *addr = g_new0(GSockAddrUnix, 1);
 
-  g_atomic_counter_set(&addr->refcnt, 1);
+  g_sockaddr_base_init(&addr->super, sizeof(struct sockaddr_un));
   addr->saun.sun_family = AF_UNIX;
   if (name)
     {
       strncpy(addr->saun.sun_path, name, sizeof(addr->saun.sun_path) - 1);
       addr->saun.sun_path[sizeof(addr->saun.sun_path) - 1] = 0;
-      addr->salen = SUN_LEN(&(addr->saun));
     }
   else
     {
       addr->saun.sun_path[0] = 0;
-      addr->salen = 2;
     }
+  addr->super.salen = SUN_LEN(&(addr->saun));
   return (GSockAddr *) addr;
 }
 
@@ -607,9 +607,8 @@ g_sockaddr_unix_new2(struct sockaddr_un *saun, int sunlen)
 {
   GSockAddrUnix *addr = g_new0(GSockAddrUnix, 1);
 
-  g_atomic_counter_set(&addr->refcnt, 1);
+  g_sockaddr_base_init(&addr->super, sunlen);
   addr->saun.sun_family = AF_UNIX;
-  addr->salen = sunlen;
   addr->saun = *saun;
   return (GSockAddr *) addr;
 }
@@ -645,7 +644,7 @@ g_sockaddr_unix_bind(int sock, GSockAddr *addr)
   if (unix_addr->saun.sun_path[0] == 0)
     return G_IO_STATUS_NORMAL;
 
-  if (bind(sock, &addr->sa, addr->salen) < 0)
+  if (bind(sock, &addr->sa, addr->super.salen) < 0)
     {
       return G_IO_STATUS_ERROR;
     }
@@ -662,12 +661,12 @@ g_sockaddr_unix_format(GSockAddr *addr, gchar *text, gulong n, gint format)
   if (format == GSA_FULL)
     {
       g_snprintf(text, n, "AF_UNIX(%s)",
-                 unix_addr->salen > sizeof(unix_addr->saun.sun_family) && unix_addr->saun.sun_path[0] ? unix_addr->saun.sun_path
+                 unix_addr->super.salen > sizeof(unix_addr->saun.sun_family) && unix_addr->saun.sun_path[0] ? unix_addr->saun.sun_path
                  : "anonymous");
     }
   else if (format == GSA_ADDRESS_ONLY || format == GSA_ADDRESS_PORT)
     {
-      g_snprintf(text, n, "%s", unix_addr->salen > sizeof(unix_addr->saun.sun_family)
+      g_snprintf(text, n, "%s", unix_addr->super.salen > sizeof(unix_addr->saun.sun_family)
                  && unix_addr->saun.sun_path[0] ? unix_addr->saun.sun_path : "anonymous");
     }
   return text;

--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -206,7 +206,6 @@ g_sockaddr_unref(GSockAddr *a)
 typedef struct _GSockAddrInet
 {
   GAtomicCounter refcnt;
-  guint32 flags;
   GSockAddrFuncs *sa_funcs;
   int salen;
   struct sockaddr_in sin;
@@ -312,7 +311,6 @@ g_sockaddr_inet_new(const gchar *ip, guint16 port)
       self = g_new0(GSockAddrInet, 1);
 
       g_atomic_counter_set(&self->refcnt, 1);
-      self->flags = 0;
       self->salen = sizeof(struct sockaddr_in);
       self->sin.sin_family = AF_INET;
       self->sin.sin_port = htons(port);
@@ -340,7 +338,6 @@ g_sockaddr_inet_new2(struct sockaddr_in *sin)
   GSockAddrInet *self = g_new0(GSockAddrInet, 1);
 
   g_atomic_counter_set(&self->refcnt, 1);
-  self->flags = 0;
   self->salen = sizeof(struct sockaddr_in);
   self->sin = *sin;
   self->sa_funcs = &inet_sockaddr_funcs;
@@ -359,7 +356,6 @@ g_sockaddr_inet_new2(struct sockaddr_in *sin)
 typedef struct _GSockAddrInet6
 {
   GAtomicCounter refcnt;
-  guint32 flags;
   GSockAddrFuncs *sa_funcs;
   int salen;
   struct sockaddr_in6 sin6;
@@ -471,7 +467,6 @@ g_sockaddr_inet6_new(const gchar *ip, guint16 port)
       addr = g_new0(GSockAddrInet6, 1);
 
       g_atomic_counter_set(&addr->refcnt, 1);
-      addr->flags = 0;
       addr->salen = sizeof(struct sockaddr_in6);
       addr->sin6.sin6_family = AF_INET6;
       addr->sin6.sin6_addr = sin6_addr;
@@ -501,7 +496,6 @@ g_sockaddr_inet6_new2(struct sockaddr_in6 *sin6)
   GSockAddrInet6 *addr = g_new0(GSockAddrInet6, 1);
 
   g_atomic_counter_set(&addr->refcnt, 1);
-  addr->flags = 0;
   addr->salen = sizeof(struct sockaddr_in6);
   addr->sin6 = *sin6;
   addr->sa_funcs = &inet6_sockaddr_funcs;
@@ -544,7 +538,6 @@ g_sockaddr_inet_or_inet6_check(GSockAddr *a)
 typedef struct _GSockAddrUnix
 {
   GAtomicCounter refcnt;
-  guint32 flags;
   GSockAddrFuncs *sa_funcs;
   int salen;
   struct sockaddr_un saun;
@@ -586,7 +579,6 @@ g_sockaddr_unix_new(const gchar *name)
   GSockAddrUnix *addr = g_new0(GSockAddrUnix, 1);
 
   g_atomic_counter_set(&addr->refcnt, 1);
-  addr->flags = 0;
   addr->sa_funcs = &unix_sockaddr_funcs;
   addr->saun.sun_family = AF_UNIX;
   if (name)
@@ -622,7 +614,6 @@ g_sockaddr_unix_new2(struct sockaddr_un *saun, int sunlen)
   GSockAddrUnix *addr = g_new0(GSockAddrUnix, 1);
 
   g_atomic_counter_set(&addr->refcnt, 1);
-  addr->flags = 0;
   addr->sa_funcs = &unix_sockaddr_funcs;
   addr->salen = sunlen;
   addr->saun = *saun;

--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -206,8 +206,8 @@ g_sockaddr_unref(GSockAddr *a)
 typedef struct _GSockAddrInet
 {
   GAtomicCounter refcnt;
-  GSockAddrFuncs *sa_funcs;
   int salen;
+  GSockAddrFuncs *sa_funcs;
   struct sockaddr_in sin;
 } GSockAddrInet;
 
@@ -356,8 +356,8 @@ g_sockaddr_inet_new2(struct sockaddr_in *sin)
 typedef struct _GSockAddrInet6
 {
   GAtomicCounter refcnt;
-  GSockAddrFuncs *sa_funcs;
   int salen;
+  GSockAddrFuncs *sa_funcs;
   struct sockaddr_in6 sin6;
 } GSockAddrInet6;
 
@@ -538,8 +538,8 @@ g_sockaddr_inet_or_inet6_check(GSockAddr *a)
 typedef struct _GSockAddrUnix
 {
   GAtomicCounter refcnt;
-  GSockAddrFuncs *sa_funcs;
   int salen;
+  GSockAddrFuncs *sa_funcs;
   struct sockaddr_un saun;
 } GSockAddrUnix;
 

--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -309,7 +309,7 @@ g_sockaddr_inet_new(const gchar *ip, guint16 port)
 
   if (inet_aton(ip, &ina))
     {
-      self = g_slice_new0(GSockAddrInet);
+      self = g_new0(GSockAddrInet, 1);
 
       g_atomic_counter_set(&self->refcnt, 1);
       self->flags = 0;
@@ -337,7 +337,7 @@ g_sockaddr_inet_new(const gchar *ip, guint16 port)
 GSockAddr *
 g_sockaddr_inet_new2(struct sockaddr_in *sin)
 {
-  GSockAddrInet *self = g_slice_new0(GSockAddrInet);
+  GSockAddrInet *self = g_new0(GSockAddrInet, 1);
 
   g_atomic_counter_set(&self->refcnt, 1);
   self->flags = 0;
@@ -468,7 +468,7 @@ g_sockaddr_inet6_new(const gchar *ip, guint16 port)
 
   if (inet_pton(AF_INET6, ip, &sin6_addr))
     {
-      addr = g_slice_new0(GSockAddrInet6);
+      addr = g_new0(GSockAddrInet6, 1);
 
       g_atomic_counter_set(&addr->refcnt, 1);
       addr->flags = 0;
@@ -498,7 +498,7 @@ g_sockaddr_inet6_new(const gchar *ip, guint16 port)
 GSockAddr *
 g_sockaddr_inet6_new2(struct sockaddr_in6 *sin6)
 {
-  GSockAddrInet6 *addr = g_slice_new0(GSockAddrInet6);
+  GSockAddrInet6 *addr = g_new0(GSockAddrInet6, 1);
 
   g_atomic_counter_set(&addr->refcnt, 1);
   addr->flags = 0;
@@ -577,7 +577,7 @@ static GSockAddrFuncs unix_sockaddr_funcs =
 GSockAddr *
 g_sockaddr_unix_new(const gchar *name)
 {
-  GSockAddrUnix *addr = g_slice_new0(GSockAddrUnix);
+  GSockAddrUnix *addr = g_new0(GSockAddrUnix, 1);
 
   g_atomic_counter_set(&addr->refcnt, 1);
   addr->flags = 0;
@@ -613,7 +613,7 @@ g_sockaddr_unix_new(const gchar *name)
 GSockAddr *
 g_sockaddr_unix_new2(struct sockaddr_un *saun, int sunlen)
 {
-  GSockAddrUnix *addr = g_slice_new0(GSockAddrUnix);
+  GSockAddrUnix *addr = g_new0(GSockAddrUnix, 1);
 
   g_atomic_counter_set(&addr->refcnt, 1);
   addr->flags = 0;

--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -98,21 +98,21 @@ g_sockaddr_new(struct sockaddr *sa, int salen)
 char *
 g_sockaddr_format(GSockAddr *a, gchar *text, gulong n, gint format)
 {
-  return a->sa_funcs->format(a, text, n, format);
+  return __g_sockaddr_funcs(a)->format(a, text, n, format);
 }
 
 guint16
 g_sockaddr_get_port(GSockAddr *a)
 {
-  g_assert(a->sa_funcs->get_port != NULL);
-  return a->sa_funcs->get_port(a);
+  g_assert(__g_sockaddr_funcs(a)->get_port != NULL);
+  return __g_sockaddr_funcs(a)->get_port(a);
 }
 
 void
 g_sockaddr_set_port(GSockAddr *a, guint16 port)
 {
-  g_assert(a->sa_funcs->set_port != NULL);
-  return a->sa_funcs->set_port(a, port);
+  g_assert(__g_sockaddr_funcs(a)->set_port != NULL);
+  return __g_sockaddr_funcs(a)->set_port(a, port);
 }
 
 guint8 *
@@ -207,7 +207,6 @@ typedef struct _GSockAddrInet
 {
   GAtomicCounter refcnt;
   int salen;
-  GSockAddrFuncs *sa_funcs;
   struct sockaddr_in sin;
 } GSockAddrInet;
 
@@ -273,7 +272,7 @@ g_sockaddr_inet_set_port(GSockAddr *s, guint16 port)
   g_sockaddr_inet_get_sa(s)->sin_port = htons(port);
 }
 
-static GSockAddrFuncs inet_sockaddr_funcs =
+GSockAddrFuncs inet_sockaddr_funcs =
 {
   .bind_prepare = g_sockaddr_inet_bind_prepare,
   NULL,
@@ -285,7 +284,7 @@ static GSockAddrFuncs inet_sockaddr_funcs =
 gboolean
 g_sockaddr_inet_check(GSockAddr *a)
 {
-  return a->sa_funcs == &inet_sockaddr_funcs;
+  return a->sa.sa_family == AF_INET;
 }
 
 /*+
@@ -315,7 +314,6 @@ g_sockaddr_inet_new(const gchar *ip, guint16 port)
       self->sin.sin_family = AF_INET;
       self->sin.sin_port = htons(port);
       self->sin.sin_addr = ina;
-      self->sa_funcs = &inet_sockaddr_funcs;
     }
   return (GSockAddr *) self;
 }
@@ -338,9 +336,9 @@ g_sockaddr_inet_new2(struct sockaddr_in *sin)
   GSockAddrInet *self = g_new0(GSockAddrInet, 1);
 
   g_atomic_counter_set(&self->refcnt, 1);
+  g_assert(sin->sin_family == AF_INET);
   self->salen = sizeof(struct sockaddr_in);
   self->sin = *sin;
-  self->sa_funcs = &inet_sockaddr_funcs;
 
   return (GSockAddr *) self;
 }
@@ -357,7 +355,6 @@ typedef struct _GSockAddrInet6
 {
   GAtomicCounter refcnt;
   int salen;
-  GSockAddrFuncs *sa_funcs;
   struct sockaddr_in6 sin6;
 } GSockAddrInet6;
 
@@ -429,7 +426,7 @@ g_sockaddr_inet6_is_v4_mapped(GSockAddr *s)
   return IN6_IS_ADDR_V4MAPPED(&g_sockaddr_inet6_get_sa(s)->sin6_addr);
 }
 
-static GSockAddrFuncs inet6_sockaddr_funcs =
+GSockAddrFuncs inet6_sockaddr_funcs =
 {
   .bind_prepare = g_sockaddr_inet_bind_prepare,
   .format = g_sockaddr_inet6_format,
@@ -440,7 +437,7 @@ static GSockAddrFuncs inet6_sockaddr_funcs =
 gboolean
 g_sockaddr_inet6_check(GSockAddr *a)
 {
-  return a->sa_funcs == &inet6_sockaddr_funcs;
+  return a->sa.sa_family == AF_INET6;
 }
 
 
@@ -471,7 +468,6 @@ g_sockaddr_inet6_new(const gchar *ip, guint16 port)
       addr->sin6.sin6_family = AF_INET6;
       addr->sin6.sin6_addr = sin6_addr;
       addr->sin6.sin6_port = htons(port);
-      addr->sa_funcs = &inet6_sockaddr_funcs;
     }
 
   return (GSockAddr *) addr;
@@ -496,9 +492,9 @@ g_sockaddr_inet6_new2(struct sockaddr_in6 *sin6)
   GSockAddrInet6 *addr = g_new0(GSockAddrInet6, 1);
 
   g_atomic_counter_set(&addr->refcnt, 1);
+  g_assert(sin6->sin6_family == AF_INET6);
   addr->salen = sizeof(struct sockaddr_in6);
   addr->sin6 = *sin6;
-  addr->sa_funcs = &inet6_sockaddr_funcs;
 
   return (GSockAddr *) addr;
 }
@@ -539,7 +535,6 @@ typedef struct _GSockAddrUnix
 {
   GAtomicCounter refcnt;
   int salen;
-  GSockAddrFuncs *sa_funcs;
   struct sockaddr_un saun;
 } GSockAddrUnix;
 
@@ -547,7 +542,7 @@ static GIOStatus g_sockaddr_unix_bind_prepare(int sock, GSockAddr *addr);
 static GIOStatus g_sockaddr_unix_bind(int sock, GSockAddr *addr);
 static gchar *g_sockaddr_unix_format(GSockAddr *addr, gchar *text, gulong n, gint format);
 
-static GSockAddrFuncs unix_sockaddr_funcs =
+GSockAddrFuncs unix_sockaddr_funcs =
 {
   .bind_prepare = g_sockaddr_unix_bind_prepare,
   .bind = g_sockaddr_unix_bind,
@@ -579,7 +574,6 @@ g_sockaddr_unix_new(const gchar *name)
   GSockAddrUnix *addr = g_new0(GSockAddrUnix, 1);
 
   g_atomic_counter_set(&addr->refcnt, 1);
-  addr->sa_funcs = &unix_sockaddr_funcs;
   addr->saun.sun_family = AF_UNIX;
   if (name)
     {
@@ -614,7 +608,7 @@ g_sockaddr_unix_new2(struct sockaddr_un *saun, int sunlen)
   GSockAddrUnix *addr = g_new0(GSockAddrUnix, 1);
 
   g_atomic_counter_set(&addr->refcnt, 1);
-  addr->sa_funcs = &unix_sockaddr_funcs;
+  addr->saun.sun_family = AF_UNIX;
   addr->salen = sunlen;
   addr->saun = *saun;
   return (GSockAddr *) addr;

--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -159,50 +159,6 @@ g_sockaddr_get_address(GSockAddr *self, guint8 *buffer, gsize buffer_size, gsize
     }
 }
 
-/*+
-
-  Increment the reference count of a GSockAddr instance.
-
-  Parameters:
-    a         pointer to GSockAddr
-
-  Returns:
-    the same instance
-
-  +*/
-GSockAddr *
-g_sockaddr_ref(GSockAddr *a)
-{
-  if (a)
-    g_atomic_counter_inc(&a->super.refcnt);
-  return a;
-}
-
-/*+
-
-  Decrement the reference count of a GSockAddr instance, and free if
-  the refcnt reaches 0.
-
-  Parameters:
-    a        GSockAddr instance
-
-  Returns:
-    none
-
-  +*/
-void
-g_sockaddr_unref(GSockAddr *a)
-{
-  /* FIXME: maybe add a callback to funcs table */
-  if (a)
-    {
-      if (g_atomic_counter_dec_and_test(&a->super.refcnt))
-        {
-          g_slice_free1(g_sockaddr_len(a), a);
-        }
-    }
-}
-
 /* AF_INET socket address */
 /*+
 

--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -563,6 +563,12 @@ static GSockAddrFuncs unix_sockaddr_funcs =
 
 /* anonymous if name == NULL */
 
+gboolean
+g_sockaddr_unix_check(GSockAddr *a)
+{
+  return a->sa.sa_family == AF_UNIX;
+}
+
 /*+
 
   Allocate and initialize a GSockAddrUnix instance.
@@ -690,13 +696,13 @@ g_sockaddr_len(GSockAddr *a)
   if (!a)
     return 0;
 
-  if (a->sa_funcs == &inet_sockaddr_funcs)
+  if (g_sockaddr_inet_check(a))
     len = sizeof(GSockAddrInet);
 #if SYSLOG_NG_ENABLE_IPV6
-  else if (a->sa_funcs == &inet6_sockaddr_funcs)
+  else if (g_sockaddr_inet6_check(a))
     len = sizeof(GSockAddrInet6);
 #endif
-  else if (a->sa_funcs == &unix_sockaddr_funcs)
+  else if (g_sockaddr_unix_check(a))
     len = sizeof(GSockAddrUnix);
   else
     g_assert_not_reached();

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -45,8 +45,8 @@ typedef struct _GSockAddrFuncs GSockAddrFuncs;
 typedef struct _GSockAddr
 {
   GAtomicCounter refcnt;
-  GSockAddrFuncs *sa_funcs;
   int salen;
+  GSockAddrFuncs *sa_funcs;
   struct sockaddr sa;
 } GSockAddr;
 

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -45,7 +45,6 @@ typedef struct _GSockAddrFuncs GSockAddrFuncs;
 typedef struct _GSockAddr
 {
   GAtomicCounter refcnt;
-  guint32 flags;
   GSockAddrFuncs *sa_funcs;
   int salen;
   struct sockaddr sa;

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -40,10 +40,15 @@
 #define GSA_ADDRESS_ONLY  1
 #define GSA_ADDRESS_PORT  2
 
-typedef struct _GSockAddr
+typedef struct _GSockAddrBase
 {
   GAtomicCounter refcnt;
   guint32 salen;
+} GSockAddrBase;
+
+typedef struct _GSockAddr
+{
+  GSockAddrBase super;
   struct sockaddr sa;
 } GSockAddr;
 

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -40,24 +40,42 @@
 #define GSA_ADDRESS_ONLY  1
 #define GSA_ADDRESS_PORT  2
 
-typedef struct _GSockAddrFuncs GSockAddrFuncs;
-
 typedef struct _GSockAddr
 {
   GAtomicCounter refcnt;
-  int salen;
-  GSockAddrFuncs *sa_funcs;
+  guint32 salen;
   struct sockaddr sa;
 } GSockAddr;
 
-struct _GSockAddrFuncs
+typedef struct _GSockAddrFuncs
 {
   GIOStatus (*bind_prepare)(gint sock, GSockAddr *addr);
   GIOStatus (*bind)(int sock, GSockAddr *addr);
   gchar   *(*format)(GSockAddr *addr, gchar *text, gulong n, gint format);
   guint16  (*get_port)          (GSockAddr *addr);
   void     (*set_port)          (GSockAddr *addr, guint16 port);
-};
+} GSockAddrFuncs;
+
+extern GSockAddrFuncs inet_sockaddr_funcs;
+extern GSockAddrFuncs inet6_sockaddr_funcs;
+extern GSockAddrFuncs unix_sockaddr_funcs;
+
+static inline GSockAddrFuncs *
+__g_sockaddr_funcs(GSockAddr *a)
+{
+  switch (a->sa.sa_family)
+    {
+    case AF_INET:
+      return &inet_sockaddr_funcs;
+    case AF_INET6:
+      return &inet6_sockaddr_funcs;
+    case AF_UNIX:
+      return &unix_sockaddr_funcs;
+    default:
+      g_assert_not_reached();
+    }
+}
+
 
 gchar *g_sockaddr_format(GSockAddr *a, gchar *text, gulong n, gint format);
 guint16 g_sockaddr_get_port(GSockAddr *a);

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -89,13 +89,31 @@ guint8 *g_sockaddr_get_address(GSockAddr *self, guint8 *buffer, gsize buffer_siz
 gsize g_sockaddr_len(GSockAddr *a);
 
 GSockAddr *g_sockaddr_new(struct sockaddr *sa, int salen);
-GSockAddr *g_sockaddr_ref(GSockAddr *a);
-void g_sockaddr_unref(GSockAddr *a);
 
 static inline struct sockaddr *
 g_sockaddr_get_sa(GSockAddr *self)
 {
   return &self->sa;
+}
+
+static inline GSockAddr *
+g_sockaddr_ref(GSockAddr *a)
+{
+  if (a)
+    g_atomic_counter_inc(&a->super.refcnt);
+  return a;
+}
+
+static inline void
+g_sockaddr_unref(GSockAddr *a)
+{
+  if (a)
+    {
+      if (g_atomic_counter_dec_and_test(&a->super.refcnt))
+        {
+          g_free(a);
+        }
+    }
 }
 
 gboolean g_sockaddr_inet_check(GSockAddr *a);

--- a/lib/gsocket.c
+++ b/lib/gsocket.c
@@ -82,7 +82,7 @@ g_bind(int fd, GSockAddr *addr)
     rc = funcs->bind(fd, addr);
   else
     {
-      if (addr && bind(fd, &addr->sa, addr->salen) < 0)
+      if (addr && bind(fd, &addr->sa, addr->super.salen) < 0)
         {
           return G_IO_STATUS_ERROR;
         }
@@ -144,7 +144,7 @@ g_connect(int fd, GSockAddr *remote)
 
   do
     {
-      rc = connect(fd, &remote->sa, remote->salen);
+      rc = connect(fd, &remote->sa, remote->super.salen);
     }
   while (rc == -1 && errno == EINTR);
   if (rc == -1)

--- a/lib/gsocket.c
+++ b/lib/gsocket.c
@@ -73,12 +73,13 @@ GIOStatus
 g_bind(int fd, GSockAddr *addr)
 {
   GIOStatus rc;
+  GSockAddrFuncs *funcs = __g_sockaddr_funcs(addr);
 
-  if (addr->sa_funcs && addr->sa_funcs->bind_prepare)
-    addr->sa_funcs->bind_prepare(fd, addr);
+  if (funcs->bind_prepare)
+    funcs->bind_prepare(fd, addr);
 
-  if (addr->sa_funcs && addr->sa_funcs->bind)
-    rc = addr->sa_funcs->bind(fd, addr);
+  if (funcs->bind)
+    rc = funcs->bind(fd, addr);
   else
     {
       if (addr && bind(fd, &addr->sa, addr->salen) < 0)

--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -288,7 +288,7 @@ resolve_sockaddr_to_local_hostname(gsize *result_len, GSockAddr *saddr, const Ho
 static const gchar *
 resolve_address_using_getnameinfo(GSockAddr *saddr, gchar *buf, gsize buf_len)
 {
-  if (getnameinfo(&saddr->sa, saddr->salen, buf, buf_len, NULL, 0, NI_NAMEREQD) == 0)
+  if (getnameinfo(&saddr->sa, saddr->super.salen, buf, buf_len, NULL, 0, NI_NAMEREQD) == 0)
     return buf;
   return NULL;
 }

--- a/lib/logmsg/tests/test_gsockaddr_serialize.c
+++ b/lib/logmsg/tests/test_gsockaddr_serialize.c
@@ -54,7 +54,7 @@ Test(gsockaddr_serialize, test_inet)
   cr_assert(g_sockaddr_serialize(sa, addr), "failed to serialize inet GSockAddr");
   cr_assert(g_sockaddr_deserialize(sa, &read_addr), "failed to read back inet GSockAddr");
 
-  cr_assert_arr_eq(g_sockaddr_inet_get_sa(addr), g_sockaddr_inet_get_sa(read_addr), addr->salen);
+  cr_assert_arr_eq(g_sockaddr_inet_get_sa(addr), g_sockaddr_inet_get_sa(read_addr), addr->super.salen);
 
   serialize_archive_free(sa);
   g_string_free(stream, TRUE);
@@ -73,7 +73,7 @@ Test(gsockaddr_serialize, test_inet6)
   cr_assert(g_sockaddr_serialize(sa, addr), "failed to serialize inet6 GSockAddr");
   cr_assert(g_sockaddr_deserialize(sa, &read_addr), "failed to read back inet6 GSockAddr");
 
-  cr_assert_arr_eq(g_sockaddr_inet6_get_sa(addr), g_sockaddr_inet6_get_sa(read_addr), addr->salen);
+  cr_assert_arr_eq(g_sockaddr_inet6_get_sa(addr), g_sockaddr_inet6_get_sa(read_addr), addr->super.salen);
 
   serialize_archive_free(sa);
   g_string_free(stream, TRUE);

--- a/tests/light/functional_tests/destination_drivers/network_destination/disk_buffer/helper_functions.py
+++ b/tests/light/functional_tests/destination_drivers/network_destination/disk_buffer/helper_functions.py
@@ -29,7 +29,7 @@ from axosyslog_light.syslog_ng_ctl.prometheus_stats_handler import MetricFilter
 
 
 SIZE_OF_MESSAGE_IN_DISKQ = 1452
-SIZE_OF_MESSAGE_IN_MEMORY = 2536
+SIZE_OF_MESSAGE_IN_MEMORY = 2504
 SIZE_OF_DISKQ = 1024 * 1024
 SIZE_OF_DISKQ_HEADER = 4096
 BufferParams = namedtuple(


### PR DESCRIPTION
This is split off from #1083 as this part is uncontroversial. It contains a number of cleanups to the gsockaddr.c module
as well as making the GSockAddr struct smaller (24 from 40 bytes)
