### PR TITLE
light: use unique loggen client ports in increased-send window tests

### DIFF
--- a/tests/light/functional_tests/source_drivers/network_source/test_static_and_dynamic_window.py
+++ b/tests/light/functional_tests/source_drivers/network_source/test_static_and_dynamic_window.py
@@ -56,7 +56,7 @@ def set_config_for_dynamic_window(config, port_allocator, dynamic_window_size, l
     return config, network_source, network_destination
 
 
-def send_messages_with_loggen(loggen, network_source, active_connections, message_counter):
+def send_messages_with_loggen(loggen, network_source, active_connections, message_counter, client_port=0):
     loggen.start(
         LoggenStartParams(
             target=network_source.options["ip"],
@@ -65,6 +65,7 @@ def send_messages_with_loggen(loggen, network_source, active_connections, messag
             inet=True,
             active_connections=active_connections,
             number=message_counter,
+            client_port=client_port,
         ),
     )
     assert wait_until_true(lambda: loggen.get_sent_message_count() == message_counter * active_connections)
@@ -250,7 +251,7 @@ def test_static_window_increased_send(config, syslog_ng, port_allocator, loggen,
     window_size = 1000 / 10  # per connection
     for msg_counter in range(10, 100 + 10, 10):
         # sent msgs in order: 10, 20, 30 ... 100
-        send_messages_with_loggen(loggen, network_source, 1, msg_counter)
+        send_messages_with_loggen(loggen, network_source, 1, msg_counter, client_port=port_allocator())
 
         sum_msg_counter += msg_counter
         sum_input_window_capacity.append(window_size)
@@ -277,7 +278,7 @@ def test_dynamic_window_increased_send(config, syslog_ng, port_allocator, loggen
     dynamic_window_for_all_connections = dynamic_window_size * 10
     for msg_counter in range(100, 1000 + 100, 100):
         # sent msgs in order: 100, 200, 300 ... 1000
-        send_messages_with_loggen(loggen, network_source, 1, msg_counter)
+        send_messages_with_loggen(loggen, network_source, 1, msg_counter, client_port=port_allocator())
 
         sum_msg_counter += msg_counter
         if sum_msg_counter > dynamic_window_for_all_connections:


### PR DESCRIPTION
The test_static_window_increased_send and test_dynamic_window_increased_send tests open a new loggen connection in each loop iteration and expect one distinct Prometheus time series per connection.

- Without a fixed client port the kernel assigns a random ephemeral source port, which does not guarantee it is unique across the iterations.
- The per-connection window metrics are labeled with connection="<ip:port>" (the peer address). When two connections happen to reuse the same port their series collapse into one, so fewer series appear than the test expects, causing intermittent assertion failures.
- Passing client_port=port_allocator() pins a distinct, free source port for each iteration, guaranteeing unique connection labels and stable metrics.

Assisted-by: Claude:claude-opus-4-8[1m]

This PR fixes such rare failures:
```
FAILED functional_tests/source_drivers/network_source/test_static_and_dynamic_window.py::test_dynamic_window_increased_send - AssertionError: Metric syslogng_input_window_available expected: [0, 0, 0, 0, 0, 0, 0, 0, 0], actual: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
```