### PR TITLE
[FilterX-jit] [Devirtualization] Optimize devirtualization

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -51,6 +51,7 @@ set(FILTERX_HEADERS
     filterx/filterx-scope.h
     filterx/filterx-scope-var-layout.h
     filterx/filterx-stashed-object.h
+    filterx/filterx-type-inference.h
     filterx/filterx-variable.h
     filterx/filterx-weakrefs.h
     filterx/filterx-dpath.h
@@ -144,6 +145,7 @@ set(FILTERX_SOURCES
     filterx/filterx-scope.c
     filterx/filterx-scope-var-layout.c
     filterx/filterx-stashed-object.c
+    filterx/filterx-type-inference.c
     filterx/filterx-variable.c
     filterx/filterx-weakrefs.c
     filterx/filterx-dpath.c

--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -246,7 +246,7 @@ if(SYSLOG_NG_ENABLE_JIT)
       COMMAND ${LLVM_CLANG}
               -D_GNU_SOURCE=1 -D_LARGEFILE64_SOURCE=1
               "-I$<JOIN:$<TARGET_PROPERTY:syslog-ng,INCLUDE_DIRECTORIES>,;-I>"
-              -emit-llvm -O3 --no-warnings
+              -emit-llvm -O3 --no-warnings -mno-outline-atomics
               -c "${CMAKE_CURRENT_SOURCE_DIR}/${_src}" -o "${_bc}"
       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${_src}"
       COMMAND_EXPAND_LISTS

--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -50,6 +50,7 @@ set(FILTERX_HEADERS
     filterx/filterx-scope.h
     filterx/filterx-scope-var-layout.h
     filterx/filterx-stashed-object.h
+    filterx/filterx-type-inference.h
     filterx/filterx-variable.h
     filterx/filterx-weakrefs.h
     filterx/filterx-dpath.h
@@ -143,6 +144,7 @@ set(FILTERX_SOURCES
     filterx/filterx-scope.c
     filterx/filterx-scope-var-layout.c
     filterx/filterx-stashed-object.c
+    filterx/filterx-type-inference.c
     filterx/filterx-variable.c
     filterx/filterx-weakrefs.c
     filterx/filterx-dpath.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -47,6 +47,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/filterx-object.h \
 	lib/filterx/filterx-env.h \
 	lib/filterx/filterx-stashed-object.h \
+	lib/filterx/filterx-type-inference.h \
 	lib/filterx/filterx-parser.h \
 	lib/filterx/filterx-pipe.h \
 	lib/filterx/filterx-private.h \
@@ -153,6 +154,7 @@ lib_filterx_libfilterx_la_SOURCES = \
 	lib/filterx/filterx-scope.c \
 	lib/filterx/filterx-sequence.c \
 	lib/filterx/filterx-stashed-object.c \
+	lib/filterx/filterx-type-inference.c \
 	lib/filterx/filterx-variable.c \
 	lib/filterx/filterx-weakrefs.c \
 	lib/filterx/func-cache-json-file.c \

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -46,6 +46,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/filterx-object.h \
 	lib/filterx/filterx-env.h \
 	lib/filterx/filterx-stashed-object.h \
+	lib/filterx/filterx-type-inference.h \
 	lib/filterx/filterx-parser.h \
 	lib/filterx/filterx-pipe.h \
 	lib/filterx/filterx-private.h \
@@ -152,6 +153,7 @@ lib_filterx_libfilterx_la_SOURCES = \
 	lib/filterx/filterx-scope.c \
 	lib/filterx/filterx-sequence.c \
 	lib/filterx/filterx-stashed-object.c \
+	lib/filterx/filterx-type-inference.c \
 	lib/filterx/filterx-variable.c \
 	lib/filterx/filterx-weakrefs.c \
 	lib/filterx/func-cache-json-file.c \

--- a/lib/filterx/expr-arithmetic-operators.c
+++ b/lib/filterx/expr-arithmetic-operators.c
@@ -383,6 +383,20 @@ _optimize_plus(FilterXExpr *s)
   return NULL;
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+static void
+_infer_types_plus(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXArithmeticOperator *self = (FilterXArithmeticOperator *) s;
+  FilterXStaticTypeSpec lhs_spec = self->super.lhs ? self->super.lhs->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+  FilterXStaticTypeSpec rhs_spec = self->super.rhs ? self->super.rhs->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+
+  s->static_type = filterx_static_type_spec_meet(lhs_spec, rhs_spec);
+}
+
+#endif
+
 static FilterXObject *
 _do_uminus(FilterXObject *operand_obj, FilterXExpr *expr)
 {
@@ -651,6 +665,7 @@ filterx_operator_plus_new(FilterXExpr *lhs, FilterXExpr *rhs)
   self->super.super.free_fn = _free_arithmetic_common;
 #if SYSLOG_NG_ENABLE_JIT
   self->super.super.compile = _compile_plus;
+  self->super.super.infer_types = _infer_types_plus;
 #endif
 
   return &self->super.super;

--- a/lib/filterx/expr-arithmetic-operators.c
+++ b/lib/filterx/expr-arithmetic-operators.c
@@ -22,6 +22,7 @@
 #include "expr-arithmetic-operators.h"
 #include "filterx/object-primitive.h"
 #include "filterx/expr-literal.h"
+#include "filterx/expr-string-operators.h"
 #include "filterx/object-extractor.h"
 #include "filterx/filterx-eval.h"
 
@@ -579,7 +580,20 @@ _compile_binary_arithmetic(FilterXExpr *s, FilterXJIT *jit, const gchar *fn_name
 static FilterXIRValue
 _compile_plus(FilterXExpr *s, FilterXJIT *jit)
 {
-  return _compile_binary_arithmetic(s, jit, "fx_jit_arithmetic_plus");
+  if (filterx_static_type_kind(s->static_type) == FILTERX_STATIC_TYPE_STRING) {
+    FilterXArithmeticOperator *self = (FilterXArithmeticOperator *) s;
+
+    FilterXIRValue lhs = self->literal_lhs
+                        ? fx_jit_emit_object_ref(jit, fx_jit_emit_const_ptr(jit, self->literal_lhs))
+                        : filterx_expr_compile_or_eval_typed(self->super.lhs, jit);
+    FilterXIRValue rhs = self->literal_rhs
+                        ? fx_jit_emit_object_ref(jit, fx_jit_emit_const_ptr(jit, self->literal_rhs))
+                        : filterx_expr_compile_or_eval(self->super.rhs, jit);
+
+    return filterx_string_concat_compile(jit, lhs, rhs, s);
+  } else {
+    return _compile_binary_arithmetic(s, jit, "fx_jit_arithmetic_plus");
+  }
 }
 
 static FilterXIRValue

--- a/lib/filterx/expr-arithmetic-operators.c
+++ b/lib/filterx/expr-arithmetic-operators.c
@@ -512,6 +512,123 @@ fx_jit_arithmetic_plus(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr
   return _do_plus(lhs, rhs, expr);
 }
 
+/* Devirtualized fast path for `integer + anything`. lhs is guaranteed to be a FilterXInteger
+ * (eval_typed of an INTEGER-static_type operand).  If rhs is also integer, performs direct
+ * integer arithmetic; otherwise falls back to the generic vtable-dispatching path.
+ * The fallback means the function is always correct even when rhs is non-integer. */
+__attribute__((used))
+FilterXObject *
+fx_jit_int_plus(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
+{
+  FilterXObject *result = NULL;
+  if (!lhs)
+    {
+      filterx_eval_push_error_static_info("Failed to add values", "Failed to evaluate left hand side");
+      goto exit;
+    }
+  if (!rhs)
+    {
+      filterx_eval_push_error_static_info("Failed to add values", "Failed to evaluate right hand side");
+      goto exit;
+    }
+
+  gint64 rhs_val;
+  if (G_LIKELY(filterx_integer_unwrap(rhs, &rhs_val)))
+    {
+      gint64 lhs_val;
+      gboolean ok G_GNUC_UNUSED = filterx_integer_unwrap(lhs, &lhs_val);
+      g_assert(ok);
+      filterx_object_unref(lhs);
+      filterx_object_unref(rhs);
+
+      gint64 sum;
+      if (__builtin_add_overflow(lhs_val, rhs_val, &sum))
+        {
+          /* filterx_object_add() rejects the same sums, see _integer_add() */
+          filterx_eval_push_error_static_info("Failed to add values", "integer overflow");
+          return NULL;
+        }
+
+      return filterx_integer_new(sum);
+    }
+
+  result = filterx_object_add(lhs, rhs);
+  if (!result)
+    filterx_eval_push_error_static_info("Failed to add values", "add() method failed");
+
+exit:
+  filterx_object_unref(lhs);
+  filterx_object_unref(rhs);
+  return result;
+}
+
+/* Unwraps a primitive number into a double, promoting an integer the way filterx_object_add()
+ * does for a mixed pair. Returns FALSE for anything that is not a primitive number (a message
+ * value for instance), leaving the caller to dispatch through the add() method instead. */
+static inline gboolean
+_unwrap_number_as_double(FilterXObject *obj, gdouble *value)
+{
+  if (filterx_double_unwrap(obj, value))
+    return TRUE;
+
+  gint64 int_value;
+  if (filterx_integer_unwrap(obj, &int_value))
+    {
+      *value = (gdouble) int_value;
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
+/* Devirtualized fast path for a `+` inferred as DOUBLE, which _infer_types_plus() claims for
+ * a statically numeric operand pair with at least one double. Which side holds the double is
+ * not known at compile time, so both operands are unwrapped as numbers; either one that does
+ * not unwrap directly falls back to the generic vtable-dispatching path, which means the
+ * function stays correct regardless. */
+__attribute__((used))
+FilterXObject *
+fx_jit_double_plus(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
+{
+  FilterXObject *result = NULL;
+  if (!lhs)
+    {
+      filterx_eval_push_error_static_info("Failed to add values", "Failed to evaluate left hand side");
+      goto exit;
+    }
+  if (!rhs)
+    {
+      filterx_eval_push_error_static_info("Failed to add values", "Failed to evaluate right hand side");
+      goto exit;
+    }
+
+  gdouble lhs_val, rhs_val;
+  if (G_LIKELY(_unwrap_number_as_double(lhs, &lhs_val) && _unwrap_number_as_double(rhs, &rhs_val)))
+    {
+      filterx_object_unref(lhs);
+      filterx_object_unref(rhs);
+
+      gdouble sum = lhs_val + rhs_val;
+      if (!isfinite(sum))
+        {
+          /* filterx_object_add() rejects the same sums, see _double_add_result() */
+          filterx_eval_push_error_static_info("Failed to add values", "double overflow");
+          return NULL;
+        }
+
+      return filterx_double_new(sum);
+    }
+
+  result = filterx_object_add(lhs, rhs);
+  if (!result)
+    filterx_eval_push_error_static_info("Failed to add values", "add() method failed");
+
+exit:
+  filterx_object_unref(lhs);
+  filterx_object_unref(rhs);
+  return result;
+}
+
 __attribute__((used))
 FilterXObject *
 fx_jit_arithmetic_uminus(FilterXObject *operand, FilterXExpr *expr)
@@ -577,23 +694,44 @@ _compile_binary_arithmetic(FilterXExpr *s, FilterXJIT *jit, const gchar *fn_name
   return LLVMBuildLoad2(ir, ffi->ptr_ty, result_slot, "result");
 }
 
+/* Emits both operands, taking a ref on a literal instead of evaluating it. Mirrors
+ * _eval_lhs()/_eval_rhs(): only the lhs is evaluated typed, which is what lets a
+ * devirtualized fast path rely on its static type. */
+static void
+_compile_operands(FilterXArithmeticOperator *self, FilterXJIT *jit, FilterXIRValue *lhs, FilterXIRValue *rhs)
+{
+  *lhs = self->literal_lhs
+         ? fx_jit_emit_object_ref(jit, fx_jit_emit_const_ptr(jit, self->literal_lhs))
+         : filterx_expr_compile_or_eval_typed(self->super.lhs, jit);
+  *rhs = self->literal_rhs
+         ? fx_jit_emit_object_ref(jit, fx_jit_emit_const_ptr(jit, self->literal_rhs))
+         : filterx_expr_compile_or_eval(self->super.rhs, jit);
+}
+
 static FilterXIRValue
 _compile_plus(FilterXExpr *s, FilterXJIT *jit)
 {
-  if (filterx_static_type_kind(s->static_type) == FILTERX_STATIC_TYPE_STRING) {
-    FilterXArithmeticOperator *self = (FilterXArithmeticOperator *) s;
+  FilterXArithmeticOperator *self = (FilterXArithmeticOperator *) s;
+  FilterXStaticType kind = filterx_static_type_kind(s->static_type);
 
-    FilterXIRValue lhs = self->literal_lhs
-                        ? fx_jit_emit_object_ref(jit, fx_jit_emit_const_ptr(jit, self->literal_lhs))
-                        : filterx_expr_compile_or_eval_typed(self->super.lhs, jit);
-    FilterXIRValue rhs = self->literal_rhs
-                        ? fx_jit_emit_object_ref(jit, fx_jit_emit_const_ptr(jit, self->literal_rhs))
-                        : filterx_expr_compile_or_eval(self->super.rhs, jit);
-
-    return filterx_string_concat_compile(jit, lhs, rhs, s);
-  } else {
+  if (kind != FILTERX_STATIC_TYPE_STRING && !_is_numeric_static_type(kind))
     return _compile_binary_arithmetic(s, jit, "fx_jit_arithmetic_plus");
-  }
+
+  FilterXIRValue lhs, rhs;
+  _compile_operands(self, jit, &lhs, &rhs);
+
+  if (kind == FILTERX_STATIC_TYPE_STRING)
+    return filterx_string_concat_compile(jit, lhs, rhs, s);
+
+  /* _infer_types_plus() claims a numeric kind only for a statically numeric operand pair:
+   * INTEGER for int + int, DOUBLE as soon as either side is a double. Both domains have a
+   * helper that adds without dispatching through the add() method. */
+  const gchar *fn_name = kind == FILTERX_STATIC_TYPE_INTEGER ? "fx_jit_int_plus" : "fx_jit_double_plus";
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  FilterXIRValue args[] = { lhs, rhs, fx_jit_emit_const_ptr(jit, self) };
+  FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
+  return fx_jit_emit_extern_call(jit, fn_name, ffi->ptr_ty, param_tys, args, 3);
 }
 
 static FilterXIRValue

--- a/lib/filterx/expr-arithmetic-operators.c
+++ b/lib/filterx/expr-arithmetic-operators.c
@@ -384,6 +384,12 @@ _optimize_plus(FilterXExpr *s)
 }
 
 #if SYSLOG_NG_ENABLE_JIT
+static inline gboolean
+_is_numeric_static_type(FilterXStaticType kind)
+{
+  return kind == FILTERX_STATIC_TYPE_INTEGER || kind == FILTERX_STATIC_TYPE_DOUBLE;
+}
+
 static void
 _infer_types_plus(FilterXExpr *s, FilterXTypeEnv *env)
 {
@@ -391,6 +397,25 @@ _infer_types_plus(FilterXExpr *s, FilterXTypeEnv *env)
   FilterXArithmeticOperator *self = (FilterXArithmeticOperator *) s;
   FilterXStaticTypeSpec lhs_spec = self->super.lhs ? self->super.lhs->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
   FilterXStaticTypeSpec rhs_spec = self->super.rhs ? self->super.rhs->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+  FilterXStaticType lhs_kind = filterx_static_type_kind(lhs_spec);
+  FilterXStaticType rhs_kind = filterx_static_type_kind(rhs_spec);
+
+  /* Numeric promotion: filterx_object_add() keeps int+int in the integer domain but widens
+   * to double as soon as either side is one, so a mixed pair is statically DOUBLE — a
+   * result a plain meet would throw away as UNKNOWN.
+   *
+   * Both kinds must be known numerics for this to hold. An UNKNOWN operand is not a
+   * "probably integer": it may be a double at runtime, which would widen the result, so the
+   * pair stays UNKNOWN. Claiming INTEGER on a merely-unknown operand would let an
+   * integer-speculating consumer treat a double as an int64. */
+  if (_is_numeric_static_type(lhs_kind) && _is_numeric_static_type(rhs_kind))
+    {
+      FilterXStaticType result = (lhs_kind == FILTERX_STATIC_TYPE_DOUBLE || rhs_kind == FILTERX_STATIC_TYPE_DOUBLE)
+                                 ? FILTERX_STATIC_TYPE_DOUBLE
+                                 : FILTERX_STATIC_TYPE_INTEGER;
+      s->static_type = filterx_static_type_kind_only(result);
+      return;
+    }
 
   s->static_type = filterx_static_type_spec_meet(lhs_spec, rhs_spec);
 }

--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -20,6 +20,7 @@
  *
  */
 #include "filterx/expr-assign.h"
+#include "filterx/expr-variable.h"
 #include "filterx/object-primitive.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/object-null.h"
@@ -138,6 +139,47 @@ _nullv_assign_compile(FilterXExpr *s, FilterXJIT *jit)
 #endif
 
 static void
+_assign_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXAssign *self = (FilterXAssign *) s;
+
+  filterx_expr_infer_types(self->super.rhs, env);
+  /* LHS may be e.g. setattr / set-subscript; visit it so deep variable reads in the LHS
+   * see the env. We do not derive the assign's result type from the LHS's static_type. */
+  filterx_expr_infer_types(self->super.lhs, env);
+
+  FilterXStaticTypeSpec rhs_spec = self->super.rhs ? self->super.rhs->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+
+  FilterXVariableHandle handle;
+  if (filterx_variable_expr_get_handle(self->super.lhs, &handle))
+    filterx_type_env_set(env, handle, rhs_spec);
+
+  s->static_type = rhs_spec;
+}
+
+static void
+_nullv_assign_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXAssign *self = (FilterXAssign *) s;
+
+  filterx_expr_infer_types(self->super.rhs, env);
+  filterx_expr_infer_types(self->super.lhs, env);
+
+  FilterXStaticTypeSpec rhs_spec = self->super.rhs ? self->super.rhs->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+
+  /* nullv-assign keeps the LHS's prior value if RHS is null. The post-statement type is
+   * therefore meet(prior, rhs), and prior is what the env currently has. */
+  FilterXVariableHandle handle;
+  if (filterx_variable_expr_get_handle(self->super.lhs, &handle))
+    {
+      FilterXStaticTypeSpec prior = filterx_type_env_get(env, handle);
+      filterx_type_env_set(env, handle, filterx_static_type_spec_meet(prior, rhs_spec));
+    }
+
+  s->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
+}
+
+static void
 filterx_assign_init_instance(FilterXAssign *self, const gchar *type,
                              FilterXExpr *lhs, FilterXExpr *rhs)
 {
@@ -153,6 +195,7 @@ filterx_assign_new(FilterXExpr *lhs, FilterXExpr *rhs)
 
   filterx_assign_init_instance(self, "assign", lhs, rhs);
   self->super.super.eval = _assign_eval;
+  self->super.super.infer_types = _assign_infer_types;
 #if SYSLOG_NG_ENABLE_JIT
   self->super.super.compile = _assign_compile;
 #endif
@@ -166,6 +209,7 @@ filterx_nullv_assign_new(FilterXExpr *lhs, FilterXExpr *rhs)
 
   filterx_assign_init_instance(self, "nullv-assign", lhs, rhs);
   self->super.super.eval = _nullv_assign_eval;
+  self->super.super.infer_types = _nullv_assign_infer_types;
 #if SYSLOG_NG_ENABLE_JIT
   self->super.super.compile = _nullv_assign_compile;
 #endif

--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -112,6 +112,22 @@ fx_jit_do_nullv_assign(FilterXExpr *s, FilterXObject *value)
   return _do_nullv_assign((FilterXAssign *) s, value);
 }
 
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_assign_stmt(FilterXExpr *s, FilterXObject *value,
+                      FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_assign(s, value), s, context, last_result);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_nullv_assign_stmt(FilterXExpr *s, FilterXObject *value,
+                            FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_nullv_assign(s, value), s, context, last_result);
+}
+
 static FilterXIRValue
 _compile_assignment(FilterXExpr *s, FilterXJIT *jit, const gchar *fn_name)
 {

--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -102,6 +102,21 @@ fx_jit_nullv_assign_suppress_error(void)
   return _suppress_error();
 }
 
+__attribute__((used))
+FilterXObject *
+fx_jit_do_nullv_assign(FilterXExpr *s, FilterXObject *value)
+{
+  return _do_nullv_assign((FilterXAssign *) s, value);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_nullv_assign_stmt(FilterXExpr *s, FilterXObject *value,
+                            FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_nullv_assign(s, value), s, context, last_result);
+}
+
 static FilterXIRValue
 _compile_assign_to_lhs(FilterXAssign *self, FilterXJIT *jit)
 {
@@ -149,6 +164,9 @@ _assign_compile(FilterXExpr *s, FilterXJIT *jit)
   return _compile_assign_to_lhs(self, jit);
 }
 
+/* nullv-assign has no compile_assign() counterpart yet, so the store itself still goes
+ * through a helper.  The RHS is compiled nevertheless, which is what makes the
+ * devirtualized operand codegen reachable from `??=` too. */
 static FilterXIRValue
 _compile_nullv_assign_to_lhs(FilterXAssign *self, FilterXJIT *jit)
 {

--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -20,6 +20,7 @@
  *
  */
 #include "filterx/expr-assign.h"
+#include "filterx/expr-variable.h"
 #include "filterx/object-primitive.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/object-null.h"
@@ -208,6 +209,47 @@ _nullv_assign_compile(FilterXExpr *s, FilterXJIT *jit)
   return _compile_nullv_assign_to_lhs(self, jit);
 }
 
+static void
+_assign_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXAssign *self = (FilterXAssign *) s;
+
+  filterx_expr_infer_types(self->super.rhs, env);
+  /* LHS may be e.g. setattr / set-subscript; visit it so deep variable reads in the LHS
+   * see the env. We do not derive the assign's result type from the LHS's static_type. */
+  filterx_expr_infer_types(self->super.lhs, env);
+
+  FilterXStaticTypeSpec rhs_spec = self->super.rhs ? self->super.rhs->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+
+  FilterXVariableHandle handle;
+  if (filterx_variable_expr_get_handle(self->super.lhs, &handle))
+    filterx_type_spec_set(env, handle, rhs_spec);
+
+  s->static_type = rhs_spec;
+}
+
+static void
+_nullv_assign_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXAssign *self = (FilterXAssign *) s;
+
+  filterx_expr_infer_types(self->super.rhs, env);
+  filterx_expr_infer_types(self->super.lhs, env);
+
+  FilterXStaticTypeSpec rhs_spec = self->super.rhs ? self->super.rhs->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+
+  /* nullv-assign keeps the LHS's prior value if RHS is null. The post-statement type is
+   * therefore meet(prior, rhs), and prior is what the env currently has. */
+  FilterXVariableHandle handle;
+  if (filterx_variable_expr_get_handle(self->super.lhs, &handle))
+    {
+      FilterXStaticTypeSpec prior = filterx_type_spec_get(env, handle);
+      filterx_type_spec_set(env, handle, filterx_static_type_spec_meet(prior, rhs_spec));
+    }
+
+  s->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
+}
+
 #endif
 
 static void
@@ -227,6 +269,7 @@ filterx_assign_new(FilterXExpr *lhs, FilterXExpr *rhs)
   filterx_assign_init_instance(self, "assign", lhs, rhs);
   self->super.super.eval = _assign_eval;
 #if SYSLOG_NG_ENABLE_JIT
+  self->super.super.infer_types = _assign_infer_types;
   self->super.super.compile = _assign_compile;
 #endif
   return &self->super.super;
@@ -240,6 +283,7 @@ filterx_nullv_assign_new(FilterXExpr *lhs, FilterXExpr *rhs)
   filterx_assign_init_instance(self, "nullv-assign", lhs, rhs);
   self->super.super.eval = _nullv_assign_eval;
 #if SYSLOG_NG_ENABLE_JIT
+  self->super.super.infer_types = _nullv_assign_infer_types;
   self->super.super.compile = _nullv_assign_compile;
 #endif
   return &self->super.super;

--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -223,7 +223,11 @@ _assign_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
 
   FilterXVariableHandle handle;
   if (filterx_variable_expr_get_handle(self->super.lhs, &handle))
-    filterx_type_spec_set(env, handle, rhs_spec);
+    {
+      /* Whole-variable overwrite: any per-key type recorded under the old value is stale. */
+      filterx_type_env_invalidate_attr_chains(env, handle);
+      filterx_type_spec_set(env, handle, rhs_spec);
+    }
 
   s->static_type = rhs_spec;
 }
@@ -238,13 +242,20 @@ _nullv_assign_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
 
   FilterXStaticTypeSpec rhs_spec = self->super.rhs ? self->super.rhs->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
 
-  /* nullv-assign keeps the LHS's prior value if RHS is null. The post-statement type is
-   * therefore meet(prior, rhs), and prior is what the env currently has. */
+  /* nullv-assign is a runtime branch: if RHS is null, LHS keeps its prior value untouched
+   * (any per-key info recorded for it is still valid); otherwise LHS is wholly replaced by
+   * RHS (the old per-key info is now stale). Model both branches on their own env clone,
+   * same as if/else, and meet them back together — this both computes meet(prior, rhs) for
+   * the handle itself and drops any attr_to_spec entries that don't survive in both branches. */
   FilterXVariableHandle handle;
   if (filterx_variable_expr_get_handle(self->super.lhs, &handle))
     {
-      FilterXStaticTypeSpec prior = filterx_type_spec_get(env, handle);
-      filterx_type_spec_set(env, handle, filterx_static_type_spec_meet(prior, rhs_spec));
+      FilterXTypeEnv *assigned_env = filterx_type_env_clone(env);
+      filterx_type_env_invalidate_attr_chains(assigned_env, handle);
+      filterx_type_spec_set(assigned_env, handle, rhs_spec);
+
+      filterx_type_env_meet_into(env, assigned_env);
+      filterx_type_env_free(assigned_env);
     }
 
   s->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -247,6 +247,23 @@ _compound_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return filterx_expr_list_foreach_ref(&self->exprs, _expr_walk_cb, args);
 }
 
+static void
+_compound_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXCompoundExpr *self = (FilterXCompoundExpr *) s;
+  gsize n = filterx_expr_list_get_length(&self->exprs);
+
+  FilterXStaticTypeSpec last = INITIAL_FILTERX_STATIC_TYPE_SPEC;
+  for (gsize i = 0; i < n; i++)
+    {
+      FilterXExpr *child = filterx_expr_list_index(&self->exprs, i);
+      filterx_expr_infer_types(child, env);
+      last = child ? child->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+    }
+
+  s->static_type = self->return_value_of_last_expr ? last : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+}
+
 #if SYSLOG_NG_ENABLE_JIT
 
 #include "filterx/jit/jit.h"
@@ -394,6 +411,7 @@ filterx_compound_expr_new(gboolean return_value_of_last_expr)
   self->super.init = _init;
   self->super.walk_children = _compound_walk;
   self->super.free_fn = _free;
+  self->super.infer_types = _compound_infer_types;
 #if SYSLOG_NG_ENABLE_JIT
   self->super.compile = _compound_compile;
 #endif

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -377,7 +377,11 @@ _compound_compile(FilterXExpr *s, FilterXJIT *jit)
                                            child->lloc->first_line, child->lloc->first_column);
 
       FilterXIRValue result = filterx_expr_compile_or_eval(child, jit);
-      FilterXIRValue action = _emit_process_expr_result(jit, result, child, eval_ctx, result_slot);
+
+      /* fold the helper call and the postlude into a single "<helper>_stmt" call where possible */
+      FilterXIRValue action = fx_jit_try_emit_stmt_action(jit, result, eval_ctx, result_slot);
+      if (!action)
+        action = _emit_process_expr_result(jit, result, child, eval_ctx, result_slot);
 
       prev_switch = LLVMBuildSwitch(ir, action, mark_failure, 2);
       LLVMAddCase(prev_switch, LLVMConstInt(ffi->i32_ty, FXC_STEP_STOP_TRUE, FALSE), finish);

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -379,7 +379,11 @@ _compound_compile(FilterXExpr *s, FilterXJIT *jit)
                                            child->lloc->first_line, child->lloc->first_column);
 
       FilterXIRValue result = filterx_expr_compile_or_eval(child, jit);
-      FilterXIRValue action = _emit_process_expr_result(jit, result, child, eval_ctx, result_slot);
+
+      /* fold the helper call and the postlude into a single "<helper>_stmt" call where possible */
+      FilterXIRValue action = fx_jit_try_emit_stmt_action(jit, result, eval_ctx, result_slot);
+      if (!action)
+        action = _emit_process_expr_result(jit, result, child, eval_ctx, result_slot);
 
       prev_switch = LLVMBuildSwitch(ir, action, mark_failure, 2);
       LLVMAddCase(prev_switch, LLVMConstInt(ffi->i32_ty, FXC_STEP_STOP_TRUE, FALSE), finish);

--- a/lib/filterx/expr-compound.c
+++ b/lib/filterx/expr-compound.c
@@ -300,6 +300,23 @@ fx_jit_process_compound_result(FilterXCompoundExpr *self, gint32 success, Filter
   return _process_compound_result(self, success, result);
 }
 
+static void
+_compound_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXCompoundExpr *self = (FilterXCompoundExpr *) s;
+  gsize n = filterx_expr_list_get_length(&self->exprs);
+
+  FilterXStaticTypeSpec last = INITIAL_FILTERX_STATIC_TYPE_SPEC;
+  for (gsize i = 0; i < n; i++)
+    {
+      FilterXExpr *child = filterx_expr_list_index(&self->exprs, i);
+      filterx_expr_infer_types(child, env);
+      last = child ? child->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+    }
+
+  s->static_type = self->return_value_of_last_expr ? last : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+}
+
 static inline FilterXIRValue
 _emit_process_compound_result(FilterXJIT *jit, FilterXCompoundExpr *self, FilterXIRValue success, FilterXIRValue result)
 {
@@ -397,6 +414,7 @@ filterx_compound_expr_new(gboolean return_value_of_last_expr)
   self->super.walk_children = _compound_walk;
   self->super.free_fn = _free;
 #if SYSLOG_NG_ENABLE_JIT
+  self->super.infer_types = _compound_infer_types;
   self->super.compile = _compound_compile;
 #endif
   self->return_value_of_last_expr = return_value_of_last_expr;

--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -267,6 +267,30 @@ _compile_conditional(FilterXExpr *s, FilterXJIT *jit)
 
 #endif
 
+static void
+_conditional_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXConditional *self = (FilterXConditional *) s;
+
+  /* The condition runs unconditionally before the branches. */
+  filterx_expr_infer_types(self->condition, env);
+
+  /* Walk each branch on its own clone of the env, then meet the resulting envs into the
+   * outer env. A missing branch is equivalent to a no-op, which still contributes the
+   * pre-branch env to the meet. */
+  FilterXTypeEnv *false_env = filterx_type_env_clone(env);
+
+  filterx_expr_infer_types(self->true_branch, env);
+  filterx_expr_infer_types(self->false_branch, false_env);
+
+  filterx_type_env_meet_into(env, false_env);
+  filterx_type_env_free(false_env);
+
+  FilterXStaticTypeSpec t_t = self->true_branch ? self->true_branch->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+  FilterXStaticTypeSpec f_t = self->false_branch ? self->false_branch->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+  s->static_type = filterx_static_type_spec_meet(t_t, f_t);
+}
+
 FilterXExpr *
 filterx_conditional_new(FilterXExpr *condition)
 {
@@ -276,6 +300,7 @@ filterx_conditional_new(FilterXExpr *condition)
   self->super.optimize = _optimize;
   self->super.walk_children = _conditional_walk;
   self->super.free_fn = _free;
+  self->super.infer_types = _conditional_infer_types;
 #if SYSLOG_NG_ENABLE_JIT
   self->super.compile = _compile_conditional;
 #endif

--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -258,6 +258,30 @@ _compile_conditional(FilterXExpr *s, FilterXJIT *jit)
   return LLVMBuildLoad2(ir, ffi->ptr_ty, result_slot, "result");
 }
 
+static void
+_conditional_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXConditional *self = (FilterXConditional *) s;
+
+  /* The condition runs unconditionally before the branches. */
+  filterx_expr_infer_types(self->condition, env);
+
+  /* Walk each branch on its own clone of the env, then meet the resulting envs into the
+   * outer env. A missing branch is equivalent to a no-op, which still contributes the
+   * pre-branch env to the meet. */
+  FilterXTypeEnv *false_env = filterx_type_env_clone(env);
+
+  filterx_expr_infer_types(self->true_branch, env);
+  filterx_expr_infer_types(self->false_branch, false_env);
+
+  filterx_type_env_meet_into(env, false_env);
+  filterx_type_env_free(false_env);
+
+  FilterXStaticTypeSpec t_t = self->true_branch ? self->true_branch->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+  FilterXStaticTypeSpec f_t = self->false_branch ? self->false_branch->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+  s->static_type = filterx_static_type_spec_meet(t_t, f_t);
+}
+
 #endif
 
 FilterXExpr *
@@ -270,6 +294,7 @@ filterx_conditional_new(FilterXExpr *condition)
   self->super.walk_children = _conditional_walk;
   self->super.free_fn = _free;
 #if SYSLOG_NG_ENABLE_JIT
+  self->super.infer_types = _conditional_infer_types;
   self->super.compile = _compile_conditional;
 #endif
   self->super.suppress_from_trace = TRUE;

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -201,6 +201,14 @@ fx_jit_do_simple_function(FilterXSimpleFunctionProto fn, FilterXExpr *expr,
   return res;
 }
 
+__attribute__((used)) __attribute__((noinline))
+FilterXObject *
+fx_jit_do_simple_function_typed(FilterXSimpleFunctionProto fn, FilterXExpr *expr,
+                                FilterXObject **args, gsize args_len)
+{
+  return filterx_expr_make_typed_object(expr, fx_jit_do_simple_function(fn, expr, args, args_len));
+}
+
 static FilterXIRValue
 _simple_function_compile(FilterXExpr *s, FilterXJIT *jit)
 {

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -21,6 +21,8 @@
  */
 #include "filterx/expr-get-subscript.h"
 #include "filterx/filterx-eval.h"
+#include "filterx/object-dict.h"
+#include "filterx/object-list.h"
 #include "stats/stats-registry.h"
 #include "stats/stats-cluster-single.h"
 
@@ -182,6 +184,80 @@ filterx_get_subscript_get_operand(FilterXExpr *s)
   return ((FilterXGetSubscript *) s)->operand;
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+typedef FilterXObject *(*FXGetSubscriptHelper)(FilterXObject *object, FilterXObject *key);
+
+static inline __attribute__((always_inline)) FilterXObject *
+_do_get_subscript(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr,
+                  FXGetSubscriptHelper helper)
+{
+  if (!variable)
+    {
+      filterx_eval_push_error_static_info("Failed to get-subscript from object", expr,
+                                          "Failed to evaluate expression");
+      return NULL;
+    }
+  if (!key)
+    {
+      filterx_eval_push_error_static_info("Failed to get-subscript from object", expr,
+                                          "Failed to evaluate key");
+      filterx_object_unref(variable);
+      return NULL;
+    }
+  FilterXObject *result = helper(variable, key);
+  if (!result)
+    filterx_eval_push_error("Failed to get-subscript from object", expr, key);
+  filterx_object_unref(key);
+  filterx_object_unref(variable);
+  return result;
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_get_subscript_dict(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
+{
+  return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_get_subscript_list(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
+{
+  return _do_get_subscript(variable, key, expr, filterx_list_get_subscript);
+}
+
+static FilterXIRValue
+_get_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  FilterXGetSubscript *self = (FilterXGetSubscript *) s;
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  const gchar *fn_name;
+  switch (filterx_static_type_kind(self->operand->static_type))
+    {
+    case FILTERX_STATIC_TYPE_DICT:
+      fn_name = "fx_jit_do_get_subscript_dict";
+      break;
+    case FILTERX_STATIC_TYPE_LIST:
+      fn_name = "fx_jit_do_get_subscript_list";
+      break;
+    default:
+      return fx_jit_emit_expr_eval(jit, s);
+    }
+
+  FilterXIRValue variable = filterx_expr_compile_or_eval_typed(self->operand, jit);
+  FilterXIRValue key = filterx_expr_compile_or_eval_typed(self->key, jit);
+  FilterXIRValue args[] = { variable, key, fx_jit_emit_const_ptr(jit, s) };
+  FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
+  return fx_jit_emit_extern_call(jit, fn_name, ffi->ptr_ty, param_tys, args, 3);
+}
+
+#endif
+
 static gboolean
 _get_subscript_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 {
@@ -212,6 +288,9 @@ filterx_get_subscript_new(FilterXExpr *operand, FilterXExpr *key)
   self->super.move = _move;
   self->super.free_fn = _free;
   self->super.infer_types = _get_subscript_infer_types;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.compile = _get_subscript_compile;
+#endif
   self->operand = operand;
   self->key = key;
   return &self->super;

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -255,6 +255,27 @@ fx_jit_do_get_subscript_dict_string_key(FilterXObject *variable, FilterXObject *
   return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript_unchecked, &FILTERX_TYPE_NAME(dict));
 }
 
+__attribute__((used)) __attribute__((noinline))
+FilterXObject *
+fx_jit_do_get_subscript_dict_typed(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
+{
+  return filterx_expr_make_typed_object(expr, fx_jit_do_get_subscript_dict(variable, key, expr));
+}
+
+__attribute__((used)) __attribute__((noinline))
+FilterXObject *
+fx_jit_do_get_subscript_list_typed(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
+{
+  return filterx_expr_make_typed_object(expr, fx_jit_do_get_subscript_list(variable, key, expr));
+}
+
+__attribute__((used)) __attribute__((noinline))
+FilterXObject *
+fx_jit_do_get_subscript_dict_string_key_typed(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
+{
+  return filterx_expr_make_typed_object(expr, fx_jit_do_get_subscript_dict_string_key(variable, key, expr));
+}
+
 static FilterXIRValue
 _get_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
 {

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -174,6 +174,14 @@ _get_subscript_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
                                                INITIAL_FILTERX_STATIC_TYPE_SPEC);
 }
 
+FilterXExpr *
+filterx_get_subscript_get_operand(FilterXExpr *s)
+{
+  if (!filterx_expr_is_get_subscript(s))
+    return NULL;
+  return ((FilterXGetSubscript *) s)->operand;
+}
+
 static gboolean
 _get_subscript_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 {

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -211,6 +211,10 @@ _do_get_subscript(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr
   FilterXObject *result = helper(variable, key);
   if (!result)
     filterx_eval_push_error("Failed to get-subscript from object", expr, key);
+  else if (filterx_object_is_ref(variable))
+    /* The dict/list helpers unwrap @variable read-only, so float the shared child against
+     * it (as the ref's get_subscript vtable does) to preserve copy-on-write on later writes. */
+    result = filterx_ref_float_shared_child(result, variable);
   filterx_object_unref(key);
   filterx_object_unref(variable);
   return result;

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -191,9 +191,17 @@ filterx_get_subscript_get_operand(FilterXExpr *s)
 
 typedef FilterXObject *(*FXGetSubscriptHelper)(FilterXObject *object, FilterXObject *key);
 
+/* The dict/list helpers downcast @variable to a concrete FilterX{Dict,List}Object, but the
+ * static type that selected this fast path is only a hint: coercing containers (e.g. otel
+ * masquerading as dict/list) yield a different runtime layout. @expected_type guards the
+ * downcast; on a mismatch we fall back to the generic vtable get_subscript.
+ *
+ * The helpers unwrap @variable read-only, so on the fast path we float the shared child
+ * against it (as the ref's get_subscript vtable does) to preserve copy-on-write on later
+ * writes. The generic fallback already floats internally via the ref vtable. */
 static inline __attribute__((always_inline)) FilterXObject *
 _do_get_subscript(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr,
-                  FXGetSubscriptHelper helper)
+                  FXGetSubscriptHelper helper, FilterXType *expected_type)
 {
   if (!variable)
     {
@@ -208,13 +216,19 @@ _do_get_subscript(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr
       filterx_object_unref(variable);
       return NULL;
     }
-  FilterXObject *result = helper(variable, key);
+
+  FilterXObject *result;
+  if (filterx_object_is_type_or_ref(variable, expected_type))
+    {
+      result = helper(variable, key);
+      if (result && filterx_object_is_ref(variable))
+        result = filterx_ref_float_shared_child(result, variable);
+    }
+  else
+    result = filterx_object_get_subscript(variable, key);
+
   if (!result)
     filterx_eval_push_error("Failed to get-subscript from object", expr, key);
-  else if (filterx_object_is_ref(variable))
-    /* The dict/list helpers unwrap @variable read-only, so float the shared child against
-     * it (as the ref's get_subscript vtable does) to preserve copy-on-write on later writes. */
-    result = filterx_ref_float_shared_child(result, variable);
   filterx_object_unref(key);
   filterx_object_unref(variable);
   return result;
@@ -224,21 +238,21 @@ __attribute__((used))
 FilterXObject *
 fx_jit_do_get_subscript_dict(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
 {
-  return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript);
+  return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript, &FILTERX_TYPE_NAME(dict));
 }
 
 __attribute__((used))
 FilterXObject *
 fx_jit_do_get_subscript_list(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
 {
-  return _do_get_subscript(variable, key, expr, filterx_list_get_subscript);
+  return _do_get_subscript(variable, key, expr, filterx_list_get_subscript, &FILTERX_TYPE_NAME(list));
 }
 
 __attribute__((used))
 FilterXObject *
 fx_jit_do_get_subscript_dict_string_key(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
 {
-  return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript_unchecked);
+  return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript_unchecked, &FILTERX_TYPE_NAME(dict));
 }
 
 static FilterXIRValue

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -164,6 +164,16 @@ _free(FilterXExpr *s)
   filterx_expr_free_method(s);
 }
 
+static void
+_get_subscript_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXGetSubscript *self = (FilterXGetSubscript *) s;
+  /* Result is one nesting level shallower than the operand. */
+  s->static_type = filterx_static_type_element(self->operand ? self->operand->static_type :
+                                               INITIAL_FILTERX_STATIC_TYPE_SPEC);
+}
+
 static gboolean
 _get_subscript_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 {
@@ -193,6 +203,7 @@ filterx_get_subscript_new(FilterXExpr *operand, FilterXExpr *key)
   self->super.walk_children = _get_subscript_walk;
   self->super.move = _move;
   self->super.free_fn = _free;
+  self->super.infer_types = _get_subscript_infer_types;
   self->operand = operand;
   self->key = key;
   return &self->super;

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -230,6 +230,13 @@ fx_jit_do_get_subscript_list(FilterXObject *variable, FilterXObject *key, Filter
   return _do_get_subscript(variable, key, expr, filterx_list_get_subscript);
 }
 
+__attribute__((used))
+FilterXObject *
+fx_jit_do_get_subscript_dict_string_key(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
+{
+  return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript_unchecked);
+}
+
 static FilterXIRValue
 _get_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
 {
@@ -240,7 +247,11 @@ _get_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
   switch (filterx_static_type_kind(self->operand->static_type))
     {
     case FILTERX_STATIC_TYPE_DICT:
-      fn_name = "fx_jit_do_get_subscript_dict";
+      /* Dict keys must be hashable strings at runtime. When inference proves the key is a
+       * string, skip the runtime hashable check by dispatching to the unchecked variant. */
+      fn_name = filterx_static_type_kind(self->key->static_type) == FILTERX_STATIC_TYPE_STRING
+                ? "fx_jit_do_get_subscript_dict_string_key"
+                : "fx_jit_do_get_subscript_dict";
       break;
     case FILTERX_STATIC_TYPE_LIST:
       fn_name = "fx_jit_do_get_subscript_list";

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -256,6 +256,27 @@ fx_jit_do_get_subscript_dict_string_key(FilterXObject *variable, FilterXObject *
   return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript_unchecked, &FILTERX_TYPE_NAME(dict));
 }
 
+__attribute__((used)) __attribute__((noinline))
+FilterXObject *
+fx_jit_do_get_subscript_dict_typed(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
+{
+  return filterx_expr_make_typed_object(expr, fx_jit_do_get_subscript_dict(variable, key, expr));
+}
+
+__attribute__((used)) __attribute__((noinline))
+FilterXObject *
+fx_jit_do_get_subscript_list_typed(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
+{
+  return filterx_expr_make_typed_object(expr, fx_jit_do_get_subscript_list(variable, key, expr));
+}
+
+__attribute__((used)) __attribute__((noinline))
+FilterXObject *
+fx_jit_do_get_subscript_dict_string_key_typed(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
+{
+  return filterx_expr_make_typed_object(expr, fx_jit_do_get_subscript_dict_string_key(variable, key, expr));
+}
+
 static FilterXIRValue
 _get_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
 {

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -21,6 +21,10 @@
  */
 #include "filterx/expr-get-subscript.h"
 #include "filterx/filterx-eval.h"
+#if SYSLOG_NG_ENABLE_JIT
+#include "filterx/object-dict.h"
+#include "filterx/object-list.h"
+#endif
 #include "stats/stats-registry.h"
 #include "stats/stats-cluster-single.h"
 
@@ -177,6 +181,80 @@ filterx_get_subscript_get_operand(FilterXExpr *s)
   return ((FilterXGetSubscript *) s)->operand;
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+typedef FilterXObject *(*FXGetSubscriptHelper)(FilterXObject *object, FilterXObject *key);
+
+static inline __attribute__((always_inline)) FilterXObject *
+_do_get_subscript(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr,
+                  FXGetSubscriptHelper helper)
+{
+  if (!variable)
+    {
+      filterx_eval_push_error_static_info("Failed to get-subscript from object",
+                                          "Failed to evaluate expression");
+      return NULL;
+    }
+  if (!key)
+    {
+      filterx_eval_push_error_static_info("Failed to get-subscript from object",
+                                          "Failed to evaluate key");
+      filterx_object_unref(variable);
+      return NULL;
+    }
+  FilterXObject *result = helper(variable, key);
+  if (!result)
+    filterx_eval_push_error("Failed to get-subscript from object", key);
+  filterx_object_unref(key);
+  filterx_object_unref(variable);
+  return result;
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_get_subscript_dict(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
+{
+  return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_get_subscript_list(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
+{
+  return _do_get_subscript(variable, key, expr, filterx_list_get_subscript);
+}
+
+static FilterXIRValue
+_get_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  FilterXGetSubscript *self = (FilterXGetSubscript *) s;
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  const gchar *fn_name;
+  switch (filterx_static_type_kind(self->operand->static_type))
+    {
+    case FILTERX_STATIC_TYPE_DICT:
+      fn_name = "fx_jit_do_get_subscript_dict";
+      break;
+    case FILTERX_STATIC_TYPE_LIST:
+      fn_name = "fx_jit_do_get_subscript_list";
+      break;
+    default:
+      return fx_jit_emit_expr_eval(jit, s);
+    }
+
+  FilterXIRValue variable = filterx_expr_compile_or_eval_typed(self->operand, jit);
+  FilterXIRValue key = filterx_expr_compile_or_eval_typed(self->key, jit);
+  FilterXIRValue args[] = { variable, key, fx_jit_emit_const_ptr(jit, s) };
+  FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
+  return fx_jit_emit_extern_call(jit, fn_name, ffi->ptr_ty, param_tys, args, 3);
+}
+
+#endif
+
 static gboolean
 _get_subscript_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 {
@@ -208,6 +286,7 @@ filterx_get_subscript_new(FilterXExpr *operand, FilterXExpr *key)
   self->super.free_fn = _free;
 #if SYSLOG_NG_ENABLE_JIT
   self->super.infer_types = _get_subscript_infer_types;
+  self->super.compile = _get_subscript_compile;
 #endif
   self->operand = operand;
   self->key = key;

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -156,6 +156,19 @@ _free(FilterXExpr *s)
   filterx_expr_free_method(s);
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+static void
+_get_subscript_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXGetSubscript *self = (FilterXGetSubscript *) s;
+  /* Result is one nesting level shallower than the operand. */
+  s->static_type = filterx_static_type_element(self->operand ? self->operand->static_type :
+                                               INITIAL_FILTERX_STATIC_TYPE_SPEC);
+}
+
+#endif
+
 static gboolean
 _get_subscript_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 {
@@ -185,6 +198,9 @@ filterx_get_subscript_new(FilterXExpr *operand, FilterXExpr *key)
   self->super.walk_children = _get_subscript_walk;
   self->super.move = _move;
   self->super.free_fn = _free;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.infer_types = _get_subscript_infer_types;
+#endif
   self->operand = operand;
   self->key = key;
   return &self->super;

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -169,6 +169,14 @@ _get_subscript_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
 
 #endif
 
+FilterXExpr *
+filterx_get_subscript_get_operand(FilterXExpr *s)
+{
+  if (!filterx_expr_is_get_subscript(s))
+    return NULL;
+  return ((FilterXGetSubscript *) s)->operand;
+}
+
 static gboolean
 _get_subscript_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 {

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -208,6 +208,10 @@ _do_get_subscript(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr
   FilterXObject *result = helper(variable, key);
   if (!result)
     filterx_eval_push_error("Failed to get-subscript from object", key);
+  else if (filterx_object_is_ref(variable))
+    /* The dict/list helpers unwrap @variable read-only, so float the shared child against
+     * it (as the ref's get_subscript vtable does) to preserve copy-on-write on later writes. */
+    result = filterx_ref_float_shared_child(result, variable);
   filterx_object_unref(key);
   filterx_object_unref(variable);
   return result;

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -227,6 +227,13 @@ fx_jit_do_get_subscript_list(FilterXObject *variable, FilterXObject *key, Filter
   return _do_get_subscript(variable, key, expr, filterx_list_get_subscript);
 }
 
+__attribute__((used))
+FilterXObject *
+fx_jit_do_get_subscript_dict_string_key(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
+{
+  return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript_unchecked);
+}
+
 static FilterXIRValue
 _get_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
 {
@@ -237,7 +244,11 @@ _get_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
   switch (filterx_static_type_kind(self->operand->static_type))
     {
     case FILTERX_STATIC_TYPE_DICT:
-      fn_name = "fx_jit_do_get_subscript_dict";
+      /* Dict keys must be hashable strings at runtime. When inference proves the key is a
+       * string, skip the runtime hashable check by dispatching to the unchecked variant. */
+      fn_name = filterx_static_type_kind(self->key->static_type) == FILTERX_STATIC_TYPE_STRING
+                ? "fx_jit_do_get_subscript_dict_string_key"
+                : "fx_jit_do_get_subscript_dict";
       break;
     case FILTERX_STATIC_TYPE_LIST:
       fn_name = "fx_jit_do_get_subscript_list";

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -188,9 +188,17 @@ filterx_get_subscript_get_operand(FilterXExpr *s)
 
 typedef FilterXObject *(*FXGetSubscriptHelper)(FilterXObject *object, FilterXObject *key);
 
+/* The dict/list helpers downcast @variable to a concrete FilterX{Dict,List}Object, but the
+ * static type that selected this fast path is only a hint: coercing containers (e.g. otel
+ * masquerading as dict/list) yield a different runtime layout. @expected_type guards the
+ * downcast; on a mismatch we fall back to the generic vtable get_subscript.
+ *
+ * The helpers unwrap @variable read-only, so on the fast path we float the shared child
+ * against it (as the ref's get_subscript vtable does) to preserve copy-on-write on later
+ * writes. The generic fallback already floats internally via the ref vtable. */
 static inline __attribute__((always_inline)) FilterXObject *
 _do_get_subscript(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr,
-                  FXGetSubscriptHelper helper)
+                  FXGetSubscriptHelper helper, FilterXType *expected_type)
 {
   if (!variable)
     {
@@ -205,7 +213,17 @@ _do_get_subscript(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr
       filterx_object_unref(variable);
       return NULL;
     }
-  FilterXObject *result = helper(variable, key);
+
+  FilterXObject *result;
+  if (filterx_object_is_type_or_ref(variable, expected_type))
+    {
+      result = helper(variable, key);
+      if (result && filterx_object_is_ref(variable))
+        result = filterx_ref_float_shared_child(result, variable);
+    }
+  else
+    result = filterx_object_get_subscript(variable, key);
+
   if (!result)
     filterx_eval_push_error("Failed to get-subscript from object", key);
   else if (filterx_object_is_ref(variable))
@@ -221,21 +239,21 @@ __attribute__((used))
 FilterXObject *
 fx_jit_do_get_subscript_dict(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
 {
-  return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript);
+  return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript, &FILTERX_TYPE_NAME(dict));
 }
 
 __attribute__((used))
 FilterXObject *
 fx_jit_do_get_subscript_list(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
 {
-  return _do_get_subscript(variable, key, expr, filterx_list_get_subscript);
+  return _do_get_subscript(variable, key, expr, filterx_list_get_subscript, &FILTERX_TYPE_NAME(list));
 }
 
 __attribute__((used))
 FilterXObject *
 fx_jit_do_get_subscript_dict_string_key(FilterXObject *variable, FilterXObject *key, FilterXExpr *expr)
 {
-  return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript_unchecked);
+  return _do_get_subscript(variable, key, expr, filterx_dict_get_subscript_unchecked, &FILTERX_TYPE_NAME(dict));
 }
 
 static FilterXIRValue

--- a/lib/filterx/expr-get-subscript.h
+++ b/lib/filterx/expr-get-subscript.h
@@ -25,6 +25,7 @@
 #include "filterx/filterx-expr.h"
 
 FilterXExpr *filterx_get_subscript_new(FilterXExpr *lhs, FilterXExpr *key);
+FilterXExpr *filterx_get_subscript_get_operand(FilterXExpr *s);
 
 FILTERX_EXPR_DECLARE_TYPE(get_subscript);
 

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -156,6 +156,14 @@ _getattr_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
                                                INITIAL_FILTERX_STATIC_TYPE_SPEC);
 }
 
+FilterXExpr *
+filterx_getattr_get_operand(FilterXExpr *s)
+{
+  if (!filterx_expr_is_getattr(s))
+    return NULL;
+  return ((FilterXGetAttr *) s)->operand;
+}
+
 #if SYSLOG_NG_ENABLE_JIT
 
 #include "filterx/jit/jit.h"

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -195,9 +195,14 @@ fx_jit_do_getattr(FilterXObject *variable, FilterXObject *attr, FilterXExpr *exp
 }
 
 /* Dict-specialized fast path. dict.attr is semantically dict[attr] with a known-string key,
- * so we call filterx_dict_get_subscript_unchecked directly, bypassing both ref's getattr
- * vtable and mapping's getattr → get_subscript hop. @attr is borrowed (owned by the
- * FilterXGetAttr struct) and must not be unrefed. */
+ * so we call filterx_dict_get_subscript_unchecked directly, bypassing the mapping's
+ * getattr → get_subscript hop. @attr is borrowed (owned by the FilterXGetAttr struct) and
+ * must not be unrefed.
+ *
+ * The unchecked lookup unwraps @variable read-only, so when @variable is a ref we must
+ * still float the shared child against it (exactly as the ref's getattr vtable does) to
+ * preserve copy-on-write; otherwise a subsequent setattr on the returned child would mutate
+ * a dict still shared with the source variable. */
 __attribute__((used))
 FilterXObject *
 fx_jit_do_getattr_dict(FilterXObject *variable, FilterXObject *attr, FilterXExpr *expr)
@@ -213,6 +218,8 @@ fx_jit_do_getattr_dict(FilterXObject *variable, FilterXObject *attr, FilterXExpr
   if (!result)
     filterx_eval_push_error_static_info("Failed to get-attribute from object", expr,
                                         "Failed to evaluate key");
+  else if (filterx_object_is_ref(variable))
+    result = filterx_ref_float_shared_child(result, variable);
 
   filterx_object_unref(variable);
   return result;

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -234,6 +234,20 @@ fx_jit_do_getattr_dict(FilterXObject *variable, FilterXObject *attr, FilterXExpr
   return result;
 }
 
+__attribute__((used)) __attribute__((noinline))
+FilterXObject *
+fx_jit_do_getattr_typed(FilterXObject *variable, FilterXObject *attr, FilterXExpr *expr)
+{
+  return filterx_expr_make_typed_object(expr, fx_jit_do_getattr(variable, attr, expr));
+}
+
+__attribute__((used)) __attribute__((noinline))
+FilterXObject *
+fx_jit_do_getattr_dict_typed(FilterXObject *variable, FilterXObject *attr, FilterXExpr *expr)
+{
+  return filterx_expr_make_typed_object(expr, fx_jit_do_getattr_dict(variable, attr, expr));
+}
+
 static FilterXIRValue
 _getattr_compile(FilterXExpr *s, FilterXJIT *jit)
 {

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -146,6 +146,16 @@ _getattr_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return TRUE;
 }
 
+static void
+_getattr_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXGetAttr *self = (FilterXGetAttr *) s;
+  /* Result is one nesting level shallower than the operand. */
+  s->static_type = filterx_static_type_element(self->operand ? self->operand->static_type :
+                                               INITIAL_FILTERX_STATIC_TYPE_SPEC);
+}
+
 #if SYSLOG_NG_ENABLE_JIT
 
 #include "filterx/jit/jit.h"
@@ -190,6 +200,7 @@ filterx_getattr_new(FilterXExpr *operand, FilterXObject *attr_name)
   self->super.is_set = _isset;
   self->super.walk_children = _getattr_walk;
   self->super.free_fn = _free;
+  self->super.infer_types = _getattr_infer_types;
 #if SYSLOG_NG_ENABLE_JIT
   self->super.compile = _getattr_compile;
 #endif

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -199,10 +199,16 @@ fx_jit_do_getattr(FilterXObject *variable, FilterXObject *attr, FilterXExpr *exp
  * getattr → get_subscript hop. @attr is borrowed (owned by the FilterXGetAttr struct) and
  * must not be unrefed.
  *
+ * The static type DICT is only a hint: coercing containers (e.g. otel_logrecord.body, which
+ * stores an assigned dict as an otel_kvlist) yield a non-dict object at runtime. Since the
+ * unchecked path downcasts to FilterXDictObject, verify the runtime layout first and fall
+ * back to the generic vtable getattr otherwise.
+ *
  * The unchecked lookup unwraps @variable read-only, so when @variable is a ref we must
  * still float the shared child against it (exactly as the ref's getattr vtable does) to
  * preserve copy-on-write; otherwise a subsequent setattr on the returned child would mutate
- * a dict still shared with the source variable. */
+ * a dict still shared with the source variable. (_do_getattr's generic path floats internally
+ * via the ref vtable, so the fallback needs no explicit float.) */
 __attribute__((used))
 FilterXObject *
 fx_jit_do_getattr_dict(FilterXObject *variable, FilterXObject *attr, FilterXExpr *expr)
@@ -213,6 +219,9 @@ fx_jit_do_getattr_dict(FilterXObject *variable, FilterXObject *attr, FilterXExpr
                                           "Failed to evaluate expression");
       return NULL;
     }
+
+  if (!filterx_object_is_type_or_ref(variable, &FILTERX_TYPE_NAME(dict)))
+    return _do_getattr(variable, attr, expr);
 
   FilterXObject *result = filterx_dict_get_subscript_unchecked(variable, attr);
   if (!result)

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -185,6 +185,7 @@ filterx_getattr_get_operand(FilterXExpr *s)
 
 #include "filterx/jit/jit.h"
 #include "filterx/jit/ffi.h"
+#include "filterx/object-dict.h"
 
 __attribute__((used))
 FilterXObject *
@@ -193,11 +194,39 @@ fx_jit_do_getattr(FilterXObject *variable, FilterXObject *attr, FilterXExpr *exp
   return _do_getattr(variable, attr, expr);
 }
 
+/* Dict-specialized fast path. dict.attr is semantically dict[attr] with a known-string key,
+ * so we call filterx_dict_get_subscript_unchecked directly, bypassing both ref's getattr
+ * vtable and mapping's getattr → get_subscript hop. @attr is borrowed (owned by the
+ * FilterXGetAttr struct) and must not be unrefed. */
+__attribute__((used))
+FilterXObject *
+fx_jit_do_getattr_dict(FilterXObject *variable, FilterXObject *attr, FilterXExpr *expr)
+{
+  if (!variable)
+    {
+      filterx_eval_push_error_static_info("Failed to get-attribute from object", expr,
+                                          "Failed to evaluate expression");
+      return NULL;
+    }
+
+  FilterXObject *result = filterx_dict_get_subscript_unchecked(variable, attr);
+  if (!result)
+    filterx_eval_push_error_static_info("Failed to get-attribute from object", expr,
+                                        "Failed to evaluate key");
+
+  filterx_object_unref(variable);
+  return result;
+}
+
 static FilterXIRValue
 _getattr_compile(FilterXExpr *s, FilterXJIT *jit)
 {
   FilterXGetAttr *self = (FilterXGetAttr *) s;
   FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  const gchar *fn_name = filterx_static_type_kind(self->operand->static_type) == FILTERX_STATIC_TYPE_DICT
+                         ? "fx_jit_do_getattr_dict"
+                         : "fx_jit_do_getattr";
 
   FilterXIRValue variable = filterx_expr_compile_or_eval_typed(self->operand, jit);
   FilterXIRValue args[] =
@@ -207,7 +236,7 @@ _getattr_compile(FilterXExpr *s, FilterXJIT *jit)
     fx_jit_emit_const_ptr(jit, self),
   };
   FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
-  return fx_jit_emit_extern_call(jit, "fx_jit_do_getattr", ffi->ptr_ty, param_tys, args, 3);
+  return fx_jit_emit_extern_call(jit, fn_name, ffi->ptr_ty, param_tys, args, 3);
 }
 
 #endif

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -22,6 +22,8 @@
 #include "filterx/expr-getattr.h"
 #include "filterx/object-string.h"
 #include "filterx/filterx-eval.h"
+#include "filterx/expr-variable.h"
+#include "filterx/filterx-type-inference.h"
 #include "stats/stats-registry.h"
 #include "stats/stats-cluster-single.h"
 
@@ -151,7 +153,22 @@ _getattr_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
 {
   filterx_expr_infer_types_default(s, env);
   FilterXGetAttr *self = (FilterXGetAttr *) s;
-  /* Result is one nesting level shallower than the operand. */
+
+  const gchar *key = filterx_string_get_value_ref_and_assert_nul(self->attr, NULL);
+
+  /* Per-key lookup: variable.k0.k1...key.  Covers single-hop accesses (variable.key) as a
+   * zero-prefix chain as well as deeper chains where each level was seeded by a setattr in
+   * an earlier block. */
+  if (self->operand)
+    {
+      FilterXStaticTypeSpec keyed = filterx_type_env_get_attr_for_chain(env, self->operand, key);
+      if (filterx_static_type_kind(keyed) != FILTERX_STATIC_TYPE_UNKNOWN)
+        {
+          s->static_type = keyed;
+          return;
+        }
+    }
+
   s->static_type = filterx_static_type_element(self->operand ? self->operand->static_type :
                                                INITIAL_FILTERX_STATIC_TYPE_SPEC);
 }

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -188,11 +188,60 @@ _getattr_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
                                                INITIAL_FILTERX_STATIC_TYPE_SPEC);
 }
 
+FilterXExpr *
+filterx_getattr_get_operand(FilterXExpr *s)
+{
+  if (!filterx_expr_is_getattr(s))
+    return NULL;
+  return ((FilterXGetAttr *) s)->operand;
+}
+
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+#include "filterx/object-dict.h"
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_getattr(FilterXObject *variable, FilterXObject *attr, FilterXExpr *expr)
+{
+  return _do_getattr(variable, attr, expr);
+}
+
+/* Dict-specialized fast path. dict.attr is semantically dict[attr] with a known-string key,
+ * so we call filterx_dict_get_subscript_unchecked directly, bypassing both ref's getattr
+ * vtable and mapping's getattr → get_subscript hop. @attr is borrowed (owned by the
+ * FilterXGetAttr struct) and must not be unrefed. */
+__attribute__((used))
+FilterXObject *
+fx_jit_do_getattr_dict(FilterXObject *variable, FilterXObject *attr, FilterXExpr *expr)
+{
+  if (!variable)
+    {
+      filterx_eval_push_error_static_info("Failed to get-attribute from object",
+                                          "Failed to evaluate expression");
+      return NULL;
+    }
+
+  FilterXObject *result = filterx_dict_get_subscript_unchecked(variable, attr);
+  if (!result)
+    filterx_eval_push_error_static_info("Failed to get-attribute from object",
+                                        "Failed to evaluate key");
+
+  filterx_object_unref(variable);
+  return result;
+}
+
 static FilterXIRValue
 _getattr_compile(FilterXExpr *s, FilterXJIT *jit)
 {
   FilterXGetAttr *self = (FilterXGetAttr *) s;
   FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  const gchar *fn_name = filterx_static_type_kind(self->operand->static_type) == FILTERX_STATIC_TYPE_DICT
+                         ? "fx_jit_do_getattr_dict"
+                         : "fx_jit_do_getattr";
 
   FilterXIRValue variable = filterx_expr_compile_or_eval_typed(self->operand, jit);
   FilterXIRValue args[] =
@@ -202,7 +251,7 @@ _getattr_compile(FilterXExpr *s, FilterXJIT *jit)
     fx_jit_emit_const_ptr(jit, self),
   };
   FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
-  return fx_jit_emit_extern_call(jit, "fx_jit_do_getattr", ffi->ptr_ty, param_tys, args, 3);
+  return fx_jit_emit_extern_call(jit, fn_name, ffi->ptr_ty, param_tys, args, 3);
 }
 
 #endif

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -141,6 +141,14 @@ _getattr_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return TRUE;
 }
 
+FilterXExpr *
+filterx_getattr_get_operand(FilterXExpr *s)
+{
+  if (!filterx_expr_is_getattr(s))
+    return NULL;
+  return ((FilterXGetAttr *) s)->operand;
+}
+
 #if SYSLOG_NG_ENABLE_JIT
 
 #include "filterx/jit/jit.h"

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -249,6 +249,20 @@ fx_jit_do_getattr_dict(FilterXObject *variable, FilterXObject *attr, FilterXExpr
   return result;
 }
 
+__attribute__((used)) __attribute__((noinline))
+FilterXObject *
+fx_jit_do_getattr_typed(FilterXObject *variable, FilterXObject *attr, FilterXExpr *expr)
+{
+  return filterx_expr_make_typed_object(expr, fx_jit_do_getattr(variable, attr, expr));
+}
+
+__attribute__((used)) __attribute__((noinline))
+FilterXObject *
+fx_jit_do_getattr_dict_typed(FilterXObject *variable, FilterXObject *attr, FilterXExpr *expr)
+{
+  return filterx_expr_make_typed_object(expr, fx_jit_do_getattr_dict(variable, attr, expr));
+}
+
 static FilterXIRValue
 _getattr_compile(FilterXExpr *s, FilterXJIT *jit)
 {

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -214,10 +214,16 @@ fx_jit_do_getattr(FilterXObject *variable, FilterXObject *attr, FilterXExpr *exp
  * getattr → get_subscript hop. @attr is borrowed (owned by the FilterXGetAttr struct) and
  * must not be unrefed.
  *
+ * The static type DICT is only a hint: coercing containers (e.g. otel_logrecord.body, which
+ * stores an assigned dict as an otel_kvlist) yield a non-dict object at runtime. Since the
+ * unchecked path downcasts to FilterXDictObject, verify the runtime layout first and fall
+ * back to the generic vtable getattr otherwise.
+ *
  * The unchecked lookup unwraps @variable read-only, so when @variable is a ref we must
  * still float the shared child against it (exactly as the ref's getattr vtable does) to
  * preserve copy-on-write; otherwise a subsequent setattr on the returned child would mutate
- * a dict still shared with the source variable. */
+ * a dict still shared with the source variable. (_do_getattr's generic path floats internally
+ * via the ref vtable, so the fallback needs no explicit float.) */
 __attribute__((used))
 FilterXObject *
 fx_jit_do_getattr_dict(FilterXObject *variable, FilterXObject *attr, FilterXExpr *expr)
@@ -228,6 +234,9 @@ fx_jit_do_getattr_dict(FilterXObject *variable, FilterXObject *attr, FilterXExpr
                                           "Failed to evaluate expression");
       return NULL;
     }
+
+  if (!filterx_object_is_type_or_ref(variable, &FILTERX_TYPE_NAME(dict)))
+    return _do_getattr(variable, attr, expr);
 
   FilterXObject *result = filterx_dict_get_subscript_unchecked(variable, attr);
   if (!result)

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -153,6 +153,16 @@ fx_jit_do_getattr(FilterXObject *variable, FilterXObject *attr, FilterXExpr *exp
   return _do_getattr(variable, attr, expr);
 }
 
+static void
+_getattr_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXGetAttr *self = (FilterXGetAttr *) s;
+  /* Result is one nesting level shallower than the operand. */
+  s->static_type = filterx_static_type_element(self->operand ? self->operand->static_type :
+                                               INITIAL_FILTERX_STATIC_TYPE_SPEC);
+}
+
 static FilterXIRValue
 _getattr_compile(FilterXExpr *s, FilterXJIT *jit)
 {
@@ -186,6 +196,7 @@ filterx_getattr_new(FilterXExpr *operand, FilterXObject *attr_name)
   self->super.walk_children = _getattr_walk;
   self->super.free_fn = _free;
 #if SYSLOG_NG_ENABLE_JIT
+  self->super.infer_types = _getattr_infer_types;
   self->super.compile = _getattr_compile;
 #endif
   self->operand = operand;

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -210,9 +210,14 @@ fx_jit_do_getattr(FilterXObject *variable, FilterXObject *attr, FilterXExpr *exp
 }
 
 /* Dict-specialized fast path. dict.attr is semantically dict[attr] with a known-string key,
- * so we call filterx_dict_get_subscript_unchecked directly, bypassing both ref's getattr
- * vtable and mapping's getattr → get_subscript hop. @attr is borrowed (owned by the
- * FilterXGetAttr struct) and must not be unrefed. */
+ * so we call filterx_dict_get_subscript_unchecked directly, bypassing the mapping's
+ * getattr → get_subscript hop. @attr is borrowed (owned by the FilterXGetAttr struct) and
+ * must not be unrefed.
+ *
+ * The unchecked lookup unwraps @variable read-only, so when @variable is a ref we must
+ * still float the shared child against it (exactly as the ref's getattr vtable does) to
+ * preserve copy-on-write; otherwise a subsequent setattr on the returned child would mutate
+ * a dict still shared with the source variable. */
 __attribute__((used))
 FilterXObject *
 fx_jit_do_getattr_dict(FilterXObject *variable, FilterXObject *attr, FilterXExpr *expr)
@@ -228,6 +233,8 @@ fx_jit_do_getattr_dict(FilterXObject *variable, FilterXObject *attr, FilterXExpr
   if (!result)
     filterx_eval_push_error_static_info("Failed to get-attribute from object",
                                         "Failed to evaluate key");
+  else if (filterx_object_is_ref(variable))
+    result = filterx_ref_float_shared_child(result, variable);
 
   filterx_object_unref(variable);
   return result;

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -22,6 +22,8 @@
 #include "filterx/expr-getattr.h"
 #include "filterx/object-string.h"
 #include "filterx/filterx-eval.h"
+#include "filterx/expr-variable.h"
+#include "filterx/filterx-type-inference.h"
 #include "stats/stats-registry.h"
 #include "stats/stats-cluster-single.h"
 
@@ -166,7 +168,22 @@ _getattr_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
 {
   filterx_expr_infer_types_default(s, env);
   FilterXGetAttr *self = (FilterXGetAttr *) s;
-  /* Result is one nesting level shallower than the operand. */
+
+  const gchar *key = filterx_string_get_value_ref_and_assert_nul(self->attr, NULL);
+
+  /* Per-key lookup: variable.k0.k1...key.  Covers single-hop accesses (variable.key) as a
+   * zero-prefix chain as well as deeper chains where each level was seeded by a setattr in
+   * an earlier block. */
+  if (self->operand)
+    {
+      FilterXStaticTypeSpec keyed = filterx_type_spec_get_attr_for_chain(env, self->operand, key);
+      if (filterx_static_type_kind(keyed) != FILTERX_STATIC_TYPE_UNKNOWN)
+        {
+          s->static_type = keyed;
+          return;
+        }
+    }
+
   s->static_type = filterx_static_type_element(self->operand ? self->operand->static_type :
                                                INITIAL_FILTERX_STATIC_TYPE_SPEC);
 }

--- a/lib/filterx/expr-getattr.h
+++ b/lib/filterx/expr-getattr.h
@@ -26,6 +26,7 @@
 #include "filterx/object-string.h"
 
 FilterXExpr *filterx_getattr_new(FilterXExpr *lhs, FilterXObject *attr_name);
+FilterXExpr *filterx_getattr_get_operand(FilterXExpr *s);
 
 FILTERX_EXPR_DECLARE_TYPE(getattr);
 

--- a/lib/filterx/expr-literal-container.c
+++ b/lib/filterx/expr-literal-container.c
@@ -202,6 +202,44 @@ _literal_container_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_dat
   return TRUE;
 }
 
+static FilterXStaticTypeSpec
+_meet_element_specs(FilterXLiteralContainer *self)
+{
+  /* A `seen` flag marks "no element observed" so empty containers stay UNKNOWN rather than
+   * degrading the meet, and a single element keeps its own spec. */
+  FilterXStaticTypeSpec acc = FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  gboolean seen = FALSE;
+  gsize len = filterx_pointer_list_get_length(&self->elements);
+  for (gsize i = 0; i < len; i++)
+    {
+      FilterXLiteralElement *elem = (FilterXLiteralElement *) filterx_pointer_list_index(&self->elements, i);
+      FilterXStaticTypeSpec value_spec = elem->value ? elem->value->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+      acc = seen ? filterx_static_type_spec_meet(acc, value_spec) : value_spec;
+      seen = TRUE;
+      if (acc == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+        break;
+    }
+  return acc;
+}
+
+static void
+_literal_dict_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXLiteralContainer *self = (FilterXLiteralContainer *) s;
+  s->static_type = filterx_static_type_make_container(FILTERX_STATIC_TYPE_DICT,
+                                                      _meet_element_specs(self));
+}
+
+static void
+_literal_list_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXLiteralContainer *self = (FilterXLiteralContainer *) s;
+  s->static_type = filterx_static_type_make_container(FILTERX_STATIC_TYPE_LIST,
+                                                      _meet_element_specs(self));
+}
+
 static void
 _literal_container_init_instance(FilterXLiteralContainer *self, const gchar *type)
 {
@@ -406,6 +444,7 @@ filterx_literal_dict_new(GList *elements)
 
   _literal_container_init_instance(self, FILTERX_EXPR_TYPE_NAME(literal_dict));
   self->super.eval = _literal_dict_eval;
+  self->super.infer_types = _literal_dict_infer_types;
   self->eval_early = _literal_dict_eval_early;
   filterx_pointer_list_add_list(&self->elements, elements);
 
@@ -518,6 +557,7 @@ filterx_literal_list_new(GList *elements)
 
   _literal_container_init_instance(self, FILTERX_EXPR_TYPE_NAME(literal_list));
   self->super.eval = _literal_list_eval;
+  self->super.infer_types = _literal_list_infer_types;
   self->eval_early = _literal_list_eval_early;
   filterx_pointer_list_add_list(&self->elements, elements);
 

--- a/lib/filterx/expr-literal-container.c
+++ b/lib/filterx/expr-literal-container.c
@@ -206,6 +206,47 @@ _literal_container_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_dat
   return TRUE;
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+static FilterXStaticTypeSpec
+_meet_element_specs(FilterXLiteralContainer *self)
+{
+  /* A `seen` flag marks "no element observed" so empty containers stay UNKNOWN rather than
+   * degrading the meet, and a single element keeps its own spec. */
+  FilterXStaticTypeSpec acc = FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  gboolean seen = FALSE;
+  gsize len = filterx_pointer_list_get_length(&self->elements);
+  for (gsize i = 0; i < len; i++)
+    {
+      FilterXLiteralElement *elem = (FilterXLiteralElement *) filterx_pointer_list_index(&self->elements, i);
+      FilterXStaticTypeSpec value_spec = elem->value ? elem->value->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+      acc = seen ? filterx_static_type_spec_meet(acc, value_spec) : value_spec;
+      seen = TRUE;
+      if (acc == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+        break;
+    }
+  return acc;
+}
+
+static void
+_literal_dict_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXLiteralContainer *self = (FilterXLiteralContainer *) s;
+  s->static_type = filterx_static_type_make_container(FILTERX_STATIC_TYPE_DICT,
+                                                      _meet_element_specs(self));
+}
+
+static void
+_literal_list_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXLiteralContainer *self = (FilterXLiteralContainer *) s;
+  s->static_type = filterx_static_type_make_container(FILTERX_STATIC_TYPE_LIST,
+                                                      _meet_element_specs(self));
+}
+
+#endif
+
 static void
 _literal_container_init_instance(FilterXLiteralContainer *self, const gchar *type)
 {
@@ -408,6 +449,9 @@ filterx_literal_dict_new(GList *elements)
 
   _literal_container_init_instance(self, FILTERX_EXPR_TYPE_NAME(literal_dict));
   self->super.eval = _literal_dict_eval;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.infer_types = _literal_dict_infer_types;
+#endif
   self->eval_early = _literal_dict_eval_early;
   filterx_pointer_list_add_list(&self->elements, elements);
 
@@ -519,6 +563,9 @@ filterx_literal_list_new(GList *elements)
 
   _literal_container_init_instance(self, FILTERX_EXPR_TYPE_NAME(literal_list));
   self->super.eval = _literal_list_eval;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.infer_types = _literal_list_infer_types;
+#endif
   self->eval_early = _literal_list_eval_early;
   filterx_pointer_list_add_list(&self->elements, elements);
 

--- a/lib/filterx/expr-literal.c
+++ b/lib/filterx/expr-literal.c
@@ -62,35 +62,22 @@ _literal_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return TRUE;
 }
 
-/* Classify a literal FilterXObject's outer kind. Containers are recognised by kind only;
- * one level of element type is computed separately in _spec_from_filterx_object. */
-static FilterXStaticType
-_kind_of_filterx_object(FilterXObject *obj)
-{
-  if (!obj)
-    return FILTERX_STATIC_TYPE_UNKNOWN;
-  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(string)))
-    return FILTERX_STATIC_TYPE_STRING;
-  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(integer)))
-    return FILTERX_STATIC_TYPE_INTEGER;
-  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(dict)))
-    return FILTERX_STATIC_TYPE_DICT;
-  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(list)))
-    return FILTERX_STATIC_TYPE_LIST;
-  return FILTERX_STATIC_TYPE_UNKNOWN;
-}
-
+/* Recursively determine the full FilterXStaticTypeSpec for a literal FilterXObject.
+ * Walks dict / list elements to compute element types, bottoming out at STRING / leaf
+ * types. The recursion follows the literal's own (finite) nesting — there is no depth cap. */
 typedef struct
 {
   FilterXStaticTypeSpec spec;   /* the meet of all elements seen so far (valid once seen) */
   gboolean seen;                /* whether any element has been observed yet */
 } _LiteralElementMeetCtx;
 
+static FilterXStaticTypeSpec _spec_from_filterx_object(FilterXObject *obj);
+
 static gboolean
 _collect_value_spec(FilterXObject *key, FilterXObject *value, gpointer user_data)
 {
   _LiteralElementMeetCtx *ctx = (_LiteralElementMeetCtx *) user_data;
-  FilterXStaticTypeSpec value_spec = filterx_static_type_kind_only(_kind_of_filterx_object(value));
+  FilterXStaticTypeSpec value_spec = _spec_from_filterx_object(value);
   /* The `seen` flag distinguishes "no elements yet" from "elements meet to UNKNOWN":
    * the first element seeds the accumulator, subsequent ones actually meet. */
   if (!ctx->seen)
@@ -104,20 +91,37 @@ _collect_value_spec(FilterXObject *key, FilterXObject *value, gpointer user_data
   return ctx->spec != FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
 }
 
-/* Determine the FilterXStaticTypeSpec for a literal FilterXObject: the outer kind plus,
- * for dict / list, one level of element type (the meet of the elements' kinds). */
 static FilterXStaticTypeSpec
 _spec_from_filterx_object(FilterXObject *obj)
 {
-  FilterXStaticType outer_kind = _kind_of_filterx_object(obj);
-  if (outer_kind != FILTERX_STATIC_TYPE_DICT && outer_kind != FILTERX_STATIC_TYPE_LIST)
-    return filterx_static_type_kind_only(outer_kind);
+  if (!obj)
+    return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
 
-  /* Empty container leaves the accumulator at UNKNOWN (the seed); a non-empty one carries the
-   * element meet. Either way ctx.spec is the element type. */
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(string)))
+    return filterx_static_type_kind_only(FILTERX_STATIC_TYPE_STRING);
+
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(integer)))
+    return filterx_static_type_kind_only(FILTERX_STATIC_TYPE_INTEGER);
+
+  FilterXStaticType outer_kind = FILTERX_STATIC_TYPE_UNKNOWN;
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(dict)))
+    outer_kind = FILTERX_STATIC_TYPE_DICT;
+  else if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(list)))
+    outer_kind = FILTERX_STATIC_TYPE_LIST;
+  else
+    return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+
+  /* Determine the meet of all element specs. The `seen` flag distinguishes "no elements
+   * observed yet" from "element type is UNKNOWN". An empty container ends the iter unseen
+   * and gets a FRESH element type — "element not yet committed" — so that the first write to
+   * it lifts the element to the written value's type (see
+   * filterx_type_env_update_on_write). FRESH is stripped before it reaches codegen. */
   _LiteralElementMeetCtx ctx = { .spec = FILTERX_STATIC_TYPE_UNKNOWN_SPEC, .seen = FALSE };
   filterx_object_iter(obj, _collect_value_spec, &ctx);
-  return filterx_static_type_make_container(outer_kind, ctx.spec);
+  FilterXStaticTypeSpec element_spec = ctx.seen
+                                       ? ctx.spec
+                                       : filterx_static_type_kind_only(FILTERX_STATIC_TYPE_FRESH);
+  return filterx_static_type_make_container(outer_kind, element_spec);
 }
 
 static void

--- a/lib/filterx/expr-literal.c
+++ b/lib/filterx/expr-literal.c
@@ -21,6 +21,10 @@
  */
 #include "filterx/expr-literal.h"
 #include "filterx/filterx-eval.h"
+#include "filterx/object-dict.h"
+#include "filterx/object-list.h"
+#include "filterx/object-string.h"
+#include "filterx/object-primitive.h"
 
 typedef struct _FilterXLiteral
 {
@@ -58,6 +62,71 @@ _literal_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return TRUE;
 }
 
+/* Classify a literal FilterXObject's outer kind. Containers are recognised by kind only;
+ * one level of element type is computed separately in _spec_from_filterx_object. */
+static FilterXStaticType
+_kind_of_filterx_object(FilterXObject *obj)
+{
+  if (!obj)
+    return FILTERX_STATIC_TYPE_UNKNOWN;
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(string)))
+    return FILTERX_STATIC_TYPE_STRING;
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(integer)))
+    return FILTERX_STATIC_TYPE_INTEGER;
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(dict)))
+    return FILTERX_STATIC_TYPE_DICT;
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(list)))
+    return FILTERX_STATIC_TYPE_LIST;
+  return FILTERX_STATIC_TYPE_UNKNOWN;
+}
+
+typedef struct
+{
+  FilterXStaticTypeSpec spec;   /* the meet of all elements seen so far (valid once seen) */
+  gboolean seen;                /* whether any element has been observed yet */
+} _LiteralElementMeetCtx;
+
+static gboolean
+_collect_value_spec(FilterXObject *key, FilterXObject *value, gpointer user_data)
+{
+  _LiteralElementMeetCtx *ctx = (_LiteralElementMeetCtx *) user_data;
+  FilterXStaticTypeSpec value_spec = filterx_static_type_kind_only(_kind_of_filterx_object(value));
+  /* The `seen` flag distinguishes "no elements yet" from "elements meet to UNKNOWN":
+   * the first element seeds the accumulator, subsequent ones actually meet. */
+  if (!ctx->seen)
+    {
+      ctx->spec = value_spec;
+      ctx->seen = TRUE;
+    }
+  else
+    ctx->spec = filterx_static_type_spec_meet(ctx->spec, value_spec);
+  /* Stop iterating once we've degraded to UNKNOWN — further meets can only stay there. */
+  return ctx->spec != FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+}
+
+/* Determine the FilterXStaticTypeSpec for a literal FilterXObject: the outer kind plus,
+ * for dict / list, one level of element type (the meet of the elements' kinds). */
+static FilterXStaticTypeSpec
+_spec_from_filterx_object(FilterXObject *obj)
+{
+  FilterXStaticType outer_kind = _kind_of_filterx_object(obj);
+  if (outer_kind != FILTERX_STATIC_TYPE_DICT && outer_kind != FILTERX_STATIC_TYPE_LIST)
+    return filterx_static_type_kind_only(outer_kind);
+
+  /* Empty container leaves the accumulator at UNKNOWN (the seed); a non-empty one carries the
+   * element meet. Either way ctx.spec is the element type. */
+  _LiteralElementMeetCtx ctx = { .spec = FILTERX_STATIC_TYPE_UNKNOWN_SPEC, .seen = FALSE };
+  filterx_object_iter(obj, _collect_value_spec, &ctx);
+  return filterx_static_type_make_container(outer_kind, ctx.spec);
+}
+
+static void
+_literal_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXLiteral *self = (FilterXLiteral *) s;
+  s->static_type = _spec_from_filterx_object(self->object);
+}
+
 #if SYSLOG_NG_ENABLE_JIT
 
 #include "filterx/jit/jit.h"
@@ -83,6 +152,7 @@ filterx_literal_init_instance(FilterXLiteral *s, FilterXObject *object)
   self->super.eval = _eval_literal;
   self->super.walk_children = _literal_walk;
   self->super.free_fn = _free;
+  self->super.infer_types = _literal_infer_types;
 #if SYSLOG_NG_ENABLE_JIT
   self->super.compile = _literal_compile;
 #endif

--- a/lib/filterx/expr-literal.c
+++ b/lib/filterx/expr-literal.c
@@ -108,6 +108,9 @@ _spec_from_filterx_object(FilterXObject *obj)
   if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(integer)))
     return filterx_static_type_kind_only(FILTERX_STATIC_TYPE_INTEGER);
 
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(double)))
+    return filterx_static_type_kind_only(FILTERX_STATIC_TYPE_DOUBLE);
+
   FilterXStaticType outer_kind = FILTERX_STATIC_TYPE_UNKNOWN;
   if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(dict)))
     outer_kind = FILTERX_STATIC_TYPE_DICT;

--- a/lib/filterx/expr-literal.c
+++ b/lib/filterx/expr-literal.c
@@ -67,35 +67,22 @@ _literal_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 #include "filterx/jit/jit.h"
 #include "filterx/jit/ffi.h"
 
-/* Classify a literal FilterXObject's outer kind. Containers are recognised by kind only;
- * one level of element type is computed separately in _spec_from_filterx_object. */
-static FilterXStaticType
-_kind_of_filterx_object(FilterXObject *obj)
-{
-  if (!obj)
-    return FILTERX_STATIC_TYPE_UNKNOWN;
-  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(string)))
-    return FILTERX_STATIC_TYPE_STRING;
-  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(integer)))
-    return FILTERX_STATIC_TYPE_INTEGER;
-  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(dict)))
-    return FILTERX_STATIC_TYPE_DICT;
-  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(list)))
-    return FILTERX_STATIC_TYPE_LIST;
-  return FILTERX_STATIC_TYPE_UNKNOWN;
-}
-
+/* Recursively determine the full FilterXStaticTypeSpec for a literal FilterXObject.
+ * Walks dict / list elements to compute element types, bottoming out at STRING / leaf
+ * types. The recursion follows the literal's own (finite) nesting — there is no depth cap. */
 typedef struct
 {
   FilterXStaticTypeSpec spec;   /* the meet of all elements seen so far (valid once seen) */
   gboolean seen;                /* whether any element has been observed yet */
 } _LiteralElementMeetCtx;
 
+static FilterXStaticTypeSpec _spec_from_filterx_object(FilterXObject *obj);
+
 static gboolean
 _collect_value_spec(FilterXObject *key, FilterXObject *value, gpointer user_data)
 {
   _LiteralElementMeetCtx *ctx = (_LiteralElementMeetCtx *) user_data;
-  FilterXStaticTypeSpec value_spec = filterx_static_type_kind_only(_kind_of_filterx_object(value));
+  FilterXStaticTypeSpec value_spec = _spec_from_filterx_object(value);
   /* The `seen` flag distinguishes "no elements yet" from "elements meet to UNKNOWN":
    * the first element seeds the accumulator, subsequent ones actually meet. */
   if (!ctx->seen)
@@ -109,20 +96,37 @@ _collect_value_spec(FilterXObject *key, FilterXObject *value, gpointer user_data
   return ctx->spec != FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
 }
 
-/* Determine the FilterXStaticTypeSpec for a literal FilterXObject: the outer kind plus,
- * for dict / list, one level of element type (the meet of the elements' kinds). */
 static FilterXStaticTypeSpec
 _spec_from_filterx_object(FilterXObject *obj)
 {
-  FilterXStaticType outer_kind = _kind_of_filterx_object(obj);
-  if (outer_kind != FILTERX_STATIC_TYPE_DICT && outer_kind != FILTERX_STATIC_TYPE_LIST)
-    return filterx_static_type_kind_only(outer_kind);
+  if (!obj)
+    return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
 
-  /* Empty container leaves the accumulator at UNKNOWN (the seed); a non-empty one carries the
-   * element meet. Either way ctx.spec is the element type. */
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(string)))
+    return filterx_static_type_kind_only(FILTERX_STATIC_TYPE_STRING);
+
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(integer)))
+    return filterx_static_type_kind_only(FILTERX_STATIC_TYPE_INTEGER);
+
+  FilterXStaticType outer_kind = FILTERX_STATIC_TYPE_UNKNOWN;
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(dict)))
+    outer_kind = FILTERX_STATIC_TYPE_DICT;
+  else if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(list)))
+    outer_kind = FILTERX_STATIC_TYPE_LIST;
+  else
+    return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+
+  /* Determine the meet of all element specs. The `seen` flag distinguishes "no elements
+   * observed yet" from "element type is UNKNOWN". An empty container ends the iter unseen
+   * and gets a FRESH element type — "element not yet committed" — so that the first write to
+   * it lifts the element to the written value's type (see
+   * filterx_type_env_update_on_write). FRESH is stripped before it reaches codegen. */
   _LiteralElementMeetCtx ctx = { .spec = FILTERX_STATIC_TYPE_UNKNOWN_SPEC, .seen = FALSE };
   filterx_object_iter(obj, _collect_value_spec, &ctx);
-  return filterx_static_type_make_container(outer_kind, ctx.spec);
+  FilterXStaticTypeSpec element_spec = ctx.seen
+                                       ? ctx.spec
+                                       : filterx_static_type_kind_only(FILTERX_STATIC_TYPE_FRESH);
+  return filterx_static_type_make_container(outer_kind, element_spec);
 }
 
 static void

--- a/lib/filterx/expr-literal.c
+++ b/lib/filterx/expr-literal.c
@@ -21,6 +21,10 @@
  */
 #include "filterx/expr-literal.h"
 #include "filterx/filterx-eval.h"
+#include "filterx/object-dict.h"
+#include "filterx/object-list.h"
+#include "filterx/object-string.h"
+#include "filterx/object-primitive.h"
 
 typedef struct _FilterXLiteral
 {
@@ -63,6 +67,71 @@ _literal_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 #include "filterx/jit/jit.h"
 #include "filterx/jit/ffi.h"
 
+/* Classify a literal FilterXObject's outer kind. Containers are recognised by kind only;
+ * one level of element type is computed separately in _spec_from_filterx_object. */
+static FilterXStaticType
+_kind_of_filterx_object(FilterXObject *obj)
+{
+  if (!obj)
+    return FILTERX_STATIC_TYPE_UNKNOWN;
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(string)))
+    return FILTERX_STATIC_TYPE_STRING;
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(integer)))
+    return FILTERX_STATIC_TYPE_INTEGER;
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(dict)))
+    return FILTERX_STATIC_TYPE_DICT;
+  if (filterx_object_is_type_or_ref(obj, &FILTERX_TYPE_NAME(list)))
+    return FILTERX_STATIC_TYPE_LIST;
+  return FILTERX_STATIC_TYPE_UNKNOWN;
+}
+
+typedef struct
+{
+  FilterXStaticTypeSpec spec;   /* the meet of all elements seen so far (valid once seen) */
+  gboolean seen;                /* whether any element has been observed yet */
+} _LiteralElementMeetCtx;
+
+static gboolean
+_collect_value_spec(FilterXObject *key, FilterXObject *value, gpointer user_data)
+{
+  _LiteralElementMeetCtx *ctx = (_LiteralElementMeetCtx *) user_data;
+  FilterXStaticTypeSpec value_spec = filterx_static_type_kind_only(_kind_of_filterx_object(value));
+  /* The `seen` flag distinguishes "no elements yet" from "elements meet to UNKNOWN":
+   * the first element seeds the accumulator, subsequent ones actually meet. */
+  if (!ctx->seen)
+    {
+      ctx->spec = value_spec;
+      ctx->seen = TRUE;
+    }
+  else
+    ctx->spec = filterx_static_type_spec_meet(ctx->spec, value_spec);
+  /* Stop iterating once we've degraded to UNKNOWN — further meets can only stay there. */
+  return ctx->spec != FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+}
+
+/* Determine the FilterXStaticTypeSpec for a literal FilterXObject: the outer kind plus,
+ * for dict / list, one level of element type (the meet of the elements' kinds). */
+static FilterXStaticTypeSpec
+_spec_from_filterx_object(FilterXObject *obj)
+{
+  FilterXStaticType outer_kind = _kind_of_filterx_object(obj);
+  if (outer_kind != FILTERX_STATIC_TYPE_DICT && outer_kind != FILTERX_STATIC_TYPE_LIST)
+    return filterx_static_type_kind_only(outer_kind);
+
+  /* Empty container leaves the accumulator at UNKNOWN (the seed); a non-empty one carries the
+   * element meet. Either way ctx.spec is the element type. */
+  _LiteralElementMeetCtx ctx = { .spec = FILTERX_STATIC_TYPE_UNKNOWN_SPEC, .seen = FALSE };
+  filterx_object_iter(obj, _collect_value_spec, &ctx);
+  return filterx_static_type_make_container(outer_kind, ctx.spec);
+}
+
+static void
+_literal_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXLiteral *self = (FilterXLiteral *) s;
+  s->static_type = _spec_from_filterx_object(self->object);
+}
+
 static FilterXIRValue
 _literal_compile(FilterXExpr *s, FilterXJIT *jit)
 {
@@ -84,6 +153,7 @@ filterx_literal_init_instance(FilterXLiteral *s, FilterXObject *object)
   self->super.walk_children = _literal_walk;
   self->super.free_fn = _free;
 #if SYSLOG_NG_ENABLE_JIT
+  self->super.infer_types = _literal_infer_types;
   self->super.compile = _literal_compile;
 #endif
   self->object = object;

--- a/lib/filterx/expr-plus-assign.c
+++ b/lib/filterx/expr-plus-assign.c
@@ -20,6 +20,7 @@
  *
  */
 #include "expr-plus-assign.h"
+#include "expr-variable.h"
 #include "filterx-eval.h"
 
 typedef struct FilterXOperatorPlusAssign
@@ -50,12 +51,39 @@ _eval_plus_assign(FilterXExpr *s)
   return res;
 }
 
+static void
+_plus_assign_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXOperatorPlusAssign *self = (FilterXOperatorPlusAssign *) s;
+
+  filterx_expr_infer_types(self->super.rhs, env);
+  filterx_expr_infer_types(self->super.lhs, env);
+
+  FilterXStaticTypeSpec rhs_spec = self->super.rhs ? self->super.rhs->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+
+  /* For string+=string / list+=list / dict+=dict the result type matches; for any mismatch
+   * (or unknown side) we collapse to UNKNOWN. The LHS env entry takes the same meet. */
+  FilterXVariableHandle handle;
+  if (filterx_variable_expr_get_handle(self->super.lhs, &handle))
+    {
+      FilterXStaticTypeSpec prior = filterx_type_env_get(env, handle);
+      FilterXStaticTypeSpec result = filterx_static_type_spec_meet(prior, rhs_spec);
+      filterx_type_env_set(env, handle, result);
+      s->static_type = result;
+    }
+  else
+    {
+      s->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
+    }
+}
+
 FilterXExpr *
 filterx_operator_plus_assign_new(FilterXExpr *lhs, FilterXExpr *rhs)
 {
   FilterXOperatorPlusAssign *self = g_new0(FilterXOperatorPlusAssign, 1);
   filterx_binary_op_init_instance(&self->super, "plus-assign", FXE_WRITE, lhs, rhs);
   self->super.super.eval = _eval_plus_assign;
+  self->super.super.infer_types = _plus_assign_infer_types;
   self->super.super.ignore_falsy_result = TRUE;
 
   return &self->super.super;

--- a/lib/filterx/expr-plus-assign.c
+++ b/lib/filterx/expr-plus-assign.c
@@ -20,6 +20,7 @@
  *
  */
 #include "expr-plus-assign.h"
+#include "expr-variable.h"
 #include "filterx-eval.h"
 
 typedef struct FilterXOperatorPlusAssign
@@ -43,12 +44,44 @@ _eval_plus_assign(FilterXExpr *s)
   return res;
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+static void
+_plus_assign_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXOperatorPlusAssign *self = (FilterXOperatorPlusAssign *) s;
+
+  filterx_expr_infer_types(self->super.rhs, env);
+  filterx_expr_infer_types(self->super.lhs, env);
+
+  FilterXStaticTypeSpec rhs_spec = self->super.rhs ? self->super.rhs->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+
+  /* For string+=string / list+=list / dict+=dict the result type matches; for any mismatch
+   * (or unknown side) we collapse to UNKNOWN. The LHS env entry takes the same meet. */
+  FilterXVariableHandle handle;
+  if (filterx_variable_expr_get_handle(self->super.lhs, &handle))
+    {
+      FilterXStaticTypeSpec prior = filterx_type_spec_get(env, handle);
+      FilterXStaticTypeSpec result = filterx_static_type_spec_meet(prior, rhs_spec);
+      filterx_type_spec_set(env, handle, result);
+      s->static_type = result;
+    }
+  else
+    {
+      s->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
+    }
+}
+
+#endif
+
 FilterXExpr *
 filterx_operator_plus_assign_new(FilterXExpr *lhs, FilterXExpr *rhs)
 {
   FilterXOperatorPlusAssign *self = g_new0(FilterXOperatorPlusAssign, 1);
   filterx_binary_op_init_instance(&self->super, "plus-assign", FXE_WRITE, lhs, rhs);
   self->super.super.eval = _eval_plus_assign;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.super.infer_types = _plus_assign_infer_types;
+#endif
   self->super.super.ignore_falsy_result = TRUE;
 
   return &self->super.super;

--- a/lib/filterx/expr-plus.c
+++ b/lib/filterx/expr-plus.c
@@ -125,11 +125,42 @@ fx_jit_do_plus(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
   return _do_plus(lhs, rhs, expr);
 }
 
+/* Devirtualized fast path for `string + string`. lhs is guaranteed to be a FilterXString
+ * (eval_typed of a STRING-static_type operand); rhs may be any string-extractable value. */
+__attribute__((used))
+FilterXObject *
+fx_jit_do_plus_string(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
+{
+  FilterXObject *result = NULL;
+  if (!lhs)
+    {
+      filterx_eval_push_error_static_info("Failed to add values", expr, "Failed to evaluate left hand side");
+      goto exit;
+    }
+  if (!rhs)
+    {
+      filterx_eval_push_error_static_info("Failed to add values", expr, "Failed to evaluate right hand side");
+      goto exit;
+    }
+  result = filterx_string_concat(lhs, rhs);
+  if (!result)
+    filterx_eval_push_error_static_info("Failed to add values", expr, "add() method failed");
+
+exit:
+  filterx_object_unref(lhs);
+  filterx_object_unref(rhs);
+  return result;
+}
+
 static FilterXIRValue
 _compile_plus(FilterXExpr *s, FilterXJIT *jit)
 {
   FilterXOperatorPlus *self = (FilterXOperatorPlus *) s;
   FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  const gchar *fn_name = s->static_type == FILTERX_STATIC_TYPE_STRING
+                         ? "fx_jit_do_plus_string"
+                         : "fx_jit_do_plus";
 
   FilterXIRValue lhs = self->literal_lhs
                        ? fx_jit_emit_object_ref(jit, fx_jit_emit_const_ptr(jit, self->literal_lhs))
@@ -140,7 +171,7 @@ _compile_plus(FilterXExpr *s, FilterXJIT *jit)
 
   FilterXIRValue args[] = { lhs, rhs, fx_jit_emit_const_ptr(jit, self) };
   FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
-  return fx_jit_emit_extern_call(jit, "fx_jit_do_plus", ffi->ptr_ty, param_tys, args, 3);
+  return fx_jit_emit_extern_call(jit, fn_name, ffi->ptr_ty, param_tys, args, 3);
 }
 
 #endif

--- a/lib/filterx/expr-plus.c
+++ b/lib/filterx/expr-plus.c
@@ -125,6 +125,47 @@ fx_jit_do_plus(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
   return _do_plus(lhs, rhs, expr);
 }
 
+/* Devirtualized fast path for `integer + anything`. lhs is guaranteed to be a FilterXInteger
+ * (eval_typed of an INTEGER-static_type operand).  If rhs is also integer, performs direct
+ * integer arithmetic; otherwise falls back to the generic vtable-dispatching path.
+ * The fallback means the function is always correct even when rhs is non-integer. */
+__attribute__((used))
+FilterXObject *
+fx_jit_do_plus_int(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
+{
+  FilterXObject *result = NULL;
+  if (!lhs)
+    {
+      filterx_eval_push_error_static_info("Failed to add values", expr, "Failed to evaluate left hand side");
+      goto exit;
+    }
+  if (!rhs)
+    {
+      filterx_eval_push_error_static_info("Failed to add values", expr, "Failed to evaluate right hand side");
+      goto exit;
+    }
+
+  gint64 rhs_val;
+  if (G_LIKELY(filterx_integer_unwrap(rhs, &rhs_val)))
+    {
+      gint64 lhs_val;
+      gboolean ok G_GNUC_UNUSED = filterx_integer_unwrap(lhs, &lhs_val);
+      g_assert(ok);
+      filterx_object_unref(lhs);
+      filterx_object_unref(rhs);
+      return filterx_integer_new(lhs_val + rhs_val);
+    }
+
+  result = filterx_object_add(lhs, rhs);
+  if (!result)
+    filterx_eval_push_error_static_info("Failed to add values", expr, "add() method failed");
+
+exit:
+  filterx_object_unref(lhs);
+  filterx_object_unref(rhs);
+  return result;
+}
+
 /* Devirtualized fast path for `string + string`. lhs is guaranteed to be a FilterXString
  * (eval_typed of a STRING-static_type operand); rhs may be any string-extractable value. */
 __attribute__((used))
@@ -158,9 +199,14 @@ _compile_plus(FilterXExpr *s, FilterXJIT *jit)
   FilterXOperatorPlus *self = (FilterXOperatorPlus *) s;
   FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
 
-  const gchar *fn_name = s->static_type == FILTERX_STATIC_TYPE_STRING
-                         ? "fx_jit_do_plus_string"
-                         : "fx_jit_do_plus";
+  FilterXStaticType result_kind = filterx_static_type_kind(s->static_type);
+  const gchar *fn_name;
+  if (result_kind == FILTERX_STATIC_TYPE_STRING)
+    fn_name = "fx_jit_do_plus_string";
+  else if (result_kind == FILTERX_STATIC_TYPE_INTEGER)
+    fn_name = "fx_jit_do_plus_int";
+  else
+    fn_name = "fx_jit_do_plus";
 
   FilterXIRValue lhs = self->literal_lhs
                        ? fx_jit_emit_object_ref(jit, fx_jit_emit_const_ptr(jit, self->literal_lhs))

--- a/lib/filterx/expr-plus.c
+++ b/lib/filterx/expr-plus.c
@@ -21,6 +21,7 @@
  */
 #include "expr-plus.h"
 #include "object-string.h"
+#include "object-primitive.h"
 #include "filterx-eval.h"
 #include "filterx/expr-literal.h"
 #include "scratch-buffers.h"
@@ -86,6 +87,23 @@ _optimize(FilterXExpr *s)
 }
 
 static void
+_plus_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXOperatorPlus *self = (FilterXOperatorPlus *) s;
+  FilterXStaticTypeSpec lhs_spec = self->super.lhs ? self->super.lhs->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+  FilterXStaticTypeSpec rhs_spec = self->super.rhs ? self->super.rhs->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+
+  /* When LHS is statically INTEGER, the result is INTEGER regardless of RHS: the JIT fast
+   * path (fx_jit_do_plus_int) handles non-integer RHS via fallback. This lets type info
+   * propagate through chains like `int_field + unknown_field + 34` without collapsing. */
+  if (filterx_static_type_kind(lhs_spec) == FILTERX_STATIC_TYPE_INTEGER)
+    s->static_type = filterx_static_type_kind_only(FILTERX_STATIC_TYPE_INTEGER);
+  else
+    s->static_type = filterx_static_type_spec_meet(lhs_spec, rhs_spec);
+}
+
+static void
 _filterx_operator_plus_free(FilterXExpr *s)
 {
   FilterXOperatorPlus *self = (FilterXOperatorPlus *) s;
@@ -134,6 +152,7 @@ filterx_operator_plus_new(FilterXExpr *lhs, FilterXExpr *rhs)
   filterx_binary_op_init_instance(&self->super, "plus", FXE_READ, lhs, rhs);
   self->super.super.optimize = _optimize;
   self->super.super.eval = _eval_plus;
+  self->super.super.infer_types = _plus_infer_types;
   self->super.super.free_fn = _filterx_operator_plus_free;
 #if SYSLOG_NG_ENABLE_JIT
   self->super.super.compile = _compile_plus;

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -20,6 +20,7 @@
  *
  */
 #include "filterx/expr-set-subscript.h"
+#include "filterx/expr-variable.h"
 #include "filterx/object-primitive.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/object-null.h"
@@ -158,6 +159,20 @@ _free(FilterXExpr *s)
   filterx_expr_free_method(s);
 }
 
+static void
+_set_subscript_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXSetSubscript *self = (FilterXSetSubscript *) s;
+
+  /* Refine the written container's element type with the assigned value (lift if the level
+   * was a freshly-built empty container, meet otherwise). This keeps element-type info alive
+   * across incremental builds (l = []; l[0] = {}; l[0].x = {}; ...) so deeper accesses
+   * devirtualize. */
+  filterx_type_env_update_on_write(env, self->object,
+                                   self->new_value ? self->new_value->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC);
+}
+
 static gboolean
 _set_subscript_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 {
@@ -183,6 +198,7 @@ filterx_set_subscript_new(FilterXExpr *object, FilterXExpr *key, FilterXExpr *ne
   self->super.eval = _set_subscript_eval;
   self->super.walk_children = _set_subscript_walk;
   self->super.free_fn = _free;
+  self->super.infer_types = _set_subscript_infer_types;
   self->object = object;
   self->key = key;
   self->new_value = new_value;

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -26,6 +26,8 @@
 #include "filterx/object-null.h"
 #include "filterx/object-message-value.h"
 #include "filterx/object-extractor.h"
+#include "filterx/object-dict.h"
+#include "filterx/object-list.h"
 #include "scratch-buffers.h"
 #include "stats/stats-registry.h"
 #include "stats/stats-cluster-single.h"
@@ -173,6 +175,102 @@ _set_subscript_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
                                    self->new_value ? self->new_value->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC);
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+typedef gboolean (*FXSetSubscriptHelper)(FilterXObject *object, FilterXObject *key, FilterXObject **value);
+
+static inline __attribute__((always_inline)) FilterXObject *
+_do_set_subscript(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr,
+                  FXSetSubscriptHelper helper)
+{
+  FilterXObject *cloned = NULL;
+  if (!new_value)
+    {
+      filterx_eval_push_error_static_info("Failed to set element of object", expr,
+                                          "Failed to evaluate right hand side");
+      goto cleanup;
+    }
+  if (!key)
+    {
+      filterx_eval_push_error_static_info("Failed to set element of object", expr,
+                                          "Failed to evaluate key");
+      goto cleanup;
+    }
+  if (!object)
+    {
+      filterx_eval_push_error_static_info("Failed to set element of object", expr,
+                                          "Failed to evaluate expression");
+      goto cleanup;
+    }
+  cloned = filterx_object_cow_fork2(filterx_object_ref(new_value), NULL);
+  if (!helper(object, key, &cloned))
+    {
+      filterx_eval_push_error("Object set-subscript failed", expr, key);
+      filterx_eval_push_error_static_info("Failed to set element of object", expr,
+                                          "set-subscript() method failed");
+      filterx_object_unref(cloned);
+      cloned = NULL;
+    }
+cleanup:
+  filterx_object_unref(object);
+  filterx_object_unref(key);
+  filterx_object_unref(new_value);
+  return cloned;
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_set_subscript_dict(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr)
+{
+  return _do_set_subscript(object, key, new_value, expr, filterx_dict_set_subscript);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_set_subscript_list(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr)
+{
+  return _do_set_subscript(object, key, new_value, expr, filterx_list_set_subscript_via_key);
+}
+
+static FilterXIRValue
+_set_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  FilterXSetSubscript *self = (FilterXSetSubscript *) s;
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  /* v1: only specialize when we have a key expression. set_subscript with self->key == NULL
+   * (e.g. list-append form) takes the interpreter path. */
+  const gchar *fn_name;
+  switch (filterx_static_type_kind(self->object->static_type))
+    {
+    case FILTERX_STATIC_TYPE_DICT:
+      fn_name = "fx_jit_do_set_subscript_dict";
+      break;
+    case FILTERX_STATIC_TYPE_LIST:
+      fn_name = "fx_jit_do_set_subscript_list";
+      break;
+    default:
+      return fx_jit_emit_expr_eval(jit, s);
+    }
+
+  if (!self->key)
+    return fx_jit_emit_expr_eval(jit, s);
+
+  /* Eval order matches the interpreter: new_value first, then key, then object. */
+  FilterXIRValue new_value = filterx_expr_compile_or_eval(self->new_value, jit);
+  FilterXIRValue key = filterx_expr_compile_or_eval(self->key, jit);
+  FilterXIRValue object = filterx_expr_compile_or_eval_typed(self->object, jit);
+
+  FilterXIRValue args[] = { object, key, new_value, fx_jit_emit_const_ptr(jit, s) };
+  FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
+  return fx_jit_emit_extern_call(jit, fn_name, ffi->ptr_ty, param_tys, args, 4);
+}
+
+#endif
+
 static gboolean
 _set_subscript_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 {
@@ -199,6 +297,9 @@ filterx_set_subscript_new(FilterXExpr *object, FilterXExpr *key, FilterXExpr *ne
   self->super.walk_children = _set_subscript_walk;
   self->super.free_fn = _free;
   self->super.infer_types = _set_subscript_infer_types;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.compile = _set_subscript_compile;
+#endif
   self->object = object;
   self->key = key;
   self->new_value = new_value;

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -235,8 +235,47 @@ fx_jit_do_set_subscript_list(FilterXObject *object, FilterXObject *key, FilterXO
   return _do_set_subscript(object, key, new_value, expr, filterx_list_set_subscript_via_key);
 }
 
+typedef FilterXObject *(*FXSetSubscriptWrapper)(FilterXObject *object, FilterXObject *key,
+                                                FilterXObject *new_value, FilterXExpr *expr);
+
+static inline __attribute__((always_inline)) FilterXObject *
+_do_nullv_set_subscript(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr,
+                        FXSetSubscriptWrapper wrapper)
+{
+  if (!new_value)
+    {
+      filterx_eval_dump_errors("FilterX: null coalesce assignment suppressing error");
+      filterx_object_unref(object);
+      filterx_object_unref(key);
+      return filterx_null_new();
+    }
+  if (filterx_object_extract_null(new_value))
+    {
+      filterx_object_unref(object);
+      filterx_object_unref(key);
+      return new_value;
+    }
+  return wrapper(object, key, new_value, expr);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_nullv_set_subscript_dict(FilterXObject *object, FilterXObject *key,
+                                   FilterXObject *new_value, FilterXExpr *expr)
+{
+  return _do_nullv_set_subscript(object, key, new_value, expr, fx_jit_do_set_subscript_dict);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_nullv_set_subscript_list(FilterXObject *object, FilterXObject *key,
+                                   FilterXObject *new_value, FilterXExpr *expr)
+{
+  return _do_nullv_set_subscript(object, key, new_value, expr, fx_jit_do_set_subscript_list);
+}
+
 static FilterXIRValue
-_set_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
+_compile_dispatch(FilterXExpr *s, FilterXJIT *jit, const gchar *fn_dict, const gchar *fn_list)
 {
   FilterXSetSubscript *self = (FilterXSetSubscript *) s;
   FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
@@ -247,10 +286,10 @@ _set_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
   switch (filterx_static_type_kind(self->object->static_type))
     {
     case FILTERX_STATIC_TYPE_DICT:
-      fn_name = "fx_jit_do_set_subscript_dict";
+      fn_name = fn_dict;
       break;
     case FILTERX_STATIC_TYPE_LIST:
-      fn_name = "fx_jit_do_set_subscript_list";
+      fn_name = fn_list;
       break;
     default:
       return fx_jit_emit_expr_eval(jit, s);
@@ -267,6 +306,20 @@ _set_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
   FilterXIRValue args[] = { object, key, new_value, fx_jit_emit_const_ptr(jit, s) };
   FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
   return fx_jit_emit_extern_call(jit, fn_name, ffi->ptr_ty, param_tys, args, 4);
+}
+
+static FilterXIRValue
+_set_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  return _compile_dispatch(s, jit, "fx_jit_do_set_subscript_dict",
+                           "fx_jit_do_set_subscript_list");
+}
+
+static FilterXIRValue
+_nullv_set_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  return _compile_dispatch(s, jit, "fx_jit_do_nullv_set_subscript_dict",
+                           "fx_jit_do_nullv_set_subscript_list");
 }
 
 #endif
@@ -314,5 +367,8 @@ filterx_nullv_set_subscript_new(FilterXExpr *object, FilterXExpr *key, FilterXEx
 
   self->type = "nullv_set_subscript";
   self->eval = _nullv_set_subscript_eval;
+#if SYSLOG_NG_ENABLE_JIT
+  self->compile = _nullv_set_subscript_compile;
+#endif
   return self;
 }

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -280,6 +280,42 @@ fx_jit_do_nullv_set_subscript_list(FilterXObject *object, FilterXObject *key,
   return _do_nullv_set_subscript(object, key, new_value, expr, fx_jit_do_set_subscript_list);
 }
 
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_set_subscript_dict_stmt(FilterXObject *object, FilterXObject *key, FilterXObject *new_value,
+                                  FilterXExpr *expr, FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_set_subscript_dict(object, key, new_value, expr), expr, context,
+                                    last_result);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_set_subscript_list_stmt(FilterXObject *object, FilterXObject *key, FilterXObject *new_value,
+                                  FilterXExpr *expr, FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_set_subscript_list(object, key, new_value, expr), expr, context,
+                                    last_result);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_nullv_set_subscript_dict_stmt(FilterXObject *object, FilterXObject *key, FilterXObject *new_value,
+                                        FilterXExpr *expr, FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_nullv_set_subscript_dict(object, key, new_value, expr), expr, context,
+                                    last_result);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_nullv_set_subscript_list_stmt(FilterXObject *object, FilterXObject *key, FilterXObject *new_value,
+                                        FilterXExpr *expr, FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_nullv_set_subscript_list(object, key, new_value, expr), expr, context,
+                                    last_result);
+}
+
 static FilterXIRValue
 _compile_dispatch(FilterXExpr *s, FilterXJIT *jit, const gchar *fn_dict, const gchar *fn_list)
 {

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -182,9 +182,13 @@ _set_subscript_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
 
 typedef gboolean (*FXSetSubscriptHelper)(FilterXObject *object, FilterXObject *key, FilterXObject **value);
 
+/* @helper downcasts @object to a concrete FilterX{Dict,List}Object; the static type that
+ * selected this fast path is only a hint, so coercing containers (e.g. otel masquerading as
+ * dict/list) may present a different runtime layout. @expected_type guards the downcast and
+ * on a mismatch we fall back to the generic vtable set_subscript (same signature). */
 static inline __attribute__((always_inline)) FilterXObject *
 _do_set_subscript(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr,
-                  FXSetSubscriptHelper helper)
+                  FXSetSubscriptHelper helper, FilterXType *expected_type)
 {
   FilterXObject *cloned = NULL;
   if (!new_value)
@@ -205,6 +209,8 @@ _do_set_subscript(FilterXObject *object, FilterXObject *key, FilterXObject *new_
                                           "Failed to evaluate expression");
       goto cleanup;
     }
+  if (!filterx_object_is_type_or_ref(object, expected_type))
+    helper = filterx_object_set_subscript;
   cloned = filterx_object_cow_fork2(filterx_object_ref(new_value), NULL);
   if (!helper(object, key, &cloned))
     {
@@ -225,14 +231,14 @@ __attribute__((used))
 FilterXObject *
 fx_jit_do_set_subscript_dict(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr)
 {
-  return _do_set_subscript(object, key, new_value, expr, filterx_dict_set_subscript);
+  return _do_set_subscript(object, key, new_value, expr, filterx_dict_set_subscript, &FILTERX_TYPE_NAME(dict));
 }
 
 __attribute__((used))
 FilterXObject *
 fx_jit_do_set_subscript_list(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr)
 {
-  return _do_set_subscript(object, key, new_value, expr, filterx_list_set_subscript_via_key);
+  return _do_set_subscript(object, key, new_value, expr, filterx_list_set_subscript_via_key, &FILTERX_TYPE_NAME(list));
 }
 
 typedef FilterXObject *(*FXSetSubscriptWrapper)(FilterXObject *object, FilterXObject *key,

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -278,6 +278,42 @@ fx_jit_do_nullv_set_subscript_list(FilterXObject *object, FilterXObject *key,
   return _do_nullv_set_subscript(object, key, new_value, expr, fx_jit_do_set_subscript_list);
 }
 
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_set_subscript_dict_stmt(FilterXObject *object, FilterXObject *key, FilterXObject *new_value,
+                                  FilterXExpr *expr, FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_set_subscript_dict(object, key, new_value, expr), expr, context,
+                                    last_result);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_set_subscript_list_stmt(FilterXObject *object, FilterXObject *key, FilterXObject *new_value,
+                                  FilterXExpr *expr, FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_set_subscript_list(object, key, new_value, expr), expr, context,
+                                    last_result);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_nullv_set_subscript_dict_stmt(FilterXObject *object, FilterXObject *key, FilterXObject *new_value,
+                                        FilterXExpr *expr, FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_nullv_set_subscript_dict(object, key, new_value, expr), expr, context,
+                                    last_result);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_nullv_set_subscript_list_stmt(FilterXObject *object, FilterXObject *key, FilterXObject *new_value,
+                                        FilterXExpr *expr, FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_nullv_set_subscript_list(object, key, new_value, expr), expr, context,
+                                    last_result);
+}
+
 static FilterXIRValue
 _compile_dispatch(FilterXExpr *s, FilterXJIT *jit, const gchar *fn_dict, const gchar *fn_list)
 {

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -26,6 +26,10 @@
 #include "filterx/object-null.h"
 #include "filterx/object-message-value.h"
 #include "filterx/object-extractor.h"
+#if SYSLOG_NG_ENABLE_JIT
+#include "filterx/object-dict.h"
+#include "filterx/object-list.h"
+#endif
 #include "scratch-buffers.h"
 #include "stats/stats-registry.h"
 #include "stats/stats-cluster-single.h"
@@ -156,6 +160,65 @@ _free(FilterXExpr *s)
 }
 
 #if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+typedef gboolean (*FXSetSubscriptHelper)(FilterXObject *object, FilterXObject *key, FilterXObject **value);
+
+static inline __attribute__((always_inline)) FilterXObject *
+_do_set_subscript(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr,
+                  FXSetSubscriptHelper helper)
+{
+  FilterXObject *cloned = NULL;
+  if (!new_value)
+    {
+      filterx_eval_push_error_static_info("Failed to set element of object",
+                                          "Failed to evaluate right hand side");
+      goto cleanup;
+    }
+  if (!key)
+    {
+      filterx_eval_push_error_static_info("Failed to set element of object",
+                                          "Failed to evaluate key");
+      goto cleanup;
+    }
+  if (!object)
+    {
+      filterx_eval_push_error_static_info("Failed to set element of object",
+                                          "Failed to evaluate expression");
+      goto cleanup;
+    }
+  cloned = filterx_object_cow_fork2(filterx_object_ref(new_value), NULL);
+  if (!helper(object, key, &cloned))
+    {
+      filterx_eval_push_error("Object set-subscript failed", key);
+      filterx_eval_push_error_static_info("Failed to set element of object",
+                                          "set-subscript() method failed");
+      filterx_object_unref(cloned);
+      cloned = NULL;
+    }
+cleanup:
+  filterx_object_unref(object);
+  filterx_object_unref(key);
+  filterx_object_unref(new_value);
+  return cloned;
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_set_subscript_dict(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr)
+{
+  return _do_set_subscript(object, key, new_value, expr, filterx_dict_set_subscript);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_set_subscript_list(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr)
+{
+  return _do_set_subscript(object, key, new_value, expr, filterx_list_set_subscript_via_key);
+}
+
 static void
 _set_subscript_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
 {
@@ -168,6 +231,40 @@ _set_subscript_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
    * devirtualize. */
   filterx_type_env_update_on_write(env, self->object,
                                    self->new_value ? self->new_value->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC);
+}
+
+static FilterXIRValue
+_set_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  FilterXSetSubscript *self = (FilterXSetSubscript *) s;
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  /* v1: only specialize when we have a key expression. set_subscript with self->key == NULL
+   * (e.g. list-append form) takes the interpreter path. */
+  const gchar *fn_name;
+  switch (filterx_static_type_kind(self->object->static_type))
+    {
+    case FILTERX_STATIC_TYPE_DICT:
+      fn_name = "fx_jit_do_set_subscript_dict";
+      break;
+    case FILTERX_STATIC_TYPE_LIST:
+      fn_name = "fx_jit_do_set_subscript_list";
+      break;
+    default:
+      return fx_jit_emit_expr_eval(jit, s);
+    }
+
+  if (!self->key)
+    return fx_jit_emit_expr_eval(jit, s);
+
+  /* Eval order matches the interpreter: new_value first, then key, then object. */
+  FilterXIRValue new_value = filterx_expr_compile_or_eval(self->new_value, jit);
+  FilterXIRValue key = filterx_expr_compile_or_eval(self->key, jit);
+  FilterXIRValue object = filterx_expr_compile_or_eval_typed(self->object, jit);
+
+  FilterXIRValue args[] = { object, key, new_value, fx_jit_emit_const_ptr(jit, s) };
+  FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
+  return fx_jit_emit_extern_call(jit, fn_name, ffi->ptr_ty, param_tys, args, 4);
 }
 
 #endif
@@ -199,6 +296,7 @@ filterx_set_subscript_new(FilterXExpr *object, FilterXExpr *key, FilterXExpr *ne
   self->super.free_fn = _free;
 #if SYSLOG_NG_ENABLE_JIT
   self->super.infer_types = _set_subscript_infer_types;
+  self->super.compile = _set_subscript_compile;
 #endif
   self->object = object;
   self->key = key;

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -233,8 +233,47 @@ _set_subscript_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
                                    self->new_value ? self->new_value->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC);
 }
 
+typedef FilterXObject *(*FXSetSubscriptWrapper)(FilterXObject *object, FilterXObject *key,
+                                                FilterXObject *new_value, FilterXExpr *expr);
+
+static inline __attribute__((always_inline)) FilterXObject *
+_do_nullv_set_subscript(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr,
+                        FXSetSubscriptWrapper wrapper)
+{
+  if (!new_value)
+    {
+      filterx_eval_dump_errors("FilterX: null coalesce assignment suppressing error");
+      filterx_object_unref(object);
+      filterx_object_unref(key);
+      return filterx_null_new();
+    }
+  if (filterx_object_extract_null(new_value))
+    {
+      filterx_object_unref(object);
+      filterx_object_unref(key);
+      return new_value;
+    }
+  return wrapper(object, key, new_value, expr);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_nullv_set_subscript_dict(FilterXObject *object, FilterXObject *key,
+                                   FilterXObject *new_value, FilterXExpr *expr)
+{
+  return _do_nullv_set_subscript(object, key, new_value, expr, fx_jit_do_set_subscript_dict);
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_nullv_set_subscript_list(FilterXObject *object, FilterXObject *key,
+                                   FilterXObject *new_value, FilterXExpr *expr)
+{
+  return _do_nullv_set_subscript(object, key, new_value, expr, fx_jit_do_set_subscript_list);
+}
+
 static FilterXIRValue
-_set_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
+_compile_dispatch(FilterXExpr *s, FilterXJIT *jit, const gchar *fn_dict, const gchar *fn_list)
 {
   FilterXSetSubscript *self = (FilterXSetSubscript *) s;
   FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
@@ -245,10 +284,10 @@ _set_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
   switch (filterx_static_type_kind(self->object->static_type))
     {
     case FILTERX_STATIC_TYPE_DICT:
-      fn_name = "fx_jit_do_set_subscript_dict";
+      fn_name = fn_dict;
       break;
     case FILTERX_STATIC_TYPE_LIST:
-      fn_name = "fx_jit_do_set_subscript_list";
+      fn_name = fn_list;
       break;
     default:
       return fx_jit_emit_expr_eval(jit, s);
@@ -265,6 +304,20 @@ _set_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
   FilterXIRValue args[] = { object, key, new_value, fx_jit_emit_const_ptr(jit, s) };
   FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
   return fx_jit_emit_extern_call(jit, fn_name, ffi->ptr_ty, param_tys, args, 4);
+}
+
+static FilterXIRValue
+_set_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  return _compile_dispatch(s, jit, "fx_jit_do_set_subscript_dict",
+                           "fx_jit_do_set_subscript_list");
+}
+
+static FilterXIRValue
+_nullv_set_subscript_compile(FilterXExpr *s, FilterXJIT *jit)
+{
+  return _compile_dispatch(s, jit, "fx_jit_do_nullv_set_subscript_dict",
+                           "fx_jit_do_nullv_set_subscript_list");
 }
 
 #endif
@@ -312,5 +365,8 @@ filterx_nullv_set_subscript_new(FilterXExpr *object, FilterXExpr *key, FilterXEx
 
   self->type = "nullv_set_subscript";
   self->eval = _nullv_set_subscript_eval;
+#if SYSLOG_NG_ENABLE_JIT
+  self->compile = _nullv_set_subscript_compile;
+#endif
   return self;
 }

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -166,9 +166,13 @@ _free(FilterXExpr *s)
 
 typedef gboolean (*FXSetSubscriptHelper)(FilterXObject *object, FilterXObject *key, FilterXObject **value);
 
+/* @helper downcasts @object to a concrete FilterX{Dict,List}Object; the static type that
+ * selected this fast path is only a hint, so coercing containers (e.g. otel masquerading as
+ * dict/list) may present a different runtime layout. @expected_type guards the downcast and
+ * on a mismatch we fall back to the generic vtable set_subscript (same signature). */
 static inline __attribute__((always_inline)) FilterXObject *
 _do_set_subscript(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr,
-                  FXSetSubscriptHelper helper)
+                  FXSetSubscriptHelper helper, FilterXType *expected_type)
 {
   FilterXObject *cloned = NULL;
   if (!new_value)
@@ -189,6 +193,8 @@ _do_set_subscript(FilterXObject *object, FilterXObject *key, FilterXObject *new_
                                           "Failed to evaluate expression");
       goto cleanup;
     }
+  if (!filterx_object_is_type_or_ref(object, expected_type))
+    helper = filterx_object_set_subscript;
   cloned = filterx_object_cow_fork2(filterx_object_ref(new_value), NULL);
   if (!helper(object, key, &cloned))
     {
@@ -209,14 +215,14 @@ __attribute__((used))
 FilterXObject *
 fx_jit_do_set_subscript_dict(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr)
 {
-  return _do_set_subscript(object, key, new_value, expr, filterx_dict_set_subscript);
+  return _do_set_subscript(object, key, new_value, expr, filterx_dict_set_subscript, &FILTERX_TYPE_NAME(dict));
 }
 
 __attribute__((used))
 FilterXObject *
 fx_jit_do_set_subscript_list(FilterXObject *object, FilterXObject *key, FilterXObject *new_value, FilterXExpr *expr)
 {
-  return _do_set_subscript(object, key, new_value, expr, filterx_list_set_subscript_via_key);
+  return _do_set_subscript(object, key, new_value, expr, filterx_list_set_subscript_via_key, &FILTERX_TYPE_NAME(list));
 }
 
 static void

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -20,6 +20,7 @@
  *
  */
 #include "filterx/expr-set-subscript.h"
+#include "filterx/expr-variable.h"
 #include "filterx/object-primitive.h"
 #include "filterx/filterx-eval.h"
 #include "filterx/object-null.h"
@@ -154,6 +155,23 @@ _free(FilterXExpr *s)
   filterx_expr_free_method(s);
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+static void
+_set_subscript_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXSetSubscript *self = (FilterXSetSubscript *) s;
+
+  /* Refine the written container's element type with the assigned value (lift if the level
+   * was a freshly-built empty container, meet otherwise). This keeps element-type info alive
+   * across incremental builds (l = []; l[0] = {}; l[0].x = {}; ...) so deeper accesses
+   * devirtualize. */
+  filterx_type_env_update_on_write(env, self->object,
+                                   self->new_value ? self->new_value->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC);
+}
+
+#endif
+
 static gboolean
 _set_subscript_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 {
@@ -179,6 +197,9 @@ filterx_set_subscript_new(FilterXExpr *object, FilterXExpr *key, FilterXExpr *ne
   self->super.eval = _set_subscript_eval;
   self->super.walk_children = _set_subscript_walk;
   self->super.free_fn = _free;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.infer_types = _set_subscript_infer_types;
+#endif
   self->object = object;
   self->key = key;
   self->new_value = new_value;

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -184,6 +184,7 @@ _setattr_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 
 #include "filterx/jit/jit.h"
 #include "filterx/jit/ffi.h"
+#include "filterx/object-dict.h"
 
 __attribute__((used))
 FilterXObject *
@@ -197,6 +198,60 @@ FilterXObject *
 fx_jit_do_nullv_setattr(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned)
 {
   return _do_nullv_setattr((FilterXSetAttr *) s, lhs, cloned);
+}
+
+/* Dict-specialized setattr: identical to _do_setattr but calls filterx_dict_set_subscript
+ * directly, bypassing the ref-setattr → mapping-setattr → set_subscript vtable chain. */
+__attribute__((used))
+FilterXObject *
+fx_jit_do_setattr_dict(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned)
+{
+  FilterXSetAttr *self = (FilterXSetAttr *) s;
+
+  if (!cloned)
+    {
+      filterx_eval_push_error_static_info("Failed to set-attribute to object", &self->super,
+                                          "Failed to evaluate right hand side");
+      goto error;
+    }
+  if (!lhs)
+    {
+      filterx_eval_push_error_static_info("Failed to set-attribute to object", &self->super,
+                                          "Failed to evaluate expression");
+      goto error;
+    }
+
+  if (!filterx_dict_set_subscript(lhs, self->attr, &cloned))
+    {
+      filterx_eval_push_error_static_info("Failed to set-attribute to object", &self->super,
+                                          "setattr() method failed");
+      goto error;
+    }
+
+  filterx_object_unref(lhs);
+  return cloned;
+
+error:
+  filterx_object_unref(lhs);
+  filterx_object_unref(cloned);
+  return NULL;
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_nullv_setattr_dict(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned)
+{
+  if (!cloned)
+    {
+      filterx_object_unref(lhs);
+      return _suppress_error();
+    }
+  if (filterx_object_extract_null(cloned))
+    {
+      filterx_object_unref(lhs);
+      return cloned;
+    }
+  return fx_jit_do_setattr_dict(s, lhs, cloned);
 }
 
 static inline FilterXIRValue
@@ -221,13 +276,21 @@ _emit_setattr_call(FilterXSetAttr *self, FilterXJIT *jit, const gchar *fn_name)
 static FilterXIRValue
 _setattr_compile(FilterXExpr *s, FilterXJIT *jit)
 {
-  return _emit_setattr_call((FilterXSetAttr *) s, jit, "fx_jit_do_setattr");
+  FilterXSetAttr *self = (FilterXSetAttr *) s;
+  const gchar *fn_name = filterx_static_type_kind(self->object->static_type) == FILTERX_STATIC_TYPE_DICT
+                         ? "fx_jit_do_setattr_dict"
+                         : "fx_jit_do_setattr";
+  return _emit_setattr_call(self, jit, fn_name);
 }
 
 static FilterXIRValue
 _nullv_setattr_compile(FilterXExpr *s, FilterXJIT *jit)
 {
-  return _emit_setattr_call((FilterXSetAttr *) s, jit, "fx_jit_do_nullv_setattr");
+  FilterXSetAttr *self = (FilterXSetAttr *) s;
+  const gchar *fn_name = filterx_static_type_kind(self->object->static_type) == FILTERX_STATIC_TYPE_DICT
+                         ? "fx_jit_do_nullv_setattr_dict"
+                         : "fx_jit_do_nullv_setattr";
+  return _emit_setattr_call(self, jit, fn_name);
 }
 
 #endif

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -20,6 +20,7 @@
  *
  */
 #include "filterx/expr-setattr.h"
+#include "filterx/expr-variable.h"
 #include "filterx/object-primitive.h"
 #include "filterx/object-string.h"
 #include "filterx/filterx-eval.h"
@@ -143,6 +144,26 @@ _free(FilterXExpr *s)
   filterx_expr_free_method(s);
 }
 
+static void
+_setattr_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXSetAttr *self = (FilterXSetAttr *) s;
+
+  /* Refine the written container's element type with the assigned value (lift if the level
+   * was a freshly-built empty container, meet otherwise). This keeps element-type info alive
+   * across incremental builds (d.a = {}; d.a.b = {}; ...) so deeper accesses devirtualize. */
+  FilterXStaticTypeSpec value_spec = self->new_value ? self->new_value->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+  filterx_type_env_update_on_write(env, self->object, value_spec);
+
+  const gchar *key = filterx_string_get_value_ref_and_assert_nul(self->attr, NULL);
+
+  /* Per-key update: variable.k0.k1...key = value.  The single-hop case (variable.key)
+   * is just a zero-prefix chain, so this covers it too.  Allows getattr deeper in a
+   * chain to find the precise type. */
+  filterx_type_env_meet_attr_for_chain(env, self->object, key, value_spec);
+}
+
 static gboolean
 _setattr_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 {
@@ -221,6 +242,7 @@ filterx_setattr_new(FilterXExpr *object, FilterXObject *attr_name, FilterXExpr *
   self->super.eval = _setattr_eval;
   self->super.walk_children = _setattr_walk;
   self->super.free_fn = _free;
+  self->super.infer_types = _setattr_infer_types;
 #if SYSLOG_NG_ENABLE_JIT
   self->super.compile = _setattr_compile;
 #endif

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -201,7 +201,12 @@ fx_jit_do_nullv_setattr(FilterXExpr *s, FilterXObject *lhs, FilterXObject *clone
 }
 
 /* Dict-specialized setattr: identical to _do_setattr but calls filterx_dict_set_subscript
- * directly, bypassing the ref-setattr → mapping-setattr → set_subscript vtable chain. */
+ * directly, bypassing the ref-setattr → mapping-setattr → set_subscript vtable chain.
+ *
+ * The static type DICT is only a hint: coercing containers (e.g. otel_logrecord.body) accept
+ * an assigned dict literal but store a non-dict object (otel_kvlist), so @lhs may not have a
+ * FilterXDictObject layout at runtime. Since filterx_dict_set_subscript downcasts to it,
+ * verify the runtime type first and fall back to the generic vtable setattr otherwise. */
 __attribute__((used))
 FilterXObject *
 fx_jit_do_setattr_dict(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned)
@@ -220,6 +225,9 @@ fx_jit_do_setattr_dict(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned
                                           "Failed to evaluate expression");
       goto error;
     }
+
+  if (!filterx_object_is_type_or_ref(lhs, &FILTERX_TYPE_NAME(dict)))
+    return _do_setattr(self, lhs, cloned);
 
   if (!filterx_dict_set_subscript(lhs, self->attr, &cloned))
     {

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -262,6 +262,38 @@ fx_jit_do_nullv_setattr_dict(FilterXExpr *s, FilterXObject *lhs, FilterXObject *
   return fx_jit_do_setattr_dict(s, lhs, cloned);
 }
 
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_setattr_stmt(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned,
+                       FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_setattr(s, lhs, cloned), s, context, last_result);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_nullv_setattr_stmt(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned,
+                             FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_nullv_setattr(s, lhs, cloned), s, context, last_result);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_setattr_dict_stmt(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned,
+                            FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_setattr_dict(s, lhs, cloned), s, context, last_result);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_nullv_setattr_dict_stmt(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned,
+                                  FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_nullv_setattr_dict(s, lhs, cloned), s, context, last_result);
+}
+
 static inline FilterXIRValue
 _emit_setattr_call(FilterXSetAttr *self, FilterXJIT *jit, const gchar *fn_name)
 {

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -160,6 +160,7 @@ _setattr_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 
 #include "filterx/jit/jit.h"
 #include "filterx/jit/ffi.h"
+#include "filterx/object-dict.h"
 
 __attribute__((used))
 FilterXObject *
@@ -195,6 +196,60 @@ _setattr_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
   filterx_type_env_meet_attr_for_chain(env, self->object, key, value_spec);
 }
 
+/* Dict-specialized setattr: identical to _do_setattr but calls filterx_dict_set_subscript
+ * directly, bypassing the ref-setattr → mapping-setattr → set_subscript vtable chain. */
+__attribute__((used))
+FilterXObject *
+fx_jit_do_setattr_dict(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned)
+{
+  FilterXSetAttr *self = (FilterXSetAttr *) s;
+
+  if (!cloned)
+    {
+      filterx_eval_push_error_static_info("Failed to set-attribute to object",
+                                          "Failed to evaluate right hand side");
+      goto error;
+    }
+  if (!lhs)
+    {
+      filterx_eval_push_error_static_info("Failed to set-attribute to object",
+                                          "Failed to evaluate expression");
+      goto error;
+    }
+
+  if (!filterx_dict_set_subscript(lhs, self->attr, &cloned))
+    {
+      filterx_eval_push_error_static_info("Failed to set-attribute to object",
+                                          "setattr() method failed");
+      goto error;
+    }
+
+  filterx_object_unref(lhs);
+  return cloned;
+
+error:
+  filterx_object_unref(lhs);
+  filterx_object_unref(cloned);
+  return NULL;
+}
+
+__attribute__((used))
+FilterXObject *
+fx_jit_do_nullv_setattr_dict(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned)
+{
+  if (!cloned)
+    {
+      filterx_object_unref(lhs);
+      return _suppress_error();
+    }
+  if (filterx_object_extract_null(cloned))
+    {
+      filterx_object_unref(lhs);
+      return cloned;
+    }
+  return fx_jit_do_setattr_dict(s, lhs, cloned);
+}
+
 static inline FilterXIRValue
 _emit_setattr_call(FilterXSetAttr *self, FilterXJIT *jit, const gchar *fn_name)
 {
@@ -217,13 +272,21 @@ _emit_setattr_call(FilterXSetAttr *self, FilterXJIT *jit, const gchar *fn_name)
 static FilterXIRValue
 _setattr_compile(FilterXExpr *s, FilterXJIT *jit)
 {
-  return _emit_setattr_call((FilterXSetAttr *) s, jit, "fx_jit_do_setattr");
+  FilterXSetAttr *self = (FilterXSetAttr *) s;
+  const gchar *fn_name = filterx_static_type_kind(self->object->static_type) == FILTERX_STATIC_TYPE_DICT
+                         ? "fx_jit_do_setattr_dict"
+                         : "fx_jit_do_setattr";
+  return _emit_setattr_call(self, jit, fn_name);
 }
 
 static FilterXIRValue
 _nullv_setattr_compile(FilterXExpr *s, FilterXJIT *jit)
 {
-  return _emit_setattr_call((FilterXSetAttr *) s, jit, "fx_jit_do_nullv_setattr");
+  FilterXSetAttr *self = (FilterXSetAttr *) s;
+  const gchar *fn_name = filterx_static_type_kind(self->object->static_type) == FILTERX_STATIC_TYPE_DICT
+                         ? "fx_jit_do_nullv_setattr_dict"
+                         : "fx_jit_do_nullv_setattr";
+  return _emit_setattr_call(self, jit, fn_name);
 }
 
 #endif

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -258,6 +258,38 @@ fx_jit_do_nullv_setattr_dict(FilterXExpr *s, FilterXObject *lhs, FilterXObject *
   return fx_jit_do_setattr_dict(s, lhs, cloned);
 }
 
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_setattr_stmt(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned,
+                       FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_setattr(s, lhs, cloned), s, context, last_result);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_nullv_setattr_stmt(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned,
+                             FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_nullv_setattr(s, lhs, cloned), s, context, last_result);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_setattr_dict_stmt(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned,
+                            FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_setattr_dict(s, lhs, cloned), s, context, last_result);
+}
+
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_do_nullv_setattr_dict_stmt(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned,
+                                  FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(fx_jit_do_nullv_setattr_dict(s, lhs, cloned), s, context, last_result);
+}
+
 static inline FilterXIRValue
 _emit_setattr_call(FilterXSetAttr *self, FilterXJIT *jit, const gchar *fn_name)
 {

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -20,6 +20,7 @@
  *
  */
 #include "filterx/expr-setattr.h"
+#include "filterx/expr-variable.h"
 #include "filterx/object-primitive.h"
 #include "filterx/object-string.h"
 #include "filterx/filterx-eval.h"
@@ -174,6 +175,26 @@ fx_jit_do_nullv_setattr(FilterXExpr *s, FilterXObject *lhs, FilterXObject *clone
   return _do_nullv_setattr((FilterXSetAttr *) s, lhs, cloned);
 }
 
+static void
+_setattr_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  filterx_expr_infer_types_default(s, env);
+  FilterXSetAttr *self = (FilterXSetAttr *) s;
+
+  /* Refine the written container's element type with the assigned value (lift if the level
+   * was a freshly-built empty container, meet otherwise). This keeps element-type info alive
+   * across incremental builds (d.a = {}; d.a.b = {}; ...) so deeper accesses devirtualize. */
+  FilterXStaticTypeSpec value_spec = self->new_value ? self->new_value->static_type : INITIAL_FILTERX_STATIC_TYPE_SPEC;
+  filterx_type_env_update_on_write(env, self->object, value_spec);
+
+  const gchar *key = filterx_string_get_value_ref_and_assert_nul(self->attr, NULL);
+
+  /* Per-key update: variable.k0.k1...key = value.  The single-hop case (variable.key)
+   * is just a zero-prefix chain, so this covers it too.  Allows getattr deeper in a
+   * chain to find the precise type. */
+  filterx_type_env_meet_attr_for_chain(env, self->object, key, value_spec);
+}
+
 static inline FilterXIRValue
 _emit_setattr_call(FilterXSetAttr *self, FilterXJIT *jit, const gchar *fn_name)
 {
@@ -218,6 +239,7 @@ filterx_setattr_new(FilterXExpr *object, FilterXObject *attr_name, FilterXExpr *
   self->super.walk_children = _setattr_walk;
   self->super.free_fn = _free;
 #if SYSLOG_NG_ENABLE_JIT
+  self->super.infer_types = _setattr_infer_types;
   self->super.compile = _setattr_compile;
 #endif
   self->object = object;

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -197,7 +197,12 @@ _setattr_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
 }
 
 /* Dict-specialized setattr: identical to _do_setattr but calls filterx_dict_set_subscript
- * directly, bypassing the ref-setattr → mapping-setattr → set_subscript vtable chain. */
+ * directly, bypassing the ref-setattr → mapping-setattr → set_subscript vtable chain.
+ *
+ * The static type DICT is only a hint: coercing containers (e.g. otel_logrecord.body) accept
+ * an assigned dict literal but store a non-dict object (otel_kvlist), so @lhs may not have a
+ * FilterXDictObject layout at runtime. Since filterx_dict_set_subscript downcasts to it,
+ * verify the runtime type first and fall back to the generic vtable setattr otherwise. */
 __attribute__((used))
 FilterXObject *
 fx_jit_do_setattr_dict(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned)
@@ -216,6 +221,9 @@ fx_jit_do_setattr_dict(FilterXExpr *s, FilterXObject *lhs, FilterXObject *cloned
                                           "Failed to evaluate expression");
       goto error;
     }
+
+  if (!filterx_object_is_type_or_ref(lhs, &FILTERX_TYPE_NAME(dict)))
+    return _do_setattr(self, lhs, cloned);
 
   if (!filterx_dict_set_subscript(lhs, self->attr, &cloned))
     {

--- a/lib/filterx/expr-string-operators.c
+++ b/lib/filterx/expr-string-operators.c
@@ -238,3 +238,47 @@ filterx_string_slicing_new(FilterXExpr *lhs, FilterXExpr *start, FilterXExpr *en
 
   return &self->super;
 }
+
+#if SYSLOG_NG_ENABLE_JIT
+
+#include "filterx/jit/jit.h"
+#include "filterx/jit/ffi.h"
+
+/* Devirtualized fast path for `string + string`. lhs is guaranteed to be a FilterXString
+ * (eval_typed of a STRING-static_type operand); rhs may be any string-extractable value. */
+__attribute__((used))
+FilterXObject *
+fx_jit_string_plus(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
+{
+  FilterXObject *result = NULL;
+  if (!lhs)
+    {
+      filterx_eval_push_error_static_info("Failed to add values", "Failed to evaluate left hand side");
+      goto exit;
+    }
+  if (!rhs)
+    {
+      filterx_eval_push_error_static_info("Failed to add values", "Failed to evaluate right hand side");
+      goto exit;
+    }
+  result = filterx_string_concat(lhs, rhs);
+  if (!result)
+    filterx_eval_push_error_static_info("Failed to add values", "add() method failed");
+
+exit:
+  filterx_object_unref(lhs);
+  filterx_object_unref(rhs);
+  return result;
+}
+
+FilterXIRValue
+filterx_string_concat_compile(FilterXJIT *jit, FilterXIRValue lhs, FilterXIRValue rhs, FilterXExpr *expr)
+{
+  FilterXJITFFI *ffi = filterx_jit_get_ffi(jit);
+
+  FilterXIRValue args[] = { lhs, rhs, fx_jit_emit_const_ptr(jit, expr) };
+  FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty, ffi->ptr_ty };
+  return fx_jit_emit_extern_call(jit, "fx_jit_string_plus", ffi->ptr_ty, param_tys, args, 3);
+}
+
+#endif

--- a/lib/filterx/expr-string-operators.h
+++ b/lib/filterx/expr-string-operators.h
@@ -27,4 +27,12 @@
 
 FilterXExpr *filterx_string_slicing_new(FilterXExpr *lhs, FilterXExpr *start, FilterXExpr *end);
 
+#if SYSLOG_NG_ENABLE_JIT
+/* Emits a devirtualized string concatenation of two already evaluated operands. @lhs must
+ * hold a FilterXString (the caller has proven this via static-type inference), @rhs any
+ * string-extractable object. Both operand references are consumed by the emitted code. */
+FilterXIRValue filterx_string_concat_compile(FilterXJIT *jit, FilterXIRValue lhs, FilterXIRValue rhs,
+                                             FilterXExpr *expr);
+#endif
+
 #endif

--- a/lib/filterx/expr-switch.c
+++ b/lib/filterx/expr-switch.c
@@ -436,6 +436,33 @@ _switch_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return TRUE;
 }
 
+static void
+_switch_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXSwitch *self = (FilterXSwitch *) s;
+
+  filterx_expr_infer_types(self->selector, env);
+
+  /* Case-value expressions are read-only in practice but visit them so any nested
+   * variable reads pick up the env. */
+  for (gsize i = 0; i < self->cases->len; i++)
+    {
+      FilterXExpr *case_expr = (FilterXExpr *) g_ptr_array_index(self->cases, i);
+      filterx_expr_infer_types(case_expr, env);
+    }
+
+  /* The body may or may not execute (no matching case + no default). Walk it on a clone
+   * and meet back, so any writes the body performs are only kept if they would also hold
+   * under the no-match path. Cross-case fall-through pessimizes the within-body view too,
+   * which is fine for v1. */
+  FilterXTypeEnv *before = filterx_type_env_clone(env);
+  filterx_expr_infer_types(self->body, env);
+  filterx_type_env_meet_into(env, before);
+  filterx_type_env_free(before);
+
+  s->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
+}
+
 FilterXExpr *
 filterx_switch_new(FilterXExpr *selector, GList *body)
 {
@@ -447,6 +474,7 @@ filterx_switch_new(FilterXExpr *selector, GList *body)
   self->super.eval = _eval_switch;
   self->super.walk_children = _switch_walk;
   self->super.free_fn = _free;
+  self->super.infer_types = _switch_infer_types;
   self->cases = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_expr_unref);
   self->literal_cache = g_hash_table_new_full((GHashFunc) filterx_object_hash, (GEqualFunc) filterx_object_equal,
                                               (GDestroyNotify) filterx_object_unref, (GDestroyNotify) filterx_expr_unref);

--- a/lib/filterx/expr-switch.c
+++ b/lib/filterx/expr-switch.c
@@ -435,6 +435,36 @@ _switch_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return TRUE;
 }
 
+#if SYSLOG_NG_ENABLE_JIT
+static void
+_switch_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXSwitch *self = (FilterXSwitch *) s;
+
+  filterx_expr_infer_types(self->selector, env);
+
+  /* Case-value expressions are read-only in practice but visit them so any nested
+   * variable reads pick up the env. */
+  for (gsize i = 0; i < self->cases->len; i++)
+    {
+      FilterXExpr *case_expr = (FilterXExpr *) g_ptr_array_index(self->cases, i);
+      filterx_expr_infer_types(case_expr, env);
+    }
+
+  /* The body may or may not execute (no matching case + no default). Walk it on a clone
+   * and meet back, so any writes the body performs are only kept if they would also hold
+   * under the no-match path. Cross-case fall-through pessimizes the within-body view too,
+   * which is fine for v1. */
+  FilterXTypeEnv *before = filterx_type_env_clone(env);
+  filterx_expr_infer_types(self->body, env);
+  filterx_type_env_meet_into(env, before);
+  filterx_type_env_free(before);
+
+  s->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
+}
+
+#endif
+
 FilterXExpr *
 filterx_switch_new(FilterXExpr *selector, GList *body)
 {
@@ -446,6 +476,9 @@ filterx_switch_new(FilterXExpr *selector, GList *body)
   self->super.eval = _eval_switch;
   self->super.walk_children = _switch_walk;
   self->super.free_fn = _free;
+#if SYSLOG_NG_ENABLE_JIT
+  self->super.infer_types = _switch_infer_types;
+#endif
   self->cases = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_expr_unref);
   self->literal_cache = g_hash_table_new_full((GHashFunc) filterx_object_hash, (GEqualFunc) filterx_object_equal,
                                               (GDestroyNotify) filterx_object_unref, (GDestroyNotify) filterx_expr_unref);

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -243,6 +243,13 @@ fx_jit_eval_variable(FilterXExpr *s)
   return _eval_variable(s);
 }
 
+__attribute__((used)) __attribute__((noinline))
+FilterXObject *
+fx_jit_eval_variable_typed(FilterXExpr *s)
+{
+  return filterx_expr_make_typed_object(s, _eval_variable(s));
+}
+
 static FilterXIRValue
 _variable_compile(FilterXExpr *s, FilterXJIT *jit)
 {

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -281,12 +281,16 @@ filterx_floating_variable_expr_new(const gchar *name)
   return filterx_variable_expr_new(name, FX_VAR_FLOATING);
 }
 
-FilterXVariableHandle
-filterx_variable_expr_get_handle(FilterXExpr *s)
+gboolean
+filterx_variable_expr_get_handle(FilterXExpr *s, FilterXVariableHandle *handle_out)
 {
+  if (!filterx_expr_is_variable(s))
+    return FALSE;
   FilterXVariableExpr *self = (FilterXVariableExpr *) s;
-
-  return self->handle;
+  if (self->handle_is_macro)
+    return FALSE;
+  *handle_out = self->handle;
+  return TRUE;
 }
 
 gboolean

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -207,6 +207,16 @@ _variable_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
   return TRUE;
 }
 
+static void
+_variable_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
+  if (self->handle_is_macro)
+    s->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
+  else
+    s->static_type = filterx_type_env_get(env, self->handle);
+}
+
 #if SYSLOG_NG_ENABLE_JIT
 
 #include "filterx/jit/jit.h"
@@ -243,6 +253,7 @@ filterx_variable_expr_new(const gchar *name, FilterXVariableType variable_type)
   self->super.walk_children = _variable_walk;
   self->super.free_fn = _free;
   self->super.eval = _eval_variable;
+  self->super.infer_types = _variable_infer_types;
 #if SYSLOG_NG_ENABLE_JIT
   self->super.compile = _variable_compile;
 #endif

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -214,7 +214,21 @@ _variable_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
   if (self->handle_is_macro)
     s->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
   else
-    s->static_type = filterx_type_env_get(env, self->handle);
+    /* The env may carry the FRESH lift-tracking sentinel at inner levels; strip it before
+     * exposing the type on the expression (used by getattr/set codegen). */
+    s->static_type = filterx_static_type_sanitize(filterx_type_env_get(env, self->handle));
+}
+
+gboolean
+filterx_variable_expr_get_handle(FilterXExpr *s, FilterXVariableHandle *handle_out)
+{
+  if (!filterx_expr_is_variable(s))
+    return FALSE;
+  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
+  if (self->handle_is_macro)
+    return FALSE;
+  *handle_out = self->handle;
+  return TRUE;
 }
 
 #if SYSLOG_NG_ENABLE_JIT
@@ -290,18 +304,6 @@ FilterXExpr *
 filterx_floating_variable_expr_new(const gchar *name)
 {
   return filterx_variable_expr_new(name, FX_VAR_FLOATING);
-}
-
-gboolean
-filterx_variable_expr_get_handle(FilterXExpr *s, FilterXVariableHandle *handle_out)
-{
-  if (!filterx_expr_is_variable(s))
-    return FALSE;
-  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
-  if (self->handle_is_macro)
-    return FALSE;
-  *handle_out = self->handle;
-  return TRUE;
 }
 
 gboolean

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -244,6 +244,16 @@ fx_jit_assign_variable_in_scope(FilterXEvalContext *context, FilterXExpr *s, Fil
   return new_value;
 }
 
+static void
+_variable_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
+{
+  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
+  if (self->handle_is_macro)
+    s->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
+  else
+    s->static_type = filterx_type_spec_get(env, self->handle);
+}
+
 static FilterXIRValue
 _variable_compile(FilterXExpr *s, FilterXJIT *jit)
 {
@@ -337,6 +347,7 @@ filterx_variable_expr_new(const gchar *name, FilterXVariableType variable_type)
   self->super.free_fn = _free;
   self->super.eval = _eval_variable;
 #if SYSLOG_NG_ENABLE_JIT
+  self->super.infer_types = _variable_infer_types;
   self->super.compile = _variable_compile;
 #endif
   self->super._update_repr = _update_repr;

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -374,12 +374,16 @@ filterx_floating_variable_expr_new(const gchar *name)
   return filterx_variable_expr_new(name, FX_VAR_FLOATING);
 }
 
-FilterXVariableHandle
-filterx_variable_expr_get_handle(FilterXExpr *s)
+gboolean
+filterx_variable_expr_get_handle(FilterXExpr *s, FilterXVariableHandle *handle_out)
 {
+  if (!filterx_expr_is_variable(s))
+    return FALSE;
   FilterXVariableExpr *self = (FilterXVariableExpr *) s;
-
-  return self->handle;
+  if (self->handle_is_macro)
+    return FALSE;
+  *handle_out = self->handle;
+  return TRUE;
 }
 
 gboolean

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -251,7 +251,9 @@ _variable_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
   if (self->handle_is_macro)
     s->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
   else
-    s->static_type = filterx_type_spec_get(env, self->handle);
+    /* The env may carry the FRESH lift-tracking sentinel at inner levels; strip it before
+     * exposing the type on the expression (used by getattr/set codegen). */
+    s->static_type = filterx_static_type_sanitize(filterx_type_spec_get(env, self->handle));
 }
 
 static FilterXIRValue

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -243,6 +243,34 @@ fx_jit_borrow_variable_value(FilterXEvalContext *context, FilterXExpr *s)
   return _borrow_variable_value((FilterXVariableExpr *) s, context);
 }
 
+/* Like fx_jit_borrow_variable_value(), but leaves the variable holding its typed
+ * representation.  This is what establishes the JIT variable cache invariant: a slot that
+ * is not the uninitialized sentinel always holds a typed object, so reads of it need no
+ * further make_typed_object().  Returns a borrowed pointer. */
+__attribute__((used))
+FilterXObject *
+fx_jit_borrow_variable_value_typed(FilterXEvalContext *context, FilterXExpr *s)
+{
+  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
+  FilterXObject *value = _borrow_variable_value(self, context);
+
+  if (!value)
+    return NULL;
+
+  /* make_typed_object() consumes a reference, so give it one of ours */
+  FilterXObject *typed = filterx_expr_make_typed_object(s, filterx_object_ref(value));
+  if (!typed)
+    return NULL;
+
+  /* When unmarshalling happened, _update_repr() has stored the typed value into the
+   * scope -- but cow_store() grounds and re-wraps it, so the scope's pointer is not
+   * necessarily @typed.  Re-borrow to hand out exactly what the scope now holds. */
+  FilterXObject *borrowed = _borrow_variable_value(self, context);
+  filterx_object_unref(typed);
+
+  return borrowed;
+}
+
 __attribute__((used))
 FilterXObject *
 fx_jit_assign_variable_in_scope(FilterXEvalContext *context, FilterXExpr *s, FilterXObject *new_value)
@@ -294,7 +322,7 @@ _variable_compile(FilterXExpr *s, FilterXJIT *jit)
   filterx_jit_ir_set_insert_point_to_sequence_tail(jit, fill);
   FilterXIRValue args[] = { filterx_jit_ir_get_eval_context(jit), fx_jit_emit_const_ptr(jit, self) };
   FilterXIRType param_tys[] = { ffi->ptr_ty, ffi->ptr_ty };
-  FilterXIRValue filled = fx_jit_emit_extern_call(jit, "fx_jit_borrow_variable_value",
+  FilterXIRValue filled = fx_jit_emit_extern_call(jit, "fx_jit_borrow_variable_value_typed",
                                                   ffi->ptr_ty, param_tys, args, 2);
   LLVMBuildStore(ir, filled, local);
   LLVMBuildBr(ir, merge);
@@ -306,7 +334,9 @@ _variable_compile(FilterXExpr *s, FilterXJIT *jit)
   FilterXIRSequence incoming_blocks[] = { cached_seq, fill };
   LLVMAddIncoming(value, incoming_values, incoming_blocks, 2);
 
-  return fx_jit_emit_object_ref(jit, value);
+  /* every writer of the slot keeps it typed, so the cached value needs no unmarshalling:
+   * take the reference through the marker twin to tell compile_typed() to skip it */
+  return fx_jit_emit_object_ref_typed(jit, value);
 }
 
 static FilterXIRValue
@@ -327,7 +357,15 @@ _variable_compile_assign(FilterXExpr *s, FilterXJIT *jit, FilterXIRValue new_val
   FilterXIRValue stored = fx_jit_emit_extern_call(jit, "fx_jit_assign_variable_in_scope",
                                                   ffi->ptr_ty, param_tys, args, 3);
 
-  LLVMBuildStore(ir, stored, local);
+  /* Only cache the assigned value when it is known to be typed, otherwise the slot would
+   * break the "a cached value is always typed" invariant that lets reads skip
+   * make_typed_object().  A marshalled value (e.g. `x = $MSG`) is dropped from the cache
+   * instead, so the next read refills it through the typed borrow. */
+  if (fx_jit_call_result_is_typed(jit, new_value))
+    LLVMBuildStore(ir, stored, local);
+  else
+    filterx_jit_ir_invalidate_variable(jit, self->scope_var_idx);
+
   return stored;
 }
 

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -229,6 +229,13 @@ fx_jit_eval_variable(FilterXExpr *s)
   return _eval_variable(s);
 }
 
+__attribute__((used)) __attribute__((noinline))
+FilterXObject *
+fx_jit_eval_variable_typed(FilterXExpr *s)
+{
+  return filterx_expr_make_typed_object(s, _eval_variable(s));
+}
+
 __attribute__((used))
 FilterXObject *
 fx_jit_borrow_variable_value(FilterXEvalContext *context, FilterXExpr *s)

--- a/lib/filterx/expr-variable.h
+++ b/lib/filterx/expr-variable.h
@@ -32,9 +32,12 @@ FilterXExpr *filterx_msg_variable_expr_new(const gchar *name);
 FilterXExpr *filterx_floating_variable_expr_new(const gchar *name);
 void filterx_variable_expr_declare(FilterXExpr *s);
 
-FilterXVariableHandle filterx_variable_expr_get_handle(FilterXExpr *s);
 gboolean filterx_variable_expr_is_macro(FilterXExpr *s);
 void filterx_variable_expr_set_scope_var_idx(FilterXExpr *s, gint idx);
+/* Returns TRUE and fills @handle_out if @s is a variable whose handle is suitable for
+ * static type tracking (i.e. not a macro-backed message variable). */
+gboolean filterx_variable_expr_get_handle(FilterXExpr *s, FilterXVariableHandle *handle_out);
+
 
 FILTERX_EXPR_DECLARE_TYPE(variable);
 

--- a/lib/filterx/expr-variable.h
+++ b/lib/filterx/expr-variable.h
@@ -32,7 +32,6 @@ FilterXExpr *filterx_msg_variable_expr_new(const gchar *name);
 FilterXExpr *filterx_floating_variable_expr_new(const gchar *name);
 void filterx_variable_expr_declare(FilterXExpr *s);
 
-FilterXVariableHandle filterx_variable_expr_get_handle(FilterXExpr *s);
 gboolean filterx_variable_expr_is_macro(FilterXExpr *s);
 void filterx_variable_expr_set_scope_var_idx(FilterXExpr *s, gint idx);
 gint filterx_variable_expr_get_scope_var_idx(FilterXExpr *s);
@@ -40,6 +39,8 @@ gint filterx_variable_expr_get_scope_var_idx(FilterXExpr *s);
 #if SYSLOG_NG_ENABLE_JIT
 void filterx_variable_expr_compile_repr_update(FilterXExpr *s, FilterXJIT *jit, FilterXIRValue new_repr);
 #endif
+gboolean filterx_variable_expr_get_handle(FilterXExpr *s, FilterXVariableHandle *handle_out);
+
 
 FILTERX_EXPR_DECLARE_TYPE(variable);
 

--- a/lib/filterx/filterx-config.c
+++ b/lib/filterx/filterx-config.c
@@ -33,6 +33,7 @@ filterx_config_free(ModuleConfig *s)
   FilterXConfig *self = (FilterXConfig *) s;
 
   filterx_env_clear(&self->global_env);
+  filterx_type_env_free(self->persistent_type_env);
   module_config_free_method(s);
 }
 
@@ -117,6 +118,7 @@ filterx_config_new(GlobalConfig *cfg)
   self->super.deinit = filterx_config_deinit;
   self->super.free_fn = filterx_config_free;
   filterx_env_init(&self->global_env);
+  self->persistent_type_env = filterx_type_env_new();
   self->enable_jit = -1;
   return self;
 }

--- a/lib/filterx/filterx-config.h
+++ b/lib/filterx/filterx-config.h
@@ -27,6 +27,7 @@
 #include "filterx/jit/jit.h"
 #include "filterx/object-string.h"
 #include "filterx/filterx-env.h"
+#include "filterx/filterx-type-inference.h"
 
 #include <string.h>
 
@@ -38,6 +39,9 @@ typedef struct _FilterXConfig
   FilterXJIT *jit;
   /* config related objects, e.g. frozen string literals, etc */
   FilterXEnvironment global_env;
+  /* Accumulated type environment across all filterx blocks in this config; used to propagate
+   * type knowledge (e.g. log.field → INTEGER) from earlier blocks to later ones. */
+  FilterXTypeEnv *persistent_type_env;
 } FilterXConfig;
 
 FilterXConfig *filterx_config_get(GlobalConfig *cfg);

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -261,6 +261,26 @@ _optimize_child_exprs(FilterXExpr *parent, FilterXExpr **child, gpointer user_da
   return TRUE;
 }
 
+static gboolean
+_infer_types_child_exprs(FilterXExpr *parent, FilterXExpr **child, gpointer user_data)
+{
+  FilterXTypeEnv *env = (FilterXTypeEnv *) user_data;
+  filterx_expr_infer_types(*child, env);
+  return TRUE;
+}
+
+void
+filterx_expr_infer_types_default(FilterXExpr *self, FilterXTypeEnv *env)
+{
+  if (!self)
+    return;
+
+  if (!filterx_expr_walk_children(self, _infer_types_child_exprs, env))
+    g_assert_not_reached();
+
+  self->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
+}
+
 FilterXExpr *
 filterx_expr_optimize(FilterXExpr *self)
 {
@@ -316,6 +336,7 @@ filterx_expr_init_instance(FilterXExpr *self, const gchar *type, FilterXEffect e
   self->plus_assign = filterx_expr_plus_assign_method;
   self->type = type;
   self->effects = effects;
+  self->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
 }
 
 FilterXExpr *

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -270,6 +270,26 @@ _filterx_expr_propagate_to_error(FilterXExpr *self)
   filterx_eval_update_error_location_from_expr(self);
 }
 
+static gboolean
+_infer_types_child_exprs(FilterXExpr *parent, FilterXExpr **child, gpointer user_data)
+{
+  FilterXTypeEnv *env = (FilterXTypeEnv *) user_data;
+  filterx_expr_infer_types(*child, env);
+  return TRUE;
+}
+
+void
+filterx_expr_infer_types_default(FilterXExpr *self, FilterXTypeEnv *env)
+{
+  if (!self)
+    return;
+
+  if (!filterx_expr_walk_children(self, _infer_types_child_exprs, env))
+    g_assert_not_reached();
+
+  self->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
+}
+
 FilterXExpr *
 filterx_expr_optimize(FilterXExpr *self)
 {
@@ -325,6 +345,7 @@ filterx_expr_init_instance(FilterXExpr *self, const gchar *type, FilterXEffect e
   self->plus_assign = filterx_expr_plus_assign_method;
   self->type = type;
   self->effects = effects;
+  self->static_type = INITIAL_FILTERX_STATIC_TYPE_SPEC;
 }
 
 FilterXExpr *

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -295,6 +295,11 @@ filterx_expr_compile_typed(FilterXExpr *self, FilterXJIT *jit)
   g_assert(self && self->compile);
   FilterXIRValue result = self->compile(self, jit);
 
+  /* avoid a separate make_typed_object() call at every operand: retarget the
+   * compiled helper call to its make-typed twin where one exists */
+  if (fx_jit_try_make_call_result_typed(jit, result))
+    return result;
+
   return fx_jit_emit_expr_make_typed_object(jit, self, result);
 }
 

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -27,6 +27,7 @@
 #include "filterx/jit/jit.h"
 #include "filterx/jit/ffi.h"
 #include "filterx-object.h"
+#include "filterx/filterx-type-inference.h"
 #include "cfg-lexer.h"
 #include "stats/stats-counter.h"
 
@@ -79,9 +80,12 @@ guint32 ignore_falsy_result:1, suppress_from_trace:1, inited:1, optimized:1, eff
   void (*deinit)(FilterXExpr *self, GlobalConfig *cfg);
   FilterXExpr *(*optimize)(FilterXExpr *self);
   FilterXIRValue (*compile)(FilterXExpr *self, FilterXJIT *jit);
+  void (*infer_types)(FilterXExpr *self, FilterXTypeEnv *env);
   void (*free_fn)(FilterXExpr *self);
 
   gboolean (*walk_children)(FilterXExpr *self, FilterXExprWalkFunc f, gpointer user_data);
+
+  FilterXStaticTypeSpec static_type;
 
   /* type of the expr, is not freed, assumed to be managed by something else
    * */
@@ -248,6 +252,11 @@ void filterx_expr_deinit_method(FilterXExpr *self, GlobalConfig *cfg);
 
 gboolean filterx_expr_init(FilterXExpr *self, GlobalConfig *cfg);
 void filterx_expr_deinit(FilterXExpr *self, GlobalConfig *cfg);
+
+/* Default infer_types implementation: walks children with the current env and leaves
+ * self->static_type at UNKNOWN. Provided as a callable so per-expr overrides can chain
+ * to it when they only need to add a post-step (e.g. to set their own static_type). */
+void filterx_expr_infer_types_default(FilterXExpr *self, FilterXTypeEnv *env);
 
 static inline gboolean
 filterx_expr_visit(FilterXExpr *self, FilterXExpr **expr, FilterXExprWalkFunc f, gpointer user_data)

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -355,6 +355,11 @@ filterx_expr_compile_typed(FilterXExpr *self, FilterXJIT *jit)
 #endif
   FilterXIRValue result = self->compile(self, jit);
 
+  /* avoid a separate make_typed_object() call at every operand: retarget the
+   * compiled helper call to its make-typed twin where one exists */
+  if (fx_jit_try_make_call_result_typed(jit, result))
+    return result;
+
   return fx_jit_emit_expr_make_typed_object(jit, self, result);
 #else
   g_assert_not_reached();

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -27,6 +27,7 @@
 #include "filterx/jit/jit.h"
 #include "filterx/jit/ffi.h"
 #include "filterx-object.h"
+#include "filterx/filterx-type-inference.h"
 #include "cfg-lexer.h"
 #include "stats/stats-counter.h"
 
@@ -81,11 +82,14 @@ guint32 ignore_falsy_result:1, suppress_from_trace:1, inited:1, optimized:1, sta
 #if SYSLOG_NG_ENABLE_JIT
   FilterXIRValue (*compile)(FilterXExpr *self, FilterXJIT *jit);
   FilterXIRValue (*compile_assign)(FilterXExpr *self, FilterXJIT *jit, FilterXIRValue new_value);
+  void (*infer_types)(FilterXExpr *self, FilterXTypeEnv *env);
 #endif
 
   void (*free_fn)(FilterXExpr *self);
 
   gboolean (*walk_children)(FilterXExpr *self, FilterXExprWalkFunc f, gpointer user_data);
+
+  FilterXStaticTypeSpec static_type;
 
   /* type of the expr, is not freed, assumed to be managed by something else
    * */
@@ -260,6 +264,11 @@ void filterx_expr_deinit_method(FilterXExpr *self, GlobalConfig *cfg);
 
 gboolean filterx_expr_init(FilterXExpr *self, GlobalConfig *cfg);
 void filterx_expr_deinit(FilterXExpr *self, GlobalConfig *cfg);
+
+/* Default infer_types implementation: walks children with the current env and leaves
+ * self->static_type at UNKNOWN. Provided as a callable so per-expr overrides can chain
+ * to it when they only need to add a post-step (e.g. to set their own static_type). */
+void filterx_expr_infer_types_default(FilterXExpr *self, FilterXTypeEnv *env);
 
 static inline gboolean
 filterx_expr_visit(FilterXExpr *self, FilterXExpr **expr, FilterXExprWalkFunc f, gpointer user_data)

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -57,7 +57,7 @@ struct _FilterXExpr
 
   /* not thread-safe */
   guint32 ref_cnt;
-guint32 ignore_falsy_result:1, suppress_from_trace:1, inited:1, optimized:1, statement:1, effects:
+guint32 ignore_falsy_result:1, suppress_from_trace:1, inited:1, optimized:1, statement:1, types_inferred:1, effects:
   FXE_EFFECT_BITFIELD_SIZE;
 
   /* not to be used except for FilterXMessageRef, replace any cached values
@@ -303,6 +303,11 @@ filterx_expr_compile(FilterXExpr *self, FilterXJIT *jit)
 {
 #if SYSLOG_NG_ENABLE_JIT
   g_assert(self && self->compile);
+#if SYSLOG_NG_ENABLE_DEBUG
+  /* static_type is only meaningful after inference; compiling an un-inferred node devirtualizes
+   * on UNKNOWN, i.e. silently emits the generic path. */
+  g_assert(self->types_inferred);
+#endif
   FilterXIRValue result = self->compile(self, jit);
 
   return fx_jit_emit_expr_propagate_to_error_if_null(jit, self, result);
@@ -327,6 +332,11 @@ filterx_expr_compile_assign(FilterXExpr *self, FilterXJIT *jit, FilterXIRValue n
 {
 #if SYSLOG_NG_ENABLE_JIT
   g_assert(self && self->compile_assign);
+#if SYSLOG_NG_ENABLE_DEBUG
+  /* static_type is only meaningful after inference; compiling an un-inferred node devirtualizes
+   * on UNKNOWN, i.e. silently emits the generic path. */
+  g_assert(self->types_inferred);
+#endif
   return self->compile_assign(self, jit, new_value);
 #else
   g_assert_not_reached();
@@ -338,6 +348,11 @@ filterx_expr_compile_typed(FilterXExpr *self, FilterXJIT *jit)
 {
 #if SYSLOG_NG_ENABLE_JIT
   g_assert(self && self->compile);
+#if SYSLOG_NG_ENABLE_DEBUG
+  /* static_type is only meaningful after inference; compiling an un-inferred node devirtualizes
+   * on UNKNOWN, i.e. silently emits the generic path. */
+  g_assert(self->types_inferred);
+#endif
   FilterXIRValue result = self->compile(self, jit);
 
   return fx_jit_emit_expr_make_typed_object(jit, self, result);

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -24,6 +24,7 @@
 #include "filterx/filterx-eval.h"
 #include "filterx/filterx-config.h"
 #include "filterx/filterx-scope-var-layout.h"
+#include "filterx/filterx-type-inference.h"
 #include "filterx/jit/jit.h"
 #include "stats/stats-registry.h"
 
@@ -76,6 +77,8 @@ log_filterx_pipe_init(LogPipe *s)
   filterx_eval_begin_compile(&compile_context, cfg);
   self->block = filterx_expr_optimize(self->block);
   filterx_eval_end_compile(&compile_context);
+
+  filterx_expr_infer_types_root(self->block);
 
   if (!filterx_expr_init(self->block, cfg))
     return FALSE;

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -78,7 +78,7 @@ log_filterx_pipe_init(LogPipe *s)
   self->block = filterx_expr_optimize(self->block);
   filterx_eval_end_compile(&compile_context);
 
-  filterx_expr_infer_types_root(self->block);
+  filterx_expr_infer_types_root_persistent(self->block, filterx_config_get(cfg)->persistent_type_env);
 
   if (!filterx_expr_init(self->block, cfg))
     return FALSE;

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -98,7 +98,7 @@ log_filterx_pipe_init(LogPipe *s)
 #if SYSLOG_NG_ENABLE_JIT
   /* Only the JIT consumes the inferred types, and the per-expression hooks are compiled out
    * without it — running the pass here would walk the whole tree to produce nothing. */
-  filterx_expr_infer_types_root(self->block);
+  filterx_expr_infer_types_root_persistent(self->block, filterx_config_get(cfg)->persistent_type_env);
 #endif
 
   return success;

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -35,6 +35,8 @@ typedef struct _LogFilterXPipe
   FilterXExpr *block;
   FilterXScopeVariableLayout *scope_var_layout;
   FilterXJITExecFunc jit_exec;
+  /* set by _infer_block_types(), asserted by _compile_block() */
+  gboolean types_inferred;
 } LogFilterXPipe;
 
 static inline const gchar *
@@ -52,6 +54,11 @@ _compile_block(LogFilterXPipe *self, GlobalConfig *cfg)
   if (!jit)
     return;
 
+  /* Codegen reads FilterXExpr::static_type to choose between a devirtualized helper and the
+   * generic fallback; an un-inferred tree reads as UNKNOWN everywhere and compiles to a correct
+   * but fully generic block.  Keep the ordering an invariant rather than a comment. */
+  g_assert(self->types_inferred);
+
   if (!filterx_expr_can_compile(self->block))
     return;
 
@@ -64,6 +71,30 @@ _compile_block(LogFilterXPipe *self, GlobalConfig *cfg)
   filterx_jit_ir_finish_current_block(jit, result);
 }
 
+/* Give every expression in the tree its static type.  The placement is load bearing:
+ *
+ *  - after filterx_expr_optimize(), which hands back replacement nodes (constant folding returns
+ *    fresh literal exprs), so a type written before folding would sit on a discarded node.  This
+ *    is the order lib/filterx/tests/test_type_inference.c codifies;
+ *  - before _compile_block(), because every compile() hook picks its devirtualized helper from
+ *    FilterXExpr::static_type.  On an un-inferred tree every node still holds
+ *    INITIAL_FILTERX_STATIC_TYPE_SPEC, so the whole block compiles to the generic fallbacks:
+ *    correct code, silently unoptimized.  Inference is codegen's precondition, not a pass that
+ *    happens to run nearby.
+ *
+ * Deliberately not gated on filterx_expr_can_compile() nor on ->jit: a block that is never
+ * compiled must still contribute its writes to persistent_type_env, otherwise a later block keeps
+ * believing a type this one invalidated.  Only the JIT reads static types and the per-expression
+ * infer_types hooks are compiled out without it, so a non-JIT build must not pay for the walk. */
+static void
+_infer_block_types(LogFilterXPipe *self, GlobalConfig *cfg G_GNUC_UNUSED)
+{
+#if SYSLOG_NG_ENABLE_JIT
+  filterx_expr_infer_types_root_persistent(self->block, filterx_config_get(cfg)->persistent_type_env);
+#endif
+  self->types_inferred = TRUE;
+}
+
 static gboolean
 _initialize_block(LogFilterXPipe *self, FilterXEvalContext *compile_context)
 {
@@ -72,6 +103,8 @@ _initialize_block(LogFilterXPipe *self, FilterXEvalContext *compile_context)
 
   if (!filterx_expr_init(self->block, cfg))
     return FALSE;
+
+  _infer_block_types(self, cfg);
   self->scope_var_layout = filterx_scope_variable_layout_new(self->block);
   _compile_block(self, cfg);
   return TRUE;
@@ -94,12 +127,6 @@ log_filterx_pipe_init(LogPipe *s)
     filterx_eval_dump_errors("FILTERX ERROR");
 
   filterx_eval_end_compile(&compile_context);
-
-#if SYSLOG_NG_ENABLE_JIT
-  /* Only the JIT consumes the inferred types, and the per-expression hooks are compiled out
-   * without it — running the pass here would walk the whole tree to produce nothing. */
-  filterx_expr_infer_types_root_persistent(self->block, filterx_config_get(cfg)->persistent_type_env);
-#endif
 
   return success;
 }

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -95,7 +95,11 @@ log_filterx_pipe_init(LogPipe *s)
 
   filterx_eval_end_compile(&compile_context);
 
+#if SYSLOG_NG_ENABLE_JIT
+  /* Only the JIT consumes the inferred types, and the per-expression hooks are compiled out
+   * without it — running the pass here would walk the whole tree to produce nothing. */
   filterx_expr_infer_types_root(self->block);
+#endif
 
   return success;
 }

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -24,6 +24,7 @@
 #include "filterx/filterx-eval.h"
 #include "filterx/filterx-config.h"
 #include "filterx/filterx-scope-var-layout.h"
+#include "filterx/filterx-type-inference.h"
 #include "filterx/jit/jit.h"
 #include "stats/stats-registry.h"
 
@@ -93,6 +94,9 @@ log_filterx_pipe_init(LogPipe *s)
     filterx_eval_dump_errors("FILTERX ERROR");
 
   filterx_eval_end_compile(&compile_context);
+
+  filterx_expr_infer_types_root(self->block);
+
   return success;
 }
 

--- a/lib/filterx/filterx-ref.c
+++ b/lib/filterx/filterx-ref.c
@@ -600,6 +600,12 @@ _filterx_ref_new(FilterXObject *value)
   return &self->super;
 }
 
+FilterXObject *
+filterx_ref_float_shared_child(FilterXObject *s, FilterXObject *c)
+{
+  return _filterx_ref_replace_shared_xref_with_a_floating_one(s, c);
+}
+
 FILTERX_DEFINE_TYPE(ref, FILTERX_TYPE_NAME(object),
                     .is_mutable = TRUE,
                     .marshal = _filterx_ref_marshal,

--- a/lib/filterx/filterx-ref.h
+++ b/lib/filterx/filterx-ref.h
@@ -172,4 +172,12 @@ filterx_ref_ground(FilterXObject *s)
 FilterXObject *filterx_ref_dup(FilterXObject *s);
 FilterXObject *_filterx_ref_new(FilterXObject *value);
 
+/* Given a child @s just read out of @c's underlying container, replace a shared child
+ * xref with a floating one parented to @c so that a later mutation triggers copy-on-write
+ * up the chain. This is the COW-critical step of the ref's getattr/get_subscript vtable;
+ * the JIT-devirtualized dict/list read fast paths must call it after a raw (ref-bypassing)
+ * lookup to preserve copy-on-write. @c must be a FilterXRef; @s may be any object (non-ref
+ * children are returned unchanged). */
+FilterXObject *filterx_ref_float_shared_child(FilterXObject *s, FilterXObject *c);
+
 #endif

--- a/lib/filterx/filterx-scope-var-layout.c
+++ b/lib/filterx/filterx-scope-var-layout.c
@@ -35,7 +35,9 @@ _collect_variable(FilterXExpr *expr, LayoutBuilder *b)
   if (filterx_variable_expr_is_macro(expr))
     return;
 
-  FilterXVariableHandle handle = filterx_variable_expr_get_handle(expr);
+  FilterXVariableHandle handle;
+
+  filterx_variable_expr_get_handle(expr, &handle);
   g_hash_table_add(b->handles_seen, GUINT_TO_POINTER((guint) handle));
   g_ptr_array_add(b->exprs, expr);
 }
@@ -89,11 +91,13 @@ _build_layout(FilterXScopeVariableLayout *self, LayoutBuilder *b)
                           GINT_TO_POINTER((gint) idx));
     }
 
+  FilterXVariableHandle handle;
+
   for (gint j = 0; j < b->exprs->len; j++)
     {
       FilterXExpr *expr = g_ptr_array_index(b->exprs, j);
       g_assert(filterx_expr_is_variable(expr));
-      FilterXVariableHandle handle = filterx_variable_expr_get_handle(expr);
+      filterx_variable_expr_get_handle(expr, &handle);
       gpointer idx = g_hash_table_lookup(handle_to_idx, GUINT_TO_POINTER((guint) handle));
 
       filterx_variable_expr_set_scope_var_idx(expr, GPOINTER_TO_INT(idx));

--- a/lib/filterx/filterx-type-inference.c
+++ b/lib/filterx/filterx-type-inference.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/filterx-type-inference.h"
+#include "filterx/filterx-expr.h"
+
+/* The canonical "no information" spec. It is the single representation of UNKNOWN: specs are
+ * never NULL. Its element points at itself, so it terminates every element chain and survives
+ * any depth walk. */
+const struct _FilterXStaticTypeNode FILTERX_STATIC_TYPE_UNKNOWN_NODE =
+{
+  .kind    = FILTERX_STATIC_TYPE_UNKNOWN,
+  .element = &FILTERX_STATIC_TYPE_UNKNOWN_NODE,
+};
+
+struct _FilterXTypeEnv
+{
+  /* Placeholder: the type environment is wired up by a later change. */
+  gint dummy;
+};
+
+/* Placeholder: container freezing is implemented by a later change. */
+FilterXStaticTypeSpec
+filterx_static_type_make_container(FilterXStaticType kind, FilterXStaticTypeSpec element)
+{
+  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+}
+
+/* Placeholder: kind freezing is implemented by a later change. */
+FilterXStaticTypeSpec
+filterx_static_type_kind_only(FilterXStaticType kind)
+{
+  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+}
+
+/* Placeholder: the per-level meet lattice is implemented by a later change. */
+FilterXStaticTypeSpec
+filterx_static_type_spec_meet(FilterXStaticTypeSpec a, FilterXStaticTypeSpec b)
+{
+  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+}
+
+FilterXTypeEnv *
+filterx_type_env_new(void)
+{
+  return g_new0(FilterXTypeEnv, 1);
+}
+
+FilterXTypeEnv *
+filterx_type_env_clone(const FilterXTypeEnv *self)
+{
+  return g_new0(FilterXTypeEnv, 1);
+}
+
+void
+filterx_type_env_free(FilterXTypeEnv *self)
+{
+  g_free(self);
+}
+
+/* Placeholder: variable type lookup is implemented by a later change. */
+FilterXStaticTypeSpec
+filterx_type_env_get(const FilterXTypeEnv *self, FilterXVariableHandle handle)
+{
+  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+}
+
+/* Placeholder: variable type recording is implemented by a later change. */
+void
+filterx_type_env_set(FilterXTypeEnv *self, FilterXVariableHandle handle, FilterXStaticTypeSpec spec)
+{
+}
+
+/* Placeholder: branch-join meet is implemented by a later change. */
+void
+filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src)
+{
+}
+
+void
+filterx_expr_infer_types(FilterXExpr *self, FilterXTypeEnv *env)
+{
+  if (!self)
+    return;
+
+  if (self->infer_types)
+    self->infer_types(self, env);
+  else
+    filterx_expr_infer_types_default(self, env);
+}
+
+void
+filterx_expr_infer_types_root(FilterXExpr *root)
+{
+  if (!root)
+    return;
+  FilterXTypeEnv *env = filterx_type_env_new();
+  filterx_expr_infer_types(root, env);
+  filterx_type_env_free(env);
+}

--- a/lib/filterx/filterx-type-inference.c
+++ b/lib/filterx/filterx-type-inference.c
@@ -22,24 +22,32 @@
 
 #include "filterx/filterx-type-inference.h"
 #include "filterx/filterx-expr.h"
+#include "filterx/expr-variable.h"
+#include "filterx/expr-getattr.h"
+#include "filterx/expr-get-subscript.h"
 
 /* The canonical "no information" spec. It lives outside the pool (it has no concrete kind to
- * key on) and is the single representation of UNKNOWN: specs are never NULL. Its element points
- * at itself, so it terminates every element chain and survives any depth walk. */
+ * key on) and is the single representation of UNKNOWN: specs are never NULL. Its element and
+ * sanitized point at itself, so it terminates every element chain and survives any depth walk. */
 const struct _FilterXStaticTypeNode FILTERX_STATIC_TYPE_UNKNOWN_NODE =
 {
-  .kind    = FILTERX_STATIC_TYPE_UNKNOWN,
-  .element = &FILTERX_STATIC_TYPE_UNKNOWN_NODE,
+  .kind      = FILTERX_STATIC_TYPE_UNKNOWN,
+  .element   = &FILTERX_STATIC_TYPE_UNKNOWN_NODE,
+  .sanitized = &FILTERX_STATIC_TYPE_UNKNOWN_NODE,
 };
 
 /* --- Frozen type-chain pool ----------------------------------------------------------
  *
  * FilterXStaticTypeSpec is a pointer to an immutable, hash-consed chain node. The pool below
  * is the single owner of every node; it is process-global and never torn down. The set of
- * distinct chains a config produces is tiny and deduplicated here (and across reloads), so a
- * spec cached on an expression stays valid for the whole life of the expression. Freezing
- * is only exercised during config init (not a hot path) and is guarded by a recursive mutex;
- * reads of an already-frozen node (kind/element) are lock-free, as nodes are immutable. */
+ * distinct chains a config produces is tiny and is deduplicated here (and across reloads),
+ * so the memory is bounded and a spec stays valid for the whole life of any FilterXExpr that
+ * caches it — including at JIT-compile time, after the inference env is freed.
+ *
+ * The pool is guarded by a recursive mutex: freezing is only exercised during config init
+ * (single-threaded in practice), and computing a node's sanitized form re-enters _get_or_create_frozen_type_spec().
+ * Reads of an already-frozen node (kind/element/sanitized) are lock-free: nodes are
+ * immutable once _get_or_create_frozen_type_spec() returns them. */
 static GRecMutex type_pool_lock;
 static GHashTable *type_pool; /* set of struct _FilterXStaticTypeNode*, keyed by (kind, element) */
 
@@ -70,7 +78,7 @@ _get_or_create_frozen_type_spec(FilterXStaticType kind, FilterXStaticTypeSpec el
   if (!type_pool)
     type_pool = g_hash_table_new(_node_hash, _node_equal);
 
-  struct _FilterXStaticTypeNode probe = { .kind = kind, .element = element };
+  struct _FilterXStaticTypeNode probe = { .kind = kind, .element = element, .sanitized = NULL };
   FilterXStaticTypeSpec existing = g_hash_table_lookup(type_pool, &probe);
   if (existing)
     {
@@ -82,6 +90,15 @@ _get_or_create_frozen_type_spec(FilterXStaticType kind, FilterXStaticTypeSpec el
   node->kind = kind;
   node->element = element;
   g_hash_table_insert(type_pool, node, node);
+
+  /* Precompute the sanitized form (chain truncated at the first FRESH level) so that
+   * filterx_static_type_sanitize()/element() are plain pointer reads at consumer time. */
+  if (kind == FILTERX_STATIC_TYPE_FRESH)
+    node->sanitized = FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  else if (element->sanitized == element)
+    node->sanitized = node;                                /* no FRESH at/below this level (incl. UNKNOWN-terminated) */
+  else
+    node->sanitized = _get_or_create_frozen_type_spec(kind, element->sanitized);   /* drop the FRESH-tainted tail */
 
   g_rec_mutex_unlock(&type_pool_lock);
   return node;
@@ -117,6 +134,11 @@ struct _FilterXTypeEnv
    * node pointer, borrowed from the global pool). Absence is equivalent to all-UNKNOWN, so we
    * never store the UNKNOWN singleton; reads normalize the GLib NULL-for-absent back to it. */
   GHashTable *handle_to_spec;
+  /* Per-key attribute type tracking for chained variable.k0.k1...key accesses.
+   * key: heap-allocated "handle:key0:key1..." string; value: FilterXStaticTypeSpec (borrowed).
+   * Tracks heterogeneous-field dicts (e.g. log.observed_time → INTEGER, log.severity_text →
+   * STRING) where the container element type would otherwise smear to UNKNOWN. */
+  GHashTable *attr_to_spec;
 };
 
 FilterXTypeEnv *
@@ -124,6 +146,7 @@ filterx_type_env_new(void)
 {
   FilterXTypeEnv *self = g_new0(FilterXTypeEnv, 1);
   self->handle_to_spec = g_hash_table_new(g_direct_hash, g_direct_equal);
+  self->attr_to_spec = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
   return self;
 }
 
@@ -138,6 +161,10 @@ filterx_type_env_clone(const FilterXTypeEnv *self)
   while (g_hash_table_iter_next(&iter, &k, &v))
     g_hash_table_insert(clone->handle_to_spec, k, v);
 
+  g_hash_table_iter_init(&iter, self->attr_to_spec);
+  while (g_hash_table_iter_next(&iter, &k, &v))
+    g_hash_table_insert(clone->attr_to_spec, g_strdup((const gchar *) k), v);
+
   return clone;
 }
 
@@ -147,6 +174,7 @@ filterx_type_env_free(FilterXTypeEnv *self)
   if (!self)
     return;
   g_hash_table_destroy(self->handle_to_spec);
+  g_hash_table_destroy(self->attr_to_spec);
   g_free(self);
 }
 
@@ -202,28 +230,37 @@ filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src)
   g_ptr_array_free(to_drop, TRUE);
   g_ptr_array_free(to_meet_keys, TRUE);
   g_ptr_array_free(to_meet_specs, TRUE);
-}
 
-/* Placeholder: per-key attribute chain lookup is implemented by a later change. */
-FilterXStaticTypeSpec
-filterx_type_env_get_attr_for_chain(const FilterXTypeEnv *self, FilterXExpr *chain_expr,
-                                    const gchar *key)
-{
-  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
-}
+  /* Also meet attr-to-spec entries: keys only in dst get dropped (source treats them as UNKNOWN). */
+  GPtrArray *attr_to_drop = g_ptr_array_new_with_free_func(g_free);
+  GPtrArray *attr_to_meet_keys = g_ptr_array_new_with_free_func(g_free);
+  GPtrArray *attr_to_meet_specs = g_ptr_array_new();
 
-/* Placeholder: per-key attribute chain recording is implemented by a later change. */
-void
-filterx_type_env_meet_attr_for_chain(FilterXTypeEnv *self, FilterXExpr *chain_expr,
-                                     const gchar *key, FilterXStaticTypeSpec spec)
-{
-}
+  g_hash_table_iter_init(&iter, dst->attr_to_spec);
+  while (g_hash_table_iter_next(&iter, &k, &v))
+    {
+      gpointer sv = g_hash_table_lookup(src->attr_to_spec, k);
+      FilterXStaticTypeSpec dst_spec = (FilterXStaticTypeSpec) v;
+      FilterXStaticTypeSpec src_spec = sv ? (FilterXStaticTypeSpec) sv : FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+      FilterXStaticTypeSpec met = filterx_static_type_spec_meet(dst_spec, src_spec);
+      if (met == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+        g_ptr_array_add(attr_to_drop, g_strdup((const gchar *) k));
+      else if (met != dst_spec)
+        {
+          g_ptr_array_add(attr_to_meet_keys, g_strdup((const gchar *) k));
+          g_ptr_array_add(attr_to_meet_specs, (gpointer) met);
+        }
+    }
 
-/* Placeholder: lift-on-write container refinement is implemented by a later change. */
-void
-filterx_type_env_update_on_write(FilterXTypeEnv *env, FilterXExpr *container_expr,
-                                 FilterXStaticTypeSpec value_spec)
-{
+  for (guint i = 0; i < attr_to_drop->len; i++)
+    g_hash_table_remove(dst->attr_to_spec, g_ptr_array_index(attr_to_drop, i));
+  for (guint i = 0; i < attr_to_meet_keys->len; i++)
+    g_hash_table_insert(dst->attr_to_spec,
+                        g_strdup((const gchar *) g_ptr_array_index(attr_to_meet_keys, i)),
+                        g_ptr_array_index(attr_to_meet_specs, i));
+  g_ptr_array_free(attr_to_drop, TRUE);
+  g_ptr_array_free(attr_to_meet_keys, TRUE);
+  g_ptr_array_free(attr_to_meet_specs, TRUE);
 }
 
 void
@@ -246,4 +283,176 @@ filterx_expr_infer_types_root(FilterXExpr *root)
   FilterXTypeEnv *env = filterx_type_env_new();
   filterx_expr_infer_types(root, env);
   filterx_type_env_free(env);
+}
+
+/* Walk a getattr/get_subscript chain down to its root variable, counting the number of
+ * hops. Returns FALSE if the chain does not bottom out at a trackable (non-macro) variable. */
+static gboolean
+_walk_to_root_variable(FilterXExpr *expr, FilterXVariableHandle *handle_out, gint *depth_out)
+{
+  gint depth = 0;
+  while (expr)
+    {
+      if (filterx_variable_expr_get_handle(expr, handle_out))
+        {
+          *depth_out = depth;
+          return TRUE;
+        }
+      if (filterx_expr_is_getattr(expr))
+        expr = filterx_getattr_get_operand(expr);
+      else if (filterx_expr_is_get_subscript(expr))
+        expr = filterx_get_subscript_get_operand(expr);
+      else
+        return FALSE;
+      depth++;
+    }
+  return FALSE;
+}
+
+/* Maximum getattr chain depth tracked in the attr-path map.
+ * Covers chains up to variable.k0.k1.k2.k3 (4 attribute hops from the root). */
+#define FILTERX_ATTR_CHAIN_MAX 4
+
+/* Walk a purely-getattr chain to its root variable, collecting attribute names
+ * top-down into keys_out[0..n_keys_out-1].  Returns FALSE for subscript hops,
+ * macro variables, or chains deeper than FILTERX_ATTR_CHAIN_MAX. */
+static gboolean
+_collect_attr_chain(FilterXExpr *expr, FilterXVariableHandle *handle_out,
+                    const gchar **keys_out, gint *n_keys_out)
+{
+  gint n = 0;
+  while (expr)
+    {
+      if (filterx_variable_expr_get_handle(expr, handle_out))
+        {
+          /* Keys were appended bottom-up; reverse to top-down. */
+          for (gint i = 0, j = n - 1; i < j; i++, j--)
+            {
+              const gchar *tmp = keys_out[i];
+              keys_out[i] = keys_out[j];
+              keys_out[j] = tmp;
+            }
+          *n_keys_out = n;
+          return TRUE;
+        }
+      if (!filterx_expr_is_getattr(expr) || n >= FILTERX_ATTR_CHAIN_MAX)
+        return FALSE;
+      keys_out[n++] = expr->name;   /* FilterXExpr::name holds the attr key for getattr nodes */
+      expr = filterx_getattr_get_operand(expr);
+    }
+  return FALSE;
+}
+
+/* Build the hash-table key string for a chained path.
+ * Format: "handle:key0:key1:...:keyN"  (n_keys entries after the handle). */
+static gchar *
+_attr_chain_key(FilterXVariableHandle handle, const gchar **keys, gint n_keys)
+{
+  GString *s = g_string_sized_new(64);
+  g_string_append_printf(s, "%u", (guint) handle);
+  for (gint i = 0; i < n_keys; i++)
+    {
+      g_string_append_c(s, ':');
+      g_string_append(s, keys[i]);
+    }
+  return g_string_free(s, FALSE);
+}
+
+/* Look up the type of <chain_expr>.<key> where chain_expr is a purely-getattr
+ * chain rooted at a non-macro variable.  Returns UNKNOWN if the path is not
+ * recorded or the chain is too deep. */
+FilterXStaticTypeSpec
+filterx_type_env_get_attr_for_chain(const FilterXTypeEnv *self, FilterXExpr *chain_expr,
+                                    const gchar *key)
+{
+  const gchar *keys[FILTERX_ATTR_CHAIN_MAX + 1];
+  gint n = 0;
+  FilterXVariableHandle handle;
+
+  if (!_collect_attr_chain(chain_expr, &handle, keys, &n) || n + 1 > FILTERX_ATTR_CHAIN_MAX + 1)
+    return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+
+  keys[n] = key;
+  gchar *k = _attr_chain_key(handle, keys, n + 1);
+  FilterXStaticTypeSpec v = (FilterXStaticTypeSpec) g_hash_table_lookup(self->attr_to_spec, k);
+  g_free(k);
+  /* Absent key (GLib NULL) is all-UNKNOWN; normalize before the (non-NULL) sanitize read. */
+  return filterx_static_type_sanitize(v ? v : FILTERX_STATIC_TYPE_UNKNOWN_SPEC);
+}
+
+/* Record that <chain_expr>.<key> = spec (using meet semantics for updates). */
+void
+filterx_type_env_meet_attr_for_chain(FilterXTypeEnv *self, FilterXExpr *chain_expr,
+                                     const gchar *key, FilterXStaticTypeSpec spec)
+{
+  if (spec == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+    return;
+
+  const gchar *keys[FILTERX_ATTR_CHAIN_MAX + 1];
+  gint n = 0;
+  FilterXVariableHandle handle;
+
+  if (!_collect_attr_chain(chain_expr, &handle, keys, &n) || n + 1 > FILTERX_ATTR_CHAIN_MAX + 1)
+    return;
+
+  keys[n] = key;
+  gchar *k = _attr_chain_key(handle, keys, n + 1);
+  FilterXStaticTypeSpec old = (FilterXStaticTypeSpec) g_hash_table_lookup(self->attr_to_spec, k);
+  FilterXStaticTypeSpec merged = (!old) ? spec : filterx_static_type_spec_meet(old, spec);
+  if (merged == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+    {
+      g_hash_table_remove(self->attr_to_spec, k);
+      g_free(k);
+    }
+  else if (merged != old)
+    g_hash_table_insert(self->attr_to_spec, k, (gpointer) merged);
+  else
+    g_free(k);
+}
+
+/* Follow the element chain @depth levels down. Walking past the end stays on the UNKNOWN
+ * singleton (its element is itself), so a too-short chain yields UNKNOWN. */
+static FilterXStaticTypeSpec
+_node_at_depth(FilterXStaticTypeSpec spec, gint depth)
+{
+  for (gint i = 0; i < depth; i++)
+    spec = spec->element;
+  return spec;
+}
+
+/* Rebuild @spec with the subchain at @depth replaced by @newtail, re-freezing the kept
+ * prefix. @spec is guaranteed non-NULL down to @depth by the caller. */
+static FilterXStaticTypeSpec
+_set_at_depth(FilterXStaticTypeSpec spec, gint depth, FilterXStaticTypeSpec newtail)
+{
+  if (depth == 0)
+    return newtail;
+  return filterx_static_type_make_container(spec->kind,
+                                            _set_at_depth(spec->element, depth - 1, newtail));
+}
+
+void
+filterx_type_env_update_on_write(FilterXTypeEnv *env, FilterXExpr *container_expr,
+                                 FilterXStaticTypeSpec value_spec)
+{
+  FilterXVariableHandle handle;
+  gint depth;
+  if (!_walk_to_root_variable(container_expr, &handle, &depth))
+    return;
+
+  /* The written value lands one level below the container we wrote into. */
+  gint level = depth + 1;
+
+  FilterXStaticTypeSpec old = filterx_type_env_get(env, handle);
+  FilterXStaticTypeSpec suffix = _node_at_depth(old, level);
+  if (suffix == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+    return;   /* UNKNOWN at the written level: no committed type to refine from */
+
+  FilterXStaticTypeSpec newtail;
+  if (suffix->kind == FILTERX_STATIC_TYPE_FRESH)
+    newtail = value_spec;                                         /* lift: commit to the written type */
+  else
+    newtail = filterx_static_type_spec_meet(suffix, value_spec);  /* meet with the committed type */
+
+  filterx_type_env_set(env, handle, _set_at_depth(old, level, newtail));
 }

--- a/lib/filterx/filterx-type-inference.c
+++ b/lib/filterx/filterx-type-inference.c
@@ -23,77 +23,185 @@
 #include "filterx/filterx-type-inference.h"
 #include "filterx/filterx-expr.h"
 
-/* The canonical "no information" spec. It is the single representation of UNKNOWN: specs are
- * never NULL. Its element points at itself, so it terminates every element chain and survives
- * any depth walk. */
+/* The canonical "no information" spec. It lives outside the pool (it has no concrete kind to
+ * key on) and is the single representation of UNKNOWN: specs are never NULL. Its element points
+ * at itself, so it terminates every element chain and survives any depth walk. */
 const struct _FilterXStaticTypeNode FILTERX_STATIC_TYPE_UNKNOWN_NODE =
 {
   .kind    = FILTERX_STATIC_TYPE_UNKNOWN,
   .element = &FILTERX_STATIC_TYPE_UNKNOWN_NODE,
 };
 
-struct _FilterXTypeEnv
-{
-  /* Placeholder: the type environment is wired up by a later change. */
-  gint dummy;
-};
+/* --- Frozen type-chain pool ----------------------------------------------------------
+ *
+ * FilterXStaticTypeSpec is a pointer to an immutable, hash-consed chain node. The pool below
+ * is the single owner of every node; it is process-global and never torn down. The set of
+ * distinct chains a config produces is tiny and deduplicated here (and across reloads), so a
+ * spec cached on an expression stays valid for the whole life of the expression. Freezing
+ * is only exercised during config init (not a hot path) and is guarded by a recursive mutex;
+ * reads of an already-frozen node (kind/element) are lock-free, as nodes are immutable. */
+static GRecMutex type_pool_lock;
+static GHashTable *type_pool; /* set of struct _FilterXStaticTypeNode*, keyed by (kind, element) */
 
-/* Placeholder: container freezing is implemented by a later change. */
+static guint
+_node_hash(gconstpointer p)
+{
+  const struct _FilterXStaticTypeNode *n = p;
+  return ((guint) n->kind) ^ (g_direct_hash(n->element) * 2654435761u);
+}
+
+static gboolean
+_node_equal(gconstpointer a, gconstpointer b)
+{
+  const struct _FilterXStaticTypeNode *na = a, *nb = b;
+  return na->kind == nb->kind && na->element == nb->element;
+}
+
+/* Return the canonical node for {kind, element}, allocating it on first sight. UNKNOWN maps
+ * to the canonical unknown singleton. @element must already be frozen (and is never NULL). */
+static FilterXStaticTypeSpec
+_get_or_create_frozen_type_spec(FilterXStaticType kind, FilterXStaticTypeSpec element)
+{
+  if (kind == FILTERX_STATIC_TYPE_UNKNOWN)
+    return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+
+  g_rec_mutex_lock(&type_pool_lock);
+
+  if (!type_pool)
+    type_pool = g_hash_table_new(_node_hash, _node_equal);
+
+  struct _FilterXStaticTypeNode probe = { .kind = kind, .element = element };
+  FilterXStaticTypeSpec existing = g_hash_table_lookup(type_pool, &probe);
+  if (existing)
+    {
+      g_rec_mutex_unlock(&type_pool_lock);
+      return existing;
+    }
+
+  struct _FilterXStaticTypeNode *node = g_new0(struct _FilterXStaticTypeNode, 1);
+  node->kind = kind;
+  node->element = element;
+  g_hash_table_insert(type_pool, node, node);
+
+  g_rec_mutex_unlock(&type_pool_lock);
+  return node;
+}
+
 FilterXStaticTypeSpec
 filterx_static_type_make_container(FilterXStaticType kind, FilterXStaticTypeSpec element)
 {
-  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  return _get_or_create_frozen_type_spec(kind, element);
 }
 
-/* Placeholder: kind freezing is implemented by a later change. */
 FilterXStaticTypeSpec
 filterx_static_type_kind_only(FilterXStaticType kind)
 {
-  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  return _get_or_create_frozen_type_spec(kind, FILTERX_STATIC_TYPE_UNKNOWN_SPEC);
 }
 
-/* Placeholder: the per-level meet lattice is implemented by a later change. */
 FilterXStaticTypeSpec
 filterx_static_type_spec_meet(FilterXStaticTypeSpec a, FilterXStaticTypeSpec b)
 {
-  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  /* Longest common prefix where kinds agree; diverging or UNKNOWN levels (and everything
+   * below) collapse to UNKNOWN. Frozen, so the result is comparable by pointer identity. */
+  if (a == b)
+    return a;                                              /* covers UNKNOWN == UNKNOWN */
+  if (a->kind != b->kind)
+    return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;               /* UNKNOWN-vs-anything diverges here too */
+  return filterx_static_type_make_container(a->kind, filterx_static_type_spec_meet(a->element, b->element));
 }
+
+struct _FilterXTypeEnv
+{
+  /* key: FilterXVariableHandle via GUINT_TO_POINTER; value: FilterXStaticTypeSpec (frozen
+   * node pointer, borrowed from the global pool). Absence is equivalent to all-UNKNOWN, so we
+   * never store the UNKNOWN singleton; reads normalize the GLib NULL-for-absent back to it. */
+  GHashTable *handle_to_spec;
+};
 
 FilterXTypeEnv *
 filterx_type_env_new(void)
 {
-  return g_new0(FilterXTypeEnv, 1);
+  FilterXTypeEnv *self = g_new0(FilterXTypeEnv, 1);
+  self->handle_to_spec = g_hash_table_new(g_direct_hash, g_direct_equal);
+  return self;
 }
 
 FilterXTypeEnv *
 filterx_type_env_clone(const FilterXTypeEnv *self)
 {
-  return g_new0(FilterXTypeEnv, 1);
+  FilterXTypeEnv *clone = filterx_type_env_new();
+  GHashTableIter iter;
+  gpointer k, v;
+
+  g_hash_table_iter_init(&iter, self->handle_to_spec);
+  while (g_hash_table_iter_next(&iter, &k, &v))
+    g_hash_table_insert(clone->handle_to_spec, k, v);
+
+  return clone;
 }
 
 void
 filterx_type_env_free(FilterXTypeEnv *self)
 {
+  if (!self)
+    return;
+  g_hash_table_destroy(self->handle_to_spec);
   g_free(self);
 }
 
-/* Placeholder: variable type lookup is implemented by a later change. */
 FilterXStaticTypeSpec
 filterx_type_env_get(const FilterXTypeEnv *self, FilterXVariableHandle handle)
 {
-  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  /* Absent key (GLib NULL) is the all-UNKNOWN default; normalize it to the unknown singleton. */
+  FilterXStaticTypeSpec spec = (FilterXStaticTypeSpec) g_hash_table_lookup(self->handle_to_spec,
+                               GUINT_TO_POINTER(handle));
+  return spec ? spec : FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
 }
 
-/* Placeholder: variable type recording is implemented by a later change. */
 void
 filterx_type_env_set(FilterXTypeEnv *self, FilterXVariableHandle handle, FilterXStaticTypeSpec spec)
 {
+  /* UNKNOWN is the absent-key default, so we never store it — drop the entry instead. */
+  if (spec == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+    g_hash_table_remove(self->handle_to_spec, GUINT_TO_POINTER(handle));
+  else
+    g_hash_table_insert(self->handle_to_spec, GUINT_TO_POINTER(handle), (gpointer) spec);
 }
 
-/* Placeholder: branch-join meet is implemented by a later change. */
 void
 filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src)
 {
+  GHashTableIter iter;
+  gpointer k, v;
+  GPtrArray *to_drop = g_ptr_array_new();
+  GPtrArray *to_meet_keys = g_ptr_array_new();
+  GPtrArray *to_meet_specs = g_ptr_array_new();
+
+  g_hash_table_iter_init(&iter, dst->handle_to_spec);
+  while (g_hash_table_iter_next(&iter, &k, &v))
+    {
+      gpointer sv = g_hash_table_lookup(src->handle_to_spec, k);
+      FilterXStaticTypeSpec dst_spec = (FilterXStaticTypeSpec) v;
+      FilterXStaticTypeSpec src_spec = sv ? (FilterXStaticTypeSpec) sv : FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+      FilterXStaticTypeSpec met = filterx_static_type_spec_meet(dst_spec, src_spec);
+      if (met == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+        g_ptr_array_add(to_drop, k);
+      else if (met != dst_spec)
+        {
+          g_ptr_array_add(to_meet_keys, k);
+          g_ptr_array_add(to_meet_specs, (gpointer) met);
+        }
+    }
+
+  for (guint i = 0; i < to_drop->len; i++)
+    g_hash_table_remove(dst->handle_to_spec, g_ptr_array_index(to_drop, i));
+  for (guint i = 0; i < to_meet_keys->len; i++)
+    g_hash_table_insert(dst->handle_to_spec, g_ptr_array_index(to_meet_keys, i),
+                        g_ptr_array_index(to_meet_specs, i));
+  g_ptr_array_free(to_drop, TRUE);
+  g_ptr_array_free(to_meet_keys, TRUE);
+  g_ptr_array_free(to_meet_specs, TRUE);
 }
 
 void

--- a/lib/filterx/filterx-type-inference.c
+++ b/lib/filterx/filterx-type-inference.c
@@ -264,6 +264,39 @@ filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src)
 }
 
 void
+filterx_type_env_propagate_to_persistent(FilterXTypeEnv *persistent, const FilterXTypeEnv *block_env)
+{
+  /* Add or meet every entry from block_env into persistent.
+   * Entries absent from persistent are added (new knowledge); present entries are met. */
+  GHashTableIter iter;
+  gpointer k, v;
+
+  g_hash_table_iter_init(&iter, block_env->handle_to_spec);
+  while (g_hash_table_iter_next(&iter, &k, &v))
+    {
+      FilterXStaticTypeSpec new_spec = (FilterXStaticTypeSpec) v;
+      FilterXVariableHandle handle = (FilterXVariableHandle) GPOINTER_TO_UINT(k);
+      FilterXStaticTypeSpec old_spec = filterx_type_env_get(persistent, handle);
+      FilterXStaticTypeSpec merged = (old_spec == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+                                     ? new_spec : filterx_static_type_spec_meet(old_spec, new_spec);
+      filterx_type_env_set(persistent, handle, merged);
+    }
+
+  g_hash_table_iter_init(&iter, block_env->attr_to_spec);
+  while (g_hash_table_iter_next(&iter, &k, &v))
+    {
+      FilterXStaticTypeSpec new_spec = (FilterXStaticTypeSpec) v;
+      /* Raw lookup: GLib NULL means the key is absent (all-UNKNOWN). */
+      FilterXStaticTypeSpec old_spec = (FilterXStaticTypeSpec) g_hash_table_lookup(persistent->attr_to_spec, k);
+      FilterXStaticTypeSpec merged = old_spec ? filterx_static_type_spec_meet(old_spec, new_spec) : new_spec;
+      if (merged == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+        g_hash_table_remove(persistent->attr_to_spec, k);             /* demote to absent */
+      else if (merged != old_spec)
+        g_hash_table_insert(persistent->attr_to_spec, g_strdup((const gchar *) k), (gpointer) merged);
+    }
+}
+
+void
 filterx_expr_infer_types(FilterXExpr *self, FilterXTypeEnv *env)
 {
   if (!self)
@@ -282,6 +315,22 @@ filterx_expr_infer_types_root(FilterXExpr *root)
     return;
   FilterXTypeEnv *env = filterx_type_env_new();
   filterx_expr_infer_types(root, env);
+  filterx_type_env_free(env);
+}
+
+void
+filterx_expr_infer_types_root_persistent(FilterXExpr *root, FilterXTypeEnv *persistent_env)
+{
+  if (!root)
+    return;
+  if (!persistent_env)
+    {
+      filterx_expr_infer_types_root(root);
+      return;
+    }
+  FilterXTypeEnv *env = filterx_type_env_clone(persistent_env);
+  filterx_expr_infer_types(root, env);
+  filterx_type_env_propagate_to_persistent(persistent_env, env);
   filterx_type_env_free(env);
 }
 

--- a/lib/filterx/filterx-type-inference.c
+++ b/lib/filterx/filterx-type-inference.c
@@ -204,6 +204,28 @@ filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src)
   g_ptr_array_free(to_meet_specs, TRUE);
 }
 
+/* Placeholder: per-key attribute chain lookup is implemented by a later change. */
+FilterXStaticTypeSpec
+filterx_type_env_get_attr_for_chain(const FilterXTypeEnv *self, FilterXExpr *chain_expr,
+                                    const gchar *key)
+{
+  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+}
+
+/* Placeholder: per-key attribute chain recording is implemented by a later change. */
+void
+filterx_type_env_meet_attr_for_chain(FilterXTypeEnv *self, FilterXExpr *chain_expr,
+                                     const gchar *key, FilterXStaticTypeSpec spec)
+{
+}
+
+/* Placeholder: lift-on-write container refinement is implemented by a later change. */
+void
+filterx_type_env_update_on_write(FilterXTypeEnv *env, FilterXExpr *container_expr,
+                                 FilterXStaticTypeSpec value_spec)
+{
+}
+
 void
 filterx_expr_infer_types(FilterXExpr *self, FilterXTypeEnv *env)
 {

--- a/lib/filterx/filterx-type-inference.c
+++ b/lib/filterx/filterx-type-inference.c
@@ -359,8 +359,8 @@ _walk_to_root_variable(FilterXExpr *expr, FilterXVariableHandle *handle_out, gin
 }
 
 /* Maximum getattr chain depth tracked in the attr-path map.
- * Covers chains up to variable.k0.k1.k2.k3 (4 attribute hops from the root). */
-#define FILTERX_ATTR_CHAIN_MAX 4
+ * Covers chains up to variable.k0.k1.k2.k3...k15 (16 attribute hops from the root). */
+#define FILTERX_ATTR_CHAIN_MAX 16
 
 /* Walk a purely-getattr chain to its root variable, collecting attribute names
  * top-down into keys_out[0..n_keys_out-1].  Returns FALSE for subscript hops,

--- a/lib/filterx/filterx-type-inference.c
+++ b/lib/filterx/filterx-type-inference.c
@@ -204,6 +204,28 @@ filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src)
   g_ptr_array_free(to_meet_specs, TRUE);
 }
 
+/* Placeholder: per-key attribute chain lookup is implemented by a later change. */
+FilterXStaticTypeSpec
+filterx_type_spec_get_attr_for_chain(const FilterXTypeEnv *self, FilterXExpr *chain_expr,
+                                     const gchar *key)
+{
+  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+}
+
+/* Placeholder: per-key attribute chain recording is implemented by a later change. */
+void
+filterx_type_env_meet_attr_for_chain(FilterXTypeEnv *self, FilterXExpr *chain_expr,
+                                     const gchar *key, FilterXStaticTypeSpec spec)
+{
+}
+
+/* Placeholder: lift-on-write container refinement is implemented by a later change. */
+void
+filterx_type_env_update_on_write(FilterXTypeEnv *env, FilterXExpr *container_expr,
+                                 FilterXStaticTypeSpec value_spec)
+{
+}
+
 void
 filterx_expr_infer_types(FilterXExpr *self, FilterXTypeEnv *env)
 {

--- a/lib/filterx/filterx-type-inference.c
+++ b/lib/filterx/filterx-type-inference.c
@@ -266,6 +266,39 @@ filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src)
 }
 
 void
+filterx_type_env_propagate_to_persistent(FilterXTypeEnv *persistent, const FilterXTypeEnv *block_env)
+{
+  /* Add or meet every entry from block_env into persistent.
+   * Entries absent from persistent are added (new knowledge); present entries are met. */
+  GHashTableIter iter;
+  gpointer k, v;
+
+  g_hash_table_iter_init(&iter, block_env->handle_to_spec);
+  while (g_hash_table_iter_next(&iter, &k, &v))
+    {
+      FilterXStaticTypeSpec new_spec = (FilterXStaticTypeSpec) v;
+      FilterXVariableHandle handle = (FilterXVariableHandle) GPOINTER_TO_UINT(k);
+      FilterXStaticTypeSpec old_spec = filterx_type_spec_get(persistent, handle);
+      FilterXStaticTypeSpec merged = (old_spec == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+                                     ? new_spec : filterx_static_type_spec_meet(old_spec, new_spec);
+      filterx_type_spec_set(persistent, handle, merged);
+    }
+
+  g_hash_table_iter_init(&iter, block_env->attr_to_spec);
+  while (g_hash_table_iter_next(&iter, &k, &v))
+    {
+      FilterXStaticTypeSpec new_spec = (FilterXStaticTypeSpec) v;
+      /* Raw lookup: GLib NULL means the key is absent (all-UNKNOWN). */
+      FilterXStaticTypeSpec old_spec = (FilterXStaticTypeSpec) g_hash_table_lookup(persistent->attr_to_spec, k);
+      FilterXStaticTypeSpec merged = old_spec ? filterx_static_type_spec_meet(old_spec, new_spec) : new_spec;
+      if (merged == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+        g_hash_table_remove(persistent->attr_to_spec, k);             /* demote to absent */
+      else if (merged != old_spec)
+        g_hash_table_insert(persistent->attr_to_spec, g_strdup((const gchar *) k), (gpointer) merged);
+    }
+}
+
+void
 filterx_expr_infer_types(FilterXExpr *self, FilterXTypeEnv *env)
 {
 #if SYSLOG_NG_ENABLE_JIT
@@ -286,6 +319,22 @@ filterx_expr_infer_types_root(FilterXExpr *root)
     return;
   FilterXTypeEnv *env = filterx_type_env_new();
   filterx_expr_infer_types(root, env);
+  filterx_type_env_free(env);
+}
+
+void
+filterx_expr_infer_types_root_persistent(FilterXExpr *root, FilterXTypeEnv *persistent_env)
+{
+  if (!root)
+    return;
+  if (!persistent_env)
+    {
+      filterx_expr_infer_types_root(root);
+      return;
+    }
+  FilterXTypeEnv *env = filterx_type_env_clone(persistent_env);
+  filterx_expr_infer_types(root, env);
+  filterx_type_env_propagate_to_persistent(persistent_env, env);
   filterx_type_env_free(env);
 }
 

--- a/lib/filterx/filterx-type-inference.c
+++ b/lib/filterx/filterx-type-inference.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/filterx-type-inference.h"
+#include "filterx/filterx-expr.h"
+
+/* The canonical "no information" spec. It is the single representation of UNKNOWN: specs are
+ * never NULL. Its element points at itself, so it terminates every element chain and survives
+ * any depth walk. */
+const struct _FilterXStaticTypeNode FILTERX_STATIC_TYPE_UNKNOWN_NODE =
+{
+  .kind    = FILTERX_STATIC_TYPE_UNKNOWN,
+  .element = &FILTERX_STATIC_TYPE_UNKNOWN_NODE,
+};
+
+struct _FilterXTypeEnv
+{
+  /* Placeholder: the type environment is wired up by a later change. */
+  gint dummy;
+};
+
+/* Placeholder: container freezing is implemented by a later change. */
+FilterXStaticTypeSpec
+filterx_static_type_make_container(FilterXStaticType kind, FilterXStaticTypeSpec element)
+{
+  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+}
+
+/* Placeholder: kind freezing is implemented by a later change. */
+FilterXStaticTypeSpec
+filterx_static_type_kind_only(FilterXStaticType kind)
+{
+  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+}
+
+/* Placeholder: the per-level meet lattice is implemented by a later change. */
+FilterXStaticTypeSpec
+filterx_static_type_spec_meet(FilterXStaticTypeSpec a, FilterXStaticTypeSpec b)
+{
+  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+}
+
+FilterXTypeEnv *
+filterx_type_env_new(void)
+{
+  return g_new0(FilterXTypeEnv, 1);
+}
+
+FilterXTypeEnv *
+filterx_type_env_clone(const FilterXTypeEnv *self)
+{
+  return g_new0(FilterXTypeEnv, 1);
+}
+
+void
+filterx_type_env_free(FilterXTypeEnv *self)
+{
+  g_free(self);
+}
+
+/* Placeholder: variable type lookup is implemented by a later change. */
+FilterXStaticTypeSpec
+filterx_type_spec_get(const FilterXTypeEnv *self, FilterXVariableHandle handle)
+{
+  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+}
+
+/* Placeholder: variable type recording is implemented by a later change. */
+void
+filterx_type_spec_set(FilterXTypeEnv *self, FilterXVariableHandle handle, FilterXStaticTypeSpec spec)
+{
+}
+
+/* Placeholder: branch-join meet is implemented by a later change. */
+void
+filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src)
+{
+}
+
+void
+filterx_expr_infer_types(FilterXExpr *self, FilterXTypeEnv *env)
+{
+#if SYSLOG_NG_ENABLE_JIT
+  if (!self)
+    return;
+
+  if (self->infer_types)
+    self->infer_types(self, env);
+  else
+    filterx_expr_infer_types_default(self, env);
+#endif
+}
+
+void
+filterx_expr_infer_types_root(FilterXExpr *root)
+{
+  if (!root)
+    return;
+  FilterXTypeEnv *env = filterx_type_env_new();
+  filterx_expr_infer_types(root, env);
+  filterx_type_env_free(env);
+}

--- a/lib/filterx/filterx-type-inference.c
+++ b/lib/filterx/filterx-type-inference.c
@@ -309,6 +309,8 @@ filterx_expr_infer_types(FilterXExpr *self, FilterXTypeEnv *env)
     self->infer_types(self, env);
   else
     filterx_expr_infer_types_default(self, env);
+
+  self->types_inferred = TRUE;
 #endif
 }
 

--- a/lib/filterx/filterx-type-inference.c
+++ b/lib/filterx/filterx-type-inference.c
@@ -23,77 +23,185 @@
 #include "filterx/filterx-type-inference.h"
 #include "filterx/filterx-expr.h"
 
-/* The canonical "no information" spec. It is the single representation of UNKNOWN: specs are
- * never NULL. Its element points at itself, so it terminates every element chain and survives
- * any depth walk. */
+/* The canonical "no information" spec. It lives outside the pool (it has no concrete kind to
+ * key on) and is the single representation of UNKNOWN: specs are never NULL. Its element points
+ * at itself, so it terminates every element chain and survives any depth walk. */
 const struct _FilterXStaticTypeNode FILTERX_STATIC_TYPE_UNKNOWN_NODE =
 {
   .kind    = FILTERX_STATIC_TYPE_UNKNOWN,
   .element = &FILTERX_STATIC_TYPE_UNKNOWN_NODE,
 };
 
-struct _FilterXTypeEnv
-{
-  /* Placeholder: the type environment is wired up by a later change. */
-  gint dummy;
-};
+/* --- Frozen type-chain pool ----------------------------------------------------------
+ *
+ * FilterXStaticTypeSpec is a pointer to an immutable, hash-consed chain node. The pool below
+ * is the single owner of every node; it is process-global and never torn down. The set of
+ * distinct chains a config produces is tiny and deduplicated here (and across reloads), so a
+ * spec cached on an expression stays valid for the whole life of the expression. Freezing
+ * is only exercised during config init (not a hot path) and is guarded by a recursive mutex;
+ * reads of an already-frozen node (kind/element) are lock-free, as nodes are immutable. */
+static GRecMutex type_pool_lock;
+static GHashTable *type_pool; /* set of struct _FilterXStaticTypeNode*, keyed by (kind, element) */
 
-/* Placeholder: container freezing is implemented by a later change. */
+static guint
+_node_hash(gconstpointer p)
+{
+  const struct _FilterXStaticTypeNode *n = p;
+  return ((guint) n->kind) ^ (g_direct_hash(n->element) * 2654435761u);
+}
+
+static gboolean
+_node_equal(gconstpointer a, gconstpointer b)
+{
+  const struct _FilterXStaticTypeNode *na = a, *nb = b;
+  return na->kind == nb->kind && na->element == nb->element;
+}
+
+/* Return the canonical node for {kind, element}, allocating it on first sight. UNKNOWN maps
+ * to the canonical unknown singleton. @element must already be frozen (and is never NULL). */
+static FilterXStaticTypeSpec
+_get_or_create_frozen_type_spec(FilterXStaticType kind, FilterXStaticTypeSpec element)
+{
+  if (kind == FILTERX_STATIC_TYPE_UNKNOWN)
+    return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+
+  g_rec_mutex_lock(&type_pool_lock);
+
+  if (!type_pool)
+    type_pool = g_hash_table_new(_node_hash, _node_equal);
+
+  struct _FilterXStaticTypeNode probe = { .kind = kind, .element = element };
+  FilterXStaticTypeSpec existing = g_hash_table_lookup(type_pool, &probe);
+  if (existing)
+    {
+      g_rec_mutex_unlock(&type_pool_lock);
+      return existing;
+    }
+
+  struct _FilterXStaticTypeNode *node = g_new0(struct _FilterXStaticTypeNode, 1);
+  node->kind = kind;
+  node->element = element;
+  g_hash_table_insert(type_pool, node, node);
+
+  g_rec_mutex_unlock(&type_pool_lock);
+  return node;
+}
+
 FilterXStaticTypeSpec
 filterx_static_type_make_container(FilterXStaticType kind, FilterXStaticTypeSpec element)
 {
-  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  return _get_or_create_frozen_type_spec(kind, element);
 }
 
-/* Placeholder: kind freezing is implemented by a later change. */
 FilterXStaticTypeSpec
 filterx_static_type_kind_only(FilterXStaticType kind)
 {
-  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  return _get_or_create_frozen_type_spec(kind, FILTERX_STATIC_TYPE_UNKNOWN_SPEC);
 }
 
-/* Placeholder: the per-level meet lattice is implemented by a later change. */
 FilterXStaticTypeSpec
 filterx_static_type_spec_meet(FilterXStaticTypeSpec a, FilterXStaticTypeSpec b)
 {
-  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  /* Longest common prefix where kinds agree; diverging or UNKNOWN levels (and everything
+   * below) collapse to UNKNOWN. Frozen, so the result is comparable by pointer identity. */
+  if (a == b)
+    return a;                                              /* covers UNKNOWN == UNKNOWN */
+  if (a->kind != b->kind)
+    return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;               /* UNKNOWN-vs-anything diverges here too */
+  return filterx_static_type_make_container(a->kind, filterx_static_type_spec_meet(a->element, b->element));
 }
+
+struct _FilterXTypeEnv
+{
+  /* key: FilterXVariableHandle via GUINT_TO_POINTER; value: FilterXStaticTypeSpec (frozen
+   * node pointer, borrowed from the global pool). Absence is equivalent to all-UNKNOWN, so we
+   * never store the UNKNOWN singleton; reads normalize the GLib NULL-for-absent back to it. */
+  GHashTable *handle_to_spec;
+};
 
 FilterXTypeEnv *
 filterx_type_env_new(void)
 {
-  return g_new0(FilterXTypeEnv, 1);
+  FilterXTypeEnv *self = g_new0(FilterXTypeEnv, 1);
+  self->handle_to_spec = g_hash_table_new(g_direct_hash, g_direct_equal);
+  return self;
 }
 
 FilterXTypeEnv *
 filterx_type_env_clone(const FilterXTypeEnv *self)
 {
-  return g_new0(FilterXTypeEnv, 1);
+  FilterXTypeEnv *clone = filterx_type_env_new();
+  GHashTableIter iter;
+  gpointer k, v;
+
+  g_hash_table_iter_init(&iter, self->handle_to_spec);
+  while (g_hash_table_iter_next(&iter, &k, &v))
+    g_hash_table_insert(clone->handle_to_spec, k, v);
+
+  return clone;
 }
 
 void
 filterx_type_env_free(FilterXTypeEnv *self)
 {
+  if (!self)
+    return;
+  g_hash_table_destroy(self->handle_to_spec);
   g_free(self);
 }
 
-/* Placeholder: variable type lookup is implemented by a later change. */
 FilterXStaticTypeSpec
 filterx_type_spec_get(const FilterXTypeEnv *self, FilterXVariableHandle handle)
 {
-  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  /* Absent key (GLib NULL) is the all-UNKNOWN default; normalize it to the unknown singleton. */
+  FilterXStaticTypeSpec spec = (FilterXStaticTypeSpec) g_hash_table_lookup(self->handle_to_spec,
+                               GUINT_TO_POINTER(handle));
+  return spec ? spec : FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
 }
 
-/* Placeholder: variable type recording is implemented by a later change. */
 void
 filterx_type_spec_set(FilterXTypeEnv *self, FilterXVariableHandle handle, FilterXStaticTypeSpec spec)
 {
+  /* UNKNOWN is the absent-key default, so we never store it — drop the entry instead. */
+  if (spec == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+    g_hash_table_remove(self->handle_to_spec, GUINT_TO_POINTER(handle));
+  else
+    g_hash_table_insert(self->handle_to_spec, GUINT_TO_POINTER(handle), (gpointer) spec);
 }
 
-/* Placeholder: branch-join meet is implemented by a later change. */
 void
 filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src)
 {
+  GHashTableIter iter;
+  gpointer k, v;
+  GPtrArray *to_drop = g_ptr_array_new();
+  GPtrArray *to_meet_keys = g_ptr_array_new();
+  GPtrArray *to_meet_specs = g_ptr_array_new();
+
+  g_hash_table_iter_init(&iter, dst->handle_to_spec);
+  while (g_hash_table_iter_next(&iter, &k, &v))
+    {
+      gpointer sv = g_hash_table_lookup(src->handle_to_spec, k);
+      FilterXStaticTypeSpec dst_spec = (FilterXStaticTypeSpec) v;
+      FilterXStaticTypeSpec src_spec = sv ? (FilterXStaticTypeSpec) sv : FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+      FilterXStaticTypeSpec met = filterx_static_type_spec_meet(dst_spec, src_spec);
+      if (met == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+        g_ptr_array_add(to_drop, k);
+      else if (met != dst_spec)
+        {
+          g_ptr_array_add(to_meet_keys, k);
+          g_ptr_array_add(to_meet_specs, (gpointer) met);
+        }
+    }
+
+  for (guint i = 0; i < to_drop->len; i++)
+    g_hash_table_remove(dst->handle_to_spec, g_ptr_array_index(to_drop, i));
+  for (guint i = 0; i < to_meet_keys->len; i++)
+    g_hash_table_insert(dst->handle_to_spec, g_ptr_array_index(to_meet_keys, i),
+                        g_ptr_array_index(to_meet_specs, i));
+  g_ptr_array_free(to_drop, TRUE);
+  g_ptr_array_free(to_meet_keys, TRUE);
+  g_ptr_array_free(to_meet_specs, TRUE);
 }
 
 void

--- a/lib/filterx/filterx-type-inference.c
+++ b/lib/filterx/filterx-type-inference.c
@@ -22,24 +22,34 @@
 
 #include "filterx/filterx-type-inference.h"
 #include "filterx/filterx-expr.h"
+#include "filterx/expr-variable.h"
+#include "filterx/expr-getattr.h"
+#include "filterx/expr-get-subscript.h"
+
+#include <string.h>
 
 /* The canonical "no information" spec. It lives outside the pool (it has no concrete kind to
- * key on) and is the single representation of UNKNOWN: specs are never NULL. Its element points
- * at itself, so it terminates every element chain and survives any depth walk. */
+ * key on) and is the single representation of UNKNOWN: specs are never NULL. Its element and
+ * sanitized point at itself, so it terminates every element chain and survives any depth walk. */
 const struct _FilterXStaticTypeNode FILTERX_STATIC_TYPE_UNKNOWN_NODE =
 {
-  .kind    = FILTERX_STATIC_TYPE_UNKNOWN,
-  .element = &FILTERX_STATIC_TYPE_UNKNOWN_NODE,
+  .kind      = FILTERX_STATIC_TYPE_UNKNOWN,
+  .element   = &FILTERX_STATIC_TYPE_UNKNOWN_NODE,
+  .sanitized = &FILTERX_STATIC_TYPE_UNKNOWN_NODE,
 };
 
 /* --- Frozen type-chain pool ----------------------------------------------------------
  *
  * FilterXStaticTypeSpec is a pointer to an immutable, hash-consed chain node. The pool below
  * is the single owner of every node; it is process-global and never torn down. The set of
- * distinct chains a config produces is tiny and deduplicated here (and across reloads), so a
- * spec cached on an expression stays valid for the whole life of the expression. Freezing
- * is only exercised during config init (not a hot path) and is guarded by a recursive mutex;
- * reads of an already-frozen node (kind/element) are lock-free, as nodes are immutable. */
+ * distinct chains a config produces is tiny and is deduplicated here (and across reloads),
+ * so the memory is bounded and a spec stays valid for the whole life of any FilterXExpr that
+ * caches it — including at JIT-compile time, after the inference env is freed.
+ *
+ * The pool is guarded by a recursive mutex: freezing is only exercised during config init
+ * (single-threaded in practice), and computing a node's sanitized form re-enters _get_or_create_frozen_type_spec().
+ * Reads of an already-frozen node (kind/element/sanitized) are lock-free: nodes are
+ * immutable once _get_or_create_frozen_type_spec() returns them. */
 static GRecMutex type_pool_lock;
 static GHashTable *type_pool; /* set of struct _FilterXStaticTypeNode*, keyed by (kind, element) */
 
@@ -70,7 +80,7 @@ _get_or_create_frozen_type_spec(FilterXStaticType kind, FilterXStaticTypeSpec el
   if (!type_pool)
     type_pool = g_hash_table_new(_node_hash, _node_equal);
 
-  struct _FilterXStaticTypeNode probe = { .kind = kind, .element = element };
+  struct _FilterXStaticTypeNode probe = { .kind = kind, .element = element, .sanitized = NULL };
   FilterXStaticTypeSpec existing = g_hash_table_lookup(type_pool, &probe);
   if (existing)
     {
@@ -82,6 +92,15 @@ _get_or_create_frozen_type_spec(FilterXStaticType kind, FilterXStaticTypeSpec el
   node->kind = kind;
   node->element = element;
   g_hash_table_insert(type_pool, node, node);
+
+  /* Precompute the sanitized form (chain truncated at the first FRESH level) so that
+   * filterx_static_type_sanitize()/element() are plain pointer reads at consumer time. */
+  if (kind == FILTERX_STATIC_TYPE_FRESH)
+    node->sanitized = FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  else if (element->sanitized == element)
+    node->sanitized = node;                                /* no FRESH at/below this level (incl. UNKNOWN-terminated) */
+  else
+    node->sanitized = _get_or_create_frozen_type_spec(kind, element->sanitized);   /* drop the FRESH-tainted tail */
 
   g_rec_mutex_unlock(&type_pool_lock);
   return node;
@@ -117,6 +136,11 @@ struct _FilterXTypeEnv
    * node pointer, borrowed from the global pool). Absence is equivalent to all-UNKNOWN, so we
    * never store the UNKNOWN singleton; reads normalize the GLib NULL-for-absent back to it. */
   GHashTable *handle_to_spec;
+  /* Per-key attribute type tracking for chained variable.k0.k1...key accesses.
+   * key: heap-allocated "handle:key0:key1..." string; value: FilterXStaticTypeSpec (borrowed).
+   * Tracks heterogeneous-field dicts (e.g. log.observed_time → INTEGER, log.severity_text →
+   * STRING) where the container element type would otherwise smear to UNKNOWN. */
+  GHashTable *attr_to_spec;
 };
 
 FilterXTypeEnv *
@@ -124,6 +148,7 @@ filterx_type_env_new(void)
 {
   FilterXTypeEnv *self = g_new0(FilterXTypeEnv, 1);
   self->handle_to_spec = g_hash_table_new(g_direct_hash, g_direct_equal);
+  self->attr_to_spec = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
   return self;
 }
 
@@ -138,6 +163,10 @@ filterx_type_env_clone(const FilterXTypeEnv *self)
   while (g_hash_table_iter_next(&iter, &k, &v))
     g_hash_table_insert(clone->handle_to_spec, k, v);
 
+  g_hash_table_iter_init(&iter, self->attr_to_spec);
+  while (g_hash_table_iter_next(&iter, &k, &v))
+    g_hash_table_insert(clone->attr_to_spec, g_strdup((const gchar *) k), v);
+
   return clone;
 }
 
@@ -147,6 +176,7 @@ filterx_type_env_free(FilterXTypeEnv *self)
   if (!self)
     return;
   g_hash_table_destroy(self->handle_to_spec);
+  g_hash_table_destroy(self->attr_to_spec);
   g_free(self);
 }
 
@@ -202,28 +232,37 @@ filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src)
   g_ptr_array_free(to_drop, TRUE);
   g_ptr_array_free(to_meet_keys, TRUE);
   g_ptr_array_free(to_meet_specs, TRUE);
-}
 
-/* Placeholder: per-key attribute chain lookup is implemented by a later change. */
-FilterXStaticTypeSpec
-filterx_type_spec_get_attr_for_chain(const FilterXTypeEnv *self, FilterXExpr *chain_expr,
-                                     const gchar *key)
-{
-  return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
-}
+  /* Also meet attr-to-spec entries: keys only in dst get dropped (source treats them as UNKNOWN). */
+  GPtrArray *attr_to_drop = g_ptr_array_new_with_free_func(g_free);
+  GPtrArray *attr_to_meet_keys = g_ptr_array_new_with_free_func(g_free);
+  GPtrArray *attr_to_meet_specs = g_ptr_array_new();
 
-/* Placeholder: per-key attribute chain recording is implemented by a later change. */
-void
-filterx_type_env_meet_attr_for_chain(FilterXTypeEnv *self, FilterXExpr *chain_expr,
-                                     const gchar *key, FilterXStaticTypeSpec spec)
-{
-}
+  g_hash_table_iter_init(&iter, dst->attr_to_spec);
+  while (g_hash_table_iter_next(&iter, &k, &v))
+    {
+      gpointer sv = g_hash_table_lookup(src->attr_to_spec, k);
+      FilterXStaticTypeSpec dst_spec = (FilterXStaticTypeSpec) v;
+      FilterXStaticTypeSpec src_spec = sv ? (FilterXStaticTypeSpec) sv : FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+      FilterXStaticTypeSpec met = filterx_static_type_spec_meet(dst_spec, src_spec);
+      if (met == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+        g_ptr_array_add(attr_to_drop, g_strdup((const gchar *) k));
+      else if (met != dst_spec)
+        {
+          g_ptr_array_add(attr_to_meet_keys, g_strdup((const gchar *) k));
+          g_ptr_array_add(attr_to_meet_specs, (gpointer) met);
+        }
+    }
 
-/* Placeholder: lift-on-write container refinement is implemented by a later change. */
-void
-filterx_type_env_update_on_write(FilterXTypeEnv *env, FilterXExpr *container_expr,
-                                 FilterXStaticTypeSpec value_spec)
-{
+  for (guint i = 0; i < attr_to_drop->len; i++)
+    g_hash_table_remove(dst->attr_to_spec, g_ptr_array_index(attr_to_drop, i));
+  for (guint i = 0; i < attr_to_meet_keys->len; i++)
+    g_hash_table_insert(dst->attr_to_spec,
+                        g_strdup((const gchar *) g_ptr_array_index(attr_to_meet_keys, i)),
+                        g_ptr_array_index(attr_to_meet_specs, i));
+  g_ptr_array_free(attr_to_drop, TRUE);
+  g_ptr_array_free(attr_to_meet_keys, TRUE);
+  g_ptr_array_free(attr_to_meet_specs, TRUE);
 }
 
 void
@@ -248,4 +287,203 @@ filterx_expr_infer_types_root(FilterXExpr *root)
   FilterXTypeEnv *env = filterx_type_env_new();
   filterx_expr_infer_types(root, env);
   filterx_type_env_free(env);
+}
+
+/* Walk a getattr/get_subscript chain down to its root variable, counting the number of
+ * hops. Returns FALSE if the chain does not bottom out at a trackable (non-macro) variable. */
+static gboolean
+_walk_to_root_variable(FilterXExpr *expr, FilterXVariableHandle *handle_out, gint *depth_out)
+{
+  gint depth = 0;
+  while (expr)
+    {
+      if (filterx_variable_expr_get_handle(expr, handle_out))
+        {
+          *depth_out = depth;
+          return TRUE;
+        }
+      if (filterx_expr_is_getattr(expr))
+        expr = filterx_getattr_get_operand(expr);
+      else if (filterx_expr_is_get_subscript(expr))
+        expr = filterx_get_subscript_get_operand(expr);
+      else
+        return FALSE;
+      depth++;
+    }
+  return FALSE;
+}
+
+/* Maximum getattr chain depth tracked in the attr-path map.
+ * Covers chains up to variable.k0.k1.k2.k3 (4 attribute hops from the root). */
+#define FILTERX_ATTR_CHAIN_MAX 4
+
+/* Walk a purely-getattr chain to its root variable, collecting attribute names
+ * top-down into keys_out[0..n_keys_out-1].  Returns FALSE for subscript hops,
+ * macro variables, or chains deeper than FILTERX_ATTR_CHAIN_MAX. */
+static gboolean
+_collect_attr_chain(FilterXExpr *expr, FilterXVariableHandle *handle_out,
+                    const gchar **keys_out, gint *n_keys_out)
+{
+  gint n = 0;
+  while (expr)
+    {
+      if (filterx_variable_expr_get_handle(expr, handle_out))
+        {
+          /* Keys were appended bottom-up; reverse to top-down. */
+          for (gint i = 0, j = n - 1; i < j; i++, j--)
+            {
+              const gchar *tmp = keys_out[i];
+              keys_out[i] = keys_out[j];
+              keys_out[j] = tmp;
+            }
+          *n_keys_out = n;
+          return TRUE;
+        }
+      if (!filterx_expr_is_getattr(expr) || n >= FILTERX_ATTR_CHAIN_MAX)
+        return FALSE;
+      keys_out[n++] = expr->name;   /* FilterXExpr::name holds the attr key for getattr nodes */
+      expr = filterx_getattr_get_operand(expr);
+    }
+  return FALSE;
+}
+
+/* Build the hash-table key string for a chained path.
+ * Format: "handle:key0:key1:...:keyN"  (n_keys entries after the handle). */
+static gchar *
+_attr_chain_key(FilterXVariableHandle handle, const gchar **keys, gint n_keys)
+{
+  GString *s = g_string_sized_new(64);
+  g_string_append_printf(s, "%u", (guint) handle);
+  for (gint i = 0; i < n_keys; i++)
+    {
+      g_string_append_c(s, ':');
+      g_string_append(s, keys[i]);
+    }
+  return g_string_free(s, FALSE);
+}
+
+/* Look up the type of <chain_expr>.<key> where chain_expr is a purely-getattr
+ * chain rooted at a non-macro variable.  Returns UNKNOWN if the path is not
+ * recorded or the chain is too deep. */
+FilterXStaticTypeSpec
+filterx_type_spec_get_attr_for_chain(const FilterXTypeEnv *self, FilterXExpr *chain_expr,
+                                     const gchar *key)
+{
+  const gchar *keys[FILTERX_ATTR_CHAIN_MAX + 1];
+  gint n = 0;
+  FilterXVariableHandle handle;
+
+  if (!_collect_attr_chain(chain_expr, &handle, keys, &n) || n + 1 > FILTERX_ATTR_CHAIN_MAX + 1)
+    return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+
+  keys[n] = key;
+  gchar *k = _attr_chain_key(handle, keys, n + 1);
+  FilterXStaticTypeSpec v = (FilterXStaticTypeSpec) g_hash_table_lookup(self->attr_to_spec, k);
+  g_free(k);
+  /* Absent key (GLib NULL) is all-UNKNOWN; normalize before the (non-NULL) sanitize read. */
+  return filterx_static_type_sanitize(v ? v : FILTERX_STATIC_TYPE_UNKNOWN_SPEC);
+}
+
+/* A whole-variable overwrite (`handle = <new value>`) makes every previously recorded
+ * <handle>:k0:k1:... entry stale: the per-key map does not know the new value's shape, so
+ * any leftover entry from the old value must not leak into reads of the new one. */
+void
+filterx_type_env_invalidate_attr_chains(FilterXTypeEnv *self, FilterXVariableHandle handle)
+{
+  gchar *prefix = g_strdup_printf("%u:", (guint) handle);
+  gsize prefix_len = strlen(prefix);
+
+  GHashTableIter iter;
+  gpointer k, v;
+  GPtrArray *to_drop = g_ptr_array_new();
+
+  g_hash_table_iter_init(&iter, self->attr_to_spec);
+  while (g_hash_table_iter_next(&iter, &k, &v))
+    {
+      if (strncmp((const gchar *) k, prefix, prefix_len) == 0)
+        g_ptr_array_add(to_drop, k);
+    }
+
+  for (guint i = 0; i < to_drop->len; i++)
+    g_hash_table_remove(self->attr_to_spec, g_ptr_array_index(to_drop, i));
+
+  g_ptr_array_free(to_drop, TRUE);
+  g_free(prefix);
+}
+
+/* Record that <chain_expr>.<key> = spec (using meet semantics for updates). */
+void
+filterx_type_env_meet_attr_for_chain(FilterXTypeEnv *self, FilterXExpr *chain_expr,
+                                     const gchar *key, FilterXStaticTypeSpec spec)
+{
+  if (spec == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+    return;
+
+  const gchar *keys[FILTERX_ATTR_CHAIN_MAX + 1];
+  gint n = 0;
+  FilterXVariableHandle handle;
+
+  if (!_collect_attr_chain(chain_expr, &handle, keys, &n) || n + 1 > FILTERX_ATTR_CHAIN_MAX + 1)
+    return;
+
+  keys[n] = key;
+  gchar *k = _attr_chain_key(handle, keys, n + 1);
+  FilterXStaticTypeSpec old = (FilterXStaticTypeSpec) g_hash_table_lookup(self->attr_to_spec, k);
+  FilterXStaticTypeSpec merged = (!old) ? spec : filterx_static_type_spec_meet(old, spec);
+  if (merged == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+    {
+      g_hash_table_remove(self->attr_to_spec, k);
+      g_free(k);
+    }
+  else if (merged != old)
+    g_hash_table_insert(self->attr_to_spec, k, (gpointer) merged);
+  else
+    g_free(k);
+}
+
+/* Follow the element chain @depth levels down. Walking past the end stays on the UNKNOWN
+ * singleton (its element is itself), so a too-short chain yields UNKNOWN. */
+static FilterXStaticTypeSpec
+_node_at_depth(FilterXStaticTypeSpec spec, gint depth)
+{
+  for (gint i = 0; i < depth; i++)
+    spec = spec->element;
+  return spec;
+}
+
+/* Rebuild @spec with the subchain at @depth replaced by @newtail, re-freezing the kept
+ * prefix. @spec is guaranteed non-NULL down to @depth by the caller. */
+static FilterXStaticTypeSpec
+_set_at_depth(FilterXStaticTypeSpec spec, gint depth, FilterXStaticTypeSpec newtail)
+{
+  if (depth == 0)
+    return newtail;
+  return filterx_static_type_make_container(spec->kind,
+                                            _set_at_depth(spec->element, depth - 1, newtail));
+}
+
+void
+filterx_type_env_update_on_write(FilterXTypeEnv *env, FilterXExpr *container_expr,
+                                 FilterXStaticTypeSpec value_spec)
+{
+  FilterXVariableHandle handle;
+  gint depth;
+  if (!_walk_to_root_variable(container_expr, &handle, &depth))
+    return;
+
+  /* The written value lands one level below the container we wrote into. */
+  gint level = depth + 1;
+
+  FilterXStaticTypeSpec old = filterx_type_spec_get(env, handle);
+  FilterXStaticTypeSpec suffix = _node_at_depth(old, level);
+  if (suffix == FILTERX_STATIC_TYPE_UNKNOWN_SPEC)
+    return;   /* UNKNOWN at the written level: no committed type to refine from */
+
+  FilterXStaticTypeSpec newtail;
+  if (suffix->kind == FILTERX_STATIC_TYPE_FRESH)
+    newtail = value_spec;                                         /* lift: commit to the written type */
+  else
+    newtail = filterx_static_type_spec_meet(suffix, value_spec);  /* meet with the committed type */
+
+  filterx_type_spec_set(env, handle, _set_at_depth(old, level, newtail));
 }

--- a/lib/filterx/filterx-type-inference.c
+++ b/lib/filterx/filterx-type-inference.c
@@ -363,8 +363,8 @@ _walk_to_root_variable(FilterXExpr *expr, FilterXVariableHandle *handle_out, gin
 }
 
 /* Maximum getattr chain depth tracked in the attr-path map.
- * Covers chains up to variable.k0.k1.k2.k3 (4 attribute hops from the root). */
-#define FILTERX_ATTR_CHAIN_MAX 4
+ * Covers chains up to variable.k0.k1.k2.k3...k15 (16 attribute hops from the root). */
+#define FILTERX_ATTR_CHAIN_MAX 16
 
 /* Walk a purely-getattr chain to its root variable, collecting attribute names
  * top-down into keys_out[0..n_keys_out-1].  Returns FALSE for subscript hops,

--- a/lib/filterx/filterx-type-inference.h
+++ b/lib/filterx/filterx-type-inference.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef FILTERX_TYPE_INFERENCE_H_INCLUDED
+#define FILTERX_TYPE_INFERENCE_H_INCLUDED
+
+#include "syslog-ng.h"
+#include "filterx/filterx-variable.h"
+
+typedef enum
+{
+  /* "no information" — the kind of the canonical unknown singleton spec
+   * (FILTERX_STATIC_TYPE_UNKNOWN_SPEC). Every enum value is a legal node kind. */
+  FILTERX_STATIC_TYPE_UNKNOWN = 0,
+  FILTERX_STATIC_TYPE_DICT    = 1,
+  FILTERX_STATIC_TYPE_LIST    = 2,
+  FILTERX_STATIC_TYPE_STRING  = 3,
+  FILTERX_STATIC_TYPE_INTEGER = 4,
+} FilterXStaticType;
+
+/* FilterXStaticTypeSpec models the static type of an expression as a linear chain of
+ * nesting levels: the outer kind, then the element type of that container, then the
+ * element type of that, and so on. Each container level has exactly one element type
+ * (heterogeneous elements meet to UNKNOWN), so the structure is a chain, not a tree.
+ *
+ * The chain is represented as frozen / hash-consed immutable nodes: structurally-equal
+ * chains are the SAME pointer, so equality is pointer identity (==) and a copy is just a
+ * pointer copy. A spec is NEVER NULL: the absent / "no information" type is the canonical
+ * unknown singleton FILTERX_STATIC_TYPE_UNKNOWN_SPEC, which also terminates every element
+ * chain. There is no depth limit. Frozen nodes live in a process-global, never-freed pool,
+ * so a spec cached on a FilterXExpr stays valid for as long as that expression does. */
+typedef const struct _FilterXStaticTypeNode *FilterXStaticTypeSpec;
+
+struct _FilterXStaticTypeNode
+{
+  FilterXStaticType kind;          /* outer kind of this chain (UNKNOWN only for the unknown singleton) */
+  FilterXStaticTypeSpec element;    /* frozen element chain (never NULL; UNKNOWN-terminated) */
+};
+
+/* The canonical "no information" spec: a single pre-seeded node whose kind is UNKNOWN and
+ * whose element points at itself, so it terminates every element chain and can be walked to
+ * any depth. Specs are never NULL — this object stands in for "absent type". */
+extern const struct _FilterXStaticTypeNode FILTERX_STATIC_TYPE_UNKNOWN_NODE;
+#define FILTERX_STATIC_TYPE_UNKNOWN_SPEC (&FILTERX_STATIC_TYPE_UNKNOWN_NODE)
+#define INITIAL_FILTERX_STATIC_TYPE_SPEC FILTERX_STATIC_TYPE_UNKNOWN_SPEC
+
+static inline FilterXStaticType
+filterx_static_type_kind(FilterXStaticTypeSpec spec)
+{
+  return spec->kind;
+}
+
+/* Drop the outermost level: returns the element type spec.
+ * Element of DICT/LIST → its element chain; element of a scalar or UNKNOWN → UNKNOWN. */
+static inline FilterXStaticTypeSpec
+filterx_static_type_element(FilterXStaticTypeSpec spec)
+{
+  FilterXStaticType kind = filterx_static_type_kind(spec);
+  if (kind != FILTERX_STATIC_TYPE_DICT && kind != FILTERX_STATIC_TYPE_LIST)
+    return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  return spec->element;
+}
+
+/* Build (freeze) a container spec from an outer kind and the element spec. */
+FilterXStaticTypeSpec filterx_static_type_make_container(FilterXStaticType kind, FilterXStaticTypeSpec element);
+
+/* Per-level meet (frozen): the longest common prefix where the kinds agree. */
+FilterXStaticTypeSpec filterx_static_type_spec_meet(FilterXStaticTypeSpec a, FilterXStaticTypeSpec b);
+
+/* Convenience for the common case where we just need the outer kind: a single-level
+ * frozen chain. Returns the UNKNOWN singleton for kind == UNKNOWN. */
+FilterXStaticTypeSpec filterx_static_type_kind_only(FilterXStaticType kind);
+
+typedef struct _FilterXTypeEnv FilterXTypeEnv;
+
+FilterXTypeEnv *filterx_type_env_new(void);
+FilterXTypeEnv *filterx_type_env_clone(const FilterXTypeEnv *self);
+void filterx_type_env_free(FilterXTypeEnv *self);
+
+FilterXStaticTypeSpec filterx_type_env_get(const FilterXTypeEnv *self, FilterXVariableHandle handle);
+void filterx_type_env_set(FilterXTypeEnv *self, FilterXVariableHandle handle, FilterXStaticTypeSpec spec);
+
+/* Meet @src into @dst in place. Handles only in one env meet with all-UNKNOWN
+ * → all-UNKNOWN (which is the absent-key default). */
+void filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src);
+
+struct _FilterXExpr;
+void filterx_expr_infer_types(struct _FilterXExpr *self, FilterXTypeEnv *env);
+void filterx_expr_infer_types_root(struct _FilterXExpr *root);
+
+#endif

--- a/lib/filterx/filterx-type-inference.h
+++ b/lib/filterx/filterx-type-inference.h
@@ -142,9 +142,16 @@ void filterx_type_env_meet_attr_for_chain(FilterXTypeEnv *self,
  * → all-UNKNOWN (which is the absent-key default). */
 void filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src);
 
+/* Propagate knowledge from @block_env into @persistent (add new entries; meet existing ones). */
+void filterx_type_env_propagate_to_persistent(FilterXTypeEnv *persistent, const FilterXTypeEnv *block_env);
+
 struct _FilterXExpr;
 void filterx_expr_infer_types(struct _FilterXExpr *self, FilterXTypeEnv *env);
 void filterx_expr_infer_types_root(struct _FilterXExpr *root);
+
+/* Like filterx_expr_infer_types_root but seeds the local env from @persistent_env first,
+ * then propagates the resulting knowledge back into @persistent_env after inference. */
+void filterx_expr_infer_types_root_persistent(struct _FilterXExpr *root, FilterXTypeEnv *persistent_env);
 
 /* Update the env after a write `container_expr.<key> = value` (setattr / set_subscript).
  * Walks @container_expr down to its root variable, counting the getattr/get_subscript depth

--- a/lib/filterx/filterx-type-inference.h
+++ b/lib/filterx/filterx-type-inference.h
@@ -34,6 +34,14 @@ typedef enum
   FILTERX_STATIC_TYPE_LIST    = 2,
   FILTERX_STATIC_TYPE_STRING  = 3,
   FILTERX_STATIC_TYPE_INTEGER = 4,
+  /* Sentinel for "freshly built empty container, element type not yet committed".
+   * Seeded by literal inference for empty {} / [] containers and carried through the
+   * env, where the first write to the container lifts it to the written value's type
+   * (see filterx_type_env_update_on_write). It must never reach codegen as if it were
+   * a real type: it is stripped from any expression's exposed static_type by
+   * filterx_static_type_sanitize() (used by element() and by variable inference).
+   * Devirt decisions only read level 0 (filterx_static_type_kind), which is never FRESH. */
+  FILTERX_STATIC_TYPE_FRESH   = 0xfe,
 } FilterXStaticType;
 
 /* FilterXStaticTypeSpec models the static type of an expression as a linear chain of
@@ -52,7 +60,8 @@ typedef const struct _FilterXStaticTypeNode *FilterXStaticTypeSpec;
 struct _FilterXStaticTypeNode
 {
   FilterXStaticType kind;          /* outer kind of this chain (UNKNOWN only for the unknown singleton) */
-  FilterXStaticTypeSpec element;    /* frozen element chain (never NULL; UNKNOWN-terminated) */
+  FilterXStaticTypeSpec element;    /* frozen element chain (never NULL; UNKNOWN-terminated); may carry FRESH inside */
+  FilterXStaticTypeSpec sanitized;  /* this chain truncated at the first FRESH level (precomputed) */
 };
 
 /* The canonical "no information" spec: a single pre-seeded node whose kind is UNKNOWN and
@@ -66,6 +75,16 @@ static inline FilterXStaticType
 filterx_static_type_kind(FilterXStaticTypeSpec spec)
 {
   return spec->kind;
+}
+
+/* Strip the FRESH lift-tracking sentinel before a spec is exposed on any expression's
+ * static_type. Placeholder: the real stripping is implemented by a later change; since
+ * the FRESH sentinel is only produced once the nested inference hooks are wired up, the
+ * identity behaviour here matches what callers observe so far. */
+static inline FilterXStaticTypeSpec
+filterx_static_type_sanitize(FilterXStaticTypeSpec spec)
+{
+  return spec;
 }
 
 /* Drop the outermost level: returns the element type spec.
@@ -98,6 +117,19 @@ void filterx_type_env_free(FilterXTypeEnv *self);
 FilterXStaticTypeSpec filterx_type_env_get(const FilterXTypeEnv *self, FilterXVariableHandle handle);
 void filterx_type_env_set(FilterXTypeEnv *self, FilterXVariableHandle handle, FilterXStaticTypeSpec spec);
 
+/* Per-key attribute type tracking: resolve or record the type of <chain_expr>.<key> where
+ * chain_expr is a getattr chain rooted at a variable.  The path "root_handle:k0:k1:...:key"
+ * is stored in the attr_to_spec table.  Tracks individual field types for heterogeneous-value
+ * dicts (e.g. log.observed_time → INTEGER, log.severity_text → STRING) without smearing, and
+ * covers the single-hop case (variable.key) as a zero-prefix chain.  A no-op when the chain is
+ * too deep or contains non-getattr hops. */
+FilterXStaticTypeSpec filterx_type_env_get_attr_for_chain(const FilterXTypeEnv *self,
+                                                          struct _FilterXExpr *chain_expr,
+                                                          const gchar *key);
+void filterx_type_env_meet_attr_for_chain(FilterXTypeEnv *self,
+                                          struct _FilterXExpr *chain_expr,
+                                          const gchar *key, FilterXStaticTypeSpec spec);
+
 /* Meet @src into @dst in place. Handles only in one env meet with all-UNKNOWN
  * → all-UNKNOWN (which is the absent-key default). */
 void filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src);
@@ -105,5 +137,21 @@ void filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src);
 struct _FilterXExpr;
 void filterx_expr_infer_types(struct _FilterXExpr *self, FilterXTypeEnv *env);
 void filterx_expr_infer_types_root(struct _FilterXExpr *root);
+
+/* Update the env after a write `container_expr.<key> = value` (setattr / set_subscript).
+ * Walks @container_expr down to its root variable, counting the getattr/get_subscript depth
+ * d, and refines the variable's spec at level d+1 using the lift-or-meet rule:
+ *
+ *   prior level kind = FRESH    → lift: commit the level to @value_spec (the just-written
+ *                                 value's full nested type, including its own FRESH).
+ *   prior level kind = known T  → meet(T-tail, value_spec): divergent kinds collapse to
+ *                                 UNKNOWN, demoting a now-heterogeneous container.
+ *   prior level kind = UNKNOWN  → leave (no committed type to refine from).
+ *
+ * A no-op if @container_expr is not rooted at a trackable variable or if the root has no
+ * known container kind at the written level. */
+void filterx_type_env_update_on_write(FilterXTypeEnv *env,
+                                      struct _FilterXExpr *container_expr,
+                                      FilterXStaticTypeSpec value_spec);
 
 #endif

--- a/lib/filterx/filterx-type-inference.h
+++ b/lib/filterx/filterx-type-inference.h
@@ -51,10 +51,15 @@ typedef enum
  *
  * The chain is represented as frozen / hash-consed immutable nodes: structurally-equal
  * chains are the SAME pointer, so equality is pointer identity (==) and a copy is just a
- * pointer copy. A spec is NEVER NULL: the absent / "no information" type is the canonical
- * unknown singleton FILTERX_STATIC_TYPE_UNKNOWN_SPEC, which also terminates every element
- * chain. There is no depth limit. Frozen nodes live in a process-global, never-freed pool,
- * so a spec cached on a FilterXExpr stays valid for as long as that expression does. */
+ * pointer copy — exactly the value semantics the inference env and the JIT consumers rely
+ * on. A spec is NEVER NULL: the absent / "no information" type is the canonical unknown
+ * singleton FILTERX_STATIC_TYPE_UNKNOWN_SPEC, which also terminates every element chain.
+ *
+ * Frozen nodes live in a process-global, never-freed pool (the set of distinct chains in
+ * any config is tiny and deduplicated across reloads), so a spec cached on a FilterXExpr
+ * stays valid for as long as that expression does — including at JIT-compile time, after
+ * the inference env has been freed. Inference is not on a hot path, so the freezing cost
+ * is irrelevant. */
 typedef const struct _FilterXStaticTypeNode *FilterXStaticTypeSpec;
 
 struct _FilterXStaticTypeNode
@@ -65,8 +70,8 @@ struct _FilterXStaticTypeNode
 };
 
 /* The canonical "no information" spec: a single pre-seeded node whose kind is UNKNOWN and
- * whose element points at itself, so it terminates every element chain and can be walked to
- * any depth. Specs are never NULL — this object stands in for "absent type". */
+ * whose element/sanitized point at itself, so it terminates every element chain and can be
+ * walked to any depth. Specs are never NULL — this object stands in for "absent type". */
 extern const struct _FilterXStaticTypeNode FILTERX_STATIC_TYPE_UNKNOWN_NODE;
 #define FILTERX_STATIC_TYPE_UNKNOWN_SPEC (&FILTERX_STATIC_TYPE_UNKNOWN_NODE)
 #define INITIAL_FILTERX_STATIC_TYPE_SPEC FILTERX_STATIC_TYPE_UNKNOWN_SPEC
@@ -78,34 +83,37 @@ filterx_static_type_kind(FilterXStaticTypeSpec spec)
 }
 
 /* Strip the FRESH lift-tracking sentinel before a spec is exposed on any expression's
- * static_type. Placeholder: the real stripping is implemented by a later change; since
- * the FRESH sentinel is only produced once the nested inference hooks are wired up, the
- * identity behaviour here matches what callers observe so far. */
+ * static_type: the chain is truncated at the first FRESH level (FRESH implies "no committed
+ * type here or below"). The sanitized form is precomputed at freeze time, so this is a plain
+ * pointer read — no pool access needed, which is why JIT consumers can call it freely. */
 static inline FilterXStaticTypeSpec
 filterx_static_type_sanitize(FilterXStaticTypeSpec spec)
 {
-  return spec;
+  return spec->sanitized;
 }
 
-/* Drop the outermost level: returns the element type spec.
- * Element of DICT/LIST → its element chain; element of a scalar or UNKNOWN → UNKNOWN. */
+/* Drop the outermost level: returns the (sanitized) element type spec.
+ * Element of DICT/LIST → its element chain with FRESH stripped; element of a scalar or
+ * UNKNOWN → UNKNOWN. The element of a FRESH-empty container sanitizes to UNKNOWN. */
 static inline FilterXStaticTypeSpec
 filterx_static_type_element(FilterXStaticTypeSpec spec)
 {
   FilterXStaticType kind = filterx_static_type_kind(spec);
   if (kind != FILTERX_STATIC_TYPE_DICT && kind != FILTERX_STATIC_TYPE_LIST)
     return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
-  return spec->element;
+  return filterx_static_type_sanitize(spec->element);
 }
 
-/* Build (freeze) a container spec from an outer kind and the element spec. */
+/* Build (freeze) a container spec from an outer kind and the element spec. Returns the
+ * canonical node for {kind, element}; arbitrary nesting depth. */
 FilterXStaticTypeSpec filterx_static_type_make_container(FilterXStaticType kind, FilterXStaticTypeSpec element);
 
-/* Per-level meet (frozen): the longest common prefix where the kinds agree. */
+/* Per-level meet (frozen): the longest common prefix where the kinds agree; once the
+ * levels diverge or hit UNKNOWN, that level and everything below it are dropped. */
 FilterXStaticTypeSpec filterx_static_type_spec_meet(FilterXStaticTypeSpec a, FilterXStaticTypeSpec b);
 
-/* Convenience for the common case where we just need the outer kind: a single-level
- * frozen chain. Returns the UNKNOWN singleton for kind == UNKNOWN. */
+/* Convenience for the common case where we just need the outer kind (no element info):
+ * a single-level frozen chain. Returns the UNKNOWN singleton for kind == UNKNOWN. */
 FilterXStaticTypeSpec filterx_static_type_kind_only(FilterXStaticType kind);
 
 typedef struct _FilterXTypeEnv FilterXTypeEnv;

--- a/lib/filterx/filterx-type-inference.h
+++ b/lib/filterx/filterx-type-inference.h
@@ -147,9 +147,16 @@ void filterx_type_env_invalidate_attr_chains(FilterXTypeEnv *self, FilterXVariab
  * → all-UNKNOWN (which is the absent-key default). */
 void filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src);
 
+/* Propagate knowledge from @block_env into @persistent (add new entries; meet existing ones). */
+void filterx_type_env_propagate_to_persistent(FilterXTypeEnv *persistent, const FilterXTypeEnv *block_env);
+
 struct _FilterXExpr;
 void filterx_expr_infer_types(struct _FilterXExpr *self, FilterXTypeEnv *env);
 void filterx_expr_infer_types_root(struct _FilterXExpr *root);
+
+/* Like filterx_expr_infer_types_root but seeds the local env from @persistent_env first,
+ * then propagates the resulting knowledge back into @persistent_env after inference. */
+void filterx_expr_infer_types_root_persistent(struct _FilterXExpr *root, FilterXTypeEnv *persistent_env);
 
 /* Update the env after a write `container_expr.<key> = value` (setattr / set_subscript).
  * Walks @container_expr down to its root variable, counting the getattr/get_subscript depth

--- a/lib/filterx/filterx-type-inference.h
+++ b/lib/filterx/filterx-type-inference.h
@@ -51,10 +51,15 @@ typedef enum
  *
  * The chain is represented as frozen / hash-consed immutable nodes: structurally-equal
  * chains are the SAME pointer, so equality is pointer identity (==) and a copy is just a
- * pointer copy. A spec is NEVER NULL: the absent / "no information" type is the canonical
- * unknown singleton FILTERX_STATIC_TYPE_UNKNOWN_SPEC, which also terminates every element
- * chain. There is no depth limit. Frozen nodes live in a process-global, never-freed pool,
- * so a spec cached on a FilterXExpr stays valid for as long as that expression does. */
+ * pointer copy — exactly the value semantics the inference env and the JIT consumers rely
+ * on. A spec is NEVER NULL: the absent / "no information" type is the canonical unknown
+ * singleton FILTERX_STATIC_TYPE_UNKNOWN_SPEC, which also terminates every element chain.
+ *
+ * Frozen nodes live in a process-global, never-freed pool (the set of distinct chains in
+ * any config is tiny and deduplicated across reloads), so a spec cached on a FilterXExpr
+ * stays valid for as long as that expression does — including at JIT-compile time, after
+ * the inference env has been freed. Inference is not on a hot path, so the freezing cost
+ * is irrelevant. */
 typedef const struct _FilterXStaticTypeNode *FilterXStaticTypeSpec;
 
 struct _FilterXStaticTypeNode
@@ -65,8 +70,8 @@ struct _FilterXStaticTypeNode
 };
 
 /* The canonical "no information" spec: a single pre-seeded node whose kind is UNKNOWN and
- * whose element points at itself, so it terminates every element chain and can be walked to
- * any depth. Specs are never NULL — this object stands in for "absent type". */
+ * whose element/sanitized point at itself, so it terminates every element chain and can be
+ * walked to any depth. Specs are never NULL — this object stands in for "absent type". */
 extern const struct _FilterXStaticTypeNode FILTERX_STATIC_TYPE_UNKNOWN_NODE;
 #define FILTERX_STATIC_TYPE_UNKNOWN_SPEC (&FILTERX_STATIC_TYPE_UNKNOWN_NODE)
 #define INITIAL_FILTERX_STATIC_TYPE_SPEC FILTERX_STATIC_TYPE_UNKNOWN_SPEC
@@ -78,34 +83,37 @@ filterx_static_type_kind(FilterXStaticTypeSpec spec)
 }
 
 /* Strip the FRESH lift-tracking sentinel before a spec is exposed on any expression's
- * static_type. Placeholder: the real stripping is implemented by a later change; since
- * the FRESH sentinel is only produced once the nested inference hooks are wired up, the
- * identity behaviour here matches what callers observe so far. */
+ * static_type: the chain is truncated at the first FRESH level (FRESH implies "no committed
+ * type here or below"). The sanitized form is precomputed at freeze time, so this is a plain
+ * pointer read — no pool access needed, which is why JIT consumers can call it freely. */
 static inline FilterXStaticTypeSpec
 filterx_static_type_sanitize(FilterXStaticTypeSpec spec)
 {
-  return spec;
+  return spec->sanitized;
 }
 
-/* Drop the outermost level: returns the element type spec.
- * Element of DICT/LIST → its element chain; element of a scalar or UNKNOWN → UNKNOWN. */
+/* Drop the outermost level: returns the (sanitized) element type spec.
+ * Element of DICT/LIST → its element chain with FRESH stripped; element of a scalar or
+ * UNKNOWN → UNKNOWN. The element of a FRESH-empty container sanitizes to UNKNOWN. */
 static inline FilterXStaticTypeSpec
 filterx_static_type_element(FilterXStaticTypeSpec spec)
 {
   FilterXStaticType kind = filterx_static_type_kind(spec);
   if (kind != FILTERX_STATIC_TYPE_DICT && kind != FILTERX_STATIC_TYPE_LIST)
     return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
-  return spec->element;
+  return filterx_static_type_sanitize(spec->element);
 }
 
-/* Build (freeze) a container spec from an outer kind and the element spec. */
+/* Build (freeze) a container spec from an outer kind and the element spec. Returns the
+ * canonical node for {kind, element}; arbitrary nesting depth. */
 FilterXStaticTypeSpec filterx_static_type_make_container(FilterXStaticType kind, FilterXStaticTypeSpec element);
 
-/* Per-level meet (frozen): the longest common prefix where the kinds agree. */
+/* Per-level meet (frozen): the longest common prefix where the kinds agree; once the
+ * levels diverge or hit UNKNOWN, that level and everything below it are dropped. */
 FilterXStaticTypeSpec filterx_static_type_spec_meet(FilterXStaticTypeSpec a, FilterXStaticTypeSpec b);
 
-/* Convenience for the common case where we just need the outer kind: a single-level
- * frozen chain. Returns the UNKNOWN singleton for kind == UNKNOWN. */
+/* Convenience for the common case where we just need the outer kind (no element info):
+ * a single-level frozen chain. Returns the UNKNOWN singleton for kind == UNKNOWN. */
 FilterXStaticTypeSpec filterx_static_type_kind_only(FilterXStaticType kind);
 
 typedef struct _FilterXTypeEnv FilterXTypeEnv;
@@ -129,6 +137,11 @@ FilterXStaticTypeSpec filterx_type_spec_get_attr_for_chain(const FilterXTypeEnv 
 void filterx_type_env_meet_attr_for_chain(FilterXTypeEnv *self,
                                           struct _FilterXExpr *chain_expr,
                                           const gchar *key, FilterXStaticTypeSpec spec);
+
+/* Drop every attr_to_spec entry rooted at @handle. Call this when a plain assignment
+ * (`handle = <value>`) replaces the whole variable: any per-key type recorded for the old
+ * value's shape no longer applies to the new one and must not be read as if it did. */
+void filterx_type_env_invalidate_attr_chains(FilterXTypeEnv *self, FilterXVariableHandle handle);
 
 /* Meet @src into @dst in place. Handles only in one env meet with all-UNKNOWN
  * → all-UNKNOWN (which is the absent-key default). */

--- a/lib/filterx/filterx-type-inference.h
+++ b/lib/filterx/filterx-type-inference.h
@@ -34,6 +34,14 @@ typedef enum
   FILTERX_STATIC_TYPE_LIST    = 2,
   FILTERX_STATIC_TYPE_STRING  = 3,
   FILTERX_STATIC_TYPE_INTEGER = 4,
+  /* Sentinel for "freshly built empty container, element type not yet committed".
+   * Seeded by literal inference for empty {} / [] containers and carried through the
+   * env, where the first write to the container lifts it to the written value's type
+   * (see filterx_type_env_update_on_write). It must never reach codegen as if it were
+   * a real type: it is stripped from any expression's exposed static_type by
+   * filterx_static_type_sanitize() (used by element() and by variable inference).
+   * Devirt decisions only read level 0 (filterx_static_type_kind), which is never FRESH. */
+  FILTERX_STATIC_TYPE_FRESH   = 0xfe,
 } FilterXStaticType;
 
 /* FilterXStaticTypeSpec models the static type of an expression as a linear chain of
@@ -52,7 +60,8 @@ typedef const struct _FilterXStaticTypeNode *FilterXStaticTypeSpec;
 struct _FilterXStaticTypeNode
 {
   FilterXStaticType kind;          /* outer kind of this chain (UNKNOWN only for the unknown singleton) */
-  FilterXStaticTypeSpec element;    /* frozen element chain (never NULL; UNKNOWN-terminated) */
+  FilterXStaticTypeSpec element;    /* frozen element chain (never NULL; UNKNOWN-terminated); may carry FRESH inside */
+  FilterXStaticTypeSpec sanitized;  /* this chain truncated at the first FRESH level (precomputed) */
 };
 
 /* The canonical "no information" spec: a single pre-seeded node whose kind is UNKNOWN and
@@ -66,6 +75,16 @@ static inline FilterXStaticType
 filterx_static_type_kind(FilterXStaticTypeSpec spec)
 {
   return spec->kind;
+}
+
+/* Strip the FRESH lift-tracking sentinel before a spec is exposed on any expression's
+ * static_type. Placeholder: the real stripping is implemented by a later change; since
+ * the FRESH sentinel is only produced once the nested inference hooks are wired up, the
+ * identity behaviour here matches what callers observe so far. */
+static inline FilterXStaticTypeSpec
+filterx_static_type_sanitize(FilterXStaticTypeSpec spec)
+{
+  return spec;
 }
 
 /* Drop the outermost level: returns the element type spec.
@@ -98,6 +117,19 @@ void filterx_type_env_free(FilterXTypeEnv *self);
 FilterXStaticTypeSpec filterx_type_spec_get(const FilterXTypeEnv *self, FilterXVariableHandle handle);
 void filterx_type_spec_set(FilterXTypeEnv *self, FilterXVariableHandle handle, FilterXStaticTypeSpec spec);
 
+/* Per-key attribute type tracking: resolve or record the type of <chain_expr>.<key> where
+ * chain_expr is a getattr chain rooted at a variable.  The path "root_handle:k0:k1:...:key"
+ * is stored in the attr_to_spec table.  Tracks individual field types for heterogeneous-value
+ * dicts (e.g. log.observed_time → INTEGER, log.severity_text → STRING) without smearing, and
+ * covers the single-hop case (variable.key) as a zero-prefix chain.  A no-op when the chain is
+ * too deep or contains non-getattr hops. */
+FilterXStaticTypeSpec filterx_type_spec_get_attr_for_chain(const FilterXTypeEnv *self,
+                                                           struct _FilterXExpr *chain_expr,
+                                                           const gchar *key);
+void filterx_type_env_meet_attr_for_chain(FilterXTypeEnv *self,
+                                          struct _FilterXExpr *chain_expr,
+                                          const gchar *key, FilterXStaticTypeSpec spec);
+
 /* Meet @src into @dst in place. Handles only in one env meet with all-UNKNOWN
  * → all-UNKNOWN (which is the absent-key default). */
 void filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src);
@@ -105,5 +137,21 @@ void filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src);
 struct _FilterXExpr;
 void filterx_expr_infer_types(struct _FilterXExpr *self, FilterXTypeEnv *env);
 void filterx_expr_infer_types_root(struct _FilterXExpr *root);
+
+/* Update the env after a write `container_expr.<key> = value` (setattr / set_subscript).
+ * Walks @container_expr down to its root variable, counting the getattr/get_subscript depth
+ * d, and refines the variable's spec at level d+1 using the lift-or-meet rule:
+ *
+ *   prior level kind = FRESH    → lift: commit the level to @value_spec (the just-written
+ *                                 value's full nested type, including its own FRESH).
+ *   prior level kind = known T  → meet(T-tail, value_spec): divergent kinds collapse to
+ *                                 UNKNOWN, demoting a now-heterogeneous container.
+ *   prior level kind = UNKNOWN  → leave (no committed type to refine from).
+ *
+ * A no-op if @container_expr is not rooted at a trackable variable or if the root has no
+ * known container kind at the written level. */
+void filterx_type_env_update_on_write(FilterXTypeEnv *env,
+                                      struct _FilterXExpr *container_expr,
+                                      FilterXStaticTypeSpec value_spec);
 
 #endif

--- a/lib/filterx/filterx-type-inference.h
+++ b/lib/filterx/filterx-type-inference.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef FILTERX_TYPE_INFERENCE_H_INCLUDED
+#define FILTERX_TYPE_INFERENCE_H_INCLUDED
+
+#include "syslog-ng.h"
+#include "filterx/filterx-variable.h"
+
+typedef enum
+{
+  /* "no information" — the kind of the canonical unknown singleton spec
+   * (FILTERX_STATIC_TYPE_UNKNOWN_SPEC). Every enum value is a legal node kind. */
+  FILTERX_STATIC_TYPE_UNKNOWN = 0,
+  FILTERX_STATIC_TYPE_DICT    = 1,
+  FILTERX_STATIC_TYPE_LIST    = 2,
+  FILTERX_STATIC_TYPE_STRING  = 3,
+  FILTERX_STATIC_TYPE_INTEGER = 4,
+} FilterXStaticType;
+
+/* FilterXStaticTypeSpec models the static type of an expression as a linear chain of
+ * nesting levels: the outer kind, then the element type of that container, then the
+ * element type of that, and so on. Each container level has exactly one element type
+ * (heterogeneous elements meet to UNKNOWN), so the structure is a chain, not a tree.
+ *
+ * The chain is represented as frozen / hash-consed immutable nodes: structurally-equal
+ * chains are the SAME pointer, so equality is pointer identity (==) and a copy is just a
+ * pointer copy. A spec is NEVER NULL: the absent / "no information" type is the canonical
+ * unknown singleton FILTERX_STATIC_TYPE_UNKNOWN_SPEC, which also terminates every element
+ * chain. There is no depth limit. Frozen nodes live in a process-global, never-freed pool,
+ * so a spec cached on a FilterXExpr stays valid for as long as that expression does. */
+typedef const struct _FilterXStaticTypeNode *FilterXStaticTypeSpec;
+
+struct _FilterXStaticTypeNode
+{
+  FilterXStaticType kind;          /* outer kind of this chain (UNKNOWN only for the unknown singleton) */
+  FilterXStaticTypeSpec element;    /* frozen element chain (never NULL; UNKNOWN-terminated) */
+};
+
+/* The canonical "no information" spec: a single pre-seeded node whose kind is UNKNOWN and
+ * whose element points at itself, so it terminates every element chain and can be walked to
+ * any depth. Specs are never NULL — this object stands in for "absent type". */
+extern const struct _FilterXStaticTypeNode FILTERX_STATIC_TYPE_UNKNOWN_NODE;
+#define FILTERX_STATIC_TYPE_UNKNOWN_SPEC (&FILTERX_STATIC_TYPE_UNKNOWN_NODE)
+#define INITIAL_FILTERX_STATIC_TYPE_SPEC FILTERX_STATIC_TYPE_UNKNOWN_SPEC
+
+static inline FilterXStaticType
+filterx_static_type_kind(FilterXStaticTypeSpec spec)
+{
+  return spec->kind;
+}
+
+/* Drop the outermost level: returns the element type spec.
+ * Element of DICT/LIST → its element chain; element of a scalar or UNKNOWN → UNKNOWN. */
+static inline FilterXStaticTypeSpec
+filterx_static_type_element(FilterXStaticTypeSpec spec)
+{
+  FilterXStaticType kind = filterx_static_type_kind(spec);
+  if (kind != FILTERX_STATIC_TYPE_DICT && kind != FILTERX_STATIC_TYPE_LIST)
+    return FILTERX_STATIC_TYPE_UNKNOWN_SPEC;
+  return spec->element;
+}
+
+/* Build (freeze) a container spec from an outer kind and the element spec. */
+FilterXStaticTypeSpec filterx_static_type_make_container(FilterXStaticType kind, FilterXStaticTypeSpec element);
+
+/* Per-level meet (frozen): the longest common prefix where the kinds agree. */
+FilterXStaticTypeSpec filterx_static_type_spec_meet(FilterXStaticTypeSpec a, FilterXStaticTypeSpec b);
+
+/* Convenience for the common case where we just need the outer kind: a single-level
+ * frozen chain. Returns the UNKNOWN singleton for kind == UNKNOWN. */
+FilterXStaticTypeSpec filterx_static_type_kind_only(FilterXStaticType kind);
+
+typedef struct _FilterXTypeEnv FilterXTypeEnv;
+
+FilterXTypeEnv *filterx_type_env_new(void);
+FilterXTypeEnv *filterx_type_env_clone(const FilterXTypeEnv *self);
+void filterx_type_env_free(FilterXTypeEnv *self);
+
+FilterXStaticTypeSpec filterx_type_spec_get(const FilterXTypeEnv *self, FilterXVariableHandle handle);
+void filterx_type_spec_set(FilterXTypeEnv *self, FilterXVariableHandle handle, FilterXStaticTypeSpec spec);
+
+/* Meet @src into @dst in place. Handles only in one env meet with all-UNKNOWN
+ * → all-UNKNOWN (which is the absent-key default). */
+void filterx_type_env_meet_into(FilterXTypeEnv *dst, const FilterXTypeEnv *src);
+
+struct _FilterXExpr;
+void filterx_expr_infer_types(struct _FilterXExpr *self, FilterXTypeEnv *env);
+void filterx_expr_infer_types_root(struct _FilterXExpr *root);
+
+#endif

--- a/lib/filterx/filterx-type-inference.h
+++ b/lib/filterx/filterx-type-inference.h
@@ -34,6 +34,7 @@ typedef enum
   FILTERX_STATIC_TYPE_LIST    = 2,
   FILTERX_STATIC_TYPE_STRING  = 3,
   FILTERX_STATIC_TYPE_INTEGER = 4,
+  FILTERX_STATIC_TYPE_DOUBLE  = 5,
   /* Sentinel for "freshly built empty container, element type not yet committed".
    * Seeded by literal inference for empty {} / [] containers and carried through the
    * env, where the first write to the container lifts it to the written value's type

--- a/lib/filterx/jit/Makefile.am
+++ b/lib/filterx/jit/Makefile.am
@@ -26,7 +26,7 @@ filterx_bitcode_compile = \
 	$(DEFS) $(DEFAULT_INCLUDES) \
 	$(AM_CPPFLAGS) $(CPPFLAGS) \
 	$(filter-out -fsanitize=%,$(AM_CFLAGS) $(CFLAGS)) \
-	-emit-llvm -O3 --no-warnings
+	-emit-llvm -O3 --no-warnings -mno-outline-atomics
 
 $(filterx_bitcode_units): %.bc: %.c
 	$(AM_V_GEN)$(filterx_bitcode_compile) -c $< -o $@

--- a/lib/filterx/jit/ffi.c
+++ b/lib/filterx/jit/ffi.c
@@ -202,6 +202,79 @@ fx_jit_emit_eval_push_error_info_printf(FilterXJIT *jit, const gchar *msg, Filte
   g_array_free(call_args, TRUE);
 }
 
+/* Helpers whose result is always a freshly created (and therefore typed)
+ * object: make_typed_object() on their result is a guaranteed no-op. */
+static const gchar *const _always_typed_helpers[] =
+{
+  "fx_jit_do_plus",
+  "fx_jit_do_plus_int",
+  "fx_jit_do_plus_string",
+  "fx_jit_arithmetic_sub",
+  "fx_jit_arithmetic_mul",
+  "fx_jit_arithmetic_div",
+  "fx_jit_arithmetic_mod",
+  "fx_jit_arithmetic_uminus",
+  "fx_jit_boolean_new",
+  "fx_jit_expr_eval_typed",
+};
+
+/* Helpers that may return marshalled objects but have a "<name>_typed" twin
+ * that applies make_typed_object() before returning. */
+static const gchar *const _typed_twin_helpers[] =
+{
+  "fx_jit_eval_variable",
+  "fx_jit_do_getattr",
+  "fx_jit_do_getattr_dict",
+  "fx_jit_do_get_subscript_dict",
+  "fx_jit_do_get_subscript_dict_string_key",
+  "fx_jit_do_get_subscript_list",
+  "fx_jit_do_simple_function",
+  "fx_jit_expr_eval",
+};
+
+static gboolean
+_name_in_list(const gchar *name, const gchar *const *list, gsize len)
+{
+  for (gsize i = 0; i < len; i++)
+    {
+      if (strcmp(name, list[i]) == 0)
+        return TRUE;
+    }
+  return FALSE;
+}
+
+gboolean
+fx_jit_try_make_call_result_typed(FilterXJIT *jit, FilterXIRValue value)
+{
+  if (!value || !LLVMIsACallInst(value))
+    return FALSE;
+
+  LLVMValueRef callee = LLVMGetCalledValue(value);
+  if (!callee)
+    return FALSE;
+
+  gsize name_len = 0;
+  const gchar *name = LLVMGetValueName2(callee, &name_len);
+  if (!name || !name_len)
+    return FALSE;
+
+  if (_name_in_list(name, _always_typed_helpers, G_N_ELEMENTS(_always_typed_helpers)))
+    return TRUE;
+
+  if (!_name_in_list(name, _typed_twin_helpers, G_N_ELEMENTS(_typed_twin_helpers)))
+    return FALSE;
+
+  gchar *twin_name = g_strconcat(name, "_typed", NULL);
+  LLVMValueRef twin = LLVMGetNamedFunction(jit->mod, twin_name);
+  if (!twin)
+    twin = LLVMAddFunction(jit->mod, twin_name, LLVMGlobalGetValueType(callee));
+  g_free(twin_name);
+
+  /* the callee is the last operand of a call instruction */
+  LLVMSetOperand(value, LLVMGetNumOperands(value) - 1, twin);
+  return TRUE;
+}
+
 FilterXIRValue
 fx_jit_emit_extern_call(FilterXJIT *jit, const gchar *name, FilterXIRType return_ty,
                         FilterXIRType *param_tys, FilterXIRValue *args, unsigned param_count)

--- a/lib/filterx/jit/ffi.c
+++ b/lib/filterx/jit/ffi.c
@@ -275,6 +275,75 @@ fx_jit_try_make_call_result_typed(FilterXJIT *jit, FilterXIRValue value)
   return TRUE;
 }
 
+/* Statement helpers that have a "<name>_stmt" twin combining the helper with
+ * fx_jit_process_expr_result().  All of them receive the statement expr among
+ * their arguments, so the twin can supply it to the postlude itself. */
+static const gchar *const _stmt_twin_helpers[] =
+{
+  "fx_jit_do_setattr",
+  "fx_jit_do_setattr_dict",
+  "fx_jit_do_nullv_setattr",
+  "fx_jit_do_nullv_setattr_dict",
+  "fx_jit_do_assign",
+  "fx_jit_do_nullv_assign",
+  "fx_jit_do_set_subscript_dict",
+  "fx_jit_do_set_subscript_list",
+  "fx_jit_do_nullv_set_subscript_dict",
+  "fx_jit_do_nullv_set_subscript_list",
+  "fx_jit_expr_eval",
+};
+
+FilterXIRValue
+fx_jit_try_emit_stmt_action(FilterXJIT *jit, FilterXIRValue result,
+                            FilterXIRValue eval_ctx, FilterXIRValue result_slot)
+{
+  if (!result || !LLVMIsACallInst(result))
+    return NULL;
+
+  /* the call is replaced, its result must not have other users */
+  if (LLVMGetFirstUse(result))
+    return NULL;
+
+  LLVMValueRef callee = LLVMGetCalledValue(result);
+  if (!callee)
+    return NULL;
+
+  gsize name_len = 0;
+  const gchar *name = LLVMGetValueName2(callee, &name_len);
+  if (!name || !name_len)
+    return NULL;
+
+  if (!_name_in_list(name, _stmt_twin_helpers, G_N_ELEMENTS(_stmt_twin_helpers)))
+    return NULL;
+
+  LLVMTypeRef fn_ty = LLVMGlobalGetValueType(callee);
+  unsigned nparams = LLVMCountParamTypes(fn_ty);
+  if (nparams != LLVMGetNumArgOperands(result))
+    return NULL;
+
+  LLVMTypeRef *param_tys = g_alloca((nparams + 2) * sizeof(LLVMTypeRef));
+  LLVMGetParamTypes(fn_ty, param_tys);
+  param_tys[nparams] = jit->ffi.ptr_ty;
+  param_tys[nparams + 1] = jit->ffi.ptr_ty;
+
+  FilterXIRValue *args = g_alloca((nparams + 2) * sizeof(FilterXIRValue));
+  for (unsigned i = 0; i < nparams; i++)
+    args[i] = LLVMGetOperand(result, i);
+  args[nparams] = eval_ctx;
+  args[nparams + 1] = result_slot;
+
+  gchar *twin_name = g_strconcat(name, "_stmt", NULL);
+  LLVMTypeRef twin_ty = LLVMFunctionType(jit->ffi.i32_ty, param_tys, nparams + 2, FALSE);
+  LLVMValueRef twin = LLVMGetNamedFunction(jit->mod, twin_name);
+  if (!twin)
+    twin = LLVMAddFunction(jit->mod, twin_name, twin_ty);
+  g_free(twin_name);
+
+  FilterXIRValue action = LLVMBuildCall2(jit->ir, twin_ty, twin, args, nparams + 2, "");
+  LLVMInstructionEraseFromParent(result);
+  return action;
+}
+
 FilterXIRValue
 fx_jit_emit_extern_call(FilterXJIT *jit, const gchar *name, FilterXIRType return_ty,
                         FilterXIRType *param_tys, FilterXIRValue *args, unsigned param_count)

--- a/lib/filterx/jit/ffi.c
+++ b/lib/filterx/jit/ffi.c
@@ -303,6 +303,74 @@ fx_jit_try_make_call_result_typed(FilterXJIT *jit, FilterXIRValue value)
   return TRUE;
 }
 
+/* Statement helpers that have a "<name>_stmt" twin combining the helper with
+ * fx_jit_process_expr_result().  All of them receive the statement expr among
+ * their arguments, so the twin can supply it to the postlude itself. */
+static const gchar *const _stmt_twin_helpers[] =
+{
+  "fx_jit_do_setattr",
+  "fx_jit_do_setattr_dict",
+  "fx_jit_do_nullv_setattr",
+  "fx_jit_do_nullv_setattr_dict",
+  "fx_jit_do_nullv_assign",
+  "fx_jit_do_set_subscript_dict",
+  "fx_jit_do_set_subscript_list",
+  "fx_jit_do_nullv_set_subscript_dict",
+  "fx_jit_do_nullv_set_subscript_list",
+  "fx_jit_expr_eval",
+};
+
+FilterXIRValue
+fx_jit_try_emit_stmt_action(FilterXJIT *jit, FilterXIRValue result,
+                            FilterXIRValue eval_ctx, FilterXIRValue result_slot)
+{
+  if (!result || !LLVMIsACallInst(result))
+    return NULL;
+
+  /* the call is replaced, its result must not have other users */
+  if (LLVMGetFirstUse(result))
+    return NULL;
+
+  LLVMValueRef callee = LLVMGetCalledValue(result);
+  if (!callee)
+    return NULL;
+
+  gsize name_len = 0;
+  const gchar *name = LLVMGetValueName2(callee, &name_len);
+  if (!name || !name_len)
+    return NULL;
+
+  if (!_name_in_list(name, _stmt_twin_helpers, G_N_ELEMENTS(_stmt_twin_helpers)))
+    return NULL;
+
+  LLVMTypeRef fn_ty = LLVMGlobalGetValueType(callee);
+  unsigned nparams = LLVMCountParamTypes(fn_ty);
+  if (nparams != LLVMGetNumArgOperands(result))
+    return NULL;
+
+  LLVMTypeRef *param_tys = g_alloca((nparams + 2) * sizeof(LLVMTypeRef));
+  LLVMGetParamTypes(fn_ty, param_tys);
+  param_tys[nparams] = jit->ffi.ptr_ty;
+  param_tys[nparams + 1] = jit->ffi.ptr_ty;
+
+  FilterXIRValue *args = g_alloca((nparams + 2) * sizeof(FilterXIRValue));
+  for (unsigned i = 0; i < nparams; i++)
+    args[i] = LLVMGetOperand(result, i);
+  args[nparams] = eval_ctx;
+  args[nparams + 1] = result_slot;
+
+  gchar *twin_name = g_strconcat(name, "_stmt", NULL);
+  LLVMTypeRef twin_ty = LLVMFunctionType(jit->ffi.i32_ty, param_tys, nparams + 2, FALSE);
+  LLVMValueRef twin = LLVMGetNamedFunction(jit->mod, twin_name);
+  if (!twin)
+    twin = LLVMAddFunction(jit->mod, twin_name, twin_ty);
+  g_free(twin_name);
+
+  FilterXIRValue action = LLVMBuildCall2(jit->ir, twin_ty, twin, args, nparams + 2, "");
+  LLVMInstructionEraseFromParent(result);
+  return action;
+}
+
 FilterXIRValue
 fx_jit_emit_extern_call(FilterXJIT *jit, const gchar *name, FilterXIRType return_ty,
                         FilterXIRType *param_tys, FilterXIRValue *args, unsigned param_count)

--- a/lib/filterx/jit/ffi.c
+++ b/lib/filterx/jit/ffi.c
@@ -70,6 +70,7 @@ filterx_jit_ffi_init(FilterXJIT *jit)
   jit->ffi.expr_make_typed_object = _declare_func(mod, "fx_jit_expr_make_typed_object", ptr, p2, 2);
 
   jit->ffi.object_ref = _declare_func(mod, "fx_jit_object_ref", ptr, p1, 1);
+  jit->ffi.object_ref_typed = _declare_func(mod, "fx_jit_object_ref_typed", ptr, p1, 1);
   jit->ffi.object_unref = _declare_func(mod, "fx_jit_object_unref", v, p1, 1);
   jit->ffi.object_cow_fork2 = _declare_func(mod, "fx_jit_object_cow_fork2", ptr, p1, 1);
   jit->ffi.object_truthy = _declare_func(mod, "fx_jit_object_truthy", i32, p1, 1);
@@ -158,6 +159,12 @@ fx_jit_emit_object_ref(FilterXJIT *jit, LLVMValueRef obj)
   return _emit_call(jit, jit->ffi.object_ref, &obj, 1);
 }
 
+FilterXIRValue
+fx_jit_emit_object_ref_typed(FilterXJIT *jit, LLVMValueRef obj)
+{
+  return _emit_call(jit, jit->ffi.object_ref_typed, &obj, 1);
+}
+
 void
 fx_jit_emit_object_unref(FilterXJIT *jit, LLVMValueRef obj)
 {
@@ -244,6 +251,7 @@ static const gchar *const _always_typed_helpers[] =
   "fx_jit_arithmetic_uminus",
   "fx_jit_boolean_new",
   "fx_jit_expr_eval_typed",
+  "fx_jit_object_ref_typed",
 };
 
 /* Helpers that may return marshalled objects but have a "<name>_typed" twin
@@ -271,20 +279,48 @@ _name_in_list(const gchar *name, const gchar *const *list, gsize len)
   return FALSE;
 }
 
-gboolean
-fx_jit_try_make_call_result_typed(FilterXJIT *jit, FilterXIRValue value)
+/* Name of the helper @value is a call to, or NULL if it is not a call at all. */
+static const gchar *
+_called_helper_name(FilterXIRValue value)
 {
   if (!value || !LLVMIsACallInst(value))
-    return FALSE;
+    return NULL;
 
   LLVMValueRef callee = LLVMGetCalledValue(value);
   if (!callee)
-    return FALSE;
+    return NULL;
 
   gsize name_len = 0;
   const gchar *name = LLVMGetValueName2(callee, &name_len);
   if (!name || !name_len)
+    return NULL;
+
+  return name;
+}
+
+gboolean
+fx_jit_call_result_is_typed(FilterXJIT *jit, FilterXIRValue value)
+{
+  const gchar *name = _called_helper_name(value);
+  if (!name)
     return FALSE;
+
+  /* a copy-on-write fork hands back either its input or a copy of it, so it never turns a
+   * typed object into a marshalled one (or the other way around) */
+  if (strcmp(name, "fx_jit_object_cow_fork2") == 0)
+    return fx_jit_call_result_is_typed(jit, LLVMGetOperand(value, 0));
+
+  return _name_in_list(name, _always_typed_helpers, G_N_ELEMENTS(_always_typed_helpers));
+}
+
+gboolean
+fx_jit_try_make_call_result_typed(FilterXJIT *jit, FilterXIRValue value)
+{
+  const gchar *name = _called_helper_name(value);
+  if (!name)
+    return FALSE;
+
+  LLVMValueRef callee = LLVMGetCalledValue(value);
 
   if (_name_in_list(name, _always_typed_helpers, G_N_ELEMENTS(_always_typed_helpers)))
     return TRUE;

--- a/lib/filterx/jit/ffi.c
+++ b/lib/filterx/jit/ffi.c
@@ -230,6 +230,79 @@ fx_jit_emit_eval_push_error_info_printf(FilterXJIT *jit, const gchar *msg, const
   g_array_free(call_args, TRUE);
 }
 
+/* Helpers whose result is always a freshly created (and therefore typed)
+ * object: make_typed_object() on their result is a guaranteed no-op. */
+static const gchar *const _always_typed_helpers[] =
+{
+  "fx_jit_do_plus",
+  "fx_jit_do_plus_int",
+  "fx_jit_do_plus_string",
+  "fx_jit_arithmetic_sub",
+  "fx_jit_arithmetic_mul",
+  "fx_jit_arithmetic_div",
+  "fx_jit_arithmetic_mod",
+  "fx_jit_arithmetic_uminus",
+  "fx_jit_boolean_new",
+  "fx_jit_expr_eval_typed",
+};
+
+/* Helpers that may return marshalled objects but have a "<name>_typed" twin
+ * that applies make_typed_object() before returning. */
+static const gchar *const _typed_twin_helpers[] =
+{
+  "fx_jit_eval_variable",
+  "fx_jit_do_getattr",
+  "fx_jit_do_getattr_dict",
+  "fx_jit_do_get_subscript_dict",
+  "fx_jit_do_get_subscript_dict_string_key",
+  "fx_jit_do_get_subscript_list",
+  "fx_jit_do_simple_function",
+  "fx_jit_expr_eval",
+};
+
+static gboolean
+_name_in_list(const gchar *name, const gchar *const *list, gsize len)
+{
+  for (gsize i = 0; i < len; i++)
+    {
+      if (strcmp(name, list[i]) == 0)
+        return TRUE;
+    }
+  return FALSE;
+}
+
+gboolean
+fx_jit_try_make_call_result_typed(FilterXJIT *jit, FilterXIRValue value)
+{
+  if (!value || !LLVMIsACallInst(value))
+    return FALSE;
+
+  LLVMValueRef callee = LLVMGetCalledValue(value);
+  if (!callee)
+    return FALSE;
+
+  gsize name_len = 0;
+  const gchar *name = LLVMGetValueName2(callee, &name_len);
+  if (!name || !name_len)
+    return FALSE;
+
+  if (_name_in_list(name, _always_typed_helpers, G_N_ELEMENTS(_always_typed_helpers)))
+    return TRUE;
+
+  if (!_name_in_list(name, _typed_twin_helpers, G_N_ELEMENTS(_typed_twin_helpers)))
+    return FALSE;
+
+  gchar *twin_name = g_strconcat(name, "_typed", NULL);
+  LLVMValueRef twin = LLVMGetNamedFunction(jit->mod, twin_name);
+  if (!twin)
+    twin = LLVMAddFunction(jit->mod, twin_name, LLVMGlobalGetValueType(callee));
+  g_free(twin_name);
+
+  /* the callee is the last operand of a call instruction */
+  LLVMSetOperand(value, LLVMGetNumOperands(value) - 1, twin);
+  return TRUE;
+}
+
 FilterXIRValue
 fx_jit_emit_extern_call(FilterXJIT *jit, const gchar *name, FilterXIRType return_ty,
                         FilterXIRType *param_tys, FilterXIRValue *args, unsigned param_count)

--- a/lib/filterx/jit/ffi.h
+++ b/lib/filterx/jit/ffi.h
@@ -93,6 +93,19 @@ FilterXIRValue fx_jit_emit_extern_call(FilterXJIT *jit, const gchar *name, Filte
  * value is guaranteed to be typed. */
 gboolean fx_jit_try_make_call_result_typed(FilterXJIT *jit, FilterXIRValue value);
 
+/* Statement postlude shared by compound statements and the "<name>_stmt"
+ * combined helpers, implemented in expr-compound.c. */
+struct _FilterXEvalContext;
+gint32 fx_jit_process_expr_result(FilterXObject *current_result, FilterXExpr *child,
+                                  struct _FilterXEvalContext *context, FilterXObject **last_result);
+
+/* If @result is a call to a statement helper that has a "<name>_stmt" twin
+ * (helper combined with fx_jit_process_expr_result()), replace the call with
+ * one to the twin and return the emitted step-action value.  Returns NULL if
+ * @result is not foldable; the caller must emit the postlude itself. */
+FilterXIRValue fx_jit_try_emit_stmt_action(FilterXJIT *jit, FilterXIRValue result,
+                                           FilterXIRValue eval_ctx, FilterXIRValue result_slot);
+
 /* private */
 void filterx_jit_ffi_init(FilterXJIT *jit);
 

--- a/lib/filterx/jit/ffi.h
+++ b/lib/filterx/jit/ffi.h
@@ -87,6 +87,12 @@ void fx_jit_emit_eval_push_error_info_printf(FilterXJIT *jit, const gchar *msg, 
 FilterXIRValue fx_jit_emit_extern_call(FilterXJIT *jit, const gchar *name, FilterXIRType return_ty,
                                        FilterXIRType *param_tys, FilterXIRValue *args, unsigned param_count);
 
+/* If @value is a call to a helper that has a make-typed twin (or whose result
+ * is inherently typed), retarget the call in place so a separate
+ * make_typed_object() call does not have to be emitted.  Returns TRUE if the
+ * value is guaranteed to be typed. */
+gboolean fx_jit_try_make_call_result_typed(FilterXJIT *jit, FilterXIRValue value);
+
 /* private */
 void filterx_jit_ffi_init(FilterXJIT *jit);
 

--- a/lib/filterx/jit/ffi.h
+++ b/lib/filterx/jit/ffi.h
@@ -50,6 +50,7 @@ typedef struct _FilterXJITFFI
   FilterXJITFFICall expr_make_typed_object;
 
   FilterXJITFFICall object_ref;
+  FilterXJITFFICall object_ref_typed;
   FilterXJITFFICall object_unref;
   FilterXJITFFICall object_cow_fork2;
   FilterXJITFFICall object_truthy;
@@ -71,6 +72,8 @@ FilterXIRValue fx_jit_emit_expr_make_typed_object(FilterXJIT *jit, FilterXExpr *
 FilterXIRValue fx_jit_emit_expr_propagate_to_error_if_null(FilterXJIT *jit, FilterXExpr *expr, FilterXIRValue result);
 
 FilterXIRValue fx_jit_emit_object_ref(FilterXJIT *jit, FilterXIRValue obj);
+/* Like fx_jit_emit_object_ref(), but also marks @obj as already unmarshalled. */
+FilterXIRValue fx_jit_emit_object_ref_typed(FilterXJIT *jit, FilterXIRValue obj);
 void fx_jit_emit_object_unref(FilterXJIT *jit, FilterXIRValue obj);
 FilterXIRValue fx_jit_emit_object_cow_fork2(FilterXJIT *jit, FilterXIRValue obj);
 FilterXIRValue fx_jit_emit_object_truthy(FilterXJIT *jit, FilterXIRValue obj);
@@ -93,6 +96,10 @@ FilterXIRValue fx_jit_emit_extern_call(FilterXJIT *jit, const gchar *name, Filte
  * make_typed_object() call does not have to be emitted.  Returns TRUE if the
  * value is guaranteed to be typed. */
 gboolean fx_jit_try_make_call_result_typed(FilterXJIT *jit, FilterXIRValue value);
+
+/* Side-effect free variant: TRUE if @value is a call whose result is inherently typed.
+ * Unlike the above it never retargets the call, so it is safe to use as a predicate. */
+gboolean fx_jit_call_result_is_typed(FilterXJIT *jit, FilterXIRValue value);
 
 /* Statement postlude shared by compound statements and the "<name>_stmt"
  * combined helpers, implemented in expr-compound.c. */

--- a/lib/filterx/jit/ffi.h
+++ b/lib/filterx/jit/ffi.h
@@ -94,6 +94,19 @@ FilterXIRValue fx_jit_emit_extern_call(FilterXJIT *jit, const gchar *name, Filte
  * value is guaranteed to be typed. */
 gboolean fx_jit_try_make_call_result_typed(FilterXJIT *jit, FilterXIRValue value);
 
+/* Statement postlude shared by compound statements and the "<name>_stmt"
+ * combined helpers, implemented in expr-compound.c. */
+struct _FilterXEvalContext;
+gint32 fx_jit_process_expr_result(FilterXObject *current_result, FilterXExpr *child,
+                                  struct _FilterXEvalContext *context, FilterXObject **last_result);
+
+/* If @result is a call to a statement helper that has a "<name>_stmt" twin
+ * (helper combined with fx_jit_process_expr_result()), replace the call with
+ * one to the twin and return the emitted step-action value.  Returns NULL if
+ * @result is not foldable; the caller must emit the postlude itself. */
+FilterXIRValue fx_jit_try_emit_stmt_action(FilterXJIT *jit, FilterXIRValue result,
+                                           FilterXIRValue eval_ctx, FilterXIRValue result_slot);
+
 /* private */
 void filterx_jit_ffi_init(FilterXJIT *jit);
 

--- a/lib/filterx/jit/ffi.h
+++ b/lib/filterx/jit/ffi.h
@@ -88,6 +88,12 @@ G_GNUC_PRINTF(3, 4);
 FilterXIRValue fx_jit_emit_extern_call(FilterXJIT *jit, const gchar *name, FilterXIRType return_ty,
                                        FilterXIRType *param_tys, FilterXIRValue *args, unsigned param_count);
 
+/* If @value is a call to a helper that has a make-typed twin (or whose result
+ * is inherently typed), retarget the call in place so a separate
+ * make_typed_object() call does not have to be emitted.  Returns TRUE if the
+ * value is guaranteed to be typed. */
+gboolean fx_jit_try_make_call_result_typed(FilterXJIT *jit, FilterXIRValue value);
+
 /* private */
 void filterx_jit_ffi_init(FilterXJIT *jit);
 

--- a/lib/filterx/jit/jit-runtime.c
+++ b/lib/filterx/jit/jit-runtime.c
@@ -47,6 +47,13 @@ fx_jit_expr_eval(FilterXExpr *self)
   return filterx_expr_eval(self);
 }
 
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_expr_eval_stmt(FilterXExpr *self, FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(filterx_expr_eval(self), self, context, last_result);
+}
+
 __attribute__((used))
 FilterXObject *
 fx_jit_expr_eval_typed(FilterXExpr *self)

--- a/lib/filterx/jit/jit-runtime.c
+++ b/lib/filterx/jit/jit-runtime.c
@@ -48,6 +48,13 @@ fx_jit_expr_eval(FilterXExpr *self)
   return filterx_expr_eval(self);
 }
 
+__attribute__((used)) __attribute__((noinline))
+gint32
+fx_jit_expr_eval_stmt(FilterXExpr *self, FilterXEvalContext *context, FilterXObject **last_result)
+{
+  return fx_jit_process_expr_result(filterx_expr_eval(self), self, context, last_result);
+}
+
 __attribute__((used))
 FilterXObject *
 fx_jit_expr_eval_typed(FilterXExpr *self)

--- a/lib/filterx/jit/jit-runtime.c
+++ b/lib/filterx/jit/jit-runtime.c
@@ -76,6 +76,16 @@ fx_jit_object_ref(FilterXObject *self)
   return filterx_object_ref(self);
 }
 
+/* Identical to fx_jit_object_ref() at runtime.  The distinct name is what marks the
+ * referenced value as already unmarshalled, so filterx_expr_compile_typed() does not
+ * have to emit a make_typed_object() call for it. */
+__attribute__((used))
+FilterXObject *
+fx_jit_object_ref_typed(FilterXObject *self)
+{
+  return filterx_object_ref(self);
+}
+
 __attribute__((used))
 FilterXObject *
 fx_jit_object_cow_fork2(FilterXObject *self)

--- a/lib/filterx/jit/jit.c
+++ b/lib/filterx/jit/jit.c
@@ -300,6 +300,18 @@ filterx_jit_ir_clear_variables(FilterXJIT *self)
   _reset_variables(self);
 }
 
+void
+filterx_jit_ir_invalidate_variable(FilterXJIT *self, gint scope_var_idx)
+{
+  g_assert(!self->mod_finalized);
+
+  if (!self->current_block_variables)
+    return;
+
+  LLVMBuildStore(self->ir, _variable_uninitialized_sentinel(self),
+                 filterx_jit_ir_get_variable(self, scope_var_idx));
+}
+
 FilterXIRValue
 filterx_jit_ir_get_eval_context(FilterXJIT *self)
 {
@@ -830,6 +842,11 @@ FilterXIRValue filterx_jit_ir_is_variable_uninitialized(FilterXJIT *self, Filter
 }
 
 void filterx_jit_ir_clear_variables(FilterXJIT *self)
+{
+  g_assert_not_reached();
+}
+
+void filterx_jit_ir_invalidate_variable(FilterXJIT *self, gint scope_var_idx)
 {
   g_assert_not_reached();
 }

--- a/lib/filterx/jit/jit.h
+++ b/lib/filterx/jit/jit.h
@@ -96,6 +96,8 @@ FilterXIRValue filterx_jit_ir_get_eval_context(FilterXJIT *self);
 FilterXIRValue filterx_jit_ir_get_variable(FilterXJIT *self, gint scope_var_idx);
 FilterXIRValue filterx_jit_ir_is_variable_uninitialized(FilterXJIT *self, FilterXIRValue variable);
 void filterx_jit_ir_clear_variables(FilterXJIT *self);
+/* Reset a single slot to the uninitialized sentinel, so the next read refills it. */
+void filterx_jit_ir_invalidate_variable(FilterXJIT *self, gint scope_var_idx);
 
 void filterx_jit_ir_set_source_location(FilterXJIT *self, const gchar *file, gint line, gint column);
 

--- a/lib/filterx/object-dict.c
+++ b/lib/filterx/object-dict.c
@@ -867,6 +867,23 @@ filterx_dict_get_subscript_unchecked(FilterXObject *s, FilterXObject *key)
   return value;
 }
 
+gboolean
+filterx_dict_set_subscript(FilterXObject *s, FilterXObject *key, FilterXObject **new_value)
+{
+  /* Mirrors _filterx_ref_set_subscript inline so the cow + parent linkage are visible to
+   * the optimizer at the JIT call site, and the dict's set_subscript fires directly. */
+  if (filterx_object_is_ref(s))
+    {
+      FilterXRef *ref = (FilterXRef *) s;
+      _filterx_ref_cow(ref);
+      gboolean result = _filterx_dict_set_subscript(ref->value, key, new_value);
+      if (result)
+        filterx_ref_set_parent_container(*new_value, s);
+      return result;
+    }
+  return _filterx_dict_set_subscript(s, key, new_value);
+}
+
 FilterXObject *
 filterx_dict_new(void)
 {

--- a/lib/filterx/object-dict.c
+++ b/lib/filterx/object-dict.c
@@ -852,6 +852,22 @@ filterx_dict_get_subscript(FilterXObject *s, FilterXObject *key)
 }
 
 FilterXObject *
+filterx_dict_get_subscript_unchecked(FilterXObject *s, FilterXObject *key)
+{
+  /* The caller is responsible for ensuring @key is hashable (i.e. a string), letting us
+   * skip the normalize_key vtable check that the generic path runs. */
+  FilterXDictObject *self = (FilterXDictObject *) filterx_ref_unwrap_ro(s);
+
+  if (!self->table)
+    return NULL;
+
+  FilterXObject *value = NULL;
+  if (!_table_lookup(self->table, key, &value))
+    return NULL;
+  return value;
+}
+
+FilterXObject *
 filterx_dict_new(void)
 {
   return filterx_dict_new_with_table(NULL);

--- a/lib/filterx/object-dict.c
+++ b/lib/filterx/object-dict.c
@@ -846,6 +846,12 @@ filterx_dict_set_subscript_by_anchor(FilterXObject *s, FilterXDictAnchor anchor,
 }
 
 FilterXObject *
+filterx_dict_get_subscript(FilterXObject *s, FilterXObject *key)
+{
+  return _filterx_dict_get_subscript(filterx_ref_unwrap_ro(s), key);
+}
+
+FilterXObject *
 filterx_dict_new(void)
 {
   return filterx_dict_new_with_table(NULL);

--- a/lib/filterx/object-dict.h
+++ b/lib/filterx/object-dict.h
@@ -42,4 +42,9 @@ void filterx_dict_set_subscript_by_anchor(FilterXObject *s, FilterXDictAnchor an
  * vtable indirection. */
 FilterXObject *filterx_dict_get_subscript(FilterXObject *s, FilterXObject *key);
 
+/* Like filterx_dict_get_subscript, but the caller asserts that @key is hashable (i.e. a
+ * string). Skips the normalize_key vtable check; intended for JIT call sites that have
+ * proven the key's static type at compile time. */
+FilterXObject *filterx_dict_get_subscript_unchecked(FilterXObject *s, FilterXObject *key);
+
 #endif

--- a/lib/filterx/object-dict.h
+++ b/lib/filterx/object-dict.h
@@ -47,4 +47,8 @@ FilterXObject *filterx_dict_get_subscript(FilterXObject *s, FilterXObject *key);
  * proven the key's static type at compile time. */
 FilterXObject *filterx_dict_get_subscript_unchecked(FilterXObject *s, FilterXObject *key);
 
+/* Devirtualized fast path for dict subscript writes. Handles the FilterXRef cow + parent
+ * linkage that the generic vtable path would route through two indirections. */
+gboolean filterx_dict_set_subscript(FilterXObject *s, FilterXObject *key, FilterXObject **new_value);
+
 #endif

--- a/lib/filterx/object-dict.h
+++ b/lib/filterx/object-dict.h
@@ -37,4 +37,9 @@ FilterXObject *filterx_dict_new_from_args(FilterXExpr *s, FilterXObject *args[],
 FilterXDictAnchor filterx_dict_get_anchor_for_key(FilterXObject *s, FilterXObject *key);
 void filterx_dict_set_subscript_by_anchor(FilterXObject *s, FilterXDictAnchor anchor, FilterXObject **new_value);
 
+/* Devirtualized fast path for dict subscript reads. Unwraps a FilterXRef wrapper and
+ * dispatches directly to the dict's get_subscript implementation, skipping the FilterXObject
+ * vtable indirection. */
+FilterXObject *filterx_dict_get_subscript(FilterXObject *s, FilterXObject *key);
+
 #endif

--- a/lib/filterx/object-list.c
+++ b/lib/filterx/object-list.c
@@ -413,6 +413,21 @@ filterx_list_get_subscript(FilterXObject *s, FilterXObject *key)
   return _filterx_list_get_subscript(filterx_ref_unwrap_ro(s), key);
 }
 
+gboolean
+filterx_list_set_subscript_via_key(FilterXObject *s, FilterXObject *key, FilterXObject **new_value)
+{
+  if (filterx_object_is_ref(s))
+    {
+      FilterXRef *ref = (FilterXRef *) s;
+      _filterx_ref_cow(ref);
+      gboolean result = _filterx_list_set_subscript(ref->value, key, new_value);
+      if (result)
+        filterx_ref_set_parent_container(*new_value, s);
+      return result;
+    }
+  return _filterx_list_set_subscript(s, key, new_value);
+}
+
 FILTERX_DEFINE_TYPE(list, FILTERX_TYPE_NAME(sequence),
                     .is_mutable = TRUE,
                     .truthy = _filterx_list_truthy,

--- a/lib/filterx/object-list.c
+++ b/lib/filterx/object-list.c
@@ -407,6 +407,12 @@ filterx_list_new_from_args(FilterXExpr *s, FilterXObject *args[], gsize args_len
   return NULL;
 }
 
+FilterXObject *
+filterx_list_get_subscript(FilterXObject *s, FilterXObject *key)
+{
+  return _filterx_list_get_subscript(filterx_ref_unwrap_ro(s), key);
+}
+
 FILTERX_DEFINE_TYPE(list, FILTERX_TYPE_NAME(sequence),
                     .is_mutable = TRUE,
                     .truthy = _filterx_list_truthy,

--- a/lib/filterx/object-list.h
+++ b/lib/filterx/object-list.h
@@ -44,6 +44,11 @@ FilterXObject *filterx_list_new(void);
 FilterXObject *filterx_list_new_from_syslog_ng_list(const gchar *repr, gssize repr_len);
 FilterXObject *filterx_list_new_from_args(FilterXExpr *s, FilterXObject *args[], gsize args_len);
 
+/* Devirtualized fast path for list subscript reads. Unwraps a FilterXRef wrapper and
+ * dispatches directly to the list's get_subscript implementation, skipping the FilterXObject
+ * vtable indirection. */
+FilterXObject *filterx_list_get_subscript(FilterXObject *s, FilterXObject *key);
+
 
 /* these are low-level, fast interfaces which bypass a lot of validations */
 

--- a/lib/filterx/object-list.h
+++ b/lib/filterx/object-list.h
@@ -49,6 +49,11 @@ FilterXObject *filterx_list_new_from_args(FilterXExpr *s, FilterXObject *args[],
  * vtable indirection. */
 FilterXObject *filterx_list_get_subscript(FilterXObject *s, FilterXObject *key);
 
+/* Devirtualized fast path for list subscript writes (by FilterXObject key, not by integer
+ * index). Handles the FilterXRef cow + parent linkage inline. Named distinctly from the
+ * by-index inline above. */
+gboolean filterx_list_set_subscript_via_key(FilterXObject *s, FilterXObject *key, FilterXObject **new_value);
+
 
 /* these are low-level, fast interfaces which bypass a lot of validations */
 

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -169,6 +169,12 @@ _string_add(FilterXObject *s, FilterXObject *object)
   return result;
 }
 
+FilterXObject *
+filterx_string_concat(FilterXObject *lhs, FilterXObject *rhs)
+{
+  return _string_add(lhs, rhs);
+}
+
 static inline FilterXString *
 _string_new(const gchar *str, gssize str_len, FilterXStringTranslateFunc translate)
 {

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -88,6 +88,11 @@ FilterXObject *filterx_string_new_from_json_literal(const gchar *str, gssize str
 FilterXObject *filterx_string_new_frozen(const gchar *str);
 
 FilterXObject *filterx_bytes_new(const gchar *str, gssize str_len);
+
+/* Devirtualized fast path for string concatenation. @lhs must be a FilterXString (the
+ * caller has proven this via static-type inference); @rhs may be any string-extractable
+ * value (FilterXString or FilterXMessageValue with string content). */
+FilterXObject *filterx_string_concat(FilterXObject *lhs, FilterXObject *rhs);
 FilterXObject *filterx_bytes_new_take(gchar *str, gssize str_len);
 FilterXObject *filterx_protobuf_new(const gchar *str, gssize str_len);
 

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -89,6 +89,11 @@ FilterXObject *filterx_string_new_from_json_literal(const gchar *str, gssize str
 FilterXObject *filterx_string_new_frozen(const gchar *str);
 
 FilterXObject *filterx_bytes_new(const gchar *str, gssize str_len);
+
+/* Devirtualized fast path for string concatenation. @lhs must be a FilterXString (the
+ * caller has proven this via static-type inference); @rhs may be any string-extractable
+ * value (FilterXString or FilterXMessageValue with string content). */
+FilterXObject *filterx_string_concat(FilterXObject *lhs, FilterXObject *rhs);
 FilterXObject *filterx_bytes_new_take(gchar *str, gssize str_len);
 FilterXObject *filterx_protobuf_new(const gchar *str, gssize str_len);
 

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -41,3 +41,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_object_ip DEPENDS json-plugin ${JSON
 add_unit_test(LIBTEST CRITERION TARGET test_expr_arithmetic_operators DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_func_set_pri DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_json_repr DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_type_inference DEPENDS syslogformat json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -43,3 +43,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_func_set_pri DEPENDS json-plugin ${J
 add_unit_test(LIBTEST CRITERION TARGET test_json_repr DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_filterx_plist DEPENDS syslogformat json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_tuple DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_type_inference DEPENDS syslogformat json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -44,7 +44,8 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_object_ip \
 		lib/filterx/tests/test_expr_arithmetic_operators \
 		lib/filterx/tests/test_func_set_pri \
-		lib/filterx/tests/test_json_repr
+		lib/filterx/tests/test_json_repr \
+		lib/filterx/tests/test_type_inference
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt
 
@@ -70,6 +71,9 @@ lib_filterx_tests_test_object_string_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_filterx_expr_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_filterx_expr_LDADD   = $(TEST_LDADD) $(PREOPEN_SYSLOGFORMAT) $(JSON_LIBS)
+
+lib_filterx_tests_test_type_inference_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_type_inference_LDADD   = $(TEST_LDADD) $(PREOPEN_SYSLOGFORMAT) $(JSON_LIBS)
 
 lib_filterx_tests_test_filterx_plist_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_filterx_plist_LDADD   = $(TEST_LDADD) $(PREOPEN_SYSLOGFORMAT) $(JSON_LIBS)

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -45,7 +45,8 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_object_ip \
 		lib/filterx/tests/test_expr_arithmetic_operators \
 		lib/filterx/tests/test_func_set_pri \
-		lib/filterx/tests/test_json_repr
+		lib/filterx/tests/test_json_repr \
+		lib/filterx/tests/test_type_inference
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt
 
@@ -74,6 +75,9 @@ lib_filterx_tests_test_object_string_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_filterx_expr_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_filterx_expr_LDADD   = $(TEST_LDADD) $(PREOPEN_SYSLOGFORMAT) $(JSON_LIBS)
+
+lib_filterx_tests_test_type_inference_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_type_inference_LDADD   = $(TEST_LDADD) $(PREOPEN_SYSLOGFORMAT) $(JSON_LIBS)
 
 lib_filterx_tests_test_filterx_plist_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_filterx_plist_LDADD   = $(TEST_LDADD) $(PREOPEN_SYSLOGFORMAT) $(JSON_LIBS)

--- a/lib/filterx/tests/test_type_inference.c
+++ b/lib/filterx/tests/test_type_inference.c
@@ -463,53 +463,49 @@ Test(filterx_type_inference, one_sided_branch_write_collapses_element_to_unknown
   filterx_expr_unref(block);
 }
 
+/* Build a fresh getattr chain d.keys[0].keys[1]...keys[n-1]. */
+static FilterXExpr *
+_build_attr_chain(const gchar **keys, gint n)
+{
+  FilterXExpr *expr = filterx_floating_variable_expr_new("d");
+  for (gint i = 0; i < n; i++)
+    expr = filterx_getattr_new(expr, filterx_string_new(keys[i], -1));
+  return expr;
+}
+
 Test(filterx_type_inference, incremental_build_past_depth_cap_is_safe)
 {
-  /* Build a chain one level past the depth cap. The within-cap levels still resolve to DICT;
-   * the write past the cap is a safe no-op (no crash, no false propagation). */
-  FilterXExpr *assign_meta = filterx_assign_new(
-                               filterx_floating_variable_expr_new("meta"),
-                               filterx_literal_dict_new(NULL));
-  FilterXExpr *set_a = filterx_setattr_new(
-                         filterx_floating_variable_expr_new("meta"),
-                         filterx_string_new("a", -1),
-                         filterx_literal_dict_new(NULL));
-  FilterXExpr *set_ab = filterx_setattr_new(
-                          filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
-                                              filterx_string_new("a", -1)),
-                          filterx_string_new("b", -1),
-                          filterx_literal_dict_new(NULL));
-  FilterXExpr *set_abc = filterx_setattr_new(
-                           filterx_getattr_new(
-                             filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
-                                                 filterx_string_new("a", -1)),
-                             filterx_string_new("b", -1)),
-                           filterx_string_new("c", -1),
-                           filterx_literal_dict_new(NULL));
-  /* This write lands past the depth cap: it must be a safe no-op. */
-  FilterXExpr *set_abcd = filterx_setattr_new(
-                            filterx_getattr_new(
-                              filterx_getattr_new(
-                                filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
-                                                    filterx_string_new("a", -1)),
-                                filterx_string_new("b", -1)),
-                              filterx_string_new("c", -1)),
-                            filterx_string_new("d", -1),
-                            filterx_literal_dict_new(NULL));
+  /* Build a getattr chain far deeper than FILTERX_ATTR_CHAIN_MAX (16). Levels within the cap
+   * resolve to DICT; writes that land past the cap are safe no-ops (no crash, no false
+   * propagation). DEPTH is chosen comfortably past the cap so the test stays meaningful
+   * regardless of the exact cap value. */
+  enum { DEPTH = 20 };
+  gchar key_storage[DEPTH][8];
+  const gchar *keys[DEPTH];
+  for (gint i = 0; i < DEPTH; i++)
+    {
+      g_snprintf(key_storage[i], sizeof(key_storage[i]), "k%d", i);
+      keys[i] = key_storage[i];
+    }
 
-  FilterXExpr *read_abc = filterx_getattr_new(
-                            filterx_getattr_new(
-                              filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
-                                                  filterx_string_new("a", -1)),
-                              filterx_string_new("b", -1)),
-                            filterx_string_new("c", -1));
+  FilterXExpr *block = filterx_compound_expr_new(TRUE);
+  filterx_compound_expr_add_ref(block, filterx_assign_new(
+                                  filterx_floating_variable_expr_new("d"),
+                                  filterx_literal_dict_new(NULL)));
+  /* d.k0 = {}; d.k0.k1 = {}; ... — the deepest writes land past the cap as no-ops. */
+  for (gint level = 0; level < DEPTH; level++)
+    filterx_compound_expr_add_ref(block, filterx_setattr_new(
+                                    _build_attr_chain(keys, level),
+                                    filterx_string_new(keys[level], -1),
+                                    filterx_literal_dict_new(NULL)));
 
-  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_meta, set_a, set_ab, set_abc,
-                                                    set_abcd, read_abc, NULL);
+  /* d.k0.k1.k2.k3 is well within the cap, so it still resolves. */
+  FilterXExpr *read = _build_attr_chain(keys, 4);
+  filterx_compound_expr_add_ref(block, read);
+
   block = _run(block);
 
-  /* meta.a.b.c is the level-3 element (within the depth-4 cap), so it still resolves. */
-  cr_assert_eq(filterx_static_type_kind(read_abc->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(read->static_type), FILTERX_STATIC_TYPE_DICT);
   filterx_expr_unref(block);
 }
 

--- a/lib/filterx/tests/test_type_inference.c
+++ b/lib/filterx/tests/test_type_inference.c
@@ -65,8 +65,8 @@ Test(filterx_type_inference, literal_dict_is_dict)
   FilterXExpr *empty_dict = filterx_literal_dict_new(NULL);
   empty_dict = _run(empty_dict);
   /* Fully-literal containers fold to a 'literal' expr at optimize time, and the
-   * literal's inference reads the underlying FilterXObject type. An empty container has no
-   * element, so the kind is DICT and element() is UNKNOWN. */
+   * literal's inference reads the underlying FilterXObject type. An empty container carries
+   * the FRESH element sentinel internally; the kind is DICT and element() sanitizes to UNKNOWN. */
   cr_assert_eq(filterx_static_type_kind(empty_dict->static_type), FILTERX_STATIC_TYPE_DICT);
   cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(empty_dict->static_type)),
                FILTERX_STATIC_TYPE_UNKNOWN);
@@ -210,6 +210,32 @@ Test(filterx_type_inference, folded_literal_dict_of_string_tracks_element_type)
   filterx_expr_unref(d);
 }
 
+Test(filterx_type_inference, folded_literal_depth3_dict_chain)
+{
+  /* {"l1": {"l2": {"l3": "leaf"}}}, fully literal → DICT_OF_DICT_OF_DICT_OF_STRING. */
+  GList *l3_elems = g_list_append(NULL, filterx_literal_element_new(
+                                    filterx_literal_new(filterx_string_new("l3", -1)),
+                                    filterx_literal_new(filterx_string_new("leaf", -1))));
+  GList *l2_elems = g_list_append(NULL, filterx_literal_element_new(
+                                    filterx_literal_new(filterx_string_new("l2", -1)),
+                                    filterx_literal_dict_new(l3_elems)));
+  GList *l1_elems = g_list_append(NULL, filterx_literal_element_new(
+                                    filterx_literal_new(filterx_string_new("l1", -1)),
+                                    filterx_literal_dict_new(l2_elems)));
+  FilterXExpr *d = filterx_literal_dict_new(l1_elems);
+  d = _run(d);
+
+  FilterXStaticTypeSpec spec = d->static_type;
+  cr_assert_eq(filterx_static_type_kind(spec), FILTERX_STATIC_TYPE_DICT);
+  spec = filterx_static_type_element(spec);
+  cr_assert_eq(filterx_static_type_kind(spec), FILTERX_STATIC_TYPE_DICT);
+  spec = filterx_static_type_element(spec);
+  cr_assert_eq(filterx_static_type_kind(spec), FILTERX_STATIC_TYPE_DICT);
+  spec = filterx_static_type_element(spec);
+  cr_assert_eq(filterx_static_type_kind(spec), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(d);
+}
+
 Test(filterx_type_inference, mixed_value_types_in_literal_dict_collapse_element)
 {
   /* {"a": "x", "b": [1, 2]} — string and list values; element type meets to UNKNOWN. */
@@ -248,6 +274,242 @@ Test(filterx_type_inference, get_subscript_shifts_operand_spec)
   block = _run(block);
 
   cr_assert_eq(filterx_static_type_kind(read->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, getattr_chain_propagates_through_three_levels)
+{
+  /* d = {"a": {"b": {"c": "leaf"}}} → DICT_OF_DICT_OF_DICT_OF_STRING.
+   * d.a.b.c → STRING. */
+  GList *l3 = g_list_append(NULL, filterx_literal_element_new(
+                              filterx_literal_new(filterx_string_new("c", -1)),
+                              filterx_literal_new(filterx_string_new("leaf", -1))));
+  GList *l2 = g_list_append(NULL, filterx_literal_element_new(
+                              filterx_literal_new(filterx_string_new("b", -1)),
+                              filterx_literal_dict_new(l3)));
+  GList *l1 = g_list_append(NULL, filterx_literal_element_new(
+                              filterx_literal_new(filterx_string_new("a", -1)),
+                              filterx_literal_dict_new(l2)));
+  FilterXExpr *assign = filterx_assign_new(
+                          filterx_floating_variable_expr_new("d"),
+                          filterx_literal_dict_new(l1));
+  FilterXExpr *read_var = filterx_floating_variable_expr_new("d");
+  FilterXExpr *get_a = filterx_getattr_new(read_var, filterx_string_new("a", -1));
+  FilterXExpr *get_b = filterx_getattr_new(get_a, filterx_string_new("b", -1));
+  FilterXExpr *get_c = filterx_getattr_new(get_b, filterx_string_new("c", -1));
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign, get_c, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_var->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(get_a->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(get_b->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(get_c->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, set_subscript_on_variable_pessimizes_element_type)
+{
+  /* d = {"a": "x"} → DICT_OF_STRING. d["b"] = 42; later read d → DICT (element UNKNOWN). */
+  GList *elems = g_list_append(NULL, filterx_literal_element_new(
+                                 filterx_literal_new(filterx_string_new("a", -1)),
+                                 filterx_literal_new(filterx_string_new("x", -1))));
+  FilterXExpr *assign = filterx_assign_new(
+                          filterx_floating_variable_expr_new("d"),
+                          filterx_literal_dict_new(elems));
+  FilterXExpr *set = filterx_set_subscript_new(
+                       filterx_floating_variable_expr_new("d"),
+                       filterx_literal_new(filterx_string_new("b", -1)),
+                       filterx_literal_new(filterx_integer_new(42)));
+  FilterXExpr *read = filterx_floating_variable_expr_new("d");
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign, set, read, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(read->static_type)), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(block);
+}
+
+/* ---- incremental container building (lift-on-write) ---- */
+
+Test(filterx_type_inference, incremental_dict_build_tracks_nested_element_types)
+{
+  /* d = {}; d.a = {}; d.a.b = {};  → d is DICT_OF_DICT_OF_DICT.
+   * Reads of d, d.a, d.a.b all resolve to DICT — the incremental build matches
+   * what a nested literal would have produced, so the deep chain devirtualizes. */
+  FilterXExpr *assign_d = filterx_assign_new(
+                            filterx_floating_variable_expr_new("d"),
+                            filterx_literal_dict_new(NULL));
+  FilterXExpr *set_a = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("d"),
+                         filterx_string_new("a", -1),
+                         filterx_literal_dict_new(NULL));
+  FilterXExpr *set_ab = filterx_setattr_new(
+                          filterx_getattr_new(filterx_floating_variable_expr_new("d"),
+                                              filterx_string_new("a", -1)),
+                          filterx_string_new("b", -1),
+                          filterx_literal_dict_new(NULL));
+
+  FilterXExpr *read_d = filterx_floating_variable_expr_new("d");
+  FilterXExpr *read_a = filterx_getattr_new(filterx_floating_variable_expr_new("d"),
+                                            filterx_string_new("a", -1));
+  FilterXExpr *read_ab = filterx_getattr_new(
+                           filterx_getattr_new(filterx_floating_variable_expr_new("d"),
+                                               filterx_string_new("a", -1)),
+                           filterx_string_new("b", -1));
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_d, set_a, set_ab,
+                                                    read_d, read_a, read_ab, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_d->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(read_a->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(read_ab->static_type), FILTERX_STATIC_TYPE_DICT);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, per_key_type_survives_heterogeneous_sibling)
+{
+  /* d = {}; d.a = {}; d.b = "s";  → d's *element* type smears to UNKNOWN, but
+   * per-key tracking keeps d.a precisely DICT: a heterogeneous sibling write does not
+   * change the fact that d.a was assigned a dict, so reading d.a still devirtualizes. */
+  FilterXExpr *assign_d = filterx_assign_new(
+                            filterx_floating_variable_expr_new("d"),
+                            filterx_literal_dict_new(NULL));
+  FilterXExpr *set_a = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("d"),
+                         filterx_string_new("a", -1),
+                         filterx_literal_dict_new(NULL));
+  FilterXExpr *set_b = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("d"),
+                         filterx_string_new("b", -1),
+                         filterx_literal_new(filterx_string_new("s", -1)));
+  FilterXExpr *read_a = filterx_getattr_new(filterx_floating_variable_expr_new("d"),
+                                            filterx_string_new("a", -1));
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_d, set_a, set_b, read_a, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_a->static_type), FILTERX_STATIC_TYPE_DICT);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, per_key_type_survives_non_container_sibling)
+{
+  /* d = {}; d.x = 5; d.y = {};  → the int write smears d's element type to
+   * UNKNOWN, but per-key tracking records d.y as DICT independently, so reading d.y
+   * still devirtualizes (d.y genuinely holds a dict regardless of the d.x sibling). */
+  FilterXExpr *assign_d = filterx_assign_new(
+                            filterx_floating_variable_expr_new("d"),
+                            filterx_literal_dict_new(NULL));
+  FilterXExpr *set_x = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("d"),
+                         filterx_string_new("x", -1),
+                         filterx_literal_new(filterx_integer_new(5)));
+  FilterXExpr *set_y = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("d"),
+                         filterx_string_new("y", -1),
+                         filterx_literal_dict_new(NULL));
+  FilterXExpr *read_y = filterx_getattr_new(filterx_floating_variable_expr_new("d"),
+                                            filterx_string_new("y", -1));
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_d, set_x, set_y, read_y, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_y->static_type), FILTERX_STATIC_TYPE_DICT);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, incremental_list_build_tracks_element_type)
+{
+  /* l = []; l[0] = {};  → l is LIST_OF_DICT, so l[0] resolves to DICT. */
+  FilterXExpr *assign_l = filterx_assign_new(
+                            filterx_floating_variable_expr_new("l"),
+                            filterx_literal_list_new(NULL));
+  FilterXExpr *set_0 = filterx_set_subscript_new(
+                         filterx_floating_variable_expr_new("l"),
+                         filterx_literal_new(filterx_integer_new(0)),
+                         filterx_literal_dict_new(NULL));
+  FilterXExpr *read_0 = filterx_get_subscript_new(
+                          filterx_floating_variable_expr_new("l"),
+                          filterx_literal_new(filterx_integer_new(0)));
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_l, set_0, read_0, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_0->static_type), FILTERX_STATIC_TYPE_DICT);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, one_sided_branch_write_collapses_element_to_unknown)
+{
+  /* d = {}; if (c) { d.a = {}; } d.a  → element is UNKNOWN after the join (one
+   * branch lifted it, the other left it fresh-empty; the meet is conservative). */
+  FilterXExpr *assign_d = filterx_assign_new(
+                            filterx_floating_variable_expr_new("d"),
+                            filterx_literal_dict_new(NULL));
+  FilterXExpr *set_a = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("d"),
+                         filterx_string_new("a", -1),
+                         filterx_literal_dict_new(NULL));
+  FilterXExpr *iff = filterx_conditional_new(filterx_floating_variable_expr_new("c"));
+  filterx_conditional_set_true_branch(iff, set_a);
+
+  FilterXExpr *read_a = filterx_getattr_new(filterx_floating_variable_expr_new("d"),
+                                            filterx_string_new("a", -1));
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_d, iff, read_a, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_a->static_type), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, incremental_build_past_depth_cap_is_safe)
+{
+  /* Build a chain one level past the depth cap. The within-cap levels still resolve to DICT;
+   * the write past the cap is a safe no-op (no crash, no false propagation). */
+  FilterXExpr *assign_meta = filterx_assign_new(
+                               filterx_floating_variable_expr_new("meta"),
+                               filterx_literal_dict_new(NULL));
+  FilterXExpr *set_a = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("meta"),
+                         filterx_string_new("a", -1),
+                         filterx_literal_dict_new(NULL));
+  FilterXExpr *set_ab = filterx_setattr_new(
+                          filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
+                                              filterx_string_new("a", -1)),
+                          filterx_string_new("b", -1),
+                          filterx_literal_dict_new(NULL));
+  FilterXExpr *set_abc = filterx_setattr_new(
+                           filterx_getattr_new(
+                             filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
+                                                 filterx_string_new("a", -1)),
+                             filterx_string_new("b", -1)),
+                           filterx_string_new("c", -1),
+                           filterx_literal_dict_new(NULL));
+  /* This write lands past the depth cap: it must be a safe no-op. */
+  FilterXExpr *set_abcd = filterx_setattr_new(
+                            filterx_getattr_new(
+                              filterx_getattr_new(
+                                filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
+                                                    filterx_string_new("a", -1)),
+                                filterx_string_new("b", -1)),
+                              filterx_string_new("c", -1)),
+                            filterx_string_new("d", -1),
+                            filterx_literal_dict_new(NULL));
+
+  FilterXExpr *read_abc = filterx_getattr_new(
+                            filterx_getattr_new(
+                              filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
+                                                  filterx_string_new("a", -1)),
+                              filterx_string_new("b", -1)),
+                            filterx_string_new("c", -1));
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_meta, set_a, set_ab, set_abc,
+                                                    set_abcd, read_abc, NULL);
+  block = _run(block);
+
+  /* meta.a.b.c is the level-3 element (within the depth-4 cap), so it still resolves. */
+  cr_assert_eq(filterx_static_type_kind(read_abc->static_type), FILTERX_STATIC_TYPE_DICT);
   filterx_expr_unref(block);
 }
 

--- a/lib/filterx/tests/test_type_inference.c
+++ b/lib/filterx/tests/test_type_inference.c
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+
+#include "filterx/filterx-type-inference.h"
+#include "filterx/filterx-expr.h"
+#include "filterx/expr-literal.h"
+#include "filterx/expr-literal-container.h"
+#include "filterx/expr-variable.h"
+#include "filterx/expr-assign.h"
+#include "filterx/expr-compound.h"
+#include "filterx/expr-condition.h"
+#include "filterx/expr-plus.h"
+#include "filterx/expr-plus-assign.h"
+#include "filterx/object-string.h"
+#include "filterx/object-dict.h"
+#include "filterx/object-list.h"
+#include "filterx/expr-get-subscript.h"
+#include "filterx/expr-getattr.h"
+#include "filterx/expr-set-subscript.h"
+#include "filterx/expr-setattr.h"
+
+#include "apphook.h"
+#include "scratch-buffers.h"
+#include "libtest/filterx-lib.h"
+
+static FilterXExpr *
+_run(FilterXExpr *root)
+{
+  root = filterx_expr_optimize(root);
+  filterx_expr_infer_types_root(root);
+  return root;
+}
+
+Test(filterx_type_inference, literal_string_is_string)
+{
+  FilterXExpr *lit = filterx_literal_new(filterx_string_new("hi", -1));
+  lit = _run(lit);
+  cr_assert_eq(filterx_static_type_kind(lit->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(lit);
+}
+
+Test(filterx_type_inference, literal_dict_is_dict)
+{
+  FilterXExpr *empty_dict = filterx_literal_dict_new(NULL);
+  empty_dict = _run(empty_dict);
+  /* Fully-literal containers fold to a 'literal' expr at optimize time, and the
+   * literal's inference reads the underlying FilterXObject type. An empty container has no
+   * element, so the kind is DICT and element() is UNKNOWN. */
+  cr_assert_eq(filterx_static_type_kind(empty_dict->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(empty_dict->static_type)),
+               FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(empty_dict);
+}
+
+Test(filterx_type_inference, literal_list_is_list)
+{
+  FilterXExpr *empty_list = filterx_literal_list_new(NULL);
+  empty_list = _run(empty_list);
+  cr_assert_eq(filterx_static_type_kind(empty_list->static_type), FILTERX_STATIC_TYPE_LIST);
+  cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(empty_list->static_type)),
+               FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(empty_list);
+}
+
+Test(filterx_type_inference, assign_propagates_rhs_type_to_subsequent_reads)
+{
+  FilterXExpr *assign_x = filterx_assign_new(
+                            filterx_floating_variable_expr_new("x"),
+                            filterx_literal_new(filterx_string_new("v", -1)));
+  FilterXExpr *read_x = filterx_floating_variable_expr_new("x");
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_x, read_x, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_x->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, reassignment_with_different_type_collapses_later_reads)
+{
+  FilterXExpr *assign_dict = filterx_assign_new(
+                               filterx_floating_variable_expr_new("y"),
+                               filterx_literal_dict_new(NULL));
+  FilterXExpr *assign_str = filterx_assign_new(
+                              filterx_floating_variable_expr_new("y"),
+                              filterx_literal_new(filterx_string_new("v", -1)));
+  FilterXExpr *read_y = filterx_floating_variable_expr_new("y");
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_dict, assign_str, read_y, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_y->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, if_branch_meet_keeps_agreement)
+{
+  /* if (cond) { $z = "a"; } else { $z = "b"; } $z   ->  $z is STRING after the if. */
+  FilterXExpr *cond = filterx_floating_variable_expr_new("c");
+  FilterXExpr *then_assign = filterx_assign_new(
+                               filterx_floating_variable_expr_new("z"),
+                               filterx_literal_new(filterx_string_new("a", -1)));
+  FilterXExpr *else_assign = filterx_assign_new(
+                               filterx_floating_variable_expr_new("z"),
+                               filterx_literal_new(filterx_string_new("b", -1)));
+
+  FilterXExpr *iff = filterx_conditional_new(cond);
+  filterx_conditional_set_true_branch(iff, then_assign);
+  filterx_conditional_set_false_branch(iff, else_assign);
+
+  FilterXExpr *read_z = filterx_floating_variable_expr_new("z");
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, iff, read_z, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_z->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, if_branch_meet_drops_on_disagreement)
+{
+  /* if (cond) { $w = "a"; } else { $w = []; } $w   ->  $w is UNKNOWN after the if. */
+  FilterXExpr *cond = filterx_floating_variable_expr_new("c");
+  FilterXExpr *then_assign = filterx_assign_new(
+                               filterx_floating_variable_expr_new("w"),
+                               filterx_literal_new(filterx_string_new("a", -1)));
+  FilterXExpr *else_assign = filterx_assign_new(
+                               filterx_floating_variable_expr_new("w"),
+                               filterx_literal_list_new(NULL));
+
+  FilterXExpr *iff = filterx_conditional_new(cond);
+  filterx_conditional_set_true_branch(iff, then_assign);
+  filterx_conditional_set_false_branch(iff, else_assign);
+
+  FilterXExpr *read_w = filterx_floating_variable_expr_new("w");
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, iff, read_w, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_w->static_type), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, if_one_sided_assign_collapses_to_unknown)
+{
+  /* $u was unknown before; one branch sets STRING, other does nothing.
+   * Meet of STRING with UNKNOWN -> UNKNOWN. */
+  FilterXExpr *cond = filterx_floating_variable_expr_new("c");
+  FilterXExpr *then_assign = filterx_assign_new(
+                               filterx_floating_variable_expr_new("u"),
+                               filterx_literal_new(filterx_string_new("a", -1)));
+
+  FilterXExpr *iff = filterx_conditional_new(cond);
+  filterx_conditional_set_true_branch(iff, then_assign);
+
+  FilterXExpr *read_u = filterx_floating_variable_expr_new("u");
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, iff, read_u, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_u->static_type), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, plus_of_two_strings_is_string)
+{
+  FilterXExpr *p = filterx_operator_plus_new(
+                     filterx_literal_new(filterx_string_new("a", -1)),
+                     filterx_literal_new(filterx_string_new("b", -1)));
+  p = _run(p);
+  /* plus optimizes literal+literal to a literal; either way the static_type should resolve. */
+  cr_assert_eq(filterx_static_type_kind(p->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(p);
+}
+
+Test(filterx_type_inference, folded_literal_dict_of_string_tracks_element_type)
+{
+  /* {"a": "x", "b": "y"} — fully literal, folds to a single FilterXDict literal. */
+  GList *elems = NULL;
+  elems = g_list_append(elems, filterx_literal_element_new(
+                          filterx_literal_new(filterx_string_new("a", -1)),
+                          filterx_literal_new(filterx_string_new("x", -1))));
+  elems = g_list_append(elems, filterx_literal_element_new(
+                          filterx_literal_new(filterx_string_new("b", -1)),
+                          filterx_literal_new(filterx_string_new("y", -1))));
+  FilterXExpr *d = filterx_literal_dict_new(elems);
+  d = _run(d);
+
+  cr_assert_eq(filterx_static_type_kind(d->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(d->static_type)),
+               FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(d);
+}
+
+Test(filterx_type_inference, mixed_value_types_in_literal_dict_collapse_element)
+{
+  /* {"a": "x", "b": [1, 2]} — string and list values; element type meets to UNKNOWN. */
+  GList *list_elems = g_list_append(NULL, filterx_literal_element_new(
+                                      NULL,
+                                      filterx_literal_new(filterx_integer_new(1))));
+  GList *elems = NULL;
+  elems = g_list_append(elems, filterx_literal_element_new(
+                          filterx_literal_new(filterx_string_new("a", -1)),
+                          filterx_literal_new(filterx_string_new("x", -1))));
+  elems = g_list_append(elems, filterx_literal_element_new(
+                          filterx_literal_new(filterx_string_new("b", -1)),
+                          filterx_literal_list_new(list_elems)));
+  FilterXExpr *d = filterx_literal_dict_new(elems);
+  d = _run(d);
+
+  cr_assert_eq(filterx_static_type_kind(d->static_type), FILTERX_STATIC_TYPE_DICT);
+  /* element type collapses because string and list don't meet. */
+  cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(d->static_type)), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(d);
+}
+
+Test(filterx_type_inference, get_subscript_shifts_operand_spec)
+{
+  /* d = {"a": "x", "b": "y"} → DICT_OF_STRING. d["a"] → STRING. */
+  GList *elems = g_list_append(NULL, filterx_literal_element_new(
+                                 filterx_literal_new(filterx_string_new("a", -1)),
+                                 filterx_literal_new(filterx_string_new("x", -1))));
+  FilterXExpr *assign = filterx_assign_new(
+                          filterx_floating_variable_expr_new("d"),
+                          filterx_literal_dict_new(elems));
+  FilterXExpr *read = filterx_get_subscript_new(
+                        filterx_floating_variable_expr_new("d"),
+                        filterx_literal_new(filterx_string_new("a", -1)));
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign, read, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(block);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  init_libtest_filterx();
+}
+
+static void
+teardown(void)
+{
+  deinit_libtest_filterx();
+  scratch_buffers_explicit_gc();
+  app_shutdown();
+}
+
+TestSuite(filterx_type_inference, .init = setup, .fini = teardown);

--- a/lib/filterx/tests/test_type_inference.c
+++ b/lib/filterx/tests/test_type_inference.c
@@ -39,6 +39,7 @@
 #include "filterx/expr-getattr.h"
 #include "filterx/expr-set-subscript.h"
 #include "filterx/expr-setattr.h"
+#include "filterx/expr-switch.h"
 
 #include "apphook.h"
 #include "scratch-buffers.h"
@@ -540,6 +541,78 @@ Test(filterx_type_inference, reassigning_root_invalidates_stale_per_key_type)
 
   cr_assert_eq(filterx_static_type_kind(read_a->static_type), FILTERX_STATIC_TYPE_UNKNOWN);
   filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, switch_meet_keeps_agreement_with_preswitch_state)
+{
+  /* z = "seed"; switch (c) { case "x": z = "a"; case "y": z = "b"; default: z = "c"; } z
+   * -> STRING. Switch inference walks the whole (fallthrough-flattened) body once and
+   * then meets that end-state against the pre-switch state, to stay safe for the case
+   * where no branch matches at runtime -- even though a default is present here, that
+   * coverage isn't modeled statically (v1). Agreement survives because every reachable
+   * path (body-ran or body-skipped) leaves z as STRING. */
+  FilterXExpr *seed_z = filterx_assign_new(
+                          filterx_floating_variable_expr_new("z"),
+                          filterx_literal_new(filterx_string_new("seed", -1)));
+
+  FilterXExpr *selector = filterx_floating_variable_expr_new("c");
+  GList *body = NULL;
+  body = g_list_append(body, filterx_switch_case_new(filterx_literal_new(filterx_string_new("x", -1))));
+  body = g_list_append(body, filterx_assign_new(filterx_floating_variable_expr_new("z"),
+                                                filterx_literal_new(filterx_string_new("a", -1))));
+  body = g_list_append(body, filterx_switch_case_new(filterx_literal_new(filterx_string_new("y", -1))));
+  body = g_list_append(body, filterx_assign_new(filterx_floating_variable_expr_new("z"),
+                                                filterx_literal_new(filterx_string_new("b", -1))));
+  body = g_list_append(body, filterx_switch_case_new(NULL)); /* default */
+  body = g_list_append(body, filterx_assign_new(filterx_floating_variable_expr_new("z"),
+                                                filterx_literal_new(filterx_string_new("c", -1))));
+  FilterXExpr *sw = filterx_switch_new(selector, body);
+
+  FilterXExpr *read_z = filterx_floating_variable_expr_new("z");
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, seed_z, sw, read_z, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_z->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, macro_variable_is_always_unknown)
+{
+  /* $FACILITY is a hard macro: read-only and computed straight from the message at eval
+   * time rather than routed through the scope/type-env machinery, so inference can never
+   * devirtualize it -- it hardcodes the read to UNKNOWN regardless of the macro's actual
+   * runtime type (always a string, in this case). */
+  FilterXExpr *read_facility = filterx_msg_variable_expr_new("FACILITY");
+  cr_assert(filterx_variable_expr_is_macro(read_facility));
+
+  read_facility = _run(read_facility);
+  cr_assert_eq(filterx_static_type_kind(read_facility->static_type), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(read_facility);
+}
+
+Test(filterx_type_inference, persistent_env_propagates_type_across_blocks)
+{
+  /* Block A: v = "a";  commits STRING for handle "v" into the persistent env.
+   * Block B, inferred independently but seeded from that same persistent env: reading v
+   * resolves to STRING -- knowledge that would be lost (v -> UNKNOWN) if the two blocks
+   * were inferred through plain filterx_expr_infer_types_root with no shared environment. */
+  FilterXTypeEnv *persistent_env = filterx_type_env_new();
+
+  FilterXExpr *block_a = filterx_assign_new(
+                           filterx_floating_variable_expr_new("v"),
+                           filterx_literal_new(filterx_string_new("a", -1)));
+  block_a = filterx_expr_optimize(block_a);
+  filterx_expr_infer_types_root_persistent(block_a, persistent_env);
+
+  FilterXExpr *read_v = filterx_floating_variable_expr_new("v");
+  FilterXExpr *block_b = filterx_expr_optimize(read_v);
+  filterx_expr_infer_types_root_persistent(block_b, persistent_env);
+
+  cr_assert_eq(filterx_static_type_kind(read_v->static_type), FILTERX_STATIC_TYPE_STRING);
+
+  filterx_expr_unref(block_a);
+  filterx_expr_unref(block_b);
+  filterx_type_env_free(persistent_env);
 }
 
 static void

--- a/lib/filterx/tests/test_type_inference.c
+++ b/lib/filterx/tests/test_type_inference.c
@@ -61,6 +61,52 @@ Test(filterx_type_inference, literal_string_is_string)
   filterx_expr_unref(lit);
 }
 
+Test(filterx_type_inference, literal_double_is_double)
+{
+  FilterXExpr *lit = filterx_literal_new(filterx_double_new(2.5));
+  lit = _run(lit);
+  cr_assert_eq(filterx_static_type_kind(lit->static_type), FILTERX_STATIC_TYPE_DOUBLE);
+  filterx_expr_unref(lit);
+}
+
+Test(filterx_type_inference, assign_propagates_double_type_to_subsequent_reads)
+{
+  FilterXExpr *assign_d = filterx_assign_new(
+                            filterx_floating_variable_expr_new("d"),
+                            filterx_literal_new(filterx_double_new(2.5)));
+  FilterXExpr *read_d = filterx_floating_variable_expr_new("d");
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_d, read_d, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_d->static_type), FILTERX_STATIC_TYPE_DOUBLE);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, integer_and_double_are_distinct_kinds)
+{
+  /* if (c) { n = 1; } else { n = 2.5; } n  ->  UNKNOWN. DOUBLE is its own kind, so it does
+   * not silently unify with INTEGER: a value that may be either is not statically an
+   * integer, which is exactly what keeps an integer-only fast path from claiming it. */
+  FilterXExpr *then_assign = filterx_assign_new(
+                               filterx_floating_variable_expr_new("n"),
+                               filterx_literal_new(filterx_integer_new(1)));
+  FilterXExpr *else_assign = filterx_assign_new(
+                               filterx_floating_variable_expr_new("n"),
+                               filterx_literal_new(filterx_double_new(2.5)));
+
+  FilterXExpr *iff = filterx_conditional_new(filterx_floating_variable_expr_new("c"));
+  filterx_conditional_set_true_branch(iff, then_assign);
+  filterx_conditional_set_false_branch(iff, else_assign);
+
+  FilterXExpr *read_n = filterx_floating_variable_expr_new("n");
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, iff, read_n, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_n->static_type), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(block);
+}
+
 Test(filterx_type_inference, literal_dict_is_dict)
 {
   FilterXExpr *empty_dict = filterx_literal_dict_new(NULL);

--- a/lib/filterx/tests/test_type_inference.c
+++ b/lib/filterx/tests/test_type_inference.c
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+
+#include "filterx/expr-arithmetic-operators.h"
+#include "filterx/filterx-type-inference.h"
+#include "filterx/filterx-expr.h"
+#include "filterx/expr-literal.h"
+#include "filterx/expr-literal-container.h"
+#include "filterx/expr-variable.h"
+#include "filterx/expr-assign.h"
+#include "filterx/expr-compound.h"
+#include "filterx/expr-condition.h"
+#include "filterx/expr-plus-assign.h"
+#include "filterx/object-string.h"
+#include "filterx/object-dict.h"
+#include "filterx/object-list.h"
+#include "filterx/expr-get-subscript.h"
+#include "filterx/expr-getattr.h"
+#include "filterx/expr-set-subscript.h"
+#include "filterx/expr-setattr.h"
+
+#include "apphook.h"
+#include "scratch-buffers.h"
+#include "libtest/filterx-lib.h"
+
+static FilterXExpr *
+_run(FilterXExpr *root)
+{
+  root = filterx_expr_optimize(root);
+  filterx_expr_infer_types_root(root);
+  return root;
+}
+
+Test(filterx_type_inference, literal_string_is_string)
+{
+  FilterXExpr *lit = filterx_literal_new(filterx_string_new("hi", -1));
+  lit = _run(lit);
+  cr_assert_eq(filterx_static_type_kind(lit->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(lit);
+}
+
+Test(filterx_type_inference, literal_dict_is_dict)
+{
+  FilterXExpr *empty_dict = filterx_literal_dict_new(NULL);
+  empty_dict = _run(empty_dict);
+  /* Fully-literal containers fold to a 'literal' expr at optimize time, and the
+   * literal's inference reads the underlying FilterXObject type. An empty container has no
+   * element, so the kind is DICT and element() is UNKNOWN. */
+  cr_assert_eq(filterx_static_type_kind(empty_dict->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(empty_dict->static_type)),
+               FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(empty_dict);
+}
+
+Test(filterx_type_inference, literal_list_is_list)
+{
+  FilterXExpr *empty_list = filterx_literal_list_new(NULL);
+  empty_list = _run(empty_list);
+  cr_assert_eq(filterx_static_type_kind(empty_list->static_type), FILTERX_STATIC_TYPE_LIST);
+  cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(empty_list->static_type)),
+               FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(empty_list);
+}
+
+Test(filterx_type_inference, assign_propagates_rhs_type_to_subsequent_reads)
+{
+  FilterXExpr *assign_x = filterx_assign_new(
+                            filterx_floating_variable_expr_new("x"),
+                            filterx_literal_new(filterx_string_new("v", -1)));
+  FilterXExpr *read_x = filterx_floating_variable_expr_new("x");
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_x, read_x, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_x->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, reassignment_with_different_type_collapses_later_reads)
+{
+  FilterXExpr *assign_dict = filterx_assign_new(
+                               filterx_floating_variable_expr_new("y"),
+                               filterx_literal_dict_new(NULL));
+  FilterXExpr *assign_str = filterx_assign_new(
+                              filterx_floating_variable_expr_new("y"),
+                              filterx_literal_new(filterx_string_new("v", -1)));
+  FilterXExpr *read_y = filterx_floating_variable_expr_new("y");
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_dict, assign_str, read_y, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_y->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, if_branch_meet_keeps_agreement)
+{
+  /* if (cond) { $z = "a"; } else { $z = "b"; } $z   ->  $z is STRING after the if. */
+  FilterXExpr *cond = filterx_floating_variable_expr_new("c");
+  FilterXExpr *then_assign = filterx_assign_new(
+                               filterx_floating_variable_expr_new("z"),
+                               filterx_literal_new(filterx_string_new("a", -1)));
+  FilterXExpr *else_assign = filterx_assign_new(
+                               filterx_floating_variable_expr_new("z"),
+                               filterx_literal_new(filterx_string_new("b", -1)));
+
+  FilterXExpr *iff = filterx_conditional_new(cond);
+  filterx_conditional_set_true_branch(iff, then_assign);
+  filterx_conditional_set_false_branch(iff, else_assign);
+
+  FilterXExpr *read_z = filterx_floating_variable_expr_new("z");
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, iff, read_z, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_z->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, if_branch_meet_drops_on_disagreement)
+{
+  /* if (cond) { $w = "a"; } else { $w = []; } $w   ->  $w is UNKNOWN after the if. */
+  FilterXExpr *cond = filterx_floating_variable_expr_new("c");
+  FilterXExpr *then_assign = filterx_assign_new(
+                               filterx_floating_variable_expr_new("w"),
+                               filterx_literal_new(filterx_string_new("a", -1)));
+  FilterXExpr *else_assign = filterx_assign_new(
+                               filterx_floating_variable_expr_new("w"),
+                               filterx_literal_list_new(NULL));
+
+  FilterXExpr *iff = filterx_conditional_new(cond);
+  filterx_conditional_set_true_branch(iff, then_assign);
+  filterx_conditional_set_false_branch(iff, else_assign);
+
+  FilterXExpr *read_w = filterx_floating_variable_expr_new("w");
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, iff, read_w, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_w->static_type), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, if_one_sided_assign_collapses_to_unknown)
+{
+  /* $u was unknown before; one branch sets STRING, other does nothing.
+   * Meet of STRING with UNKNOWN -> UNKNOWN. */
+  FilterXExpr *cond = filterx_floating_variable_expr_new("c");
+  FilterXExpr *then_assign = filterx_assign_new(
+                               filterx_floating_variable_expr_new("u"),
+                               filterx_literal_new(filterx_string_new("a", -1)));
+
+  FilterXExpr *iff = filterx_conditional_new(cond);
+  filterx_conditional_set_true_branch(iff, then_assign);
+
+  FilterXExpr *read_u = filterx_floating_variable_expr_new("u");
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, iff, read_u, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_u->static_type), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, plus_of_two_strings_is_string)
+{
+  FilterXExpr *p = filterx_operator_plus_new(
+                     filterx_literal_new(filterx_string_new("a", -1)),
+                     filterx_literal_new(filterx_string_new("b", -1)));
+  p = _run(p);
+  /* plus optimizes literal+literal to a literal; either way the static_type should resolve. */
+  cr_assert_eq(filterx_static_type_kind(p->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(p);
+}
+
+Test(filterx_type_inference, folded_literal_dict_of_string_tracks_element_type)
+{
+  /* {"a": "x", "b": "y"} — fully literal, folds to a single FilterXDict literal. */
+  GList *elems = NULL;
+  elems = g_list_append(elems, filterx_literal_element_new(
+                          filterx_literal_new(filterx_string_new("a", -1)),
+                          filterx_literal_new(filterx_string_new("x", -1))));
+  elems = g_list_append(elems, filterx_literal_element_new(
+                          filterx_literal_new(filterx_string_new("b", -1)),
+                          filterx_literal_new(filterx_string_new("y", -1))));
+  FilterXExpr *d = filterx_literal_dict_new(elems);
+  d = _run(d);
+
+  cr_assert_eq(filterx_static_type_kind(d->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(d->static_type)),
+               FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(d);
+}
+
+Test(filterx_type_inference, mixed_value_types_in_literal_dict_collapse_element)
+{
+  /* {"a": "x", "b": [1]} — string and list values; element type meets to UNKNOWN. */
+  GList *list_elems = g_list_append(NULL, filterx_literal_element_new(
+                                      NULL,
+                                      filterx_literal_new(filterx_integer_new(1))));
+  GList *elems = NULL;
+  elems = g_list_append(elems, filterx_literal_element_new(
+                          filterx_literal_new(filterx_string_new("a", -1)),
+                          filterx_literal_new(filterx_string_new("x", -1))));
+  elems = g_list_append(elems, filterx_literal_element_new(
+                          filterx_literal_new(filterx_string_new("b", -1)),
+                          filterx_literal_list_new(list_elems)));
+  FilterXExpr *d = filterx_literal_dict_new(elems);
+  d = _run(d);
+
+  cr_assert_eq(filterx_static_type_kind(d->static_type), FILTERX_STATIC_TYPE_DICT);
+  /* element type collapses because string and list don't meet. */
+  cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(d->static_type)), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(d);
+}
+
+Test(filterx_type_inference, get_subscript_shifts_operand_spec)
+{
+  /* d = {"a": "x", "b": "y"} → DICT_OF_STRING. d["a"] → STRING. */
+  GList *elems = g_list_append(NULL, filterx_literal_element_new(
+                                 filterx_literal_new(filterx_string_new("a", -1)),
+                                 filterx_literal_new(filterx_string_new("x", -1))));
+  elems = g_list_append(elems, filterx_literal_element_new(
+                          filterx_literal_new(filterx_string_new("b", -1)),
+                          filterx_literal_new(filterx_string_new("y", -1))));
+  FilterXExpr *assign = filterx_assign_new(
+                          filterx_floating_variable_expr_new("d"),
+                          filterx_literal_dict_new(elems));
+  FilterXExpr *read = filterx_get_subscript_new(
+                        filterx_floating_variable_expr_new("d"),
+                        filterx_literal_new(filterx_string_new("a", -1)));
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign, read, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(block);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  init_libtest_filterx();
+}
+
+static void
+teardown(void)
+{
+  deinit_libtest_filterx();
+  scratch_buffers_explicit_gc();
+  app_shutdown();
+}
+
+/* Every per-expression infer_types hook is compiled out when the JIT is disabled (no LLVM),
+ * so the pass walks the tree without installing anything and leaves every expression at
+ * UNKNOWN. There is no inference to assert against in that configuration, so skip the suite
+ * rather than fail it. */
+#if SYSLOG_NG_ENABLE_JIT
+#define TYPE_INFERENCE_TESTS_DISABLED FALSE
+#else
+#define TYPE_INFERENCE_TESTS_DISABLED TRUE
+#endif
+
+TestSuite(filterx_type_inference, .init = setup, .fini = teardown,
+          .disabled = TYPE_INFERENCE_TESTS_DISABLED);

--- a/lib/filterx/tests/test_type_inference.c
+++ b/lib/filterx/tests/test_type_inference.c
@@ -470,53 +470,49 @@ Test(filterx_type_inference, one_sided_branch_write_collapses_element_to_unknown
   filterx_expr_unref(block);
 }
 
+/* Build a fresh getattr chain d.keys[0].keys[1]...keys[n-1]. */
+static FilterXExpr *
+_build_attr_chain(const gchar **keys, gint n)
+{
+  FilterXExpr *expr = filterx_floating_variable_expr_new("d");
+  for (gint i = 0; i < n; i++)
+    expr = filterx_getattr_new(expr, filterx_string_new(keys[i], -1));
+  return expr;
+}
+
 Test(filterx_type_inference, incremental_build_past_depth_cap_is_safe)
 {
-  /* Build a chain one level past the depth cap. The within-cap levels still resolve to DICT;
-   * the write past the cap is a safe no-op (no crash, no false propagation). */
-  FilterXExpr *assign_meta = filterx_assign_new(
-                               filterx_floating_variable_expr_new("meta"),
-                               filterx_literal_dict_new(NULL));
-  FilterXExpr *set_a = filterx_setattr_new(
-                         filterx_floating_variable_expr_new("meta"),
-                         filterx_string_new("a", -1),
-                         filterx_literal_dict_new(NULL));
-  FilterXExpr *set_ab = filterx_setattr_new(
-                          filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
-                                              filterx_string_new("a", -1)),
-                          filterx_string_new("b", -1),
-                          filterx_literal_dict_new(NULL));
-  FilterXExpr *set_abc = filterx_setattr_new(
-                           filterx_getattr_new(
-                             filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
-                                                 filterx_string_new("a", -1)),
-                             filterx_string_new("b", -1)),
-                           filterx_string_new("c", -1),
-                           filterx_literal_dict_new(NULL));
-  /* This write lands past the depth cap: it must be a safe no-op. */
-  FilterXExpr *set_abcd = filterx_setattr_new(
-                            filterx_getattr_new(
-                              filterx_getattr_new(
-                                filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
-                                                    filterx_string_new("a", -1)),
-                                filterx_string_new("b", -1)),
-                              filterx_string_new("c", -1)),
-                            filterx_string_new("d", -1),
-                            filterx_literal_dict_new(NULL));
+  /* Build a getattr chain far deeper than FILTERX_ATTR_CHAIN_MAX (16). Levels within the cap
+   * resolve to DICT; writes that land past the cap are safe no-ops (no crash, no false
+   * propagation). DEPTH is chosen comfortably past the cap so the test stays meaningful
+   * regardless of the exact cap value. */
+  enum { DEPTH = 20 };
+  gchar key_storage[DEPTH][8];
+  const gchar *keys[DEPTH];
+  for (gint i = 0; i < DEPTH; i++)
+    {
+      g_snprintf(key_storage[i], sizeof(key_storage[i]), "k%d", i);
+      keys[i] = key_storage[i];
+    }
 
-  FilterXExpr *read_abc = filterx_getattr_new(
-                            filterx_getattr_new(
-                              filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
-                                                  filterx_string_new("a", -1)),
-                              filterx_string_new("b", -1)),
-                            filterx_string_new("c", -1));
+  FilterXExpr *block = filterx_compound_expr_new(TRUE);
+  filterx_compound_expr_add_ref(block, filterx_assign_new(
+                                  filterx_floating_variable_expr_new("d"),
+                                  filterx_literal_dict_new(NULL)));
+  /* d.k0 = {}; d.k0.k1 = {}; ... — the deepest writes land past the cap as no-ops. */
+  for (gint level = 0; level < DEPTH; level++)
+    filterx_compound_expr_add_ref(block, filterx_setattr_new(
+                                    _build_attr_chain(keys, level),
+                                    filterx_string_new(keys[level], -1),
+                                    filterx_literal_dict_new(NULL)));
 
-  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_meta, set_a, set_ab, set_abc,
-                                                    set_abcd, read_abc, NULL);
+  /* d.k0.k1.k2.k3 is well within the cap, so it still resolves. */
+  FilterXExpr *read = _build_attr_chain(keys, 4);
+  filterx_compound_expr_add_ref(block, read);
+
   block = _run(block);
 
-  /* meta.a.b.c is the level-3 element (within the depth-4 cap), so it still resolves. */
-  cr_assert_eq(filterx_static_type_kind(read_abc->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(read->static_type), FILTERX_STATIC_TYPE_DICT);
   filterx_expr_unref(block);
 }
 

--- a/lib/filterx/tests/test_type_inference.c
+++ b/lib/filterx/tests/test_type_inference.c
@@ -65,8 +65,8 @@ Test(filterx_type_inference, literal_dict_is_dict)
   FilterXExpr *empty_dict = filterx_literal_dict_new(NULL);
   empty_dict = _run(empty_dict);
   /* Fully-literal containers fold to a 'literal' expr at optimize time, and the
-   * literal's inference reads the underlying FilterXObject type. An empty container has no
-   * element, so the kind is DICT and element() is UNKNOWN. */
+   * literal's inference reads the underlying FilterXObject type. An empty container carries
+   * the FRESH element sentinel internally; the kind is DICT and element() sanitizes to UNKNOWN. */
   cr_assert_eq(filterx_static_type_kind(empty_dict->static_type), FILTERX_STATIC_TYPE_DICT);
   cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(empty_dict->static_type)),
                FILTERX_STATIC_TYPE_UNKNOWN);
@@ -210,6 +210,32 @@ Test(filterx_type_inference, folded_literal_dict_of_string_tracks_element_type)
   filterx_expr_unref(d);
 }
 
+Test(filterx_type_inference, folded_literal_depth3_dict_chain)
+{
+  /* {"l1": {"l2": {"l3": "leaf"}}}, fully literal → DICT_OF_DICT_OF_DICT_OF_STRING. */
+  GList *l3_elems = g_list_append(NULL, filterx_literal_element_new(
+                                    filterx_literal_new(filterx_string_new("l3", -1)),
+                                    filterx_literal_new(filterx_string_new("leaf", -1))));
+  GList *l2_elems = g_list_append(NULL, filterx_literal_element_new(
+                                    filterx_literal_new(filterx_string_new("l2", -1)),
+                                    filterx_literal_dict_new(l3_elems)));
+  GList *l1_elems = g_list_append(NULL, filterx_literal_element_new(
+                                    filterx_literal_new(filterx_string_new("l1", -1)),
+                                    filterx_literal_dict_new(l2_elems)));
+  FilterXExpr *d = filterx_literal_dict_new(l1_elems);
+  d = _run(d);
+
+  FilterXStaticTypeSpec spec = d->static_type;
+  cr_assert_eq(filterx_static_type_kind(spec), FILTERX_STATIC_TYPE_DICT);
+  spec = filterx_static_type_element(spec);
+  cr_assert_eq(filterx_static_type_kind(spec), FILTERX_STATIC_TYPE_DICT);
+  spec = filterx_static_type_element(spec);
+  cr_assert_eq(filterx_static_type_kind(spec), FILTERX_STATIC_TYPE_DICT);
+  spec = filterx_static_type_element(spec);
+  cr_assert_eq(filterx_static_type_kind(spec), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(d);
+}
+
 Test(filterx_type_inference, mixed_value_types_in_literal_dict_collapse_element)
 {
   /* {"a": "x", "b": [1]} — string and list values; element type meets to UNKNOWN. */
@@ -251,6 +277,272 @@ Test(filterx_type_inference, get_subscript_shifts_operand_spec)
   block = _run(block);
 
   cr_assert_eq(filterx_static_type_kind(read->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, getattr_chain_propagates_through_three_levels)
+{
+  /* d = {"a": {"b": {"c": "leaf"}}} → DICT_OF_DICT_OF_DICT_OF_STRING.
+   * d.a.b.c → STRING. */
+  GList *l3 = g_list_append(NULL, filterx_literal_element_new(
+                              filterx_literal_new(filterx_string_new("c", -1)),
+                              filterx_literal_new(filterx_string_new("leaf", -1))));
+  GList *l2 = g_list_append(NULL, filterx_literal_element_new(
+                              filterx_literal_new(filterx_string_new("b", -1)),
+                              filterx_literal_dict_new(l3)));
+  GList *l1 = g_list_append(NULL, filterx_literal_element_new(
+                              filterx_literal_new(filterx_string_new("a", -1)),
+                              filterx_literal_dict_new(l2)));
+  FilterXExpr *assign = filterx_assign_new(
+                          filterx_floating_variable_expr_new("d"),
+                          filterx_literal_dict_new(l1));
+  FilterXExpr *read_var = filterx_floating_variable_expr_new("d");
+  FilterXExpr *get_a = filterx_getattr_new(read_var, filterx_string_new("a", -1));
+  FilterXExpr *get_b = filterx_getattr_new(get_a, filterx_string_new("b", -1));
+  FilterXExpr *get_c = filterx_getattr_new(get_b, filterx_string_new("c", -1));
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign, get_c, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_var->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(get_a->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(get_b->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(get_c->static_type), FILTERX_STATIC_TYPE_STRING);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, set_subscript_on_variable_pessimizes_element_type)
+{
+  /* d = {"a": "x"} → DICT_OF_STRING. d["b"] = 42; later read d → DICT (element UNKNOWN). */
+  GList *elems = g_list_append(NULL, filterx_literal_element_new(
+                                 filterx_literal_new(filterx_string_new("a", -1)),
+                                 filterx_literal_new(filterx_string_new("x", -1))));
+  FilterXExpr *assign = filterx_assign_new(
+                          filterx_floating_variable_expr_new("d"),
+                          filterx_literal_dict_new(elems));
+  FilterXExpr *set = filterx_set_subscript_new(
+                       filterx_floating_variable_expr_new("d"),
+                       filterx_literal_new(filterx_string_new("b", -1)),
+                       filterx_literal_new(filterx_integer_new(42)));
+  FilterXExpr *read = filterx_floating_variable_expr_new("d");
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign, set, read, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(assign->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(assign->static_type)), FILTERX_STATIC_TYPE_STRING);
+
+  cr_assert_eq(filterx_static_type_kind(read->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(read->static_type)), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(block);
+}
+
+/* ---- incremental container building (lift-on-write) ---- */
+
+Test(filterx_type_inference, incremental_dict_build_tracks_nested_element_types)
+{
+  /* d = {}; d.a = {}; d.a.b = {};  → d is DICT_OF_DICT_OF_DICT.
+   * Reads of d, d.a, d.a.b all resolve to DICT — the incremental build matches
+   * what a nested literal would have produced, so the deep chain devirtualizes. */
+  FilterXExpr *assign_d = filterx_assign_new(
+                            filterx_floating_variable_expr_new("d"),
+                            filterx_literal_dict_new(NULL));
+  FilterXExpr *set_a = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("d"),
+                         filterx_string_new("a", -1),
+                         filterx_literal_dict_new(NULL));
+  FilterXExpr *set_ab = filterx_setattr_new(
+                          filterx_getattr_new(filterx_floating_variable_expr_new("d"),
+                                              filterx_string_new("a", -1)),
+                          filterx_string_new("b", -1),
+                          filterx_literal_dict_new(NULL));
+
+  FilterXExpr *read_d = filterx_floating_variable_expr_new("d");
+  FilterXExpr *read_a = filterx_getattr_new(filterx_floating_variable_expr_new("d"),
+                                            filterx_string_new("a", -1));
+  FilterXExpr *read_ab = filterx_getattr_new(
+                           filterx_getattr_new(filterx_floating_variable_expr_new("d"),
+                                               filterx_string_new("a", -1)),
+                           filterx_string_new("b", -1));
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_d, set_a, set_ab,
+                                                    read_d, read_a, read_ab, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_d->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(read_a->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(read_ab->static_type), FILTERX_STATIC_TYPE_DICT);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, per_key_type_survives_heterogeneous_sibling)
+{
+  /* d = {}; d.a = {}; d.b = "s";  → d's *element* type smears to UNKNOWN, but
+   * per-key tracking keeps d.a precisely DICT: a heterogeneous sibling write does not
+   * change the fact that d.a was assigned a dict, so reading d.a still devirtualizes. */
+  FilterXExpr *assign_d = filterx_assign_new(
+                            filterx_floating_variable_expr_new("d"),
+                            filterx_literal_dict_new(NULL));
+  FilterXExpr *set_a = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("d"),
+                         filterx_string_new("a", -1),
+                         filterx_literal_dict_new(NULL));
+  FilterXExpr *set_b = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("d"),
+                         filterx_string_new("b", -1),
+                         filterx_literal_new(filterx_string_new("s", -1)));
+  FilterXExpr *read_a = filterx_getattr_new(filterx_floating_variable_expr_new("d"),
+                                            filterx_string_new("a", -1));
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_d, set_a, set_b, read_a, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_a->static_type), FILTERX_STATIC_TYPE_DICT);
+  cr_assert_eq(filterx_static_type_kind(filterx_static_type_element(read_a->static_type)), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, per_key_type_survives_non_container_sibling)
+{
+  /* d = {}; d.x = 5; d.y = {};  → the int write smears d's element type to
+   * UNKNOWN, but per-key tracking records d.y as DICT independently, so reading d.y
+   * still devirtualizes (d.y genuinely holds a dict regardless of the d.x sibling). */
+  FilterXExpr *assign_d = filterx_assign_new(
+                            filterx_floating_variable_expr_new("d"),
+                            filterx_literal_dict_new(NULL));
+  FilterXExpr *set_x = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("d"),
+                         filterx_string_new("x", -1),
+                         filterx_literal_new(filterx_integer_new(5)));
+  FilterXExpr *set_y = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("d"),
+                         filterx_string_new("y", -1),
+                         filterx_literal_dict_new(NULL));
+  FilterXExpr *read_y = filterx_getattr_new(filterx_floating_variable_expr_new("d"),
+                                            filterx_string_new("y", -1));
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_d, set_x, set_y, read_y, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_y->static_type), FILTERX_STATIC_TYPE_DICT);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, incremental_list_build_tracks_element_type)
+{
+  /* l = []; l[0] = {};  → l is LIST_OF_DICT, so l[0] resolves to DICT. */
+  FilterXExpr *assign_l = filterx_assign_new(
+                            filterx_floating_variable_expr_new("l"),
+                            filterx_literal_list_new(NULL));
+  FilterXExpr *set_0 = filterx_set_subscript_new(
+                         filterx_floating_variable_expr_new("l"),
+                         filterx_literal_new(filterx_integer_new(0)),
+                         filterx_literal_dict_new(NULL));
+  FilterXExpr *read_0 = filterx_get_subscript_new(
+                          filterx_floating_variable_expr_new("l"),
+                          filterx_literal_new(filterx_integer_new(0)));
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_l, set_0, read_0, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_0->static_type), FILTERX_STATIC_TYPE_DICT);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, one_sided_branch_write_collapses_element_to_unknown)
+{
+  /* d = {}; if (c) { d.a = {}; } d.a  → element is UNKNOWN after the join (one
+   * branch lifted it, the other left it fresh-empty; the meet is conservative). */
+  FilterXExpr *assign_d = filterx_assign_new(
+                            filterx_floating_variable_expr_new("d"),
+                            filterx_literal_dict_new(NULL));
+  FilterXExpr *set_a = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("d"),
+                         filterx_string_new("a", -1),
+                         filterx_literal_dict_new(NULL));
+  FilterXExpr *iff = filterx_conditional_new(filterx_floating_variable_expr_new("c"));
+  filterx_conditional_set_true_branch(iff, set_a);
+
+  FilterXExpr *read_a = filterx_getattr_new(filterx_floating_variable_expr_new("d"),
+                                            filterx_string_new("a", -1));
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_d, iff, read_a, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_a->static_type), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, incremental_build_past_depth_cap_is_safe)
+{
+  /* Build a chain one level past the depth cap. The within-cap levels still resolve to DICT;
+   * the write past the cap is a safe no-op (no crash, no false propagation). */
+  FilterXExpr *assign_meta = filterx_assign_new(
+                               filterx_floating_variable_expr_new("meta"),
+                               filterx_literal_dict_new(NULL));
+  FilterXExpr *set_a = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("meta"),
+                         filterx_string_new("a", -1),
+                         filterx_literal_dict_new(NULL));
+  FilterXExpr *set_ab = filterx_setattr_new(
+                          filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
+                                              filterx_string_new("a", -1)),
+                          filterx_string_new("b", -1),
+                          filterx_literal_dict_new(NULL));
+  FilterXExpr *set_abc = filterx_setattr_new(
+                           filterx_getattr_new(
+                             filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
+                                                 filterx_string_new("a", -1)),
+                             filterx_string_new("b", -1)),
+                           filterx_string_new("c", -1),
+                           filterx_literal_dict_new(NULL));
+  /* This write lands past the depth cap: it must be a safe no-op. */
+  FilterXExpr *set_abcd = filterx_setattr_new(
+                            filterx_getattr_new(
+                              filterx_getattr_new(
+                                filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
+                                                    filterx_string_new("a", -1)),
+                                filterx_string_new("b", -1)),
+                              filterx_string_new("c", -1)),
+                            filterx_string_new("d", -1),
+                            filterx_literal_dict_new(NULL));
+
+  FilterXExpr *read_abc = filterx_getattr_new(
+                            filterx_getattr_new(
+                              filterx_getattr_new(filterx_floating_variable_expr_new("meta"),
+                                                  filterx_string_new("a", -1)),
+                              filterx_string_new("b", -1)),
+                            filterx_string_new("c", -1));
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_meta, set_a, set_ab, set_abc,
+                                                    set_abcd, read_abc, NULL);
+  block = _run(block);
+
+  /* meta.a.b.c is the level-3 element (within the depth-4 cap), so it still resolves. */
+  cr_assert_eq(filterx_static_type_kind(read_abc->static_type), FILTERX_STATIC_TYPE_DICT);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, reassigning_root_invalidates_stale_per_key_type)
+{
+  /* d = {}; d.a = {};   -> per-key records handle_d:a = DICT
+    * d = "s";            -> whole variable overwritten; d is now a STRING
+    * d.a                 -> must NOT still resolve to DICT. Reading an attr off a
+    *                        string is statically UNKNOWN; the earlier per-key entry is stale. */
+  FilterXExpr *assign_dict = filterx_assign_new(
+                               filterx_floating_variable_expr_new("d"),
+                               filterx_literal_dict_new(NULL));
+  FilterXExpr *set_a = filterx_setattr_new(
+                         filterx_floating_variable_expr_new("d"),
+                         filterx_string_new("a", -1),
+                         filterx_literal_dict_new(NULL));
+  FilterXExpr *reassign_str = filterx_assign_new(
+                                filterx_floating_variable_expr_new("d"),
+                                filterx_literal_new(filterx_string_new("s", -1)));
+  FilterXExpr *read_a = filterx_getattr_new(filterx_floating_variable_expr_new("d"),
+                                            filterx_string_new("a", -1));
+
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE, assign_dict, set_a, reassign_str, read_a, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(read_a->static_type), FILTERX_STATIC_TYPE_UNKNOWN);
   filterx_expr_unref(block);
 }
 

--- a/lib/filterx/tests/test_type_inference.c
+++ b/lib/filterx/tests/test_type_inference.c
@@ -238,6 +238,87 @@ Test(filterx_type_inference, plus_of_two_strings_is_string)
   filterx_expr_unref(p);
 }
 
+/* Build `<var> = <literal>;` — plus constant-folds a literal+literal pair, so operands have
+ * to come from variables for _infer_types_plus to be the thing under test. */
+static FilterXExpr *
+_assign_literal(const gchar *name, FilterXObject *value)
+{
+  return filterx_assign_new(filterx_floating_variable_expr_new(name), filterx_literal_new(value));
+}
+
+Test(filterx_type_inference, plus_of_two_integers_is_integer)
+{
+  /* a = 1; b = 2; a + b  ->  INTEGER. */
+  FilterXExpr *sum = filterx_operator_plus_new(filterx_floating_variable_expr_new("a"),
+                                               filterx_floating_variable_expr_new("b"));
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE,
+                                                    _assign_literal("a", filterx_integer_new(1)),
+                                                    _assign_literal("b", filterx_integer_new(2)),
+                                                    sum, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(sum->static_type), FILTERX_STATIC_TYPE_INTEGER);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, plus_of_integer_and_double_is_double)
+{
+  /* a = 1; d = 2.5; a + d  ->  DOUBLE, in both operand orders: filterx_object_add() widens
+   * to double whichever side carries it, so the result kind does not depend on the order. */
+  FilterXExpr *int_first = filterx_operator_plus_new(filterx_floating_variable_expr_new("a"),
+                                                     filterx_floating_variable_expr_new("d"));
+  FilterXExpr *double_first = filterx_operator_plus_new(filterx_floating_variable_expr_new("d"),
+                                                        filterx_floating_variable_expr_new("a"));
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE,
+                                                    _assign_literal("a", filterx_integer_new(1)),
+                                                    _assign_literal("d", filterx_double_new(2.5)),
+                                                    int_first, double_first, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(int_first->static_type), FILTERX_STATIC_TYPE_DOUBLE);
+  cr_assert_eq(filterx_static_type_kind(double_first->static_type), FILTERX_STATIC_TYPE_DOUBLE);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, plus_of_integer_and_unknown_is_unknown)
+{
+  /* a = 1; a + $u  ->  UNKNOWN, NOT INTEGER. $u is a macro, so it is statically unknown and
+   * may well be a double at runtime, which would widen the sum. An INTEGER claim here would
+   * be a claim an integer-speculating consumer is entitled to act on. */
+  FilterXExpr *sum = filterx_operator_plus_new(filterx_floating_variable_expr_new("a"),
+                                               filterx_msg_variable_expr_new("FACILITY"));
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE,
+                                                    _assign_literal("a", filterx_integer_new(1)),
+                                                    sum, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(sum->static_type), FILTERX_STATIC_TYPE_UNKNOWN);
+  filterx_expr_unref(block);
+}
+
+Test(filterx_type_inference, mixed_numeric_sum_does_not_poison_a_later_sum)
+{
+  /* a = 1; d = 2.5; x = a + d; x + a  ->  DOUBLE throughout.
+   *
+   * The chain is what makes an over-eager INTEGER claim dangerous rather than merely
+   * imprecise: `a + d` is a double at runtime, so recording x as INTEGER would hand the
+   * following `x + a` an integer-typed operand that is not one. */
+  FilterXExpr *inner = filterx_operator_plus_new(filterx_floating_variable_expr_new("a"),
+                                                 filterx_floating_variable_expr_new("d"));
+  FilterXExpr *assign_x = filterx_assign_new(filterx_floating_variable_expr_new("x"), inner);
+  FilterXExpr *outer = filterx_operator_plus_new(filterx_floating_variable_expr_new("x"),
+                                                 filterx_floating_variable_expr_new("a"));
+  FilterXExpr *block = filterx_compound_expr_new_va(TRUE,
+                                                    _assign_literal("a", filterx_integer_new(1)),
+                                                    _assign_literal("d", filterx_double_new(2.5)),
+                                                    assign_x, outer, NULL);
+  block = _run(block);
+
+  cr_assert_eq(filterx_static_type_kind(inner->static_type), FILTERX_STATIC_TYPE_DOUBLE);
+  cr_assert_eq(filterx_static_type_kind(outer->static_type), FILTERX_STATIC_TYPE_DOUBLE);
+  filterx_expr_unref(block);
+}
+
 Test(filterx_type_inference, folded_literal_dict_of_string_tracks_element_type)
 {
   /* {"a": "x", "b": "y"} — fully literal, folds to a single FilterXDict literal. */


### PR DESCRIPTION
Requires #1134 & #1139.

# Expression optimization

Before: each successfully ran JIT-compiled expression made call to `make_typed_object` which had a lot of call overhead (ie. call count = call places in code - function of filterx code length)

**Optimizations:**
- Drop this call when we know that we know that it's superfluous (see array `_always_typed_helpers`)
- Emit this call only from helpers instead of every expression (see array `_typed_twin_helpers`)
We have much less helpers (~"FilterX language elements") than expressions ("FilterX code") so several call places got eliminated.
- Essentially the call places in code is function of expression kind count minus count of no-op places

# Statement optimization

Before: each statement called `fx_jit_process_expr_result` to set the actual block's state (ie. call count = call places in code - function of filterx code length)

**Optimization:**
- Emit this call only from helpers instead of every statement (see array `_stmt_twin_helpers`)
We have much less helpers (~"FilterX language elements") than expressions ("FilterX code") so several call places got eliminated.
