### PR TITLE
Http openobserve error handling

### DIFF
--- a/modules/http-adapters/CMakeLists.txt
+++ b/modules/http-adapters/CMakeLists.txt
@@ -13,6 +13,8 @@ set(HTTP_ADAPTERS_SOURCES
     http-adapters-plugin.c
     splunk-adapter.c
     splunk-adapter.h
+    openobserve-adapter.c
+    openobserve-adapter.h
 )
 
 add_module(

--- a/modules/http-adapters/Makefile.am
+++ b/modules/http-adapters/Makefile.am
@@ -6,6 +6,8 @@ modules_http_adapters_libhttp_adapters_la_SOURCES = \
   modules/http-adapters/http-adapter.h \
   modules/http-adapters/splunk-adapter.c \
   modules/http-adapters/splunk-adapter.h \
+  modules/http-adapters/openobserve-adapter.c \
+  modules/http-adapters/openobserve-adapter.h \
   modules/http-adapters/http-adapters-grammar.y \
   modules/http-adapters/http-adapters-plugin.c \
   modules/http-adapters/http-adapters-parser.h \

--- a/modules/http-adapters/http-adapter.c
+++ b/modules/http-adapters/http-adapter.c
@@ -21,6 +21,8 @@
  */
 
 #include "http-adapter.h"
+#include "splunk-adapter.h"
+#include "openobserve-adapter.h"
 
 #define HTTP_ADAPTER_PLUGIN "http-adapter"
 
@@ -56,4 +58,14 @@ http_adapter_init_instance(HttpAdapter *self)
   log_driver_plugin_init_instance(&(self->super), HTTP_ADAPTER_PLUGIN);
   self->super.attach = _attach;
   self->super.detach = _detach;
+}
+
+HttpAdapter *
+http_adapter_new_by_name(const gchar *name)
+{
+  if (strcmp(name, "splunk") == 0)
+    return splunk_adapter_new();
+  if (strcmp(name, "openobserve") == 0)
+    return openobserve_adapter_new();
+  return NULL;
 }

--- a/modules/http-adapters/http-adapter.c
+++ b/modules/http-adapters/http-adapter.c
@@ -23,8 +23,52 @@
 #include "http-adapter.h"
 #include "splunk-adapter.h"
 #include "openobserve-adapter.h"
+#include "compat/string.h"
 
 #define HTTP_ADAPTER_PLUGIN "http-adapter"
+
+json_object *
+http_adapter_parse_response_json(GString *response)
+{
+  struct json_object *jso;
+  struct json_tokener *tok;
+
+  tok = json_tokener_new();
+  jso = json_tokener_parse_ex(tok, response->str, response->len);
+  if (tok->err != json_tokener_success || !jso)
+    {
+      msg_error("http-response-adapter(): failed to parse JSON response",
+                evt_tag_str("input", response->str),
+                tok->err != json_tokener_success ? evt_tag_str("json_error", json_tokener_error_desc(tok->err)) : NULL);
+      json_tokener_free(tok);
+      return NULL;
+    }
+  json_tokener_free(tok);
+  return jso;
+}
+
+void
+http_adapter_locate_offending_payload(HttpResponseSignalData *data)
+{
+  const gchar *line = data->request_body->str;
+
+  for (gint i = 0; i < data->offending_message; i++)
+    {
+      const gchar *nl = strchr(line, '\n');
+      if (!nl)
+        goto notfound;
+      line = nl + 1;
+    }
+  data->offending_request_len = strchrnul(line, '\n') - line;
+  if (data->offending_request_len != 0)
+    {
+      data->offending_request_start = line - data->request_body->str;
+      return;
+    }
+
+notfound:
+  data->offending_request_start = data->offending_request_len = 0;
+}
 
 static void
 _on_http_response_received(HttpAdapter *self, HttpResponseSignalData *data)

--- a/modules/http-adapters/http-adapter.h
+++ b/modules/http-adapters/http-adapter.h
@@ -47,5 +47,6 @@ http_adapter_free(HttpAdapter *self)
 }
 
 void http_adapter_init_instance(HttpAdapter *self);
+HttpAdapter *http_adapter_new_by_name(const gchar *name);
 
 #endif

--- a/modules/http-adapters/http-adapter.h
+++ b/modules/http-adapters/http-adapter.h
@@ -25,6 +25,7 @@
 
 #include "driver.h"
 #include "modules/http/http-signals.h"
+#include <json.h>
 
 typedef struct _HttpAdapter HttpAdapter;
 
@@ -48,5 +49,8 @@ http_adapter_free(HttpAdapter *self)
 
 void http_adapter_init_instance(HttpAdapter *self);
 HttpAdapter *http_adapter_new_by_name(const gchar *name);
+
+json_object *http_adapter_parse_response_json(GString *response);
+void http_adapter_locate_offending_payload(HttpResponseSignalData *data);
 
 #endif

--- a/modules/http-adapters/http-adapters-grammar.ym
+++ b/modules/http-adapters/http-adapters-grammar.ym
@@ -21,8 +21,7 @@
  */
 
 %code top {
-#include "splunk-adapter.h"
-#include "openobserve-adapter.h"
+#include "http-adapter.h"
 
 }
 
@@ -74,15 +73,8 @@ driver
 http_response_adapter
     : KW_RESPONSE_ADAPTER '(' string ')'
       {
-        if (strcmp($3, "splunk") == 0)
-          $$ = splunk_adapter_new();
-        else if (strcmp($3, "openobserve") == 0)
-          $$ = openobserve_adapter_new();
-        else
-          {
-            CHECK_ERROR(FALSE, @3, "Unknown response adapter \"%s\"", $3);
-            $$ = NULL;
-          }
+        $$ = http_adapter_new_by_name($3);
+        CHECK_ERROR($$ != NULL, @3, "Unknown response adapter \"%s\"", $3);
         free($3);
       }
     ;

--- a/modules/http-adapters/http-adapters-grammar.ym
+++ b/modules/http-adapters/http-adapters-grammar.ym
@@ -22,6 +22,7 @@
 
 %code top {
 #include "splunk-adapter.h"
+#include "openobserve-adapter.h"
 
 }
 
@@ -73,9 +74,16 @@ driver
 http_response_adapter
     : KW_RESPONSE_ADAPTER '(' string ')'
       {
-        CHECK_ERROR(strcmp($3, "splunk") == 0, @3, "Unknown response adapter \"%s\"", $3);
-        $$ = splunk_adapter_new();
-	free($3);
+        if (strcmp($3, "splunk") == 0)
+          $$ = splunk_adapter_new();
+        else if (strcmp($3, "openobserve") == 0)
+          $$ = openobserve_adapter_new();
+        else
+          {
+            CHECK_ERROR(FALSE, @3, "Unknown response adapter \"%s\"", $3);
+            $$ = NULL;
+          }
+        free($3);
       }
     ;
 

--- a/modules/http-adapters/openobserve-adapter.c
+++ b/modules/http-adapters/openobserve-adapter.c
@@ -34,6 +34,23 @@ _adapt_openobserve_response(HttpAdapter *self, HttpResponseSignalData *data)
   if (data->http_code != 200)
     return;
 
+  /* performance optimization:
+   *   - unfortunately the status code does not help us narrow down to cases
+   *     where our post generated a failure
+   *
+   *   - I used heuristics to decide if we need to properly parse the response
+   *
+   *   - the first "},{" filters out cases where we have multiple items in the
+   *     "status" member, in that case we have to parse
+   *
+   *   - if we have a single element in "status", then we check that the
+   *     number of failed entries is zero
+   */
+
+  if (strstr(data->response_body->str, "},{") == NULL &&
+      strstr(data->response_body->str, ",\"failed\":0") != NULL)
+    return;
+
   struct json_object *jso = http_adapter_parse_response_json(data->response_body);
   if (!jso)
     return;

--- a/modules/http-adapters/openobserve-adapter.c
+++ b/modules/http-adapters/openobserve-adapter.c
@@ -95,7 +95,8 @@ _adapt_openobserve_response(HttpAdapter *self, HttpResponseSignalData *data)
       data->offending_message = (guint) total_successful;
       if (data->offending_message >= data->batch_size)
         data->offending_message = 0;
-      http_adapter_locate_offending_payload(data);
+      else
+        http_adapter_locate_offending_payload(data);
     }
 
 exit:

--- a/modules/http-adapters/openobserve-adapter.c
+++ b/modules/http-adapters/openobserve-adapter.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "openobserve-adapter.h"
+#include "compat/string.h"
+#include <json.h>
+
+static json_object *
+_parse_response_json(GString *response)
+{
+  struct json_object *jso;
+  struct json_tokener *tok;
+
+  tok = json_tokener_new();
+  jso = json_tokener_parse_ex(tok, response->str, response->len);
+  if (tok->err != json_tokener_success || !jso)
+    {
+      msg_error("http-response-adapter(): failed to parse JSON response",
+                evt_tag_str("input", response->str),
+                tok->err != json_tokener_success ? evt_tag_str("json_error", json_tokener_error_desc(tok->err)) : NULL);
+      json_tokener_free(tok);
+      return NULL;
+    }
+  json_tokener_free(tok);
+  return jso;
+}
+
+static void
+_locate_offending_payload(HttpResponseSignalData *data)
+{
+  const gchar *line = data->request_body->str;
+
+  for (gint i = 0; i < data->offending_message; i++)
+    {
+      const gchar *nl = strchr(line, '\n');
+      if (!nl)
+        goto notfound;
+      line = nl + 1;
+    }
+  data->offending_request_len = strchrnul(line, '\n') - line;
+  if (data->offending_request_len != 0)
+    {
+      data->offending_request_start = line - data->request_body->str;
+      return;
+    }
+
+notfound:
+  data->offending_request_start = data->offending_request_len = 0;
+}
+
+/* OpenObserve returns HTTP 200 for partial batch failures, with a JSON body of the form:
+ *   {"code":200,"status":[{"name":"<stream>","successful":N,"failed":M,"error":"<reason>"},...]}
+ *
+ * The adapter detects failures in the status array and identifies the first failing message
+ * by assuming messages are processed in order: the first failure is at index total_successful.
+ */
+static void
+_adapt_openobserve_response(HttpAdapter *self, HttpResponseSignalData *data)
+{
+  if (data->http_code != 200)
+    return;
+
+  struct json_object *jso = _parse_response_json(data->response_body);
+  if (!jso)
+    return;
+
+  struct json_object *status_jso = NULL;
+  if (!json_object_object_get_ex(jso, "status", &status_jso))
+    goto exit;
+
+  if (!json_object_is_type(status_jso, json_type_array))
+    goto exit;
+
+  gint total_successful = 0;
+  gint total_failed = 0;
+  const gchar *first_error = NULL;
+
+  gint num_entries = json_object_array_length(status_jso);
+  for (gint i = 0; i < num_entries; i++)
+    {
+      struct json_object *entry = json_object_array_get_idx(status_jso, i);
+      struct json_object *successful_jso = NULL;
+      struct json_object *failed_jso = NULL;
+      struct json_object *error_jso = NULL;
+
+      json_object_object_get_ex(entry, "successful", &successful_jso);
+      json_object_object_get_ex(entry, "failed", &failed_jso);
+      json_object_object_get_ex(entry, "error", &error_jso);
+
+      if (successful_jso)
+        total_successful += json_object_get_int(successful_jso);
+      if (failed_jso)
+        total_failed += json_object_get_int(failed_jso);
+      if (error_jso && !first_error)
+        first_error = json_object_get_string(error_jso);
+    }
+
+  if (total_failed > 0)
+    {
+      msg_notice("openobserve: partial batch failure reported by server",
+                 evt_tag_int("successful", total_successful),
+                 evt_tag_int("failed", total_failed),
+                 first_error ? evt_tag_str("error", first_error) : NULL);
+      data->offending_message = (guint) total_successful;
+      if (data->offending_message >= data->batch_size)
+        data->offending_message = 0;
+      _locate_offending_payload(data);
+    }
+
+exit:
+  json_object_put(jso);
+}
+
+
+HttpAdapter *
+openobserve_adapter_new(void)
+{
+  HttpAdapter *self = g_new0(HttpAdapter, 1);
+  http_adapter_init_instance(self);
+  self->adapt_response = _adapt_openobserve_response;
+  return self;
+}

--- a/modules/http-adapters/openobserve-adapter.c
+++ b/modules/http-adapters/openobserve-adapter.c
@@ -20,51 +20,7 @@
  *
  */
 #include "openobserve-adapter.h"
-#include "compat/string.h"
 #include <json.h>
-
-static json_object *
-_parse_response_json(GString *response)
-{
-  struct json_object *jso;
-  struct json_tokener *tok;
-
-  tok = json_tokener_new();
-  jso = json_tokener_parse_ex(tok, response->str, response->len);
-  if (tok->err != json_tokener_success || !jso)
-    {
-      msg_error("http-response-adapter(): failed to parse JSON response",
-                evt_tag_str("input", response->str),
-                tok->err != json_tokener_success ? evt_tag_str("json_error", json_tokener_error_desc(tok->err)) : NULL);
-      json_tokener_free(tok);
-      return NULL;
-    }
-  json_tokener_free(tok);
-  return jso;
-}
-
-static void
-_locate_offending_payload(HttpResponseSignalData *data)
-{
-  const gchar *line = data->request_body->str;
-
-  for (gint i = 0; i < data->offending_message; i++)
-    {
-      const gchar *nl = strchr(line, '\n');
-      if (!nl)
-        goto notfound;
-      line = nl + 1;
-    }
-  data->offending_request_len = strchrnul(line, '\n') - line;
-  if (data->offending_request_len != 0)
-    {
-      data->offending_request_start = line - data->request_body->str;
-      return;
-    }
-
-notfound:
-  data->offending_request_start = data->offending_request_len = 0;
-}
 
 /* OpenObserve returns HTTP 200 for partial batch failures, with a JSON body of the form:
  *   {"code":200,"status":[{"name":"<stream>","successful":N,"failed":M,"error":"<reason>"},...]}
@@ -78,7 +34,7 @@ _adapt_openobserve_response(HttpAdapter *self, HttpResponseSignalData *data)
   if (data->http_code != 200)
     return;
 
-  struct json_object *jso = _parse_response_json(data->response_body);
+  struct json_object *jso = http_adapter_parse_response_json(data->response_body);
   if (!jso)
     return;
 
@@ -122,7 +78,7 @@ _adapt_openobserve_response(HttpAdapter *self, HttpResponseSignalData *data)
       data->offending_message = (guint) total_successful;
       if (data->offending_message >= data->batch_size)
         data->offending_message = 0;
-      _locate_offending_payload(data);
+      http_adapter_locate_offending_payload(data);
     }
 
 exit:

--- a/modules/http-adapters/openobserve-adapter.c
+++ b/modules/http-adapters/openobserve-adapter.c
@@ -51,9 +51,11 @@ _adapt_openobserve_response(HttpAdapter *self, HttpResponseSignalData *data)
       strstr(data->response_body->str, ",\"failed\":0") != NULL)
     return;
 
+  data->result = HTTP_SLOT_CRITICAL_ERROR;
+
   struct json_object *jso = http_adapter_parse_response_json(data->response_body);
   if (!jso)
-    return;
+    goto exit;
 
   struct json_object *status_jso = NULL;
   if (!json_object_object_get_ex(jso, "status", &status_jso))
@@ -97,6 +99,10 @@ _adapt_openobserve_response(HttpAdapter *self, HttpResponseSignalData *data)
         data->offending_message = 0;
       else
         http_adapter_locate_offending_payload(data);
+    }
+  else
+    {
+      data->result = HTTP_SLOT_SUCCESS;
     }
 
 exit:

--- a/modules/http-adapters/openobserve-adapter.h
+++ b/modules/http-adapters/openobserve-adapter.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef OPENOBSERVE_ADAPTER_H_INCLUDED
+#define OPENOBSERVE_ADAPTER_H_INCLUDED 1
+
+#include "http-adapter.h"
+
+HttpAdapter *openobserve_adapter_new(void);
+
+#endif

--- a/modules/http-adapters/splunk-adapter.c
+++ b/modules/http-adapters/splunk-adapter.c
@@ -20,60 +20,14 @@
  *
  */
 #include "http-adapter.h"
-#include "compat/string.h"
 #include <json.h>
-
-static json_object *
-_parse_response_json(GString *response)
-{
-  struct json_object *jso;
-  struct json_tokener *tok;
-
-  tok = json_tokener_new();
-  jso = json_tokener_parse_ex(tok, response->str, response->len);
-  if (tok->err != json_tokener_success || !jso)
-    {
-      msg_error("http-response-adapter(): failed to parse JSON response",
-                evt_tag_str("input", response->str),
-                tok->err != json_tokener_success ? evt_tag_str ("json_error", json_tokener_error_desc(tok->err)) : NULL);
-      json_tokener_free (tok);
-      return NULL;
-    }
-  json_tokener_free(tok);
-  return jso;
-}
-
-static void
-_locate_offending_payload(HttpResponseSignalData *data)
-{
-  const gchar *line = data->request_body->str;
-
-  for (gint i = 0; i < data->offending_message; i++)
-    {
-      const gchar *nl = strchr(line, '\n');
-      if (!nl)
-        goto notfound;
-      line = nl + 1;
-    }
-  data->offending_request_len = strchrnul(line, '\n') - line;
-  if (data->offending_request_len != 0)
-    {
-      data->offending_request_start = line - data->request_body->str;
-      return;
-    }
-
-notfound:
-
-  data->offending_request_start = data->offending_request_len = 0;
-  return;
-}
 
 static void
 _adapt_splunk_response(HttpAdapter *self, HttpResponseSignalData *data)
 {
   if (data->http_code >= 400)
     {
-      struct json_object *jso = _parse_response_json(data->response_body);
+      struct json_object *jso = http_adapter_parse_response_json(data->response_body);
       if (jso)
         {
           struct json_object *text_jso = NULL;
@@ -85,7 +39,7 @@ _adapt_splunk_response(HttpAdapter *self, HttpResponseSignalData *data)
           data->offending_message = json_object_get_int(event_num_jso);
           if (data->offending_message >= data->batch_size)
             data->offending_message = 0;
-          _locate_offending_payload(data);
+          http_adapter_locate_offending_payload(data);
 exit:
           json_object_put(jso);
         }

--- a/modules/http-adapters/splunk-adapter.c
+++ b/modules/http-adapters/splunk-adapter.c
@@ -39,7 +39,8 @@ _adapt_splunk_response(HttpAdapter *self, HttpResponseSignalData *data)
           data->offending_message = json_object_get_int(event_num_jso);
           if (data->offending_message >= data->batch_size)
             data->offending_message = 0;
-          http_adapter_locate_offending_payload(data);
+          else
+            http_adapter_locate_offending_payload(data);
 exit:
           json_object_put(jso);
         }

--- a/modules/http-adapters/splunk-adapter.c
+++ b/modules/http-adapters/splunk-adapter.c
@@ -27,6 +27,7 @@ _adapt_splunk_response(HttpAdapter *self, HttpResponseSignalData *data)
 {
   if (data->http_code >= 400)
     {
+      data->result = HTTP_SLOT_CRITICAL_ERROR;
       struct json_object *jso = http_adapter_parse_response_json(data->response_body);
       if (jso)
         {

--- a/modules/http-adapters/splunk-adapter.c
+++ b/modules/http-adapters/splunk-adapter.c
@@ -22,30 +22,35 @@
 #include "http-adapter.h"
 #include <json.h>
 
+/* only confirmed event rejections are flagged as critical errors, other
+ * 4XX/5XX responses (auth failures, server errors) are left to the default
+ * status code mapping, which knows which of those are worth retrying */
 static void
 _adapt_splunk_response(HttpAdapter *self, HttpResponseSignalData *data)
 {
-  if (data->http_code >= 400)
-    {
-      data->result = HTTP_SLOT_CRITICAL_ERROR;
-      struct json_object *jso = http_adapter_parse_response_json(data->response_body);
-      if (jso)
-        {
-          struct json_object *text_jso = NULL;
-          struct json_object *event_num_jso = NULL;
-          if (!json_object_object_get_ex(jso, "text", &text_jso))
-            goto exit;
-          if (!json_object_object_get_ex(jso, "invalid-event-number", &event_num_jso))
-            goto exit;
-          data->offending_message = json_object_get_int(event_num_jso);
-          if (data->offending_message >= data->batch_size)
-            data->offending_message = 0;
-          else
-            http_adapter_locate_offending_payload(data);
+  if (data->http_code < 400)
+    return;
+
+  struct json_object *jso = http_adapter_parse_response_json(data->response_body);
+  if (!jso)
+    return;
+
+  struct json_object *text_jso = NULL;
+  struct json_object *event_num_jso = NULL;
+  if (!json_object_object_get_ex(jso, "text", &text_jso))
+    goto exit;
+  if (!json_object_object_get_ex(jso, "invalid-event-number", &event_num_jso))
+    goto exit;
+
+  data->result = HTTP_SLOT_CRITICAL_ERROR;
+  data->offending_message = json_object_get_int(event_num_jso);
+  if (data->offending_message >= data->batch_size)
+    data->offending_message = 0;
+  else
+    http_adapter_locate_offending_payload(data);
+
 exit:
-          json_object_put(jso);
-        }
-    }
+  json_object_put(jso);
 }
 
 

--- a/modules/http-adapters/tests/CMakeLists.txt
+++ b/modules/http-adapters/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_unit_test(CRITERION TARGET test_splunk_adapter INCLUDES ${PROJECT_SOURCE_DIR} DEPENDS http-adapters)
+add_unit_test(CRITERION TARGET test_openobserve_adapter INCLUDES ${PROJECT_SOURCE_DIR} DEPENDS http-adapters)

--- a/modules/http-adapters/tests/Makefile.am
+++ b/modules/http-adapters/tests/Makefile.am
@@ -1,7 +1,8 @@
 if ENABLE_HTTP
 
 modules_http_adapters_tests_TESTS                        = \
-        modules/http-adapters/tests/test_splunk_adapter
+        modules/http-adapters/tests/test_splunk_adapter \
+        modules/http-adapters/tests/test_openobserve_adapter
 
 check_PROGRAMS                                  += ${modules_http_adapters_tests_TESTS}
 
@@ -10,6 +11,13 @@ EXTRA_modules_http_adapters_tests_test_splunk_adapter_DEPENDENCIES =      \
 modules_http_adapters_tests_test_splunk_adapter_CFLAGS     = $(TEST_CFLAGS) -I$(top_srcdir)/modules/http-adapters
 modules_http_adapters_tests_test_splunk_adapter_LDADD      = $(TEST_LDADD)
 modules_http_adapters_tests_test_splunk_adapter_LDFLAGS    = \
+        -dlpreopen $(top_builddir)/modules/http-adapters/libhttp-adapters.la
+
+EXTRA_modules_http_adapters_tests_test_openobserve_adapter_DEPENDENCIES =      \
+        $(top_builddir)/modules/http-adapters/libhttp-adapters.la
+modules_http_adapters_tests_test_openobserve_adapter_CFLAGS     = $(TEST_CFLAGS) -I$(top_srcdir)/modules/http-adapters
+modules_http_adapters_tests_test_openobserve_adapter_LDADD      = $(TEST_LDADD)
+modules_http_adapters_tests_test_openobserve_adapter_LDFLAGS    = \
         -dlpreopen $(top_builddir)/modules/http-adapters/libhttp-adapters.la
 
 

--- a/modules/http-adapters/tests/test_openobserve_adapter.c
+++ b/modules/http-adapters/tests/test_openobserve_adapter.c
@@ -50,6 +50,7 @@ Test(openobserve_adapter, test_partial_failure_sets_offending_message)
 
   http_adapter_adapt_response(oa, &data);
 
+  cr_assert_eq(data.http_code, 400);
   cr_assert_eq(data.offending_message, 2);
 
   gchar *offending_request = _extract_offending_request(&data);
@@ -77,6 +78,7 @@ Test(openobserve_adapter, test_all_failed_points_to_first_message)
 
   http_adapter_adapt_response(oa, &data);
 
+  cr_assert_eq(data.http_code, 400);
   cr_assert_eq(data.offending_message, 0);
 
   gchar *offending_request = _extract_offending_request(&data);
@@ -106,6 +108,7 @@ Test(openobserve_adapter, test_all_successful_no_change)
 
   http_adapter_adapt_response(oa, &data);
 
+  cr_assert_eq(data.http_code, 200);
   cr_assert_eq(data.offending_message, 0);
   cr_assert_eq(data.offending_request_start, 0);
   cr_assert_eq(data.offending_request_len, 0);
@@ -135,6 +138,7 @@ Test(openobserve_adapter, test_multiple_status_entries_sum_successful)
 
   http_adapter_adapt_response(oa, &data);
 
+  cr_assert_eq(data.http_code, 400);
   /* First failed message is at index 2+1=3 (0-based) */
   cr_assert_eq(data.offending_message, 3);
 
@@ -164,6 +168,34 @@ Test(openobserve_adapter, test_successful_count_exceeds_batch_size_resets_to_zer
 
   http_adapter_adapt_response(oa, &data);
 
+  cr_assert_eq(data.http_code, 400);
+  cr_assert_eq(data.offending_message, 0);
+  cr_assert_eq(data.offending_request_start, 0);
+  cr_assert_eq(data.offending_request_len, 0);
+
+  g_string_free(data.request_body, TRUE);
+  g_string_free(data.response_body, TRUE);
+  http_adapter_free(oa);
+}
+
+Test(openobserve_adapter, test_successful_request_action)
+{
+  HttpAdapter *oa = openobserve_adapter_new();
+  /* successful count is larger than batch_size (shouldn't happen in practice, but be safe) */
+  HttpResponseSignalData data =
+  {
+    .http_code = 200,
+    .batch_size = 3,
+    .request_body = g_string_new("msg1\nmsg2\nmsg3\n"),
+    .response_body = g_string_new(
+      "{\"code\":200,\"status\":[{\"name\":\"default\",\"successful\":1,\"failed\":0}]}"
+    ),
+    0
+  };
+
+  http_adapter_adapt_response(oa, &data);
+
+  cr_assert_eq(data.http_code, 200);
   cr_assert_eq(data.offending_message, 0);
   cr_assert_eq(data.offending_request_start, 0);
   cr_assert_eq(data.offending_request_len, 0);
@@ -178,7 +210,7 @@ Test(openobserve_adapter, test_non_200_response_ignored)
   HttpAdapter *oa = openobserve_adapter_new();
   HttpResponseSignalData data =
   {
-    .http_code = 400,
+    .http_code = 401,
     .batch_size = 2,
     .request_body = g_string_new("msg1\nmsg2\n"),
     .response_body = g_string_new(
@@ -191,6 +223,7 @@ Test(openobserve_adapter, test_non_200_response_ignored)
 
   http_adapter_adapt_response(oa, &data);
 
+  cr_assert_eq(data.http_code, 401);
   /* Non-200 responses are not processed by this adapter */
   cr_assert_eq(data.offending_message, 0);
   cr_assert_eq(data.offending_request_start, 0);
@@ -217,6 +250,7 @@ Test(openobserve_adapter, test_invalid_json_handled_gracefully)
 
   http_adapter_adapt_response(oa, &data);
 
+  cr_assert_eq(data.http_code, 400);
   cr_assert_eq(data.offending_message, 0);
   cr_assert_eq(data.offending_request_start, 0);
   cr_assert_eq(data.offending_request_len, 0);

--- a/modules/http-adapters/tests/test_openobserve_adapter.c
+++ b/modules/http-adapters/tests/test_openobserve_adapter.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "openobserve-adapter.h"
+#include "http-adapter.h"
+#include "apphook.h"
+#include "modules/http/http-signals.h"
+#include <criterion/criterion.h>
+
+static inline gchar *
+_extract_offending_request(HttpResponseSignalData *data)
+{
+  if (data->offending_request_len != 0)
+    return g_strndup(&data->request_body->str[data->offending_request_start], data->offending_request_len);
+  else
+    return g_strdup(data->request_body->str);
+}
+
+Test(openobserve_adapter, test_partial_failure_sets_offending_message)
+{
+  HttpAdapter *oa = openobserve_adapter_new();
+  HttpResponseSignalData data =
+  {
+    .http_code = 200,
+    .batch_size = 4,
+    .request_body = g_string_new("msg1\nmsg2\nmsg3\nmsg4\n"),
+    .response_body = g_string_new(
+      "{\"code\":200,\"status\":[{\"name\":\"network\",\"successful\":2,\"failed\":2,\"error\":\"Cant parse timestamp\"}]}"
+    ),
+    0
+  };
+
+  http_adapter_adapt_response(oa, &data);
+
+  cr_assert_eq(data.offending_message, 2);
+
+  gchar *offending_request = _extract_offending_request(&data);
+  cr_assert_str_eq(offending_request, "msg3");
+  g_free(offending_request);
+
+  g_string_free(data.request_body, TRUE);
+  g_string_free(data.response_body, TRUE);
+  http_adapter_free(oa);
+}
+
+Test(openobserve_adapter, test_all_failed_points_to_first_message)
+{
+  HttpAdapter *oa = openobserve_adapter_new();
+  HttpResponseSignalData data =
+  {
+    .http_code = 200,
+    .batch_size = 3,
+    .request_body = g_string_new("msg1\nmsg2\nmsg3\n"),
+    .response_body = g_string_new(
+      "{\"code\":200,\"status\":[{\"name\":\"network\",\"successful\":0,\"failed\":3,\"error\":\"Cant parse timestamp\"}]}"
+    ),
+    0
+  };
+
+  http_adapter_adapt_response(oa, &data);
+
+  cr_assert_eq(data.offending_message, 0);
+
+  gchar *offending_request = _extract_offending_request(&data);
+  cr_assert_str_eq(offending_request, "msg1");
+  g_free(offending_request);
+
+  g_string_free(data.request_body, TRUE);
+  g_string_free(data.response_body, TRUE);
+  http_adapter_free(oa);
+}
+
+Test(openobserve_adapter, test_all_successful_no_change)
+{
+  HttpAdapter *oa = openobserve_adapter_new();
+  HttpResponseSignalData data =
+  {
+    .http_code = 200,
+    .batch_size = 3,
+    .request_body = g_string_new("msg1\nmsg2\nmsg3\n"),
+    .response_body = g_string_new(
+      "{\"code\":200,\"status\":[{\"name\":\"network\",\"successful\":3,\"failed\":0}]}"
+    ),
+    .offending_message = 0,
+    .offending_request_start = 0,
+    .offending_request_len = 0,
+  };
+
+  http_adapter_adapt_response(oa, &data);
+
+  cr_assert_eq(data.offending_message, 0);
+  cr_assert_eq(data.offending_request_start, 0);
+  cr_assert_eq(data.offending_request_len, 0);
+
+  g_string_free(data.request_body, TRUE);
+  g_string_free(data.response_body, TRUE);
+  http_adapter_free(oa);
+}
+
+Test(openobserve_adapter, test_multiple_status_entries_sum_successful)
+{
+  HttpAdapter *oa = openobserve_adapter_new();
+  /* Two streams: first has 2 successful, second has 1 successful then 2 failed */
+  HttpResponseSignalData data =
+  {
+    .http_code = 200,
+    .batch_size = 5,
+    .request_body = g_string_new("msg1\nmsg2\nmsg3\nmsg4\nmsg5\n"),
+    .response_body = g_string_new(
+      "{\"code\":200,\"status\":["
+      "{\"name\":\"stream_a\",\"successful\":2,\"failed\":0},"
+      "{\"name\":\"stream_b\",\"successful\":1,\"failed\":2,\"error\":\"invalid field\"}"
+      "]}"
+    ),
+    0
+  };
+
+  http_adapter_adapt_response(oa, &data);
+
+  /* First failed message is at index 2+1=3 (0-based) */
+  cr_assert_eq(data.offending_message, 3);
+
+  gchar *offending_request = _extract_offending_request(&data);
+  cr_assert_str_eq(offending_request, "msg4");
+  g_free(offending_request);
+
+  g_string_free(data.request_body, TRUE);
+  g_string_free(data.response_body, TRUE);
+  http_adapter_free(oa);
+}
+
+Test(openobserve_adapter, test_successful_count_exceeds_batch_size_resets_to_zero)
+{
+  HttpAdapter *oa = openobserve_adapter_new();
+  /* successful count is larger than batch_size (shouldn't happen in practice, but be safe) */
+  HttpResponseSignalData data =
+  {
+    .http_code = 200,
+    .batch_size = 3,
+    .request_body = g_string_new("msg1\nmsg2\nmsg3\n"),
+    .response_body = g_string_new(
+      "{\"code\":200,\"status\":[{\"name\":\"network\",\"successful\":5,\"failed\":2,\"error\":\"overflow\"}]}"
+    ),
+    0
+  };
+
+  http_adapter_adapt_response(oa, &data);
+
+  cr_assert_eq(data.offending_message, 0);
+  cr_assert_eq(data.offending_request_start, 0);
+  cr_assert_eq(data.offending_request_len, 0);
+
+  g_string_free(data.request_body, TRUE);
+  g_string_free(data.response_body, TRUE);
+  http_adapter_free(oa);
+}
+
+Test(openobserve_adapter, test_non_200_response_ignored)
+{
+  HttpAdapter *oa = openobserve_adapter_new();
+  HttpResponseSignalData data =
+  {
+    .http_code = 400,
+    .batch_size = 2,
+    .request_body = g_string_new("msg1\nmsg2\n"),
+    .response_body = g_string_new(
+      "{\"code\":400,\"status\":[{\"name\":\"network\",\"successful\":0,\"failed\":2,\"error\":\"bad request\"}]}"
+    ),
+    .offending_message = 0,
+    .offending_request_start = 0,
+    .offending_request_len = 0,
+  };
+
+  http_adapter_adapt_response(oa, &data);
+
+  /* Non-200 responses are not processed by this adapter */
+  cr_assert_eq(data.offending_message, 0);
+  cr_assert_eq(data.offending_request_start, 0);
+  cr_assert_eq(data.offending_request_len, 0);
+
+  g_string_free(data.request_body, TRUE);
+  g_string_free(data.response_body, TRUE);
+  http_adapter_free(oa);
+}
+
+Test(openobserve_adapter, test_invalid_json_handled_gracefully)
+{
+  HttpAdapter *oa = openobserve_adapter_new();
+  HttpResponseSignalData data =
+  {
+    .http_code = 200,
+    .batch_size = 2,
+    .request_body = g_string_new("msg1\nmsg2\n"),
+    .response_body = g_string_new("not valid json"),
+    .offending_message = 0,
+    .offending_request_start = 0,
+    .offending_request_len = 0,
+  };
+
+  http_adapter_adapt_response(oa, &data);
+
+  cr_assert_eq(data.offending_message, 0);
+  cr_assert_eq(data.offending_request_start, 0);
+  cr_assert_eq(data.offending_request_len, 0);
+
+  g_string_free(data.request_body, TRUE);
+  g_string_free(data.response_body, TRUE);
+  http_adapter_free(oa);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+}
+
+static void
+teardown(void)
+{
+  app_shutdown();
+}
+
+TestSuite(openobserve_adapter, .init = setup, .fini = teardown);

--- a/modules/http-adapters/tests/test_openobserve_adapter.c
+++ b/modules/http-adapters/tests/test_openobserve_adapter.c
@@ -50,7 +50,7 @@ Test(openobserve_adapter, test_partial_failure_sets_offending_message)
 
   http_adapter_adapt_response(oa, &data);
 
-  cr_assert_eq(data.http_code, 400);
+  cr_assert_eq(data.result, HTTP_SLOT_CRITICAL_ERROR);
   cr_assert_eq(data.offending_message, 2);
 
   gchar *offending_request = _extract_offending_request(&data);
@@ -78,7 +78,7 @@ Test(openobserve_adapter, test_all_failed_points_to_first_message)
 
   http_adapter_adapt_response(oa, &data);
 
-  cr_assert_eq(data.http_code, 400);
+  cr_assert_eq(data.result, HTTP_SLOT_CRITICAL_ERROR);
   cr_assert_eq(data.offending_message, 0);
 
   gchar *offending_request = _extract_offending_request(&data);
@@ -138,7 +138,7 @@ Test(openobserve_adapter, test_multiple_status_entries_sum_successful)
 
   http_adapter_adapt_response(oa, &data);
 
-  cr_assert_eq(data.http_code, 400);
+  cr_assert_eq(data.result, HTTP_SLOT_CRITICAL_ERROR);
   /* First failed message is at index 2+1=3 (0-based) */
   cr_assert_eq(data.offending_message, 3);
 
@@ -168,7 +168,7 @@ Test(openobserve_adapter, test_successful_count_exceeds_batch_size_resets_to_zer
 
   http_adapter_adapt_response(oa, &data);
 
-  cr_assert_eq(data.http_code, 400);
+  cr_assert_eq(data.result, HTTP_SLOT_CRITICAL_ERROR);
   cr_assert_eq(data.offending_message, 0);
   cr_assert_eq(data.offending_request_start, 0);
   cr_assert_eq(data.offending_request_len, 0);
@@ -214,7 +214,7 @@ Test(openobserve_adapter, test_non_200_response_ignored)
     .batch_size = 2,
     .request_body = g_string_new("msg1\nmsg2\n"),
     .response_body = g_string_new(
-      "{\"code\":400,\"status\":[{\"name\":\"network\",\"successful\":0,\"failed\":2,\"error\":\"bad request\"}]}"
+      "{\"code\":401,\"status\":[{\"name\":\"network\",\"successful\":0,\"failed\":2,\"error\":\"bad request\"}]}"
     ),
     .offending_message = 0,
     .offending_request_start = 0,
@@ -223,7 +223,7 @@ Test(openobserve_adapter, test_non_200_response_ignored)
 
   http_adapter_adapt_response(oa, &data);
 
-  cr_assert_eq(data.http_code, 401);
+  cr_assert_eq(data.result, HTTP_SLOT_SUCCESS);
   /* Non-200 responses are not processed by this adapter */
   cr_assert_eq(data.offending_message, 0);
   cr_assert_eq(data.offending_request_start, 0);
@@ -250,7 +250,7 @@ Test(openobserve_adapter, test_invalid_json_handled_gracefully)
 
   http_adapter_adapt_response(oa, &data);
 
-  cr_assert_eq(data.http_code, 400);
+  cr_assert_eq(data.result, HTTP_SLOT_CRITICAL_ERROR);
   cr_assert_eq(data.offending_message, 0);
   cr_assert_eq(data.offending_request_start, 0);
   cr_assert_eq(data.offending_request_len, 0);

--- a/modules/http-adapters/tests/test_splunk_adapter.c
+++ b/modules/http-adapters/tests/test_splunk_adapter.c
@@ -48,6 +48,7 @@ Test(http_adapters, test_splunk_adapter_extract_offending_message)
 
   http_adapter_adapt_response(sa, &data);
 
+  cr_assert_eq(data.result, HTTP_SLOT_CRITICAL_ERROR);
   cr_assert_eq(data.offending_message, 1);
 
   gchar *offending_request = _extract_offending_request(&data);
@@ -73,6 +74,7 @@ Test(http_adapters, test_splunk_adapter_request_is_short)
   };
 
   http_adapter_adapt_response(sa, &data);
+  cr_assert_eq(data.result, HTTP_SLOT_CRITICAL_ERROR);
   cr_assert_eq(data.offending_message, 3);
   cr_assert_eq(data.offending_request_start, 0);
   cr_assert_eq(data.offending_request_len, 0);
@@ -96,7 +98,54 @@ Test(http_adapters, test_splunk_adapter_request_is_even_shorter)
   };
 
   http_adapter_adapt_response(sa, &data);
+  cr_assert_eq(data.result, HTTP_SLOT_CRITICAL_ERROR);
   cr_assert_eq(data.offending_message, 3);
+  cr_assert_eq(data.offending_request_start, 0);
+  cr_assert_eq(data.offending_request_len, 0);
+
+  g_string_free(data.request_body, TRUE);
+  g_string_free(data.response_body, TRUE);
+  http_adapter_free(sa);
+}
+
+Test(http_adapters, test_splunk_adapter_generic_error_uses_default_mapping)
+{
+  HttpAdapter *sa = splunk_adapter_new();
+  HttpResponseSignalData data =
+  {
+    .http_code = 403,
+    .batch_size = 2,
+    .request_body = g_string_new("foo1\nfoo2\n"),
+    .response_body = g_string_new("{\"text\":\"Invalid token\",\"code\":4}"),
+    0
+  };
+
+  http_adapter_adapt_response(sa, &data);
+  cr_assert_eq(data.result, HTTP_SLOT_SUCCESS);
+  cr_assert_eq(data.offending_message, 0);
+  cr_assert_eq(data.offending_request_start, 0);
+  cr_assert_eq(data.offending_request_len, 0);
+
+  g_string_free(data.request_body, TRUE);
+  g_string_free(data.response_body, TRUE);
+  http_adapter_free(sa);
+}
+
+Test(http_adapters, test_splunk_adapter_non_json_error_uses_default_mapping)
+{
+  HttpAdapter *sa = splunk_adapter_new();
+  HttpResponseSignalData data =
+  {
+    .http_code = 401,
+    .batch_size = 2,
+    .request_body = g_string_new("foo1\nfoo2\n"),
+    .response_body = g_string_new("<html>unauthorized</html>"),
+    0
+  };
+
+  http_adapter_adapt_response(sa, &data);
+  cr_assert_eq(data.result, HTTP_SLOT_SUCCESS);
+  cr_assert_eq(data.offending_message, 0);
   cr_assert_eq(data.offending_request_start, 0);
   cr_assert_eq(data.offending_request_len, 0);
 

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -798,11 +798,18 @@ _flush_on_target(HTTPDestinationWorker *self, const gchar *url)
 
   EMIT(owner->super.super.super.signal_slot_connector, signal_http_response, &self->response_signal);
 
-  if (self->response_signal.result == HTTP_SLOT_RESOLVED)
+  switch (self->response_signal.result)
     {
-      msg_debug("http: HTTP error resolved issue, retry",
+    case HTTP_SLOT_RESOLVED:
+      msg_debug("http: HTTP slot resolved issue the error, retry",
                 evt_tag_long("http_code", http_code));
       return LTR_RETRY;
+    case HTTP_SLOT_CRITICAL_ERROR:
+      msg_debug("http: HTTP slot indicated critical error, reporting broken connection",
+                evt_tag_long("http_code", http_code));
+      return LTR_NOT_CONNECTED;
+    default:
+      break;
     }
 
   return _map_http_status_code(self, url, http_code);

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -805,9 +805,9 @@ _flush_on_target(HTTPDestinationWorker *self, const gchar *url)
                 evt_tag_long("http_code", http_code));
       return LTR_RETRY;
     case HTTP_SLOT_CRITICAL_ERROR:
-      msg_debug("http: HTTP slot indicated critical error, reporting broken connection",
+      msg_debug("http: HTTP slot indicated critical error, reporting error",
                 evt_tag_long("http_code", http_code));
-      return LTR_NOT_CONNECTED;
+      return LTR_ERROR;
     default:
       break;
     }

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -801,7 +801,7 @@ _flush_on_target(HTTPDestinationWorker *self, const gchar *url)
   switch (self->response_signal.result)
     {
     case HTTP_SLOT_RESOLVED:
-      msg_debug("http: HTTP slot resolved issue the error, retry",
+      msg_debug("http: HTTP slot resolved the error, retry",
                 evt_tag_long("http_code", http_code));
       return LTR_RETRY;
     case HTTP_SLOT_CRITICAL_ERROR:

--- a/news/feature-1103-1.md
+++ b/news/feature-1103-1.md
@@ -1,0 +1,7 @@
+`http()`: errors reported by a response-adapter() are now retried as many
+times as retries() allows and the batch is dropped afterwards.
+
+`splunk-hec-event()`: the destination now enables response-adapter(splunk)
+by default. When Splunk rejects an event of a batch, the offending message
+is logged and the batch is retried. Other HTTP errors keep their previous
+handling.

--- a/news/feature-1103.md
+++ b/news/feature-1103.md
@@ -1,0 +1,4 @@
+`http()`: add response-adapter(openobserve) support, which processes HTTP
+responses from OpenObserve backends. OpenObserve normally returns HTTP 200
+OK even for requests that fail partially, and this setting will turn that
+into an actual error, so it can be retried.

--- a/scl/openobserve/openobserve.conf
+++ b/scl/openobserve/openobserve.conf
@@ -56,6 +56,7 @@ block destination openobserve-log(
         body_suffix(`body_suffix`)
         delimiter(`delimiter`)
         body("$(format-json --scope none `record`)")
+	response-adapter(openobserve)
         `__VARARGS__`
     );
 };

--- a/scl/splunk/splunk.conf
+++ b/scl/splunk/splunk.conf
@@ -124,6 +124,7 @@ block destination splunk_hec_event(
     timeout(`timeout`)
     workers(`workers`)
     use_system_cert_store(`use_system_cert_store`)
+    response-adapter(splunk)
     `__VARARGS__`
   );
 };

--- a/tests/light/functional_tests/destination_drivers/http/test_http_destination.py
+++ b/tests/light/functional_tests/destination_drivers/http/test_http_destination.py
@@ -20,10 +20,14 @@
 # COPYING for details.
 #
 #############################################################################
+import pytest
 
 
 OPENOBSERVE_PARTIAL_FAILURE = '{"code":200,"status":[{"name":"stream","successful":0,"failed":1,"error":"Cant parse timestamp"}]}'
 OPENOBSERVE_SUCCESS = '{"code":200,"status":[{"name":"stream","successful":1,"failed":0}]}'
+
+SPLUNK_PARTIAL_FAILURE = '"{\"text\":\"Event field cannot be blank\",\"code\":13,\"invalid-event-number\":1}"'
+SPLUNK_SUCCESS = '"{\"text\":\"everything ok\",\"code\":0}"'
 
 
 def test_http_destination_accepts_messages(config, syslog_ng, port_allocator):
@@ -47,7 +51,25 @@ def test_http_destination_accepts_messages(config, syslog_ng, port_allocator):
     assert all("test message" in msg for msg in messages)
 
 
-def test_http_destination_openobserve_retries_on_partial_failure(config, syslog_ng, port_allocator):
+@pytest.mark.parametrize(
+    "adapter,failure_response,success_response", [
+        pytest.param(
+            "openobserve",
+            (200, OPENOBSERVE_PARTIAL_FAILURE),
+            (200, OPENOBSERVE_SUCCESS),
+            id="openobserve",
+        ),
+        pytest.param(
+            "splunk",
+            (400, SPLUNK_PARTIAL_FAILURE),
+            (200, SPLUNK_SUCCESS),
+            id="splunk",
+        ),
+    ],
+)
+def test_http_destination_adapter_retries_on_partial_failure(
+    config, syslog_ng, port_allocator, adapter, failure_response, success_response,
+):
     port = port_allocator()
 
     generator_source = config.create_example_msg_generator_source(
@@ -58,11 +80,8 @@ def test_http_destination_openobserve_retries_on_partial_failure(config, syslog_
         port=port,
         body=config.stringify("${MSG}"),
         time_reopen=1,
-        response_adapter=config.stringify("openobserve"),
-        responses=[
-            (200, OPENOBSERVE_PARTIAL_FAILURE),
-            (200, OPENOBSERVE_SUCCESS),
-        ],
+        response_adapter=config.stringify(adapter),
+        responses=[failure_response, success_response],
     )
     config.create_logpath(statements=[generator_source, http_destination])
 

--- a/tests/light/functional_tests/destination_drivers/http/test_http_destination.py
+++ b/tests/light/functional_tests/destination_drivers/http/test_http_destination.py
@@ -22,6 +22,10 @@
 #############################################################################
 
 
+OPENOBSERVE_PARTIAL_FAILURE = '{"code":200,"status":[{"name":"stream","successful":0,"failed":1,"error":"Cant parse timestamp"}]}'
+OPENOBSERVE_SUCCESS = '{"code":200,"status":[{"name":"stream","successful":1,"failed":0}]}'
+
+
 def test_http_destination_accepts_messages(config, syslog_ng, port_allocator):
     port = port_allocator()
     num_messages = 5
@@ -41,3 +45,30 @@ def test_http_destination_accepts_messages(config, syslog_ng, port_allocator):
     messages = http_destination.read_logs(num_messages)
     assert len(messages) == num_messages
     assert all("test message" in msg for msg in messages)
+
+
+def test_http_destination_openobserve_retries_on_partial_failure(config, syslog_ng, port_allocator):
+    port = port_allocator()
+
+    generator_source = config.create_example_msg_generator_source(
+        num=1,
+        template=config.stringify("test message"),
+    )
+    http_destination = config.create_http_destination(
+        port=port,
+        body=config.stringify("${MSG}"),
+        time_reopen=1,
+        response_adapter=config.stringify("openobserve"),
+        responses=[
+            (200, OPENOBSERVE_PARTIAL_FAILURE),
+            (200, OPENOBSERVE_SUCCESS),
+        ],
+    )
+    config.create_logpath(statements=[generator_source, http_destination])
+
+    syslog_ng.start(config)
+
+    # Expect 2 POST requests: initial attempt (failure) + retry (success)
+    requests = http_destination.read_logs(2)
+    assert len(requests) == 2
+    assert all("test message" in r for r in requests)

--- a/tests/light/functional_tests/destination_drivers/http/test_http_destination.py
+++ b/tests/light/functional_tests/destination_drivers/http/test_http_destination.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+def test_http_destination_accepts_messages(config, syslog_ng, port_allocator):
+    port = port_allocator()
+    num_messages = 5
+
+    generator_source = config.create_example_msg_generator_source(
+        num=num_messages,
+        template=config.stringify("test message"),
+    )
+    http_destination = config.create_http_destination(
+        port=port,
+        body=config.stringify("${MSG} ${UNIQID}"),
+    )
+    config.create_logpath(statements=[generator_source, http_destination])
+
+    syslog_ng.start(config)
+
+    messages = http_destination.read_logs(num_messages)
+    assert len(messages) == num_messages
+    assert all("test message" in msg for msg in messages)

--- a/tests/light/functional_tests/destination_drivers/http/test_http_destination.py
+++ b/tests/light/functional_tests/destination_drivers/http/test_http_destination.py
@@ -26,8 +26,8 @@ import pytest
 OPENOBSERVE_PARTIAL_FAILURE = '{"code":200,"status":[{"name":"stream","successful":0,"failed":1,"error":"Cant parse timestamp"}]}'
 OPENOBSERVE_SUCCESS = '{"code":200,"status":[{"name":"stream","successful":1,"failed":0}]}'
 
-SPLUNK_PARTIAL_FAILURE = '"{\"text\":\"Event field cannot be blank\",\"code\":13,\"invalid-event-number\":1}"'
-SPLUNK_SUCCESS = '"{\"text\":\"everything ok\",\"code\":0}"'
+SPLUNK_PARTIAL_FAILURE = '{"text":"Event field cannot be blank","code":13,"invalid-event-number":0}'
+SPLUNK_SUCCESS = '{"text":"Success","code":0}'
 
 
 def test_http_destination_accepts_messages(config, syslog_ng, port_allocator):

--- a/tests/light/src/axosyslog_light/driver_io/http/http_server_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/http/http_server_io.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import queue
+import threading
+import time
+from http.server import BaseHTTPRequestHandler
+from http.server import HTTPServer
+
+from axosyslog_light.common.blocking import DEFAULT_TIMEOUT
+
+
+class HttpServerIO():
+    def __init__(self, port: int, response_code: int = 200) -> None:
+        self._port = port
+        self._response_code = response_code
+        self._queue = queue.Queue()
+        self._server = None
+        self._thread = None
+
+    def start_listener(self):
+        q = self._queue
+        response_code = self._response_code
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                content_length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(content_length)
+                q.put(body.decode("utf-8"))
+                self.send_response(response_code)
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.close_connection = True
+
+            def do_PUT(self):
+                self.do_POST()
+
+            def log_message(self, format, *args):
+                pass
+
+        self._server = HTTPServer(("127.0.0.1", self._port), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop_listener(self):
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._thread.join(timeout=5.0)
+            self._server = None
+            self._thread = None
+
+    def read_number_of_messages(self, counter: int, timeout: float = DEFAULT_TIMEOUT):
+        messages = []
+        deadline = time.monotonic() + timeout
+        while len(messages) < counter:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise Exception("Timeout waiting for {} messages, received {}".format(counter, len(messages)))
+            try:
+                msg = self._queue.get(timeout=min(remaining, 0.1))
+                messages.append(msg)
+            except queue.Empty:
+                pass
+        return messages
+
+    def read_until_messages(self, expected_messages, timeout: float = DEFAULT_TIMEOUT):
+        received = []
+        to_find = list(expected_messages)
+        deadline = time.monotonic() + timeout
+        while to_find:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise Exception("Timeout waiting for messages. Still missing: {}".format(to_find))
+            try:
+                msg = self._queue.get(timeout=min(remaining, 0.1))
+                received.append(msg)
+                for expected in list(to_find):
+                    if expected in msg:
+                        to_find.remove(expected)
+            except queue.Empty:
+                pass
+        return received

--- a/tests/light/src/axosyslog_light/driver_io/http/http_server_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/http/http_server_io.py
@@ -30,25 +30,43 @@ from axosyslog_light.common.blocking import DEFAULT_TIMEOUT
 
 
 class HttpServerIO():
-    def __init__(self, port: int, response_code: int = 200) -> None:
+    def __init__(self, port: int, response_code: int = 200, responses=None) -> None:
         self._port = port
-        self._response_code = response_code
+        self._default_response = (response_code, "")
+        self._responses = list(responses) if responses is not None else None
+        self._response_counter = 0
+        self._counter_lock = threading.Lock()
         self._queue = queue.Queue()
         self._server = None
         self._thread = None
 
+    def _next_response(self):
+        if self._responses is None:
+            return self._default_response
+        with self._counter_lock:
+            idx = min(self._response_counter, len(self._responses) - 1)
+            self._response_counter += 1
+            return self._responses[idx]
+
     def start_listener(self):
         q = self._queue
-        response_code = self._response_code
+        next_response = self._next_response
 
         class Handler(BaseHTTPRequestHandler):
             def do_POST(self):
                 content_length = int(self.headers.get("Content-Length", 0))
                 body = self.rfile.read(content_length)
                 q.put(body.decode("utf-8"))
-                self.send_response(response_code)
+                status_code, response_body = next_response()
+                response_bytes = response_body.encode("utf-8") if response_body else b""
+                self.send_response(status_code)
+                if response_bytes:
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(response_bytes)))
                 self.send_header("Connection", "close")
                 self.end_headers()
+                if response_bytes:
+                    self.wfile.write(response_bytes)
                 self.close_connection = True
 
             def do_PUT(self):

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/http_destination.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/http_destination.py
@@ -35,7 +35,11 @@ class HttpDestination(DestinationDriver):
         **options,
     ) -> None:
         self.driver_name = "http"
-        self._io = HttpServerIO(port, response_code=options.pop("response_code", 200))
+        self._io = HttpServerIO(
+            port,
+            response_code=options.pop("response_code", 200),
+            responses=options.pop("responses", None),
+        )
         self._io.start_listener()
 
         options.setdefault("url", '"http://127.0.0.1:{}"'.format(port))

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/http_destination.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/http_destination.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from axosyslog_light.driver_io.http.http_server_io import HttpServerIO
+from axosyslog_light.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
+from axosyslog_light.syslog_ng_ctl.legacy_stats_handler import LegacyStatsHandler
+from axosyslog_light.syslog_ng_ctl.prometheus_stats_handler import PrometheusStatsHandler
+
+
+class HttpDestination(DestinationDriver):
+    def __init__(
+        self,
+        stats_handler: LegacyStatsHandler,
+        prometheus_stats_handler: PrometheusStatsHandler,
+        port: int,
+        **options,
+    ) -> None:
+        self.driver_name = "http"
+        self._io = HttpServerIO(port, response_code=options.pop("response_code", 200))
+        self._io.start_listener()
+
+        options.setdefault("url", '"http://127.0.0.1:{}"'.format(port))
+        options.setdefault("batch_lines", 1)
+
+        super(HttpDestination, self).__init__(stats_handler, prometheus_stats_handler, [], options)
+
+    def stop_listener(self):
+        self._io.stop_listener()
+
+    def read_logs(self, counter):
+        return self._io.read_number_of_messages(counter)
+
+    def read_until_logs(self, logs):
+        return self._io.read_until_messages(logs)

--- a/tests/light/src/axosyslog_light/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/syslog_ng_config.py
@@ -34,6 +34,7 @@ from axosyslog_light.syslog_ng_config.statements.destinations.bigquery_destinati
 from axosyslog_light.syslog_ng_config.statements.destinations.clickhouse_destination import ClickhouseDestination
 from axosyslog_light.syslog_ng_config.statements.destinations.example_destination import ExampleDestination
 from axosyslog_light.syslog_ng_config.statements.destinations.file_destination import FileDestination
+from axosyslog_light.syslog_ng_config.statements.destinations.http_destination import HttpDestination
 from axosyslog_light.syslog_ng_config.statements.destinations.network_destination import NetworkDestination
 from axosyslog_light.syslog_ng_config.statements.destinations.snmp_destination import SnmpDestination
 from axosyslog_light.syslog_ng_config.statements.destinations.unix_dgram_destination import UnixDgramDestination
@@ -283,6 +284,11 @@ class SyslogNgConfig(object):
         # syslog-ng disconnects; the AppendRows handler otherwise blocks.
         self.teardown.register_process_stop_callback(bigquery_destination.stop_listener)
         return bigquery_destination
+
+    def create_http_destination(self, port: int, **options):
+        http_destination = HttpDestination(self._stats_handler, self._prometheus_stats_handler, port, **options)
+        self.teardown.register(http_destination.stop_listener)
+        return http_destination
 
     def create_clickhouse_destination(self, **options):
         clickhouse_destination = ClickhouseDestination(self._stats_handler, self._prometheus_stats_handler, **options)


### PR DESCRIPTION
This PR adds a htto-adapter that processes HTTP responses from OpenObserve. Normally OpenObserve returns HTTP 200 even for batches which failed, and unless we check the returned JSON in the response, we won't know if the request worked out or not.

The adapter checks if the "failed" number of events is zero or not and returns an error condition to the HTTP destination on those cases so it can be retried.