### PR TITLE
Add large timeout for syslog-ng spawn

### DIFF
--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "axosyslog-light"
-version = "1.18.1"
+version = "1.18.2"
 description = "Lightweight End-to-End Test Framework for AxoSyslog."
 authors = ["Andras Mitzki <andras.mitzki@axoflow.com>", "Attila Szakacs <attila.szakacs@axoflow.com>"]
 readme = "README.md"

--- a/tests/light/src/axosyslog_light/syslog_ng/syslog_ng.py
+++ b/tests/light/src/axosyslog_light/syslog_ng/syslog_ng.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from subprocess import Popen
 
 from axosyslog_light.common.blocking import wait_until_false
-from axosyslog_light.common.blocking import wait_until_true
+from axosyslog_light.common.blocking import wait_until_true_custom
 from axosyslog_light.syslog_ng.console_log_reader import ConsoleLogReader
 from axosyslog_light.syslog_ng.syslog_ng_executor import SyslogNgExecutor
 from axosyslog_light.syslog_ng.syslog_ng_executor import SyslogNgStartParams
@@ -198,7 +198,7 @@ class SyslogNg(object):
                 self.__validate_crash_returncode(self._process.returncode)
                 self.__error_handling("syslog-ng is not running")
             return s._syslog_ng_ctl.is_control_socket_alive()
-        return wait_until_true(is_alive, self)
+        return wait_until_true_custom(is_alive, (self,), timeout=120)
 
     def __wait_for_start(self) -> None:
         # wait for start and check start result


### PR DESCRIPTION
Increase startup timeout during light tests. It's needed due to some large configs, as initial JIT compilation takes time on startup.

```
# JIT enabled
Tests passed in 120.49s (0:02:00)

# JIT disabled
Tests passed in 81.47s (0:01:21)
```