### PR TITLE
github-actions: add callgrind instruction count comment job

### DIFF
--- a/.github/workflows/comment-callgrind-changes.yml
+++ b/.github/workflows/comment-callgrind-changes.yml
@@ -1,0 +1,126 @@
+name: Comment callgrind changes (PR)
+
+on:
+  workflow_run:
+    workflows: [CI @ devshell]
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event.workflow_run.head_repository.owner.login }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  update-or-remove-comment-on-pr:
+    name: Update or remove PR comment
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # post/update/delete callgrind diff comment on PR
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+        # The download-artifact action cannot download artifacts from other workflows.
+        # Copied from https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
+      - name: Download comment artifact
+        id: download
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "callgrind-comment"
+            })[0];
+            if (!matchArtifact) {
+              // The callgrind job may not have run (e.g. it was cancelled or failed
+              // before uploading). Nothing to comment on.
+              core.setOutput('found', 'false');
+              core.notice('No callgrind-comment artifact found, nothing to do');
+              return;
+            }
+            core.setOutput('found', 'true');
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/callgrind-comment.zip`, Buffer.from(download.data));
+
+      - name: Unzip comment artifact
+        if: steps.download.outputs.found == 'true'
+        run: unzip callgrind-comment.zip
+
+      - name: Get PR ID
+        id: pr-id
+        if: steps.download.outputs.found == 'true'
+        env:
+          HEAD_REPO_URL: ${{ github.event.workflow_run.head_repository.url }}
+          REPO_URL: ${{ github.event.workflow_run.repository.url }}
+          REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_REPO_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+        run: |
+          # The pull_requests array always come empty when querying a workflow run's data if it is started from a fork. This might be a GitHub bug.
+          # There is also no json field in the `gh run view` command, which could give us the PR ID, so we can only query it based on the fork and branch.
+          # See https://github.com/orgs/community/discussions/25220
+
+          if [[ "${HEAD_REPO_URL}" == "${REPO_URL}" ]]; then
+            PR_ID=$(gh pr view -R "${REPO}" "${HEAD_BRANCH}" --json "number" --jq ".number")
+          else
+            # PR is from a fork
+            PR_ID=$(gh pr view -R "${REPO}" "${HEAD_REPO_OWNER}:${HEAD_BRANCH}" --json "number" --jq ".number")
+          fi
+
+          echo "pr-id=${PR_ID}" >> $GITHUB_OUTPUT
+
+      - name: Update or remove PR comment
+        if: steps.download.outputs.found == 'true'
+        env:
+            REPO: ${{ github.repository }}
+            PR_ID: ${{ steps.pr-id.outputs.pr-id }}
+        run: |
+          EXISTING_COMMENT_ID=$( \
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/${REPO}/issues/${PR_ID}/comments \
+              --jq '.[] | select(.user.login=="github-actions[bot]") | select(.user.type=="Bot") | select(.user.id==41898282) | select(.body | startswith("#### Callgrind instruction count changes")) | .id')
+
+          if [[ -s "${GITHUB_WORKSPACE}/callgrind-comment.json" ]]; then
+            if [[ -n "${EXISTING_COMMENT_ID}" ]]; then
+              gh api \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                --method PATCH \
+                /repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID} \
+                --input ${GITHUB_WORKSPACE}/callgrind-comment.json
+              echo -e "\n::notice::Updated comment: ${EXISTING_COMMENT_ID}"
+            else
+              gh api \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                --method POST \
+                /repos/${REPO}/issues/${PR_ID}/comments \
+                --input ${GITHUB_WORKSPACE}/callgrind-comment.json
+              echo -e "\n::notice::Created new comment"
+            fi
+          else
+            if [[ -n "${EXISTING_COMMENT_ID}" ]]; then
+              gh api \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                --method DELETE \
+                /repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}
+              echo -e "\n::notice::Removed comment: ${EXISTING_COMMENT_ID}"
+            else
+              echo -e "\n::notice::Nothing to do"
+            fi
+          fi

--- a/.github/workflows/comment-cfg-grammar-changes.yml
+++ b/.github/workflows/comment-cfg-grammar-changes.yml
@@ -24,6 +24,7 @@ jobs:
         # The download-artifact action cannot download artifacts from other workflows.
         # Copied from https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
       - name: Download comment artifact
+        id: download
         uses: actions/github-script@v9.0.0
         with:
           script: |
@@ -35,6 +36,14 @@ jobs:
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "comment"
             })[0];
+            if (!matchArtifact) {
+              // The check workflow may not have produced the artifact (e.g. it was
+              // cancelled or failed). Nothing to comment on.
+              core.setOutput('found', 'false');
+              core.notice('No comment artifact found, nothing to do');
+              return;
+            }
+            core.setOutput('found', 'true');
             let download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
@@ -45,10 +54,12 @@ jobs:
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/comment.zip`, Buffer.from(download.data));
 
       - name: Unzip comment artifact
+        if: steps.download.outputs.found == 'true'
         run: unzip comment.zip
 
       - name: Get PR ID
         id: pr-id
+        if: steps.download.outputs.found == 'true'
         env:
           HEAD_REPO_URL: ${{ github.event.workflow_run.head_repository.url }}
           REPO_URL: ${{ github.event.workflow_run.repository.url }}
@@ -70,6 +81,7 @@ jobs:
           echo "pr-id=${PR_ID}" >> $GITHUB_OUTPUT
 
       - name: Update or remove PR comment
+        if: steps.download.outputs.found == 'true'
         env:
             REPO: ${{ github.repository }}
             PR_ID: ${{ steps.pr-id.outputs.pr-id }}

--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -286,6 +286,81 @@ jobs:
           name: callgrind_annotate.txt
           path: dbld/build/callgrind/*/callgrind_annotate.txt
 
+      - name: Generate callgrind diff comment
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_HEAD: ${{ steps.commits.outputs.BASE_HEAD }}
+          PR_HEAD: ${{ steps.commits.outputs.PR_HEAD }}
+        run: |
+          COMMENT_FILE="${GITHUB_WORKSPACE}/callgrind-comment.json"
+          : > "${COMMENT_FILE}"
+
+          PR_ANNOTATE="dbld/build/callgrind/pr/callgrind_annotate.txt"
+          BASE_ANNOTATE="dbld/build/callgrind/base/callgrind_annotate.txt"
+
+          if ! git diff --name-only "${BASE_HEAD}" "${PR_HEAD}" | grep -v test | grep -qE '(^|/)filterx'; then
+            echo "::notice::PR does not change filterx code (excluding tests), no callgrind comment"
+            exit 0
+          fi
+
+          if [[ ! -f "${PR_ANNOTATE}" || ! -f "${BASE_ANNOTATE}" ]]; then
+            echo "::notice::Missing callgrind profile (base build may have failed), no callgrind comment"
+            exit 0
+          fi
+
+          extract_ir() {
+            grep -m1 'PROGRAM TOTALS' "$1" | grep -oE '[0-9,]+' | head -1 | tr -d ','
+          }
+
+          # Insert thousands separators, preserving a leading +/- sign.
+          group() {
+            printf '%s' "$1" | sed -E ':a;s/^([+-]?[0-9]+)([0-9]{3})/\1,\2/;ta'
+          }
+
+          BASE_IR=$(extract_ir "${BASE_ANNOTATE}")
+          PR_IR=$(extract_ir "${PR_ANNOTATE}")
+
+          if [[ -z "${BASE_IR}" || -z "${PR_IR}" ]]; then
+            echo "::notice::Could not parse instruction counts, no callgrind comment"
+            exit 0
+          fi
+
+          DIFF=$((PR_IR - BASE_IR))
+          PCT=$(awk "BEGIN { if (${BASE_IR} > 0) printf \"%+.2f\", (${DIFF} / ${BASE_IR}) * 100; else printf \"n/a\" }")
+
+          if [[ "${DIFF}" -gt 0 ]]; then
+            VERDICT='**increase**'
+          elif [[ "${DIFF}" -lt 0 ]]; then
+            VERDICT='**decrease**'
+          else
+            VERDICT='**no change**'
+          fi
+
+          BODY=$(cat <<EOF
+          #### Callgrind instruction count changes
+
+          This Pull Request changes filterx code. The filterx callgrind benchmark reports ${VERDICT} in instruction count.
+
+          | | Instructions (Ir) | Diff (Ir) | Diff (%) |
+          | --- | --- | --- | --- |
+          | base | $(group "${BASE_IR}") | 0 | 0.00% |
+          | PR | $(group "${PR_IR}") | $(group "$(printf '%+d' "${DIFF}")") | ${PCT}% |
+
+          EOF
+          )
+
+          jq -n --arg body "${BODY}" '{body: $body}' > "${COMMENT_FILE}"
+          echo "::notice::Generated callgrind comment (diff: ${DIFF} Ir, ${PCT}%)"
+
+      - name: "Artifact: callgrind comment"
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: callgrind-comment
+          path: callgrind-comment.json
+          include-hidden-files: true
+          if-no-files-found: error
+
   style-check:
     name: Style check
     runs-on: ubuntu-latest

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -24,3 +24,4 @@ rules:
   dangerous-triggers:
     ignore:
       - comment-cfg-grammar-changes.yml
+      - comment-callgrind-changes.yml


### PR DESCRIPTION
Posts a single comment (and edits it if necessary) if we modified filterx related, non-test code.

PRs for reference:
* https://github.com/alltilla/axosyslog/pull/1
* https://github.com/alltilla/axosyslog/pull/2
* https://github.com/alltilla/axosyslog/pull/3
* https://github.com/alltilla/axosyslog/pull/4

The only problem is that the measurement is not fix (see the comments in PR 2, 3, 4). There are small differences in the base measurement, too. We might want to fix that.