### PR TITLE
journald-source: add read_old_on_error() option to control where to continue after a position restore attempt failure

### DIFF
--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -411,7 +411,7 @@ _skip_old_records(JournalReader *self)
   int rc = sd_journal_next(self->journal);
   if (rc < 0)
     {
-      msg_error("systemd-journal: Error processing read-old-records(no), sd_journal_next() failed after sd_journal_seek_tail()",
+      msg_error("systemd-journal: Error skipping old records, sd_journal_next() failed after sd_journal_seek_tail()",
                 evt_tag_errno("error", -rc));
       return FALSE;
     }
@@ -478,10 +478,12 @@ _seek_to_saved_state(JournalReader *self)
     {
       persist_state_unmap_entry(self->persist_state, self->persist_handle);
 
-      return _seek_to_head(self);
+      msg_error("systemd-journal: Failed to seek the journal to the last saved cursor position.",
+                evt_tag_str("cursor", state->cursor));
+      return self->options->read_old_records_on_error ? _seek_to_head(self) : _skip_old_records(self);
     }
 
-  msg_debug("systemd-journal: Seeking the journal to the last cursor position",
+  msg_debug("systemd-journal: Seeking the journal to the last saved cursor position",
             evt_tag_str("cursor", state->cursor));
 
   persist_state_unmap_entry(self->persist_state, self->persist_handle);
@@ -1022,6 +1024,12 @@ journal_reader_options_set_match_boot(JournalReaderOptions *self, gboolean enabl
 }
 
 void
+journal_reader_options_set_read_old_records_on_error(JournalReaderOptions *self, gboolean enable)
+{
+  self->read_old_records_on_error = enable;
+}
+
+void
 journal_reader_options_defaults(JournalReaderOptions *options)
 {
   log_source_options_defaults(&options->super);
@@ -1032,6 +1040,7 @@ journal_reader_options_defaults(JournalReaderOptions *options)
   options->max_field_size = DEFAULT_FIELD_SIZE;
   options->match_boot = FALSE;
   options->super.read_old_records = TRUE;
+  options->read_old_records_on_error = options->super.read_old_records;
 }
 
 void

--- a/modules/systemd-journal/journal-reader.h
+++ b/modules/systemd-journal/journal-reader.h
@@ -45,6 +45,7 @@ typedef struct _JournalReaderOptions
   gchar *namespace;
   GList *matches;
   gboolean match_boot;
+  gboolean read_old_records_on_error;
 } JournalReaderOptions;
 
 JournalReader *journal_reader_new(GlobalConfig *cfg);
@@ -61,6 +62,7 @@ void journal_reader_options_set_namespace(JournalReaderOptions *self, gchar *nam
 void journal_reader_options_set_log_fetch_limit(JournalReaderOptions *self, gint log_fetch_limit);
 void journal_reader_options_set_matches(JournalReaderOptions *self, GList *matches);
 void journal_reader_options_set_match_boot(JournalReaderOptions *self, gboolean enable);
+void journal_reader_options_set_read_old_records_on_error(JournalReaderOptions *self, gboolean enable);
 void journal_reader_options_defaults(JournalReaderOptions *options);
 void journal_reader_options_destroy(JournalReaderOptions *options);
 

--- a/modules/systemd-journal/systemd-journal-grammar.ym
+++ b/modules/systemd-journal/systemd-journal-grammar.ym
@@ -59,6 +59,7 @@ JournalReaderOptions *last_journal_reader_options;
 %token KW_NAMESPACE
 %token KW_MATCHES
 %token KW_MATCH_BOOT
+%token KW_READ_OLD_RECORDS_ON_ERROR
 
 %type   <ptr> source_systemd_journal
 %type   <ptr> source_systemd_journal_params
@@ -131,6 +132,7 @@ source_systemd_journal_option
           {
             journal_reader_options_set_match_boot(last_journal_reader_options, $3);
           }
+        | KW_READ_OLD_RECORDS_ON_ERROR '(' yesno ')'	{ journal_reader_options_set_read_old_records_on_error(last_journal_reader_options, $3); }
         | source_option
 	| source_driver_option
         ;

--- a/modules/systemd-journal/systemd-journal-parser.c
+++ b/modules/systemd-journal/systemd-journal-parser.c
@@ -37,6 +37,7 @@ static CfgLexerKeyword systemd_journal_keywords[] =
   { "namespace",                  KW_NAMESPACE },
   { "matches",                    KW_MATCHES },
   { "match_boot",                 KW_MATCH_BOOT },
+  { "read_old_on_error",          KW_READ_OLD_RECORDS_ON_ERROR },
   { NULL }
 };
 


### PR DESCRIPTION
Cherry-picked from syslog-ng/syslog-ng#5647