### PR TITLE
light: pin client ports for remaining single-connection loggen calls

### DIFF
--- a/tests/light/functional_tests/source_drivers/network_source/test_static_and_dynamic_window.py
+++ b/tests/light/functional_tests/source_drivers/network_source/test_static_and_dynamic_window.py
@@ -144,7 +144,7 @@ def test_static_window_config_options(config, syslog_ng, port_allocator, loggen,
 
     syslog_ng.start(config)
 
-    send_messages_with_loggen(loggen, network_source, 1, 1)
+    send_messages_with_loggen(loggen, network_source, 1, 1, port_allocator())
     wait_for_sum_prometheus_metric_values(config, expected_static_window_size)
 
     syslog_ng.stop()
@@ -183,7 +183,7 @@ def test_update_static_window_option_value(config, syslog_ng, port_allocator, lo
     # phase 2: update log_iw_size value and check the new value is applied
     network_source.options["log_iw_size"] = 6000
     syslog_ng.reload(config)
-    send_messages_with_loggen(loggen, network_source, 1, 1)
+    send_messages_with_loggen(loggen, network_source, 1, 1, port_allocator())
     # we have sent 1 * 1 msg,
     # static window size for new connection is 6000/10=600, available window for new connection 600-1=599
     wait_for_sum_prometheus_metric_values(config, {"syslogng_input_window_available": (10 * 1) + 599, "syslogng_input_window_capacity": (10 * 500) + 600})
@@ -208,7 +208,7 @@ def test_update_dynamic_window_option_value(config, syslog_ng, port_allocator, l
     # phase 2: update log_iw_size value and check the new value is applied
     network_source.options["dynamic_window_size"] = 6000
     syslog_ng.reload(config)
-    send_messages_with_loggen(loggen, network_source, 1, 1)
+    send_messages_with_loggen(loggen, network_source, 1, 1, port_allocator())
     # we have sent 1 * 1 msg
     # dynamic window capacity for new connection is 1, as loggen has exited
     # available window size is 0, as the dynamic window is fully occupied
@@ -312,7 +312,7 @@ def test_fill_static_window_for_all_source_connections(config, syslog_ng, port_a
 
     # phase 2: send additional messages and check that the new connections are rejected
     assert not syslog_ng.is_message_in_console_log("Number of allowed concurrent connections reached, rejecting connection")
-    send_messages_with_loggen(loggen, network_source, 1, 1)
+    send_messages_with_loggen(loggen, network_source, 1, 1, port_allocator())
     assert syslog_ng.is_message_in_console_log("Number of allowed concurrent connections reached, rejecting connection")
 
     network_destination.start_listener()
@@ -340,7 +340,7 @@ def test_fill_dynamic_window_for_all_source_connections(config, syslog_ng, port_
 
     # phase 2: send additional messages and check that the new connections are rejected
     assert not syslog_ng.is_message_in_console_log("Number of allowed concurrent connections reached, rejecting connection")
-    send_messages_with_loggen(loggen, network_source, 1, 1)
+    send_messages_with_loggen(loggen, network_source, 1, 1, port_allocator())
     assert syslog_ng.wait_for_message_in_console_log("Number of allowed concurrent connections reached, rejecting connection")
 
     network_destination.start_listener()


### PR DESCRIPTION
Commit 213528b fixed test_static_window_increased_send and test_dynamic_window_increased_send, but the other tests in this file (e.g. test_update_dynamic_window_option_value) still open their single-connection loggen runs without a fixed client port.

- Without client_port the kernel assigns a random ephemeral source port, which is not guaranteed to be unique across the phases of a test.
- The per-connection window metrics are labeled with connection="<ip:port>" (the peer address). When a later connection reuses a port freed by an earlier one, their time series collapse into one, so fewer series appear than the test expects, causing intermittent assertion failures.
- Passing client_port=port_allocator() pins a distinct, free source port (from the ~20000 range, below the kernel ephemeral range), guaranteeing unique connection labels and stable metrics.

Only active_connections=1 calls are changed; loggen rejects a client port when more than one connection is requested.

Assisted-by: Claude:claude-opus-4-8[1m]
