### PR TITLE
Filterx switch range case

### DIFF
--- a/lib/filterx/expr-switch.c
+++ b/lib/filterx/expr-switch.c
@@ -24,6 +24,7 @@
 #include "expr-compound.h"
 #include "expr-comparison.h"
 #include "expr-literal.h"
+#include "expr-function.h"
 #include "object-string.h"
 #include "object-primitive.h"
 #include "filterx-eval.h"
@@ -101,7 +102,56 @@ _switch_case_single_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_da
 static gboolean
 _switch_case_range_match(FilterXSwitchCase *s, FilterXObject *selector, GError **error)
 {
-  return TRUE;
+
+  if (!(filterx_object_is_type(selector, &FILTERX_TYPE_NAME(integer))
+        || filterx_object_is_type(selector, &FILTERX_TYPE_NAME(double))))
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "Failed to evaluate range case operator. Selector value must be a double or integer, got: %s",
+                  filterx_object_get_type_name(selector));
+      return FALSE;
+    }
+
+  FilterXSwitchCaseRange *self = (FilterXSwitchCaseRange *) s;
+  FilterXObject *lower = filterx_expr_eval_typed(self->lower);
+  if (!lower)
+    return FALSE;
+  if (!(filterx_object_is_type(lower, &FILTERX_TYPE_NAME(integer))
+        || filterx_object_is_type(lower, &FILTERX_TYPE_NAME(double))))
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "Failed to evaluate range case operator. Lower value must be a double or integer, got: %s",
+                  filterx_object_get_type_name(lower));
+      filterx_object_unref(lower);
+      return FALSE;
+    }
+  FilterXObject *upper = filterx_expr_eval_typed(self->upper);
+  if (!upper)
+    {
+      filterx_object_unref(lower);
+      return FALSE;
+    }
+  if (!(filterx_object_is_type(upper, &FILTERX_TYPE_NAME(integer))
+        || filterx_object_is_type(upper, &FILTERX_TYPE_NAME(double))))
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "Failed to evaluate range case operator. Upper value must be a double or integer, got: %s",
+                  filterx_object_get_type_name(upper));
+      filterx_object_unref(lower);
+      filterx_object_unref(upper);
+      return FALSE;
+    }
+  gboolean result = FALSE;
+  if (filterx_compare_objects(lower, upper, FCMPX_NUM_BASED | FCMPX_LT))
+    result = filterx_compare_objects(lower, selector, FCMPX_NUM_BASED | FCMPX_LT | FCMPX_EQ) &&
+             filterx_compare_objects(selector, upper, FCMPX_NUM_BASED | FCMPX_LT);
+  else
+    g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                "Failed to evaluate range case operator. Upper boundary has to be greater than lower: %s",
+                filterx_object_get_type_name(upper));
+  filterx_object_unref(lower);
+  filterx_object_unref(upper);
+  return result;
 }
 
 static void

--- a/lib/filterx/expr-switch.c
+++ b/lib/filterx/expr-switch.c
@@ -44,6 +44,13 @@ typedef struct _FilterXSwitchCaseSingle
   FilterXExpr *value;   /* NULL for the default case */
 } FilterXSwitchCaseSingle;
 
+typedef struct _FilterXSwitchCaseRange
+{
+  FilterXSwitchCase super;
+  FilterXExpr *lower;
+  FilterXExpr *upper;
+} FilterXSwitchCaseRange;
+
 static inline gboolean
 filterx_switch_case_is_default(FilterXSwitchCase *self)
 {
@@ -91,6 +98,30 @@ _switch_case_single_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_da
   return TRUE;
 }
 
+static gboolean
+_switch_case_range_match(FilterXSwitchCase *s, FilterXObject *selector, GError **error)
+{
+  return TRUE;
+}
+
+static void
+_switch_case_range_free(FilterXExpr *s)
+{
+  FilterXSwitchCaseRange *self = (FilterXSwitchCaseRange *) s;
+  filterx_expr_unref(self->lower);
+  filterx_expr_unref(self->upper);
+  filterx_expr_free_method(s);
+}
+
+static gboolean
+_switch_case_range_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
+{
+  FilterXSwitchCaseRange *self = (FilterXSwitchCaseRange *) s;
+  if (!filterx_expr_visit(s, &self->lower, f, user_data))
+    return FALSE;
+  return filterx_expr_visit(s, &self->upper, f, user_data);
+}
+
 FilterXExpr *
 filterx_switch_case_new(FilterXExpr *value)
 {
@@ -101,6 +132,20 @@ filterx_switch_case_new(FilterXExpr *value)
   self->super.match = value ? _switch_case_single_match : NULL;
   self->super.target = -1;
   self->value = value;
+  return &self->super.super;
+}
+
+FilterXExpr *
+filterx_switch_case_range_new(FilterXExpr *lower, FilterXExpr *upper)
+{
+  FilterXSwitchCaseRange *self = g_new0(FilterXSwitchCaseRange, 1);
+  filterx_expr_init_instance(&self->super.super, FILTERX_EXPR_TYPE_NAME(switch_case), FXE_READ);
+  self->super.super.free_fn = _switch_case_range_free;
+  self->super.super.walk_children = _switch_case_range_walk;
+  self->super.match = _switch_case_range_match;
+  self->super.target = -1;
+  self->lower = lower;
+  self->upper = upper;
   return &self->super.super;
 }
 

--- a/lib/filterx/expr-switch.c
+++ b/lib/filterx/expr-switch.c
@@ -33,14 +33,21 @@ typedef struct _FilterXSwitchCase FilterXSwitchCase;
 
 struct _FilterXSwitchCase
 {
-  FilterXUnaryOp super;
+  FilterXExpr super;
+  gboolean (*match)(FilterXSwitchCase *self, FilterXObject *selector, GError **error);
   gsize target;
 };
+
+typedef struct _FilterXSwitchCaseSingle
+{
+  FilterXSwitchCase super;
+  FilterXExpr *value;   /* NULL for the default case */
+} FilterXSwitchCaseSingle;
 
 static inline gboolean
 filterx_switch_case_is_default(FilterXSwitchCase *self)
 {
-  return self->super.operand == NULL;
+  return self->match == NULL;
 }
 
 static void
@@ -55,17 +62,45 @@ filterx_switch_case_get_target(FilterXSwitchCase *self)
   return self->target;
 }
 
-static inline FilterXObject *
-_eval_switch_case(FilterXSwitchCase *self)
+static gboolean
+_switch_case_single_match(FilterXSwitchCase *s, FilterXObject *selector, GError **error)
 {
-  return filterx_expr_eval_typed(self->super.operand);
+  FilterXSwitchCaseSingle *self = (FilterXSwitchCaseSingle *) s;
+  FilterXObject *value = filterx_expr_eval_typed(self->value);
+  if (!value)
+    return FALSE;
+  gboolean result = filterx_compare_objects(selector, value, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_EQ);
+  filterx_object_unref(value);
+  return result;
+}
+
+static void
+_switch_case_single_free(FilterXExpr *s)
+{
+  FilterXSwitchCaseSingle *self = (FilterXSwitchCaseSingle *) s;
+  filterx_expr_unref(self->value);
+  filterx_expr_free_method(s);
+}
+
+static gboolean
+_switch_case_single_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
+{
+  FilterXSwitchCaseSingle *self = (FilterXSwitchCaseSingle *) s;
+  if (self->value)
+    return filterx_expr_visit(s, &self->value, f, user_data);
+  return TRUE;
 }
 
 FilterXExpr *
 filterx_switch_case_new(FilterXExpr *value)
 {
-  FilterXSwitchCase *self = g_new0(FilterXSwitchCase, 1);
-  filterx_unary_op_init_instance(&self->super, FILTERX_EXPR_TYPE_NAME(switch_case), FXE_READ, value);
+  FilterXSwitchCaseSingle *self = g_new0(FilterXSwitchCaseSingle, 1);
+  filterx_expr_init_instance(&self->super.super, FILTERX_EXPR_TYPE_NAME(switch_case), FXE_READ);
+  self->super.super.free_fn = _switch_case_single_free;
+  self->super.super.walk_children = _switch_case_single_walk;
+  self->super.match = value ? _switch_case_single_match : NULL;
+  self->super.target = -1;
+  self->value = value;
   return &self->super.super;
 }
 
@@ -99,10 +134,15 @@ _try_to_cache_literal_switch_case(FilterXSwitch *self, FilterXExpr *switch_case_
 {
   FilterXSwitchCase *switch_case = (FilterXSwitchCase *) switch_case_expr;
 
-  if (!filterx_expr_is_literal(switch_case->super.operand))
+  /* Only single-value (non-default, non-range) cases can be hash-cached */
+  if (switch_case->match != _switch_case_single_match)
     return FALSE;
 
-  FilterXObject *case_value = filterx_literal_get_value(switch_case->super.operand);
+  FilterXSwitchCaseSingle *single = (FilterXSwitchCaseSingle *) switch_case;
+  if (!filterx_expr_is_literal(single->value))
+    return FALSE;
+
+  FilterXObject *case_value = filterx_literal_get_value(single->value);
   if (!case_value)
     return FALSE;
 
@@ -113,10 +153,8 @@ _try_to_cache_literal_switch_case(FilterXSwitch *self, FilterXExpr *switch_case_
     }
 
   /* NOTE: g_hash_table_insert() frees the key if it was a duplicate */
-  if (!g_hash_table_insert(self->literal_cache, filterx_object_ref(case_value),
-                           filterx_expr_ref(&switch_case->super.super)))
+  if (!g_hash_table_insert(self->literal_cache, filterx_object_ref(case_value), filterx_expr_ref(&switch_case->super)))
     {
-
       /* Switch case already exists, this is not allowed. */
       _store_duplicate_cases_error(self, filterx_string_get_value_as_cstr(case_value));
     }
@@ -180,23 +218,15 @@ _find_matching_literal_case(FilterXSwitch *self, FilterXObject *selector)
 }
 
 static FilterXSwitchCase *
-_find_matching_case(FilterXSwitch *self, FilterXObject *selector)
+_find_matching_case(FilterXSwitch *self, FilterXObject *selector, GError **error)
 {
   for (gsize i = 0; i < self->cases->len; i++)
     {
       FilterXSwitchCase *switch_case = (FilterXSwitchCase *) g_ptr_array_index(self->cases, i);
-
-      FilterXObject *value = _eval_switch_case(switch_case);
-      if (!value)
-        continue;
-
-      if (filterx_compare_objects(selector, value, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_EQ))
-        {
-          filterx_object_unref(value);
-          return switch_case;
-        }
-
-      filterx_object_unref(value);
+      if (switch_case->match(switch_case, selector, error))
+        return switch_case;
+      if (error)
+        return NULL;
     }
   return NULL;
 }
@@ -214,10 +244,19 @@ _eval_switch(FilterXExpr *s)
     }
 
   FilterXSwitchCase *switch_case;
+  GError *error = NULL;
 
   switch_case = _find_matching_literal_case(self, selector);
   if (!switch_case)
-    switch_case = _find_matching_case(self, selector);
+    switch_case = _find_matching_case(self, selector, &error);
+
+  if (error)
+    {
+      filterx_eval_push_error_info_printf("Failed to evaluate switch", &self->super, "%s", error->message);
+      g_clear_error(&error);
+      filterx_object_unref(selector);
+      return NULL;
+    }
 
   gssize target = -1;
   if (switch_case)

--- a/lib/filterx/expr-switch.h
+++ b/lib/filterx/expr-switch.h
@@ -31,6 +31,7 @@ FilterXExpr *filterx_switch_new(FilterXExpr *selector, GList *body);
 
 /* a case in the switch statement */
 FilterXExpr *filterx_switch_case_new(FilterXExpr *value);
+FilterXExpr *filterx_switch_case_range_new(FilterXExpr *lower, FilterXExpr *upper);
 
 FILTERX_EXPR_DECLARE_TYPE(switch);
 FILTERX_EXPR_DECLARE_TYPE(switch_case);

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -538,6 +538,7 @@ cases
 
 case
 	: KW_CASE expr ':' 			{ $$ = filterx_switch_case_new($2); }
+	| KW_CASE expr LL_DOTDOT expr ':'	{ $$ = filterx_switch_case_range_new($2, $4); }
 	| KW_DEFAULT ':'			{ $$ = filterx_switch_case_new(NULL); }
 	| stmt					{ $$ = $1; }
 	;

--- a/news/feature-1093.md
+++ b/news/feature-1093.md
@@ -1,0 +1,17 @@
+`switch`: add ranged case support for FilterX `switch`
+
+Example usage:
+```
+selector = 5;
+switch (selector) {
+    case 1..4:
+        result = "below";
+        break;
+    case 5:
+        result = "exact";
+        break;
+    default:
+        result = "above";
+        break;
+};
+```

--- a/tests/light/functional_tests/filterx/test_filterx_control.py
+++ b/tests/light/functional_tests/filterx/test_filterx_control.py
@@ -541,8 +541,77 @@ def test_switch_invalid_case(config, syslog_ng):
         msg="string",
         filterx_expr_1=r"""
             switch (${values.str}) {
+              default:
+                result = "default";
+                break;
               case invalid.expr:
                 result = "no-no";
+                break;
+            };
+            $MSG=result;
+        """,
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "default"
+
+
+def test_switch_range_case_match(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config,
+        filterx_expr_1=r"""
+            switch (${values.int}) {
+              case 1..10:
+                result = "in-range";
+                break;
+              default:
+                result = "out-of-range";
+                break;
+            };
+            $MSG=result;
+        """,
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "in-range"
+
+
+def test_switch_range_case_no_match(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config,
+        filterx_expr_1=r"""
+            switch (${values.int}) {
+              case 10..20:
+                result = "in-range";
+                break;
+              default:
+                result = "out-of-range";
+                break;
+            };
+            $MSG=result;
+        """,
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "out-of-range"
+
+
+def test_switch_range_case_overlapping_first_wins(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config,
+        filterx_expr_1=r"""
+            switch (${values.int}) {
+              case 1..6:
+                result = "first";
+                break;
+              case 5..10:
+                result = "second";
                 break;
               default:
                 result = "default";
@@ -555,4 +624,26 @@ def test_switch_invalid_case(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "default"
+    assert file_true.read_log() == "first"
+
+
+def test_switch_range_case_double(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config,
+        filterx_expr_1=r"""
+            switch (${values.double}) {
+              case 30.0..35.0:
+                result = "in-range";
+                break;
+              default:
+                result = "out-of-range";
+                break;
+            };
+            $MSG=result;
+        """,
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "in-range"


### PR DESCRIPTION
Example usage:
```
switch (${values.int}) {
    case 1..4:
        result = "below";
        break;
    case 5:
        result = "exact";
        break;
    default:
        result = "above";
        break;
};
```
