### PR TITLE
Light filterx pipeline smoke

### DIFF
--- a/dbld/callgrind-syslog-ng.conf
+++ b/dbld/callgrind-syslog-ng.conf
@@ -724,7 +724,7 @@ channel {
     };
   };
 };
-destination "devnull-dd4560bf" {
+destination "filedest-dd4560bf" {
   channel {
     filterx {
       classified_metric_labels += {
@@ -733,7 +733,9 @@ destination "devnull-dd4560bf" {
           "flow": meta.flow,
         };
     };
-    destination{};
+    destination{
+      file("output.txt");
+    };
   };
 };
 log "axorouter-minio-axorouter" {
@@ -767,7 +769,7 @@ log "axorouter-minio-axorouter" {
 ;
   };
   log {
-    destination("devnull-dd4560bf");
+    destination("filedest-dd4560bf");
     flags(flow-control);
   };
 };

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -62,6 +62,7 @@ tests/light/pytest.ini
 tests/light/tox.ini
 tests/light/.pre-commit-config.yaml
 tests/light/reports
+tests/light/shared_files/.*syslog-ng\.conf$
 .github/workflows/.*$
 lib/logmsg/tests/messages/syslog-ng-(pe-)?[.0-9]*-msg.h$
 lib/logmsg/tests/messages/axosyslog-[.0-9]*-msg.h$

--- a/tests/light/functional_tests/filterx/test_filterx_pipeline_smoke.py
+++ b/tests/light/functional_tests/filterx/test_filterx_pipeline_smoke.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+# Copyright (c) 2026 Andras Mitzki <andras.mitzki@axoflow.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from pathlib import Path
+
+from axosyslog_light.common.file import copy_shared_file
+from axosyslog_light.driver_io.file.file_io import FileIO
+
+
+def test_filterx_pipeline_smoke(config, syslog_ng, testcase_parameters, loggen, syslog_ng_ctl):
+    copy_shared_file(testcase_parameters, "callgrind-syslog-ng.conf")
+    copy_shared_file(testcase_parameters, "callgrind-samples.log")
+    config_content = Path("callgrind-syslog-ng.conf").read_text()
+    config.set_raw_config(config_content)
+
+    syslog_ng.start(config)
+    network_source = config.create_network_source(ip="localhost", port=2000)
+    logs = FileIO("callgrind-samples.log").read_all()
+    network_source.write_logs(logs)
+
+    file_destination = config.create_file_destination(file_name="output.txt")
+    assert len(file_destination.read_logs(len(logs))) == len(logs)
+
+    syslog_ng.stop()

--- a/tests/light/shared_files/callgrind-samples.log
+++ b/tests/light/shared_files/callgrind-samples.log
@@ -1,0 +1,1 @@
+../../../dbld/callgrind-samples.log

--- a/tests/light/shared_files/callgrind-syslog-ng.conf
+++ b/tests/light/shared_files/callgrind-syslog-ng.conf
@@ -1,0 +1,1 @@
+../../../dbld/callgrind-syslog-ng.conf


### PR DESCRIPTION
Added new test_filterx_pipeline testcase to use with the previously committed callgrind-syslog-ng.conf and callgrind-samples.log files. 