### PR TITLE
Fix scope sync

### DIFF
--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -101,6 +101,9 @@ _pull_variable_from_parent_scope(FilterXScope *self, FilterXVariablePullMode pul
         }
     }
 
+  if (pull_mode == FX_VAR_PULL_MOVE)
+    parent_variable->variable_type = FX_VAR_NONE;
+
   msg_trace("Filterx scope, pulling scope variable",
             evt_tag_str("variable", log_msg_get_value_name((filterx_variable_get_nv_handle(output)), NULL)));
   return output;

--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -254,78 +254,83 @@ filterx_scope_sync(FilterXScope *self, LogMessage **pmsg, const LogPathOptions *
 
   gint msg_generation = self->msg->generation;
 
-  for (guint32 i = 0; i < self->variables_size; i++)
+  for (FilterXScope *scope = self;
+       scope && filterx_scope_is_dirty(scope) && !filterx_scope_is_fork_point(scope);
+       scope = scope->parent_scope)
     {
-      FilterXVariable *v = &self->variables[i];
-      if (!v->variable_type)
-        continue;
+      for (guint32 i = 0; i < scope->variables_size; i++)
+        {
+          FilterXVariable *v = &scope->variables[i];
+          if (!v->variable_type)
+            continue;
 
-      /* we don't need to sync the value if:
-       *
-       *  1) this is a floating variable; OR
-       *
-       *  2) the value was extracted from the message but was not changed in
-       *     place (for mutable objects), and was not assigned to.
-       *
-       */
-      if (filterx_variable_is_floating(v))
-        {
-          /* we could unset undeclared, floating values here as we are
-           * transitioning to the next filterx block.  But this is also
-           * addressed by the variable generation counter mechanism.  This
-           * means that we will unset those if some expr actually refers to
-           * it.  Also, we skip the entire sync exercise, unless we have
-           * message tied values, so we need to work even if floating
-           * variables are not synced.
+          /* we don't need to sync the value if:
            *
-           * With that said, let's not clear these.
+           *  1) this is a floating variable; OR
+           *
+           *  2) the value was extracted from the message but was not changed in
+           *     place (for mutable objects), and was not assigned to.
+           *
            */
-        }
-      else if (v->value == NULL)
-        {
-          if (log_msg_is_value_set(self->msg, filterx_variable_get_nv_handle(v)))
+          if (filterx_variable_is_floating(v))
             {
+              /* we could unset undeclared, floating values here as we are
+               * transitioning to the next filterx block.  But this is also
+               * addressed by the variable generation counter mechanism.  This
+               * means that we will unset those if some expr actually refers to
+               * it.  Also, we skip the entire sync exercise, unless we have
+               * message tied values, so we need to work even if floating
+               * variables are not synced.
+               *
+               * With that said, let's not clear these.
+               */
+            }
+          else if (v->value == NULL)
+            {
+              if (log_msg_is_value_set(self->msg, filterx_variable_get_nv_handle(v)))
+                {
+                  filterx_scope_set_message(self, log_msg_make_writable(pmsg, path_options));
+                  g_assert(v->generation == msg_generation);
+
+                  msg_trace("Filterx sync: whiteout variable, unsetting in message",
+                            evt_tag_str("variable", log_msg_get_value_name(filterx_variable_get_nv_handle(v), NULL)));
+                  log_msg_unset_value(self->msg, filterx_variable_get_nv_handle(v));
+                }
+
+              filterx_variable_unassign(v);
+              v->generation++;
+            }
+          else if (filterx_variable_is_assigned(v) || filterx_object_is_dirty(v->value))
+            {
+              LogMessageValueType t;
+
+              if (!buffer)
+                buffer = scratch_buffers_alloc();
+
               filterx_scope_set_message(self, log_msg_make_writable(pmsg, path_options));
               g_assert(v->generation == msg_generation);
-
-              msg_trace("Filterx sync: whiteout variable, unsetting in message",
+              msg_trace("Filterx sync: changed variable in scope, overwriting in message",
                         evt_tag_str("variable", log_msg_get_value_name(filterx_variable_get_nv_handle(v), NULL)));
-              log_msg_unset_value(self->msg, filterx_variable_get_nv_handle(v));
+
+              g_string_truncate(buffer, 0);
+              if (!filterx_object_marshal(v->value, buffer, &t))
+                g_assert_not_reached();
+              log_msg_set_value_with_type(self->msg, filterx_variable_get_nv_handle(v), buffer->str, buffer->len, t);
+              filterx_object_set_dirty(v->value, FALSE);
+              filterx_variable_unassign(v);
+              v->generation++;
             }
-
-          filterx_variable_unassign(v);
-          v->generation++;
+          else
+            {
+              msg_trace("Filterx sync: variable in scope and message in sync, not doing anything",
+                        evt_tag_str("variable", log_msg_get_value_name(filterx_variable_get_nv_handle(v), NULL)));
+              v->generation++;
+            }
         }
-      else if (filterx_variable_is_assigned(v) || filterx_object_is_dirty(v->value))
-        {
-          LogMessageValueType t;
-
-          if (!buffer)
-            buffer = scratch_buffers_alloc();
-
-          filterx_scope_set_message(self, log_msg_make_writable(pmsg, path_options));
-          g_assert(v->generation == msg_generation);
-          msg_trace("Filterx sync: changed variable in scope, overwriting in message",
-                    evt_tag_str("variable", log_msg_get_value_name(filterx_variable_get_nv_handle(v), NULL)));
-
-          g_string_truncate(buffer, 0);
-          if (!filterx_object_marshal(v->value, buffer, &t))
-            g_assert_not_reached();
-          log_msg_set_value_with_type(self->msg, filterx_variable_get_nv_handle(v), buffer->str, buffer->len, t);
-          filterx_object_set_dirty(v->value, FALSE);
-          filterx_variable_unassign(v);
-          v->generation++;
-        }
-      else
-        {
-          msg_trace("Filterx sync: variable in scope and message in sync, not doing anything",
-                    evt_tag_str("variable", log_msg_get_value_name(filterx_variable_get_nv_handle(v), NULL)));
-          v->generation++;
-        }
+      scope->dirty = FALSE;
     }
   /* FIXME: hack ! */
   self->msg->generation = msg_generation + 1;
-  self->dirty = FALSE;
 }
 
 gsize
@@ -351,8 +356,7 @@ filterx_scope_init_instance(FilterXScope *storage, gsize storage_size, FilterXSc
     {
       self->parent_scope = parent_scope;
       self->generation = parent_scope->generation + 1;
-      if (parent_scope->variables_used > 0)
-        self->dirty = parent_scope->dirty;
+      self->dirty = parent_scope->dirty;
       self->syncable = parent_scope->syncable;
       self->msg = log_msg_ref(parent_scope->msg);
     }

--- a/lib/filterx/tests/test_scope.c
+++ b/lib/filterx/tests/test_scope.c
@@ -99,6 +99,38 @@ Test(filterx_scope, test_scope_sync)
   filterx_scope_variable_layout_free(l);
 }
 
+Test(filterx_scope, test_scope_sync_walks_parent_scopes_until_fork_point)
+{
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+
+  FilterXVariableHandle handles[] = {filterx_map_varname_to_handle("$var", FX_VAR_MESSAGE_TIED)};
+  FilterXScopeVariableLayout *l = filterx_scope_variable_layout_new_from_handles(handles, G_N_ELEMENTS(handles));
+
+  FilterXScope *s = filterx_scope_new(NULL, l);
+  LogMessage *msg = log_msg_new_empty();
+  filterx_scope_set_message(s, msg);
+
+  FilterXVariableHandle var = filterx_map_varname_to_handle("$var", FX_VAR_MESSAGE_TIED);
+  FilterXVariable *v = filterx_scope_register_variable(s, FX_VAR_MESSAGE_TIED, var, 0);
+  FilterXObject *o = filterx_boolean_new(TRUE);
+  filterx_scope_set_variable(s, v, &o, TRUE);
+  filterx_object_unref(o);
+  filterx_scope_set_dirty(s);
+
+  FilterXScope *s2 = filterx_scope_new(s, l);
+  filterx_scope_sync(s2, &msg, &path_options);
+
+  LogMessageValueType type;
+  const gchar *value = log_msg_get_value_with_type(msg, filterx_variable_get_nv_handle(v), NULL, &type);
+  cr_assert_eq(type, LM_VT_BOOLEAN);
+  cr_assert_str_eq(value, "true");
+
+  log_msg_unref(msg);
+  filterx_scope_free(s2);
+  filterx_scope_free(s);
+  filterx_scope_variable_layout_free(l);
+}
+
 static gboolean
 _assert_var_false(FilterXVariable *variable, gpointer user_data)
 {

--- a/tests/light/functional_tests/filterx/test_filterx_scope.py
+++ b/tests/light/functional_tests/filterx/test_filterx_scope.py
@@ -448,3 +448,93 @@ def test_changes_in_abandoned_branches_are_ignored(config, syslog_ng):
 
     assert file_final.get_stats()["processed"] == 1
     assert file_final.read_log() == '{"common":"common","iffalse":"false"}'
+
+
+def test_sync_through_linear_filterx_block_chain(config, syslog_ng):
+    (file_true, file_false, _) = create_config(
+        config, [
+            """
+            $MSG = "acila";
+            """,
+            """
+            a = 3;
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "acila"
+
+
+def test_sync_through_linear_filterx_block_chain_moved_variable(config, syslog_ng):
+    (file_true, file_false, _) = create_config(
+        config, [
+            """
+            $MSG = "acila";
+            """,
+            """
+            a = $MSG;
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "acila"
+
+
+def test_sync_through_linear_filterx_block_chain_moved_variable_left_in_parent_scope(config, syslog_ng):
+    (file_true, file_false, _) = create_config(
+        config, [
+            """
+            $MSG = "kecske";
+            """,
+            """
+            a = $MSG;
+            """,
+            """
+            a = 3;
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "kecske"
+
+
+def test_sync_stops_at_fork_point_when_branch_is_abandoned(config, syslog_ng):
+    (file_true, file_false, _) = create_config(
+        config, init_exprs=[
+            """
+            $MSG = "initial";
+            """,
+        ], true_exprs=[
+            """
+            $MSG = "kecske";
+            """,
+            """
+            a = 3;
+            hiba;
+            """,
+        ], false_exprs=[
+            """
+            $MSG = "acila";
+            """,
+            """
+            a = $MSG;
+            """,
+            """
+            b = 3;
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_false.get_stats()["processed"] == 1
+    assert "processed" not in file_true.get_stats()
+    assert file_false.read_log() == "acila"


### PR DESCRIPTION
A feature called "scope reuse" has recently been removed in favor of variable moving and O(1) lookup.

filterx_scope_sync() dependended on scope reuse in a hidden way: it was only called on fork points and when a non-filterx block was inserted after a FilterX block; but sync() itself was not recursive, it only synced the latest scope, not all the consecutive scopes.

This commit fixes it by adding the recursion: going back until the last fork point, syncing everything. `scope->dirty = FALSE` makes sure scopes are synced only once, for example, when a rewrite rule is inserted between 2 FilterX blocks.

Note: This is a temporary fix, a cleaner idea will be implemented later: allocating one single scope (and a merged precalculated variable layout) for all consecutive blocks. This basically reintroduces the "scope reuse" feature without losing O(1) lookups, so the end result will be even faster.