### PR TITLE
`network()` dest: `flush-lines()`/`writev()` support

### DIFF
--- a/lib/logproto/logproto-client.c
+++ b/lib/logproto/logproto-client.c
@@ -81,6 +81,7 @@ log_proto_client_options_defaults(LogProtoClientOptions *options)
 {
   options->drop_input = FALSE;
   options->idle_timeout = 0;
+  options->flush_lines = 0;
 }
 
 void

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -35,6 +35,7 @@ typedef struct _LogProtoClientOptions
 {
   gboolean drop_input;
   gint idle_timeout;
+  gint flush_lines;
 } LogProtoClientOptions;
 
 typedef union _LogProtoClientOptionsStorage

--- a/lib/logproto/logproto-framed-client.c
+++ b/lib/logproto/logproto-framed-client.c
@@ -82,5 +82,12 @@ log_proto_framed_client_new(LogTransport *transport, const LogProtoClientOptions
   log_proto_text_client_init(&self->super, transport, options);
   self->super.super.post = log_proto_framed_client_post;
   self->super.state = LPFCS_FRAME_SEND;
+
+  /* the framed client writes the frame header and message through the partial
+   * path, never the batch, so opt out of batching and drop the unused buffer */
+  g_free(self->super.batch.iov);
+  self->super.batch.iov = NULL;
+  self->super.batch.size = 1;
+
   return &self->super.super;
 }

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -25,6 +25,7 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <string.h>
 
 static LogProtoStatus log_proto_text_client_flush(LogProtoClient *s);
 
@@ -36,7 +37,7 @@ log_proto_text_client_poll_prepare(LogProtoClient *s, GIOCondition *cond, GIOCon
   *cond = G_IO_OUT | G_IO_IN;
   *idle_cond = G_IO_IN;
 
-  return self->partial != NULL;
+  return self->partial != NULL || self->batch.count > 0;
 }
 
 static gboolean
@@ -48,7 +49,7 @@ log_proto_unidirectional_text_client_poll_prepare(LogProtoClient *s, GIOConditio
   *cond = G_IO_OUT;
   *idle_cond = 0;
 
-  return self->partial != NULL;
+  return self->partial != NULL || self->batch.count > 0;
 }
 
 static LogProtoStatus
@@ -152,11 +153,89 @@ _flush_single(LogProtoTextClient *self)
   return LPS_SUCCESS;
 }
 
+/* advance over `written` freshly sent bytes, freeing and acking each message
+ * that went out whole, then compacting the unsent tail to the front so the
+ * freed slots can be reused right away.  only the iovec descriptors move, not
+ * the payloads; a short write leaves the head's offset in partial_pos. */
+static void
+_advance_batch(LogProtoTextClient *self, gsize written)
+{
+  gint acked = 0;
+  while (acked < self->batch.count)
+    {
+      gsize remaining = self->batch.iov[acked].iov_len - self->batch.partial_pos;
+      if (written < remaining)
+        {
+          self->batch.partial_pos += written;
+          break;
+        }
+
+      written -= remaining;
+      g_free(self->batch.iov[acked].iov_base);
+      self->batch.partial_pos = 0;
+      ++acked;
+    }
+
+  if (acked)
+    {
+      log_proto_client_msg_ack(&self->super, acked);
+      self->batch.count -= acked;
+      memmove(self->batch.iov, &self->batch.iov[acked], self->batch.count * sizeof(*self->batch.iov));
+    }
+}
+
+/* write the queued batch out with a single writev(), resuming from the head's
+ * offset when an earlier short write left a tail behind. */
+static LogProtoStatus
+_flush_batch(LogProtoTextClient *self)
+{
+  if (self->batch.count == 0)
+    return LPS_SUCCESS;
+
+  struct iovec *iov = self->batch.iov;
+  gint iov_count = self->batch.count;
+
+  /* the first pending chunk may be partially sent from an earlier short write */
+  struct iovec first = iov[0];
+  iov[0].iov_base = (guchar *) first.iov_base + self->batch.partial_pos;
+  iov[0].iov_len = first.iov_len - self->batch.partial_pos;
+
+  gssize rc = log_transport_stack_writev(&self->super.transport_stack, iov, iov_count);
+  iov[0] = first;
+
+  if (rc < 0)
+    {
+      if (errno == EAGAIN || errno == EINTR)
+        return LPS_SUCCESS;
+      msg_error("I/O error occurred while writing",
+                evt_tag_int("fd", self->super.transport_stack.fd),
+                evt_tag_error(EVT_TAG_OSERROR));
+      return LPS_ERROR;
+    }
+
+  _advance_batch(self, rc);
+  return LPS_SUCCESS;
+}
+
+static inline gboolean
+_batching_enabled(LogProtoTextClient *self)
+{
+  if (self->batch.size <= 1)
+    return FALSE;
+
+  LogTransport *t = log_transport_stack_get_active(&self->super.transport_stack);
+  return t && t->writev;
+}
+
 static LogProtoStatus
 log_proto_text_client_flush(LogProtoClient *s)
 {
   LogProtoTextClient *self = (LogProtoTextClient *) s;
-  return _flush_single(self);
+
+  if (!_batching_enabled(self))
+    return _flush_single(self);
+
+  return _flush_batch(self);
 }
 
 LogProtoStatus
@@ -209,6 +288,12 @@ _post_single(LogProtoClient *s, guchar *msg, gsize msg_len, gboolean *consumed)
   return log_proto_text_client_submit_write(s, msg, msg_len, (GDestroyNotify) g_free, -1);
 }
 
+static inline gboolean
+_can_queue_to_batch(LogProtoTextClient *self)
+{
+  return self->batch.count < self->batch.size;
+}
+
 /*
  * log_proto_text_client_post:
  * @msg: formatted log message to send (this might be consumed by this function)
@@ -223,7 +308,30 @@ _post_single(LogProtoClient *s, guchar *msg, gsize msg_len, gboolean *consumed)
 static LogProtoStatus
 log_proto_text_client_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg, gsize msg_len, gboolean *consumed)
 {
-  return _post_single(s, msg, msg_len, consumed);
+  LogProtoTextClient *self = (LogProtoTextClient *) s;
+
+  if (!_batching_enabled(self))
+    return _post_single(s, msg, msg_len, consumed);
+
+  *consumed = FALSE;
+
+  if (!_can_queue_to_batch(self))
+    {
+      LogProtoStatus result = log_proto_text_client_flush(s);
+      if (result != LPS_SUCCESS || !_can_queue_to_batch(self))
+        /* no room yet (flush failed or buffer not drained) -> caller resends */
+        return result;
+    }
+
+  self->batch.iov[self->batch.count].iov_base = (void *) msg;
+  self->batch.iov[self->batch.count].iov_len = msg_len;
+  ++self->batch.count;
+  *consumed = TRUE;
+
+  if (self->batch.count == self->batch.size)
+    return log_proto_text_client_flush(s);
+
+  return LPS_SUCCESS;
 }
 
 void
@@ -233,6 +341,11 @@ log_proto_text_client_free(LogProtoClient *s)
   if (self->partial_free)
     self->partial_free(self->partial);
   self->partial = NULL;
+  /* messages still queued in the batch were consumed but never acked, so they
+   * are held only in the flow-control backlog; rewind them before we drop the
+   * buffers, otherwise a teardown on reconnect would lose them */
+  if (self->batch.count > 0)
+    log_proto_client_msg_rewind(&self->super);
   for (gint i = 0; i < self->batch.count; ++i)
     g_free(self->batch.iov[i].iov_base);
   g_free(self->batch.iov);

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -104,9 +104,8 @@ _prohibit_in(LogProtoClient *s)
 
 
 static LogProtoStatus
-log_proto_text_client_flush(LogProtoClient *s)
+_flush_single(LogProtoTextClient *self)
 {
-  LogProtoTextClient *self = (LogProtoTextClient *) s;
   gint rc;
 
   if (!self->partial)
@@ -150,6 +149,13 @@ log_proto_text_client_flush(LogProtoClient *s)
 
   /* NOTE: we return here to give a chance to the framed protocol to send the frame header. */
   return LPS_SUCCESS;
+}
+
+static LogProtoStatus
+log_proto_text_client_flush(LogProtoClient *s)
+{
+  LogProtoTextClient *self = (LogProtoTextClient *) s;
+  return _flush_single(self);
 }
 
 LogProtoStatus

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -24,6 +24,7 @@
 #include "messages.h"
 
 #include <errno.h>
+#include <limits.h>
 
 static LogProtoStatus log_proto_text_client_flush(LogProtoClient *s);
 
@@ -232,8 +233,22 @@ log_proto_text_client_free(LogProtoClient *s)
   if (self->partial_free)
     self->partial_free(self->partial);
   self->partial = NULL;
+  for (gint i = 0; i < self->batch.count; ++i)
+    g_free(self->batch.iov[i].iov_base);
+  g_free(self->batch.iov);
+  self->batch.iov = NULL;
   log_proto_client_free_method(s);
 };
+
+static gint
+_calculate_batch_size(const LogProtoClientOptions *options)
+{
+  gint batch_size = (options && options->flush_lines > 1) ? options->flush_lines : 1;
+#ifdef IOV_MAX
+  batch_size = MIN(batch_size, IOV_MAX);
+#endif
+  return batch_size;
+}
 
 void
 log_proto_text_client_init(LogProtoTextClient *self, LogTransport *transport, const LogProtoClientOptions *options)
@@ -245,6 +260,9 @@ log_proto_text_client_init(LogProtoTextClient *self, LogTransport *transport, co
   self->super.post = log_proto_text_client_post;
   self->super.free_fn = log_proto_text_client_free;
   self->next_state = -1;
+
+  self->batch.size = _calculate_batch_size(options);
+  self->batch.iov = g_new0(struct iovec, self->batch.size);
 }
 
 LogProtoClient *

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -174,19 +174,8 @@ log_proto_text_client_submit_write(LogProtoClient *s, guchar *msg, gsize msg_len
 }
 
 
-/*
- * log_proto_text_client_post:
- * @msg: formatted log message to send (this might be consumed by this function)
- * @msg_len: length of @msg
- * @consumed: pointer to a gboolean that gets set if the message was consumed by this function
- * @error: error information, if any
- *
- * This function posts a message to the log transport, performing buffering
- * of partially sent data if needed. The return value indicates whether we
- * successfully sent this message, or if it should be resent by the caller.
- **/
 static LogProtoStatus
-log_proto_text_client_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg, gsize msg_len, gboolean *consumed)
+_post_single(LogProtoClient *s, guchar *msg, gsize msg_len, gboolean *consumed)
 {
   LogProtoTextClient *self = (LogProtoTextClient *) s;
 
@@ -217,6 +206,23 @@ log_proto_text_client_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg, g
 
   *consumed = TRUE;
   return log_proto_text_client_submit_write(s, msg, msg_len, (GDestroyNotify) g_free, -1);
+}
+
+/*
+ * log_proto_text_client_post:
+ * @msg: formatted log message to send (this might be consumed by this function)
+ * @msg_len: length of @msg
+ * @consumed: pointer to a gboolean that gets set if the message was consumed by this function
+ * @error: error information, if any
+ *
+ * This function posts a message to the log transport, performing buffering
+ * of partially sent data if needed. The return value indicates whether we
+ * successfully sent this message, or if it should be resent by the caller.
+ **/
+static LogProtoStatus
+log_proto_text_client_post(LogProtoClient *s, LogMessage *logmsg, guchar *msg, gsize msg_len, gboolean *consumed)
+{
+  return _post_single(s, msg, msg_len, consumed);
 }
 
 void

--- a/lib/logproto/logproto-text-client.h
+++ b/lib/logproto/logproto-text-client.h
@@ -40,6 +40,7 @@ typedef struct _LogProtoTextClient
     struct iovec *iov;
     gint size;
     gint count;
+    gsize partial_pos;
   } batch;
 } LogProtoTextClient;
 

--- a/lib/logproto/logproto-text-client.h
+++ b/lib/logproto/logproto-text-client.h
@@ -25,6 +25,8 @@
 
 #include "logproto-client.h"
 
+#include <sys/uio.h>
+
 typedef struct _LogProtoTextClient
 {
   LogProtoClient super;
@@ -32,6 +34,13 @@ typedef struct _LogProtoTextClient
   guchar *partial;
   GDestroyNotify partial_free;
   gsize partial_len, partial_pos;
+
+  struct
+  {
+    struct iovec *iov;
+    gint size;
+    gint count;
+  } batch;
 } LogProtoTextClient;
 
 LogProtoStatus log_proto_text_client_submit_write(LogProtoClient *s, guchar *msg, gsize msg_len,

--- a/lib/transport/transport-haproxy.c
+++ b/lib/transport/transport-haproxy.c
@@ -839,6 +839,9 @@ log_transport_haproxy_new(LogTransportIndex base, LogTransportIndex switch_to, g
     {
       /* for UDP, only v2 is supported */
       self->super.super.read = _haproxy_dgram_read;
+      /* a datagram socket has no writev(); don't let the adapter advertise the
+       * forwarded one, so the batching layer keeps coalescing off for it */
+      self->super.super.writev = NULL;
       self->header_fetch_state = LPPTS_PROXY_V2_READ_PACKET;
     }
   else if (sock_type == SOCK_STREAM)

--- a/lib/transport/transport-socket.c
+++ b/lib/transport/transport-socket.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/uio.h>
 
 static gint
 _determine_address_family(gint fd)
@@ -276,11 +277,26 @@ log_transport_stream_socket_shutdown(LogTransport *s)
     shutdown(s->fd, SHUT_RDWR);
 }
 
+static gssize
+log_transport_stream_socket_writev_method(LogTransport *s, struct iovec *iov, gint iov_count)
+{
+  LogTransportSocket *self = (LogTransportSocket *) s;
+  gssize rc;
+
+  do
+    {
+      rc = writev(self->super.fd, iov, iov_count);
+    }
+  while (rc == -1 && errno == EINTR);
+  return rc;
+}
+
 void
 log_transport_stream_socket_init_instance(LogTransportSocket *self, gint fd)
 {
   log_transport_socket_init_instance(self, "stream-socket", fd);
   self->super.shutdown = log_transport_stream_socket_shutdown;
+  self->super.writev = log_transport_stream_socket_writev_method;
 }
 
 LogTransport *

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -42,6 +42,11 @@ typedef struct _LogTransportTLS
 
   GByteArray *writev_buf;
 
+  /* a blocked SSL_write() must be repeated with the identical buffer; writev()
+   * remembers the pending one here (NULL when nothing is pending) and replays it */
+  gconstpointer write_blocked_buf;
+  gsize write_blocked_len;
+
   StatsClusterKeyBuilder *kb;
 } LogTransportTLS;
 
@@ -397,7 +402,14 @@ log_transport_tls_writev_method(LogTransport *s, struct iovec *iov, gint iov_cou
   gconstpointer buf;
   gsize len;
 
-  if (iov_count == 1)
+  if (self->write_blocked_buf)
+    {
+      /* OpenSSL requires a blocked SSL_write() to be repeated with the identical
+       * buffer; replay the pending one, ignoring the iov the caller passes now */
+      buf = self->write_blocked_buf;
+      len = self->write_blocked_len;
+    }
+  else if (iov_count == 1)
     {
       /* a single chunk needs no coalescing; SSL_write() straight from the iov
        * so the payload is not copied into writev_buf */
@@ -417,7 +429,19 @@ log_transport_tls_writev_method(LogTransport *s, struct iovec *iov, gint iov_cou
       len = self->writev_buf->len;
     }
 
-  return log_transport_tls_write_method(s, (gpointer) buf, len);
+  gssize rc = log_transport_tls_write_method(s, (gpointer) buf, len);
+
+  if (rc < 0 && errno == EAGAIN)
+    {
+      self->write_blocked_buf = buf;
+      self->write_blocked_len = len;
+    }
+  else
+    {
+      self->write_blocked_buf = NULL;
+      self->write_blocked_len = 0;
+    }
+  return rc;
 }
 
 TLSSession *

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -40,6 +40,8 @@ typedef struct _LogTransportTLS
   TLSSession *tls_session;
   gboolean sending_shutdown;
 
+  GByteArray *writev_buf;
+
   StatsClusterKeyBuilder *kb;
 } LogTransportTLS;
 
@@ -388,6 +390,36 @@ tls_error:
   return -1;
 }
 
+static gssize
+log_transport_tls_writev_method(LogTransport *s, struct iovec *iov, gint iov_count)
+{
+  LogTransportTLS *self = (LogTransportTLS *) s;
+  gconstpointer buf;
+  gsize len;
+
+  if (iov_count == 1)
+    {
+      /* a single chunk needs no coalescing; SSL_write() straight from the iov
+       * so the payload is not copied into writev_buf */
+      buf = iov[0].iov_base;
+      len = iov[0].iov_len;
+    }
+  else
+    {
+      if (G_UNLIKELY(!self->writev_buf))
+        self->writev_buf = g_byte_array_new();
+
+      g_byte_array_set_size(self->writev_buf, 0);
+      for (gint i = 0; i < iov_count; i++)
+        g_byte_array_append(self->writev_buf, iov[i].iov_base, iov[i].iov_len);
+
+      buf = self->writev_buf->data;
+      len = self->writev_buf->len;
+    }
+
+  return log_transport_tls_write_method(s, (gpointer) buf, len);
+}
+
 TLSSession *
 log_tansport_tls_get_session(LogTransport *s)
 {
@@ -420,6 +452,7 @@ log_transport_tls_new(TLSSession *tls_session, LogTransportIndex base)
   self->super.super.cond = LTIO_NOTHING;
   self->super.super.read = log_transport_tls_read_method;
   self->super.super.write = log_transport_tls_write_method;
+  self->super.super.writev = log_transport_tls_writev_method;
   self->super.super.shutdown = log_transport_tls_shutdown_method;
   self->super.super.free_fn = log_transport_tls_free_method;
   self->super.super.register_stats = log_transport_tls_register_stats;
@@ -437,6 +470,9 @@ log_transport_tls_free_method(LogTransport *s)
 
   if (self->kb)
     stats_cluster_key_builder_free(self->kb);
+
+  if (self->writev_buf)
+    g_byte_array_free(self->writev_buf, TRUE);
 
   tls_session_free(self->tls_session);
   log_transport_adapter_free_method(s);

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -395,6 +395,12 @@ tls_error:
   return -1;
 }
 
+/*
+ * SSL_write() splits anything larger than one TLS record's worth of plaintext
+ * into multiple records anyway, so there's no point coalescing past that.
+ */
+#define TLS_WRITEV_COALESCE_MAX SSL3_RT_MAX_PLAIN_LENGTH
+
 static gssize
 log_transport_tls_writev_method(LogTransport *s, struct iovec *iov, gint iov_count)
 {
@@ -423,7 +429,11 @@ log_transport_tls_writev_method(LogTransport *s, struct iovec *iov, gint iov_cou
 
       g_byte_array_set_size(self->writev_buf, 0);
       for (gint i = 0; i < iov_count; i++)
-        g_byte_array_append(self->writev_buf, iov[i].iov_base, iov[i].iov_len);
+        {
+          if (i > 0 && self->writev_buf->len + iov[i].iov_len > TLS_WRITEV_COALESCE_MAX)
+            break;
+          g_byte_array_append(self->writev_buf, iov[i].iov_base, iov[i].iov_len);
+        }
 
       buf = self->writev_buf->data;
       len = self->writev_buf->len;

--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -159,6 +159,7 @@
 #define VERSION_4_23 "syslog-ng 4.23"
 #define VERSION_4_24 "syslog-ng 4.24"
 #define VERSION_4_25 "syslog-ng 4.25"
+#define VERSION_4_26 "syslog-ng 4.26"
 
 /* VERSION_VALUE_* references versions as integers to be compared against stuff like cfg->user_version */
 /* VERSION_STR_* references versions as strings to be shown to the user */
@@ -228,18 +229,19 @@
 #define VERSION_VALUE_4_23 0x0417
 #define VERSION_VALUE_4_24 0x0418
 #define VERSION_VALUE_4_25 0x0419
+#define VERSION_VALUE_4_26 0x041a
 
 /* config version code, in the same format as GlobalConfig->version */
-#define VERSION_VALUE_CURRENT   VERSION_VALUE_4_25
-#define VERSION_STR_CURRENT     "4.25"
-#define VERSION_PRODUCT_CURRENT VERSION_4_25
+#define VERSION_VALUE_CURRENT   VERSION_VALUE_4_26
+#define VERSION_STR_CURRENT     "4.26"
+#define VERSION_PRODUCT_CURRENT VERSION_4_26
 
 /* this value points to the last syslog-ng version where we changed the
  * meaning of any setting in the configuration file.  Basically, it is the
  * highest value passed to any cfg_is_config_version_older() call.
  */
-#define VERSION_VALUE_LAST_SEMANTIC_CHANGE  VERSION_VALUE_4_2
-#define VERSION_STR_LAST_SEMANTIC_CHANGE    "4.2"
+#define VERSION_VALUE_LAST_SEMANTIC_CHANGE  VERSION_VALUE_4_26
+#define VERSION_STR_LAST_SEMANTIC_CHANGE    "4.26"
 
 #define version_convert_from_user(v)  (v)
 

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -420,12 +420,36 @@ afsocket_dd_setup_proto_factory(AFSocketDestDriver *self)
   return TRUE;
 }
 
+static void
+_afsocket_dd_set_flush_lines(AFSocketDestDriver *self, gboolean explicit)
+{
+  GlobalConfig *cfg = log_pipe_get_config(&self->super.super.super);
+
+  if (cfg_is_config_version_older(cfg, VERSION_VALUE_4_26) && !explicit)
+    {
+      msg_warning_once("WARNING: with " VERSION_4_26 ", network() and tcp() destinations using "
+                       "a stream or TLS transport coalesce outgoing writes (flush-lines() defaults "
+                       "to 100) for a possible higher throughput. Bump @version to 4.26 or set "
+                       "flush-lines() explicitly to adopt it now and silence this warning. "
+                       "Retaining the pre-4.26 one write() per message behavior for now");
+      self->writer_options.proto_options.super.flush_lines = 1;
+      return;
+    }
+
+  self->writer_options.proto_options.super.flush_lines = self->writer_options.flush_lines;
+}
+
 static gboolean
 afsocket_dd_setup_writer_options(AFSocketDestDriver *self)
 {
   GlobalConfig *cfg = log_pipe_get_config(&self->super.super.super);
 
+  gboolean flush_lines_explicit = (self->writer_options.flush_lines != -1);
+
   log_writer_options_init(&self->writer_options, cfg, 0);
+
+  _afsocket_dd_set_flush_lines(self, flush_lines_explicit);
+
   return TRUE;
 }
 

--- a/news/feature-1133.md
+++ b/news/feature-1133.md
@@ -1,0 +1,12 @@
+`network()`, `tcp()`: honor `flush-lines()` by coalescing writes
+
+The `network()` and `tcp()` destinations now coalesce up to `flush-lines()` formatted messages into a
+single write instead of writing each message separately, cutting system call overhead and improving
+throughput.
+
+This covers stream and TLS transports. UDP and other datagram transports still write one message per
+packet, and `syslog()` is unaffected because it frames each message individually.
+
+`flush-lines()` previously had no effect on these destinations. Starting with configuration version
+`@config: 4.26` it defaults to 100, enabling coalescing, while older configurations keep the previous
+one-write-per-message behavior.

--- a/tests/light/functional_tests/destination_drivers/network_destination/test_tls_destination_write_batching.py
+++ b/tests/light/functional_tests/destination_drivers/network_destination/test_tls_destination_write_batching.py
@@ -36,9 +36,10 @@ def _build_tls_destination(config, port_allocator, testcase_parameters, **extra_
     return tls_destination
 
 
-def _messages(count):
-    # zero-padded index so order is checkable; payload long enough to span several TLS records
-    return [f"tls-batch-seq-{i:06d}-{'x' * 200}" for i in range(count)]
+def _messages(count, payload=200):
+    # zero-padded index so order is checkable; payload pads the line so a batch
+    # can be pushed past a TLS record when needed
+    return [f"tls-batch-seq-{i:06d}-{'x' * payload}" for i in range(count)]
 
 
 def _assert_received_in_order(received, sent):
@@ -111,6 +112,30 @@ def test_tls_destination_no_batch_old_version_is_correct(config, syslog_ng, port
     syslog_ng.start(config)
 
     sent = _messages(200)
+    network_source.write_logs(sent)
+
+    received = tls_destination.read_logs(len(sent))
+    _assert_received_in_order(received, sent)
+
+
+def test_tls_destination_batch_larger_than_tls_record(config, syslog_ng, port_allocator, testcase_parameters):
+    """@version 4.26: a batch whose coalesced size exceeds one 16 KB TLS record makes the
+    writev() coalescing cap stop mid-batch; the logproto cursor must resume from the unsent
+    tail and still deliver every message intact and in order.
+
+    flush-lines(64) x ~1 KB messages is ~64 KB per batch -- several records past the cap --
+    so each batch goes out as multiple SSL_write() calls.
+    """
+    config.set_version("4.26")
+
+    network_source = config.create_network_source(port=port_allocator())
+    tls_destination = _build_tls_destination(config, port_allocator, testcase_parameters, flush_lines=64)
+    config.create_logpath(statements=[network_source, tls_destination])
+
+    tls_destination.start_listener()
+    syslog_ng.start(config)
+
+    sent = _messages(640, payload=1024)  # 10 full batches, each well over one TLS record
     network_source.write_logs(sent)
 
     received = tls_destination.read_logs(len(sent))

--- a/tests/light/functional_tests/destination_drivers/network_destination/test_tls_destination_write_batching.py
+++ b/tests/light/functional_tests/destination_drivers/network_destination/test_tls_destination_write_batching.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from axosyslog_light.common.file import copy_shared_file
+
+
+def _build_tls_destination(config, port_allocator, testcase_parameters, **extra_options):
+    ca = copy_shared_file(testcase_parameters, "valid-ca.crt")
+    tls_destination = config.create_network_destination(
+        ip="localhost", port=port_allocator(), transport="tls",
+        tls={
+            "ca-file": ca,
+            "peer-verify": "yes",
+        },
+        **extra_options,
+    )
+    return tls_destination
+
+
+def _messages(count):
+    # zero-padded index so order is checkable; payload long enough to span several TLS records
+    return [f"tls-batch-seq-{i:06d}-{'x' * 200}" for i in range(count)]
+
+
+def _assert_received_in_order(received, sent):
+    assert len(received) == len(sent), f"expected {len(sent)} messages, got {len(received)}"
+    for got, expected in zip(received, sent):
+        token = expected.split("-x")[0]
+        assert token in got, f"out-of-order or corrupted: expected {token!r} in {got!r}"
+
+
+def test_tls_destination_batches_preserve_all_messages(config, syslog_ng, port_allocator, testcase_parameters):
+    """@version 4.26: many messages arrive intact and in order across many batches."""
+    config.set_version("4.26")
+
+    network_source = config.create_network_source(port=port_allocator())
+    tls_destination = _build_tls_destination(config, port_allocator, testcase_parameters)
+    config.create_logpath(statements=[network_source, tls_destination])
+
+    tls_destination.start_listener()
+    syslog_ng.start(config)
+
+    sent = _messages(1000)
+    network_source.write_logs(sent)
+
+    received = tls_destination.read_logs(len(sent))
+    _assert_received_in_order(received, sent)
+
+
+def test_tls_destination_explicit_flush_lines(config, syslog_ng, port_allocator, testcase_parameters):
+    """Explicit flush-lines() sets the batch size; send full batches plus a tail."""
+    config.set_version("4.26")
+
+    network_source = config.create_network_source(port=port_allocator())
+    tls_destination = _build_tls_destination(config, port_allocator, testcase_parameters, flush_lines=50)
+    config.create_logpath(statements=[network_source, tls_destination])
+
+    tls_destination.start_listener()
+    syslog_ng.start(config)
+
+    sent = _messages(525)  # 10 full batches of 50 + a 25-message tail
+    network_source.write_logs(sent)
+
+    received = tls_destination.read_logs(len(sent))
+    _assert_received_in_order(received, sent)
+
+
+def test_tls_destination_single_message_is_flushed(config, syslog_ng, port_allocator, testcase_parameters):
+    """A lone message must not be stranded waiting for the batch to fill."""
+    config.set_version("4.26")
+
+    network_source = config.create_network_source(port=port_allocator())
+    tls_destination = _build_tls_destination(config, port_allocator, testcase_parameters)
+    config.create_logpath(statements=[network_source, tls_destination])
+
+    tls_destination.start_listener()
+    syslog_ng.start(config)
+
+    network_source.write_log("tls-batch-single")
+    assert tls_destination.read_until_logs(["tls-batch-single"])
+
+
+def test_tls_destination_no_batch_old_version_is_correct(config, syslog_ng, port_allocator, testcase_parameters):
+    """@version 4.0: the version gate keeps the non-batched path; output still correct."""
+    config.set_version("4.0")
+
+    network_source = config.create_network_source(port=port_allocator())
+    tls_destination = _build_tls_destination(config, port_allocator, testcase_parameters)
+    config.create_logpath(statements=[network_source, tls_destination])
+
+    tls_destination.start_listener()
+    syslog_ng.start(config)
+
+    sent = _messages(200)
+    network_source.write_logs(sent)
+
+    received = tls_destination.read_logs(len(sent))
+    _assert_received_in_order(received, sent)


### PR DESCRIPTION
This improves performance in certain scenarios, like the one in https://github.com/VirtualMetric/PipeBench

No `framed` support yet, we might want to implement that later.