### PR TITLE
kubernetes: fix unit test mock for kubernetes client >=36

### DIFF
--- a/modules/python-modules/syslogng/modules/kubernetes/tests/test_kubernetes_api_enrichment.py
+++ b/modules/python-modules/syslogng/modules/kubernetes/tests/test_kubernetes_api_enrichment.py
@@ -208,10 +208,14 @@ def mock_api_response_nginx(mocker):
         ]
     }
 
-    yield mocker.patch('kubernetes.client.rest.RESTClientObject.request', return_value=mocker.Mock(**{
+    # kubernetes>=33 calls response.getheader("content-type") and decodes response.data.
+    mock_response = mocker.Mock(**{
         'status_code': 200,
-        'data': json.dumps(response_json)
-    }))
+        'status': 200,
+        'data': json.dumps(response_json).encode('utf-8'),
+    })
+    mock_response.getheader = mocker.Mock(return_value='application/json')
+    yield mocker.patch('kubernetes.client.rest.RESTClientObject.request', return_value=mock_response)
 
 
 def test_kubernetes_api_enrichment_can_be_instantiated():

--- a/modules/python-modules/syslogng/modules/kubernetes/tests/test_kubernetes_api_enrichment.py
+++ b/modules/python-modules/syslogng/modules/kubernetes/tests/test_kubernetes_api_enrichment.py
@@ -208,7 +208,7 @@ def mock_api_response_nginx(mocker):
         ]
     }
 
-    # kubernetes>=33 calls response.getheader("content-type") and decodes response.data.
+    # kubernetes>=36 calls response.getheader("content-type") and decodes response.data.
     mock_response = mocker.Mock(**{
         'status_code': 200,
         'status': 200,


### PR DESCRIPTION
Backports syslog-ng/syslog-ng#5704.

Corrected the kubernetes client version in the mock comment: the fix is needed for the kubernetes python client >=36, not >=33.

Assisted-by: Claude:claude-opus-4-8[1m]