### PR TITLE
correlation: fix radix parser end-of-input handling

### DIFF
--- a/modules/correlation/pdb-load.c
+++ b/modules/correlation/pdb-load.c
@@ -1231,7 +1231,11 @@ pdb_rule_set_load(PDBRuleSet *self, GlobalConfig *cfg, const gchar *config, GLis
     }
 
   if (state.load_examples)
-    *examples = state.examples;
+    {
+      *examples = state.examples;
+      /* Ownership transferred to caller; prevent cleanup from freeing it. */
+      state.examples = NULL;
+    }
 
   success = TRUE;
 

--- a/modules/correlation/radix.c
+++ b/modules/correlation/radix.c
@@ -288,7 +288,8 @@ r_parser_set(gchar *str, gint *len, const gchar *param, gpointer state, RParserM
   if (!param)
     return FALSE;
 
-  while (strchr(param, str[*len]))
+  /* Guard against matching '\0' via strchr(param, '\0'). */
+  while (str[*len] && strchr(param, str[*len]))
     (*len)++;
 
   if (*len > 0)
@@ -316,8 +317,11 @@ r_parser_email(gchar *str, gint *len, const gchar *param, gpointer state, RParse
   *len = 0;
 
   if (param)
-    while (strchr(param, str[*len]))
-      (*len)++;
+    {
+      /* Guard against matching '\0' via strchr(param, '\0'). */
+      while (str[*len] && strchr(param, str[*len]))
+        (*len)++;
+    }
 
   if (match)
     match->ofs = *len;
@@ -326,7 +330,8 @@ r_parser_email(gchar *str, gint *len, const gchar *param, gpointer state, RParse
   if (str[*len] == '.')
     return FALSE;
 
-  while (g_ascii_isalnum(str[*len]) || (strchr(email, str[*len])))
+  /* Guard against matching '\0' via strchr(email, '\0'). */
+  while (str[*len] && (g_ascii_isalnum(str[*len]) || (strchr(email, str[*len]))))
     (*len)++;
   /* last character of e-mail can not be a period */
   if (str[*len-1] == '.')
@@ -354,8 +359,11 @@ r_parser_email(gchar *str, gint *len, const gchar *param, gpointer state, RParse
 
   end = *len;
   if (param)
-    while (strchr(param, str[*len]))
-      (*len)++;
+    {
+      /* Guard against matching '\0' via strchr(param, '\0'). */
+      while (str[*len] && strchr(param, str[*len]))
+        (*len)++;
+    }
 
   if (match)
     match->len = end - *len - match->ofs;

--- a/modules/correlation/radix.c
+++ b/modules/correlation/radix.c
@@ -1500,7 +1500,6 @@ _find_node_recursively(RFindNodeState *state, RNode *root, gchar *key, gint keyl
   if (literal_prefix_inputlen == keylen && (literal_prefix_radixlen == root->keylen || root->keylen == -1))
     {
       /* key completely consumed by the literal */
-
       if (state->applicable_nodes)
         {
           /* collect all matching nodes */
@@ -1510,6 +1509,17 @@ _find_node_recursively(RFindNodeState *state, RNode *root, gchar *key, gint keyl
 
       if (root->value)
         return root;
+
+      /* Parser nodes can have children that match empty suffixes (e.g. OPTIONALSET). */
+      if (root->keylen == -1)
+        {
+          gchar *remaining_key = key + literal_prefix_inputlen;
+          gint remaining_keylen = keylen - literal_prefix_inputlen;
+
+          /* Input exhausted; only parser children can match. */
+          RNode *ret = _find_child_by_parser(state, root, remaining_key, remaining_keylen);
+          return ret;
+        }
     }
   else if ((root->keylen < 1) || (literal_prefix_inputlen < keylen && literal_prefix_radixlen >= root->keylen))
     {

--- a/modules/correlation/tests/test_parsers_e2e.c
+++ b/modules/correlation/tests/test_parsers_e2e.c
@@ -99,8 +99,8 @@ _destroy_pattern_db(PatternDB *patterndb, gchar *filename)
 
 typedef struct _test_parsers_e2e_param
 {
-  const gchar *rule;
-  const gchar *pattern;
+  gchar rule[192];
+  gchar pattern[192];
   gboolean match;
 } TestParsersE2EParam;
 
@@ -123,6 +123,8 @@ ParameterizedTestParameters(parsers_e2e, test_parsers)
     {"@ESTRING:TEST:endmark@", "ab ba", FALSE},
     {"@ESTRING:TEST:&gt;@", "ab ba > ab", TRUE},
     {"@ESTRING:TEST:&gt;@", "ab ba", FALSE},
+    {"@ESTRING:TEST:&amp;@", "ab ba & ab", TRUE},
+    {"@ESTRING:TEST:&amp;@", "ab ba", FALSE},
     {"@FLOAT:TEST@", "1234", TRUE},
     {"@FLOAT:TEST@", "1234.567", TRUE},
     {"@FLOAT:TEST@", "1.2.3.4", TRUE},
@@ -162,12 +164,21 @@ ParameterizedTestParameters(parsers_e2e, test_parsers)
     {"@QSTRING:TEST:&lt;&gt;@", "< aabb >", TRUE},
     {"@QSTRING:TEST:&lt;&gt;@", "aabb>", FALSE},
     {"@QSTRING:TEST:&lt;&gt;@", "<aabb", FALSE},
+    {"@QSTRING:TEST:&quot;@", "\"aa bb\"", TRUE},
+    {"@QSTRING:TEST:&quot;@", "aa bb\"", FALSE},
+    {"@QSTRING:TEST:&apos;@", "'aa bb'", TRUE},
+    {"@QSTRING:TEST:&apos;@", "'aa bb", FALSE},
     {"@STRING:TEST@", "aabb", TRUE},
     {"@STRING:TEST@", "aa bb", TRUE},
     {"@STRING:TEST@", "1234", TRUE},
     {"@STRING:TEST@", "ab1234", TRUE},
     {"@STRING:TEST@", "1234bb", TRUE},
-    {"@STRING:TEST@", "1.2.3.4", TRUE}
+    {"@STRING:TEST@", "1.2.3.4", TRUE},
+    /* Test the example we have in the documentation */
+    {
+      "Accepted @STRING:SSH_AUTH_METHOD:-_@ for @STRING:SSH_USERNAME:._-@ from @IPvANY:SSH_CLIENT_ADDRESS@ port @NUMBER:SSH_PORT_NUMBER@ ssh2",
+      "Accepted password for sampleuser from 10.50.0.247 port 42156 ssh2", TRUE
+    }
   };
 
   return cr_make_param_array(TestParsersE2EParam, parser_params, G_N_ELEMENTS(parser_params));

--- a/modules/correlation/tests/test_patterndb.c
+++ b/modules/correlation/tests/test_patterndb.c
@@ -31,6 +31,9 @@
 #include "filter/filter-expr.h"
 #include "patterndb.h"
 #include "pdb-file.h"
+#include "pdb-load.h"
+#include "pdb-example.h"
+#include "pdb-ruleset.h"
 #include "plugin.h"
 #include "cfg.h"
 #include "timerwheel.h"
@@ -859,6 +862,43 @@ Test(pattern_db, test_set_at_end_of_input_does_not_match_zero_chars)
   assert_msg_matches_and_nvpair_equals(patterndb, "prefix ", "s", " ");
 
   _destroy_pattern_db(patterndb, filename);
+  g_free(filename);
+}
+
+Test(pattern_db, test_pdb_rule_set_load_examples_ownership)
+{
+  /* Load a pdb with two <example> entries via pdb_rule_set_load() and walk
+     the returned list, asserting each PDBExample is reachable and carries
+     intact program/message strings owned by the caller. */
+  gchar *filename = NULL;
+  g_file_open_tmp("patterndbXXXXXX.xml", &filename, NULL);
+  g_file_set_contents(filename, pdb_test_optionalset_at_end_of_pattern_with_examples,
+                      strlen(pdb_test_optionalset_at_end_of_pattern_with_examples), NULL);
+
+  PDBRuleSet *ruleset = pdb_rule_set_new(NULL);
+  GList *examples = NULL;
+
+  cr_assert(pdb_rule_set_load(ruleset, configuration, filename, &examples),
+            "pdb_rule_set_load failed");
+  cr_assert_not_null(examples, "caller should receive the examples list");
+
+  gint count = 0;
+  for (GList *l = examples; l; l = l->next)
+    {
+      PDBExample *example = (PDBExample *) l->data;
+      cr_assert_not_null(example, "example node holds a NULL pointer");
+      cr_assert_not_null(example->program, "example->program freed by loader");
+      cr_assert_not_null(example->message, "example->message freed by loader");
+      cr_assert_str_eq(example->program, "prog1",
+                       "example->program corrupted: got '%s'", example->program);
+      count++;
+    }
+  cr_assert_eq(count, 2, "expected 2 examples, got %d", count);
+
+  g_list_foreach(examples, (GFunc) pdb_example_free, NULL);
+  g_list_free(examples);
+  pdb_rule_set_free(ruleset);
+  g_unlink(filename);
   g_free(filename);
 }
 

--- a/modules/correlation/tests/test_patterndb.c
+++ b/modules/correlation/tests/test_patterndb.c
@@ -794,6 +794,74 @@ Test(pattern_db, test_program_template)
   log_template_unref(template);
 }
 
+Test(pattern_db, test_value_with_type_attribute)
+{
+  gchar *filename;
+  PatternDB *patterndb = _create_pattern_db(pdb_test_value_with_type, &filename);
+
+  /* Test that typed test values are loaded and memory is properly managed */
+  assert_msg_matches_and_nvpair_equals(patterndb, "test typed values: 42 hello world",
+                                       "count", "42");
+  assert_msg_matches_and_nvpair_equals(patterndb, "test typed values: 42 hello world",
+                                       "message", "hello");
+  assert_msg_matches_and_nvpair_equals(patterndb, "test typed values: 42 hello world",
+                                       "level", "world");
+
+  _destroy_pattern_db(patterndb, filename);
+  g_free(filename);
+}
+
+Test(pattern_db, test_optionalset_at_end_of_pattern)
+{
+  /* OPTIONALSET as last parser must match zero chars at end-of-input and the
+     subsequent named-value extraction must not overshoot. */
+  gchar *filename;
+  PatternDB *patterndb = _create_pattern_db(pdb_test_optionalset_at_end_of_pattern, &filename);
+
+  /* Trailing space present: OPTIONALSET consumes the literal space. */
+  assert_msg_matches_and_has_tag(patterndb,
+                                 "[dcef7d1c-6b79-48c6-a1ac-39cdc9bff966] ",
+                                 ".classifier.system", TRUE);
+  assert_msg_matches_and_nvpair_equals(patterndb,
+                                       "[dcef7d1c-6b79-48c6-a1ac-39cdc9bff966] ",
+                                       "id", "dcef7d1c-6b79-48c6-a1ac-39cdc9bff966");
+  assert_msg_matches_and_nvpair_equals(patterndb,
+                                       "[dcef7d1c-6b79-48c6-a1ac-39cdc9bff966] ",
+                                       "s", " ");
+
+  /* No trailing space: OPTIONALSET must match zero chars at end-of-input. */
+  assert_msg_matches_and_has_tag(patterndb,
+                                 "[dcef7d1c-6b79-48c6-a1ac-39cdc9bff966]",
+                                 ".classifier.system", TRUE);
+  assert_msg_matches_and_nvpair_equals(patterndb,
+                                       "[dcef7d1c-6b79-48c6-a1ac-39cdc9bff966]",
+                                       "id", "dcef7d1c-6b79-48c6-a1ac-39cdc9bff966");
+  assert_msg_matches_and_nvpair_equals(patterndb,
+                                       "[dcef7d1c-6b79-48c6-a1ac-39cdc9bff966]",
+                                       "s", "");
+
+  _destroy_pattern_db(patterndb, filename);
+  g_free(filename);
+}
+
+Test(pattern_db, test_set_at_end_of_input_does_not_match_zero_chars)
+{
+  /* @SET@ must require at least one matching char; at end-of-input it must
+     not silently match the terminating NUL. */
+  gchar *filename;
+  PatternDB *patterndb = _create_pattern_db(pdb_test_set_at_end_of_input, &filename);
+
+  LogMessage *msg = _construct_message("prog1", "prefix");
+  cr_assert_not(_process(patterndb, msg),
+                "SET at end-of-input must not match when there are no chars to consume");
+  log_msg_unref(msg);
+
+  assert_msg_matches_and_nvpair_equals(patterndb, "prefix ", "s", " ");
+
+  _destroy_pattern_db(patterndb, filename);
+  g_free(filename);
+}
+
 void setup(void)
 {
   app_startup();

--- a/modules/correlation/tests/test_patterndb.h
+++ b/modules/correlation/tests/test_patterndb.h
@@ -632,6 +632,26 @@
  </ruleset>\
 </patterndb>"
 
+#define pdb_test_optionalset_at_end_of_pattern_with_examples "\
+<patterndb version='6' pub_date='2010-02-22'>\
+ <ruleset name='rails' id='8db0c6d8-f6ef-11ef-a968-18cf5efc6bb4'>\
+  <patterns>\
+   <pattern>prog1</pattern>\
+  </patterns>\
+  <rules>\
+   <rule id='8e8384e8-f6ef-11ef-a968-18cf5efc6bb4' provider='test' class='system'>\
+    <patterns>\
+     <pattern>@QSTRING:id:[]@@OPTIONALSET:s: @</pattern>\
+    </patterns>\
+    <examples>\
+     <example><test_message program='prog1'>[dcef7d1c-6b79-48c6-a1ac-39cdc9bff966]</test_message></example>\
+     <example><test_message program='prog1'>[dcef7d1c-6b79-48c6-a1ac-39cdc9bff966]  </test_message></example>\
+    </examples>\
+   </rule>\
+  </rules>\
+ </ruleset>\
+</patterndb>"
+
 #define pdb_test_set_at_end_of_input "\
 <patterndb version='6' pub_date='2010-02-22'>\
  <ruleset name='set_eoi' id='8db0c6d8-f6ef-11ef-a968-18cf5efc6bb5'>\

--- a/modules/correlation/tests/test_patterndb.h
+++ b/modules/correlation/tests/test_patterndb.h
@@ -583,4 +583,69 @@
 </ruleset>\
 </patterndb>"
 
+#define pdb_test_value_with_type "\
+<patterndb version='6' pub_date='2010-02-22'>\
+ <ruleset name='testset' id='1'>\
+  <patterns>\
+    <pattern>prog1</pattern>\
+  </patterns>\
+  <rules>\
+    <rule provider='test' id='11' class='system'>\
+     <patterns>\
+      <pattern>test typed values: @NUMBER:count@ @ESTRING:message: @@ESTRING:level:@</pattern>\
+     </patterns>\
+     <examples>\
+       <example>\
+         <test_message program='prog1'>test typed values: 42 hello world</test_message>\
+         <test_values>\
+            <test_value name='count' type='integer'>42</test_value>\
+            <test_value name='message' type='string'>hello</test_value>\
+            <test_value name='level'>world</test_value>\
+         </test_values>\
+       </example>\
+       <example>\
+         <test_message program='prog1'>test typed values: 123 foo bar</test_message>\
+         <test_values>\
+            <test_value name='count' type='integer'>123</test_value>\
+            <test_value name='message' type='string'>foo</test_value>\
+         </test_values>\
+       </example>\
+     </examples>\
+    </rule>\
+  </rules>\
+ </ruleset>\
+</patterndb>"
+
+#define pdb_test_optionalset_at_end_of_pattern "\
+<patterndb version='6' pub_date='2010-02-22'>\
+ <ruleset name='rails' id='8db0c6d8-f6ef-11ef-a968-18cf5efc6bb4'>\
+  <patterns>\
+   <pattern>prog1</pattern>\
+  </patterns>\
+  <rules>\
+   <rule id='8e8384e8-f6ef-11ef-a968-18cf5efc6bb4' provider='test' class='system'>\
+    <patterns>\
+     <pattern>@QSTRING:id:[]@@OPTIONALSET:s: @</pattern>\
+    </patterns>\
+   </rule>\
+  </rules>\
+ </ruleset>\
+</patterndb>"
+
+#define pdb_test_set_at_end_of_input "\
+<patterndb version='6' pub_date='2010-02-22'>\
+ <ruleset name='set_eoi' id='8db0c6d8-f6ef-11ef-a968-18cf5efc6bb5'>\
+  <patterns>\
+   <pattern>prog1</pattern>\
+  </patterns>\
+  <rules>\
+   <rule id='8e8384e8-f6ef-11ef-a968-18cf5efc6bb5' provider='test' class='system'>\
+    <patterns>\
+     <pattern>prefix@SET:s: @</pattern>\
+    </patterns>\
+   </rule>\
+  </rules>\
+ </ruleset>\
+</patterndb>"
+
 #endif

--- a/modules/correlation/tests/test_radix.c
+++ b/modules/correlation/tests/test_radix.c
@@ -1037,6 +1037,11 @@ ParameterizedTestParameters(dbparser, test_radix_search_matches)
       .key = "[AAA]  ",
       .expected_pattern = {"q", "AAA", "s", "  ", NULL},
     },
+    {
+      .node_to_insert = {"@QSTRING:q:[]@@OPTIONALSET:s: @", NULL},
+      .key = "[AAA]",
+      .expected_pattern = {"q", "AAA", "s", "", NULL},
+    },
     /* test_mcaddr_matches */
     {
       .node_to_insert = {"@MACADDR:macaddr@", NULL},

--- a/modules/correlation/tests/test_radix.c
+++ b/modules/correlation/tests/test_radix.c
@@ -272,6 +272,7 @@ Test(dbparser, test_parsers, .init = test_setup, .fini = test_teardown)
   insert_node(root, "AAA@SET:set@AAA");
   insert_node(root, "AAA@OPTIONALSET@AAA");
   insert_node(root, "AAA@OPTIONALSET:set@AAA");
+
   insert_node(root, "AAA@MACADDR@AAA");
   insert_node(root, "newline@NUMBER@\n2ndline\n");
   insert_node(root, "AAA@PCRE:set@AAA");
@@ -1005,6 +1006,12 @@ ParameterizedTestParameters(dbparser, test_radix_search_matches)
       .expected_pattern = {"set", "  ", NULL},
     },
     {
+      .node_to_insert = {"@SET:set:  @", NULL},
+      .key = "  ",
+      .expected_pattern = {"set", "  ", NULL},
+    },
+    /* test_optional_set_matches */
+    {
       .node_to_insert = {"@OPTIONALSET:set:  @", NULL},
       .key = " aaa",
       .expected_pattern = {"set", " ", NULL},
@@ -1018,6 +1025,17 @@ ParameterizedTestParameters(dbparser, test_radix_search_matches)
       .node_to_insert = {"@OPTIONALSET:set:  @", NULL},
       .key = "aaa",
       .expected_pattern = {"set", "", NULL},
+    },
+    {
+      .node_to_insert = {"@OPTIONALSET:set:  @", NULL},
+      .key = "  ",
+      .expected_pattern = {"set", "  ", NULL},
+    },
+    /* test_optional_set_matches at the end */
+    {
+      .node_to_insert = {"@QSTRING:q:[]@@OPTIONALSET:s: @", NULL},
+      .key = "[AAA]  ",
+      .expected_pattern = {"q", "AAA", "s", "  ", NULL},
     },
     /* test_mcaddr_matches */
     {
@@ -1045,6 +1063,16 @@ ParameterizedTestParameters(dbparser, test_radix_search_matches)
       .node_to_insert = {"@EMAIL:email:[<]>@", NULL },
       .key = "[blint@balabit.hu]",
       .expected_pattern = {"email", "blint@balabit.hu", NULL},
+    },
+    {
+      .node_to_insert = {"@EMAIL:email:[<]>@", NULL },
+      .key = "a@b.c",
+      .expected_pattern = {"email", "a@b.c", NULL},
+    },
+    {
+      .node_to_insert = {"@EMAIL:email:[<]>@", NULL },
+      .key = "<a@b.c>",
+      .expected_pattern = {"email", "a@b.c", NULL},
     },
     /* test_hostname_matches */
     {

--- a/news/bugfix-1110.md
+++ b/news/bugfix-1110.md
@@ -1,0 +1,6 @@
+`correlation`: fix radix parser end-of-input handling
+
+Fixes two related radix matcher edge cases at end of input.
+
+Parser scans now stop before '\0' to avoid reading past end-of-input and to keep captured lengths correct.
+Parser-node traversal now continues with empty remaining input, so OPTIONALSET children can still match.


### PR DESCRIPTION
Backports syslog-ng/syslog-ng#5690.

Fixes two related radix matcher edge cases at end of input.

- Parser scans now stop before '\0' to avoid reading past end-of-input and to keep captured lengths correct.
- Parser-node traversal now continues with empty remaining input, so OPTIONALSET children can still match.

Also fixes a regression caused by 5b77cceef signaled by @smortex

Upstream issues: syslog-ng/syslog-ng#5678, syslog-ng/syslog-ng#5710

---

Note: the pdb_rule_set_load double-free fix is defensive-only in AxoSyslog — the regression cause (5b77cceef) is not present here, since pdb_rule_set_load does not call _pdb_loader_cleanup() and so never double-frees state.examples. The accompanying tests remain useful regardless.

Assisted-by: Claude:claude-opus-4-8[1m]
