### PR TITLE
filterx-config: disable JIT by default

### DIFF
--- a/lib/filterx/filterx-config.c
+++ b/lib/filterx/filterx-config.c
@@ -91,7 +91,7 @@ filterx_config_init(ModuleConfig *s, GlobalConfig *cfg)
 #endif
 
   if (self->enable_jit == -1)
-    self->enable_jit = TRUE;
+    self->enable_jit = FALSE;
 
   if (self->enable_jit)
     self->jit = _create_jit(self->jit_debug_info);


### PR DESCRIPTION
It's not ready to be enabled by default:
- startup time has to be improved on big filterx blocks (cache, filterx block dedup, smaller inline thresholds, etc.)
- the performance is not predictable across CPU models (needs further investigation)