### PR TITLE
light: keep the fd-leak baseline in-process

### DIFF
--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -287,11 +287,18 @@ def pytest_runtest_setup(item):
     os.chdir(testcase_dir)
 
 
+# Captured once per worker process at session start.  This is purely
+# per-process state (each worker has its own open fds), so it must stay
+# in-process and must not be shared between xdist workers via session_data.
+_base_number_of_open_fds = None
+
+
 def pytest_sessionstart(session):
     if xdist.is_xdist_controller(session):
         return
 
-    base_number_of_open_fds = len(psutil.Process().open_files())
+    global _base_number_of_open_fds
+    _base_number_of_open_fds = len(psutil.Process().open_files())
 
     with get_session_data() as session_data:
         testrunuid = os.environ.get("PYTEST_XDIST_TESTRUNUID", uuid.uuid4().hex)  # generate one if not running in xdist
@@ -317,7 +324,6 @@ def pytest_sessionstart(session):
 
         session_data["session_started"] = True
         session_data["reports_dir"] = reports_dir
-        session_data["base_number_of_open_fds"] = base_number_of_open_fds
 
 
 def _write_testsuite_summary(session):
@@ -360,11 +366,9 @@ def light_extra_files(target_dir):
 
 @pytest.fixture(autouse=True)
 def setup(request):
-    with get_session_data() as session_data:
-        base_number_of_open_fds = session_data["base_number_of_open_fds"]
     number_of_open_fds = len(psutil.Process().open_files())
     if request.config.getoption("--run-under") != "valgrind":
-        assert base_number_of_open_fds + 1 == number_of_open_fds, "Previous testcase has unclosed opened fds"
+        assert _base_number_of_open_fds + 1 == number_of_open_fds, "Previous testcase has unclosed opened fds"
     else:
         blocking.DEFAULT_TIMEOUT = 60
         blocking.POLL_FREQ = 500


### PR DESCRIPTION
The session fd-leak check captured the open-fd baseline once and stored it in the shared, file-backed `session_data` under a single key, written only by the first xdist worker to win the lock. Every other worker then asserted its own live fd count against that one worker's snapshot, so the check fired spuriously for nearly all tests under parallel runs while passing serially. This regressed in 13e00f682, which dropped the earlier xdist guard.

The baseline is purely per-process state: each worker measures its own open fds at session start and only that same worker reads it back. It never needs to be shared, so routing it through `session_data` was both unnecessary and the cause of the bug. This keeps it in a module-level variable captured in `pytest_sessionstart` and read in the `setup` fixture, removing the cross-worker race entirely instead of working around it with per-worker keying.

### Validation
- Isolated replica with workers forced to diverge at baseline: buggy single-key = 24/60 errored, in-process fix = 0.
- Full `functional_tests/` e2e suite run 5×4 under `-n8` (ASAN build): **0** `unclosed opened fds` assertions, every fd-check at the expected `base+1`. The only failures were ClickHouse/webhook tests needing external services, identical every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)