### PR TITLE
filterx/expr-comparison: use string() cast to do string based comparison

### DIFF
--- a/lib/filterx/expr-comparison.c
+++ b/lib/filterx/expr-comparison.c
@@ -87,8 +87,7 @@ _convert_filterx_object_to_string(FilterXObject *obj, gsize *len)
     }
 
   GString *buffer = scratch_buffers_alloc();
-  LogMessageValueType lmvt;
-  if (!filterx_object_marshal(obj, buffer, &lmvt))
+  if (!filterx_object_str(obj, buffer))
     return NULL;
 
   *len = buffer->len;

--- a/lib/filterx/tests/test_expr_comparison.c
+++ b/lib/filterx/tests/test_expr_comparison.c
@@ -485,8 +485,8 @@ Test(expr_comparison, test_string_to_numeric_string_based_comparison)
 Test(expr_comparison, test_string_to_null_string_based_comparison)
 {
   _assert_comparison(filterx_string_new("3", 1), filterx_null_new(), FCMPX_EQ | FCMPX_STRING_BASED, FALSE);
-  _assert_comparison(filterx_string_new("3", 1), filterx_null_new(), FCMPX_LT | FCMPX_STRING_BASED, FALSE);
-  _assert_comparison(filterx_string_new("3", 1), filterx_null_new(), FCMPX_GT | FCMPX_STRING_BASED, TRUE);
+  _assert_comparison(filterx_string_new("3", 1), filterx_null_new(), FCMPX_LT | FCMPX_STRING_BASED, TRUE);
+  _assert_comparison(filterx_string_new("3", 1), filterx_null_new(), FCMPX_GT | FCMPX_STRING_BASED, FALSE);
   _assert_comparison(filterx_string_new("3", 1), filterx_null_new(), FCMPX_NE | FCMPX_STRING_BASED, TRUE);
 }
 
@@ -518,22 +518,22 @@ Test(expr_comparison, test_string_to_boolean_string_based_comparison)
 Test(expr_comparison, test_string_to_datetime_string_based_comparison)
 {
   UnixTime ut = { .ut_sec = 1701350398, .ut_usec = 123000, .ut_gmtoff = 3600 };
-  _assert_comparison(filterx_string_new("1701350398.123000+01:00", 23), filterx_datetime_new(&ut),
+  _assert_comparison(filterx_string_new("1701350398.123000", -1), filterx_datetime_new(&ut),
                      FCMPX_EQ | FCMPX_STRING_BASED, TRUE);
-  _assert_comparison(filterx_string_new("1701350398.123000+01:00", 23), filterx_datetime_new(&ut),
+  _assert_comparison(filterx_string_new("1701350398.123000", -1), filterx_datetime_new(&ut),
                      FCMPX_LT | FCMPX_STRING_BASED, FALSE);
-  _assert_comparison(filterx_string_new("1701350398.123000+01:00", 23), filterx_datetime_new(&ut),
+  _assert_comparison(filterx_string_new("1701350398.123000", -1), filterx_datetime_new(&ut),
                      FCMPX_GT | FCMPX_STRING_BASED, FALSE);
-  _assert_comparison(filterx_string_new("1701350398.123000+01:00", 23), filterx_datetime_new(&ut),
+  _assert_comparison(filterx_string_new("1701350398.123000", -1), filterx_datetime_new(&ut),
                      FCMPX_NE | FCMPX_STRING_BASED, FALSE);
 
-  _assert_comparison(filterx_string_new("1701350398.124000+01:00", 23), filterx_datetime_new(&ut),
+  _assert_comparison(filterx_string_new("1701350398.124000", -1), filterx_datetime_new(&ut),
                      FCMPX_EQ | FCMPX_STRING_BASED, FALSE);
-  _assert_comparison(filterx_string_new("1701350398.124000+01:00", 23), filterx_datetime_new(&ut),
+  _assert_comparison(filterx_string_new("1701350398.124000", -1), filterx_datetime_new(&ut),
                      FCMPX_LT | FCMPX_STRING_BASED, FALSE);
-  _assert_comparison(filterx_string_new("1701350398.124000+01:00", 23), filterx_datetime_new(&ut),
+  _assert_comparison(filterx_string_new("1701350398.124000", -1), filterx_datetime_new(&ut),
                      FCMPX_GT | FCMPX_STRING_BASED, TRUE);
-  _assert_comparison(filterx_string_new("1701350398.124000+01:00", 23), filterx_datetime_new(&ut),
+  _assert_comparison(filterx_string_new("1701350398.124000", -1), filterx_datetime_new(&ut),
                      FCMPX_NE | FCMPX_STRING_BASED, TRUE);
 }
 

--- a/news/bugfix-1098.md
+++ b/news/bugfix-1098.md
@@ -1,0 +1,5 @@
+comparisons in filterx: when comparing values with different types as
+strings, use the result of the string() cast instead of relying on the
+marshalled format.  This is an incompatible change when comparing null() and
+datetime() objects against strings, but comparing those to strings is rare
+and this was considered to be a more intuitive behaviour.


### PR DESCRIPTION
Previously we were using the format generated by filterx_object_marshal(), however that does not make much sense and is probably an artifact from the past where string() did not exist. This is a breaking change for datetime and null objects.

Let's discuss if this makes sense or not.