### PR TITLE
autotools: Fix versioning running from git worktree

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -29,7 +29,7 @@ cd $BASEDIR/../
 
 if [ "$VERSION" != "" ]; then
   echo $VERSION | tr -d '\n'
-elif [ -d .git ] && GIT_VERSION=$(git describe --match 'axosyslog-[0-9]*' --tags --dirty --abbrev=7); then
+elif [ -e .git ] && GIT_VERSION=$(git describe --match 'axosyslog-[0-9]*' --tags --dirty --abbrev=7); then
   echo $GIT_VERSION | sed 's/^axosyslog-//' | tr '-' '.' | tr -d '\n'
 else
   cat VERSION.txt | tr -d '\n'


### PR DESCRIPTION
In git worktrees the .git directory is replaced with a file pointing to the real one. The versioning script now recognizes this and acts as it's running in a git directory.