### PR TITLE
lib,modules: fix static analyzer findings

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -914,7 +914,7 @@ cfg_lexer_find_generator_plugin(CfgLexer *self, GlobalConfig *cfg, gint context,
 static CFG_STYPE
 cfg_lexer_copy_token(const CFG_STYPE *original)
 {
-  CFG_STYPE dest;
+  CFG_STYPE dest = {0};
   int type = original->type;
   dest.type = type;
 

--- a/lib/host-id.c
+++ b/lib/host-id.c
@@ -31,15 +31,10 @@ guint32 global_host_id = 0;
 static guint32
 _create_host_id(void)
 {
-  union
-  {
-    unsigned char _raw[sizeof(guint32)];
-    guint32 id;
-  } host_id;
+  guint32 host_id;
 
-  RAND_bytes(host_id._raw, sizeof(host_id._raw));
-
-  return host_id.id;
+  RAND_bytes((unsigned char *) &host_id, sizeof(host_id));
+  return host_id;
 }
 
 static gboolean

--- a/lib/transport/tls-verifier.c
+++ b/lib/transport/tls-verifier.c
@@ -174,7 +174,7 @@ tls_wildcard_match(const gchar *host_name, const gchar *pattern)
 gboolean
 tls_verify_certificate_name(X509 *cert, const gchar *host_name)
 {
-  gchar pattern_buf[256];
+  gchar pattern_buf[256] = "";
   gint ext_ndx;
   gboolean found = FALSE, result = FALSE;
 
@@ -204,9 +204,8 @@ tls_verify_certificate_name(X509 *cert, const gchar *host_name)
 
                   if (dnsname_len > sizeof(pattern_buf) - 1)
                     {
-                      found = TRUE;
-                      result = FALSE;
-                      break;
+                      /* skip this oversized SAN entry, but keep checking the rest */
+                      continue;
                     }
 
                   memcpy(pattern_buf, dnsname, dnsname_len);
@@ -218,9 +217,15 @@ tls_verify_certificate_name(X509 *cert, const gchar *host_name)
               else if (gen_name->type == GEN_IPADD)
                 {
                   gchar dotted_ip[64] = {0};
-                  int addr_family = AF_INET;
-                  if (gen_name->d.iPAddress->length == 16)
+                  /* only 4 (IPv4) and 16 (IPv6) byte payloads are valid; skip malformed entries
+                   * to avoid feeding inet_ntop a mismatched source size */
+                  int addr_family;
+                  if (gen_name->d.iPAddress->length == 4)
+                    addr_family = AF_INET;
+                  else if (gen_name->d.iPAddress->length == 16)
                     addr_family = AF_INET6;
+                  else
+                    continue;
 
                   if (inet_ntop(addr_family, gen_name->d.iPAddress->data, dotted_ip, sizeof(dotted_ip)))
                     {

--- a/lib/transport/transport-socket.c
+++ b/lib/transport/transport-socket.c
@@ -163,7 +163,7 @@ log_transport_socket_read_method(LogTransport *s, gpointer buf, gsize buflen, Lo
 {
   LogTransportSocket *self = (LogTransportSocket *) s;
   gint rc;
-  struct msghdr msg;
+  struct msghdr msg = {0};
   struct iovec iov[1];
   struct sockaddr_storage ss;
 #if defined(SYSLOG_NG_HAVE_CTRLBUF_IN_MSGHDR)

--- a/lib/uuid.c
+++ b/lib/uuid.c
@@ -24,36 +24,25 @@
 #include "uuid.h"
 
 #include <openssl/rand.h>
-#include <arpa/inet.h>
 
 void
 uuid_gen_random(gchar *buf, gsize buflen)
 {
-  union
-  {
-    struct
-    {
-      guint32 time_low;
-      guint16 time_mid;
-      guint16 time_hi_and_version;
-      guint8  clk_seq_hi_res;
-      guint8  clk_seq_low;
-      guint8  node[6];
-      guint16 node_low;
-      guint32 node_hi;
-    };
-    guchar __rnd[16];
-  } uuid;
+  /* RFC 4122 version 4 (random) UUID; flat byte buffer avoids union-access
+   * and out-of-bounds warnings from static analyzers, writes over the 16 bytes,
+   * and needs no htons(). */
+  guchar rnd[16];
 
-  RAND_bytes(uuid.__rnd, sizeof(uuid));
+  RAND_bytes(rnd, sizeof(rnd));
 
-  uuid.clk_seq_hi_res = (uuid.clk_seq_hi_res & ~0xC0) | 0x80;
-  uuid.time_hi_and_version = htons((uuid.time_hi_and_version & ~0xF000) | 0x4000);
+  rnd[6] = (rnd[6] & 0x0F) | 0x40; /* version 4: top nibble of byte 6 */
+  rnd[8] = (rnd[8] & 0x3F) | 0x80; /* RFC 4122 variant: top two bits of byte 8 */
 
-  g_snprintf(buf, buflen, "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-             uuid.time_low, uuid.time_mid, uuid.time_hi_and_version,
-             uuid.clk_seq_hi_res, uuid.clk_seq_low,
-             uuid.node[0], uuid.node[1], uuid.node[2],
-             uuid.node[3], uuid.node[4], uuid.node[5]);
-
+  g_snprintf(buf, buflen,
+             "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+             rnd[0], rnd[1], rnd[2], rnd[3],
+             rnd[4], rnd[5],
+             rnd[6], rnd[7],
+             rnd[8], rnd[9],
+             rnd[10], rnd[11], rnd[12], rnd[13], rnd[14], rnd[15]);
 }

--- a/modules/diskq/diskq-options.c
+++ b/modules/diskq/diskq-options.c
@@ -117,6 +117,7 @@ disk_queue_options_set_default_options(DiskQueueOptions *self)
 {
   self->capacity_bytes = -1;
   self->reliable = FALSE;
+  self->compaction = FALSE;
   self->flow_control_window_bytes = -1;
   self->front_cache_size = -1;
   self->dir = g_strdup(get_installation_path_for(SYSLOG_NG_PATH_LOCALSTATEDIR));

--- a/modules/python-modules/syslogng/modules/hypr/tests/test_confgen.py
+++ b/modules/python-modules/syslogng/modules/hypr/tests/test_confgen.py
@@ -24,7 +24,7 @@ from syslogng.modules import hypr
 import base64
 
 
-def test_config_generator_all_options(mocker):
+def test_config_generator_default_options(mocker):
     mocker.patch("requests.get", return_value=mocker.Mock(**{
         'status_code': 200,
         'json': mocker.Mock(return_value=[
@@ -51,7 +51,7 @@ def test_config_generator_all_options(mocker):
                 "bearer_token" => "%s"
                 "page_size" => 100
                 "initial_hours" => 4
-                "ignore_persistence" => False
+                "ignore_persistence" => no
                 "log_level" => "INFO"
             )
             flags()

--- a/modules/python-modules/syslogng/modules/hypr/tests/test_hypr_audit_source.py
+++ b/modules/python-modules/syslogng/modules/hypr/tests/test_hypr_audit_source.py
@@ -60,8 +60,10 @@ def test_hypr_audit_source_lifecycle_without_actually_fetching_messages(minimal_
     sut = hypr.HyprAuditSource()
 
     assert sut.init(minimal_config) is True
-    assert sut.open() is True
-    assert sut.close() is None
+    opened = sut.open()
+    assert opened is True
+    closed = sut.close()
+    assert closed is None
     sut.deinit()
 
 
@@ -117,7 +119,8 @@ def test_hypr_audit_source_complete_lifecycle(minimal_config, mocker):
     sut = hypr.HyprAuditSource()
 
     assert sut.init(minimal_config) is True
-    assert sut.open() is True
+    opened = sut.open()
+    assert opened is True
 
     index = 0
     status, msg = sut.fetch()
@@ -149,7 +152,8 @@ def test_hypr_audit_source_complete_lifecycle(minimal_config, mocker):
     assert status == sut.NO_DATA
     assert index == 2
 
-    assert sut.close() is None
+    closed = sut.close()
+    assert closed is None
     sut.deinit()
 
 
@@ -192,7 +196,8 @@ def test_hypr_audit_source_complete_lifecycle_no_parse(minimal_config, mocker):
     sut.flags["parse"] = False
 
     assert sut.init(minimal_config) is True
-    assert sut.open() is True
+    opened = sut.open()
+    assert opened is True
 
     status, msg = sut.fetch()
 
@@ -200,5 +205,6 @@ def test_hypr_audit_source_complete_lifecycle_no_parse(minimal_config, mocker):
     assert msg['MESSAGE'] == b'{"rpAppId": "rp_foo", "eventTimeInUTC": 1666427394, "message": "whatever first", "counter": 1, "single_nested": {"double_nested": {"none": null}}, "float": 123.456, "string_list": ["foo", "bar"], "non_string_list": [1, 2], "bool": true}'
     assert msg['PROGRAM'] == b'Hypr-rpFoo'
 
-    assert sut.close() is None
+    closed = sut.close()
+    assert closed is None
     sut.deinit()

--- a/modules/python-modules/syslogng/modules/webhook/source.py
+++ b/modules/python-modules/syslogng/modules/webhook/source.py
@@ -180,7 +180,6 @@ class HTTPSource(LogSource):
 
     def request_exit(self) -> None:
         asyncio.run_coroutine_threadsafe(self.stopServer(), self.event_loop)
-        pass
 
     def log_access(self, req: tornado.web.RequestHandler) -> None:
         self.logger.debug(f"{req.get_status()} {req._request_summary()}")

--- a/modules/python-modules/syslogng/persist.py
+++ b/modules/python-modules/syslogng/persist.py
@@ -36,6 +36,11 @@ except ImportError:
         def __init__(self, persist_name):
             self.persist_name = persist_name
 
+        def __eq__(self, other):
+            if not isinstance(other, self.__class__):
+                return NotImplemented
+            return self.persist_name == other.persist_name and dict.__eq__(self, other)
+
 
 class Persist(Persist):
     def __init__(self, persist_name, defaults=None):

--- a/modules/python-modules/syslogng/source.py
+++ b/modules/python-modules/syslogng/source.py
@@ -58,17 +58,17 @@ except ImportError:
         NO_DATA = auto()
 
     # Fake InstantAckTracker
-    class InstantAckTracker(dict):
+    class InstantAckTracker:
         def __init__(self, ack_callback):
             self.ack_callback = ack_callback
 
     # Fake ConsecutiveAckTracker
-    class ConsecutiveAckTracker(dict):
+    class ConsecutiveAckTracker:
         def __init__(self, ack_callback):
             self.ack_callback = ack_callback
 
     # Fake BatchedAckTracker
-    class BatchedAckTracker(dict):
+    class BatchedAckTracker:
         def __init__(self, timeout, batch_size, batched_ack_callback):
             self.timeout = timeout
             self.batch_size = batch_size


### PR DESCRIPTION
Backports syslog-ng/syslog-ng#5706.

The tls-verifier commit (2a3068691e1692115a19f39bd2f166e3785e37e1) keeps the upstream logic, adjusting only the ASN1 API calls to match AxoSyslog's current code.

Assisted-by: Claude:claude-opus-4-8[1m]
