### PR TITLE
Logmsg handle locking fixes

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -2048,12 +2048,18 @@ log_msg_registry_init(void)
 
   for (i = 0; macros[i].name; i++)
     {
-      if (nv_registry_get_handle(logmsg_registry, macros[i].name) == 0)
+      macros[i].handle = nv_registry_get_handle(logmsg_registry, macros[i].name);
+      if (macros[i].handle == 0)
         {
-          NVHandle handle;
+          /* not a registered builtin nv-pair: this is a real hard-macro.
+           *
+           * Some of the name-value pairs registered above also have a
+           * wrapper macro, like $HOST or $MSG, in those cases we don't want
+           * the flag setting to be applied, as that would prevent changing
+           * the value */
 
-          handle = nv_registry_alloc_handle(logmsg_registry, macros[i].name);
-          nv_registry_set_handle_flags(logmsg_registry, handle, (macros[i].id << 8) + LM_VF_MACRO);
+          macros[i].handle  = nv_registry_alloc_handle(logmsg_registry, macros[i].name);
+          nv_registry_set_handle_flags(logmsg_registry, macros[i].handle, (macros[i].id << 8) + LM_VF_MACRO);
         }
     }
 

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -2082,6 +2082,22 @@ log_msg_registry_deinit(void)
 }
 
 void
+log_msg_macros_foreach(LogMessageMacrosForeachFunc func, gpointer user_data)
+{
+  for (gint i = 0; macros[i].name; i++)
+    {
+      if (!log_msg_is_handle_macro(macros[i].handle))
+        {
+          /* builtin values with a macro wrapper */
+          continue;
+        }
+
+      if (!func(macros[i].handle, macros[i].name, user_data))
+        break;
+    }
+}
+
+void
 log_msg_registry_foreach(GHFunc func, gpointer user_data)
 {
   nv_registry_foreach(logmsg_registry, func, user_data);

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -458,7 +458,8 @@ const gchar *log_msg_get_match_with_type(const LogMessage *self, gint index_,
 const gchar *log_msg_get_match_if_set_with_type(const LogMessage *self, gint index_,
                                                 gssize *value_len, LogMessageValueType *type);
 
-
+typedef gboolean (*LogMessageMacrosForeachFunc)(NVHandle handle, const gchar *name, gpointer user_data);
+void log_msg_macros_foreach(LogMessageMacrosForeachFunc func, gpointer user_data);
 
 static inline const gchar *
 log_msg_get_value_if_set_with_type(const LogMessage *self, NVHandle handle,

--- a/lib/logmsg/nvhandle-descriptors.c
+++ b/lib/logmsg/nvhandle-descriptors.c
@@ -62,6 +62,35 @@ nvhandle_desc_array_expand(NVHandleDescArray *self)
   self->allocated_len = new_alloc;
 }
 
+/*
+ * This function is called from the NVHandle allocation path, under the
+ * protection of the nv_registry_lock.
+ *
+ * NOTE: the read side of `self->data` is not locked in any way.  The only
+ * reason this works is that allocation must happen before any read side
+ * would start using a specific handle.
+ *
+ * By the time a reader would start reading the `self->data` pointer,
+ * `self->data` is either pointing to a new array (if another handle was
+ * allocated and expansion was needed), or it is still pointing to an old
+ * array (if expansion was not necessary).
+ *
+ * In either case, the reader dereferences a memory area that is kept around
+ * in the `old_buffers` array until syslog-ng is terminated.
+ *
+ * While we could do an atomic update to `self->data` and `self->len`, the
+ * read side actually:
+ *
+ *  1) never checks len, so changes and checks against len are always under
+ *     the protection of the lock
+ *  2) works both the old and the new values of data, so visibility is not a
+ *     concern
+ *  3) pointer writes are never torn (e.g.  we can't see values with
+ *     upper/lower bits mixed from old/new values)
+ *
+ * The only assumption that the code must meet is that any handles used on
+ * the read side must first be allocated.
+ */
 void
 nvhandle_desc_array_append(NVHandleDescArray *self, NVHandleDesc *desc)
 {

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -35,12 +35,15 @@ nv_registry_get_handle(NVRegistry *self, const gchar *name)
 {
   gpointer p;
 
+  g_mutex_lock(&nv_registry_lock);
   p = g_hash_table_lookup(self->name_map, name);
+  g_mutex_unlock(&nv_registry_lock);
   if (p)
     return GPOINTER_TO_UINT(p);
   return 0;
 }
 
+/* this can be called from multiple threads */
 NVHandle
 nv_registry_alloc_handle(NVRegistry *self, const gchar *name)
 {
@@ -135,7 +138,9 @@ nv_registry_set_handle_flags(NVRegistry *self, NVHandle handle, guint16 flags)
 void
 nv_registry_foreach(NVRegistry *self, GHFunc callback, gpointer user_data)
 {
+  g_mutex_lock(&nv_registry_lock);
   g_hash_table_foreach(self->name_map, callback, user_data);
+  g_mutex_unlock(&nv_registry_lock);
 }
 
 NVRegistry *

--- a/lib/template/macros.h
+++ b/lib/template/macros.h
@@ -116,6 +116,7 @@ typedef struct _LogMacroDef
 {
   const char *name;
   int id;
+  NVHandle handle;
 } LogMacroDef;
 
 extern LogMacroDef macros[];

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -230,24 +230,14 @@ _collect_nvpair_names_from_logmsg(NVHandle handle, const gchar *name, const gcha
 }
 
 static gboolean
-_is_macro_name_visible_to_user(const gchar *name, NVHandle handle)
+_collect_macro_names(NVHandle handle, const gchar *name, gpointer user_data)
 {
-  return log_msg_is_handle_macro(handle);
-}
+  PyObject *list = (PyObject *) user_data;
 
-static void
-_collect_macro_names(gpointer key, gpointer value, gpointer user_data)
-{
-  const gchar *name = (const gchar *)key;
-  NVHandle handle = GPOINTER_TO_UINT(value);
-  PyObject *list = (PyObject *)user_data;
-
-  if (_is_macro_name_visible_to_user(name, handle))
-    {
-      PyObject *py_name = PyBytes_FromString(name);
-      PyList_Append(list, py_name);
-      Py_XDECREF(py_name);
-    }
+  PyObject *py_name = PyBytes_FromString(name);
+  PyList_Append(list, py_name);
+  Py_XDECREF(py_name);
+  return TRUE;
 }
 
 static PyObject *
@@ -256,8 +246,8 @@ _logmessage_get_keys_method(PyLogMessage *self)
   PyObject *keys = PyList_New(0);
   LogMessage *msg = self->msg;
 
-  log_msg_values_foreach(msg, _collect_nvpair_names_from_logmsg, (gpointer) keys);
-  log_msg_registry_foreach(_collect_macro_names, keys);
+  log_msg_values_foreach(msg, _collect_nvpair_names_from_logmsg, keys);
+  log_msg_macros_foreach(_collect_macro_names, keys);
 
   return keys;
 }

--- a/news/bugfix-1122.md
+++ b/news/bugfix-1122.md
@@ -1,0 +1,5 @@
+`logmsg`: fix crash when iterating name-value registry concurrently
+
+The hash table mapping value names to handles was iterated without locking, which could crash AxoSyslog
+when another thread registered new name-value pairs at the same time. This happened for example when the
+Python `LogMessage.keys()` method ran while a `kv-parser()` was processing messages on a parallel path.


### PR DESCRIPTION
This PR fixes #1101 and as the fix would dramatically deteriorate the performance of the LogMessage.keys() method in our Python code, it also adds an alternative implementation that is much faster.

The problem is that the hash used to map names to handles is not locked properly when a caller is trying to iterate all
registered name-value pairs, as was done during LogMessage.keys() in our Python binding. Honestly I don't think including the macros in the result of keys() makes a lot of sense, but I did not want to break compatibility.

After fixing the locking issue, my testcase I used to reproduce the issue took 95 seconds to run. With the improved implementation to iterate macros, it takes roughly 1 second.

Testcase for reproduction:

Config:
```
@version: current

python {

import syslogng

class FooDestination(syslogng.LogDestination):

    def __init__(self):
        pass

    def init(self,args):
        return True

    def open(self):
        return True

    def close(self):
        return True

    def deinit(self):
        pass

    def send(self, msg):
        foo = msg.keys()
        return True


};


log {
	source { tcp(port(2000)); };
	destination { 
		python(class(FooDestination)); 
	};
	flags(flow-control);
};

log {
	source { tcp(port(2001) ); };

	parser { kv-parser(); };
	destination { file("/dev/null"); };
};

```

One connection is generating a lot of name-value pairs through kv-parser() on port 2001:
```
$ for i in `seq 1 1000000`; do echo program: foo$i=wahtever bar$[i+5000000]=whatever2  zar$[i+5000000]=whatever2 xxx=yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy; done | nc -q0 localhost 2001
```

The other connection is just exercising the Python destination:
```
$ time for i in `seq 1 100000`; do echo valami ; done | nc -q0 localhost 2000
```
