### PR TITLE
Fix `--check-startup`

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -264,6 +264,13 @@ cfg_shutdown(GlobalConfig *cfg)
   main_loop_exit(main_loop);
 }
 
+static gboolean
+cfg_is_dry_run(GlobalConfig *cfg)
+{
+  MainLoopOptions *main_loop_options = main_loop_get_options();
+  return main_loop_is_dry_run(main_loop_options);
+}
+
 gboolean
 cfg_is_shutting_down(GlobalConfig *cfg)
 {
@@ -322,6 +329,9 @@ cfg_init(GlobalConfig *cfg)
 
   _run_module_post_cfg_inits(cfg);
   app_config_post_init();
+
+  if (cfg_is_dry_run(cfg))
+    return TRUE;
 
   /*
    * TLDR: A half-initialized pipeline turned out to be really hard to deinitialize

--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -40,11 +40,11 @@
 ControlServer *control_server;
 ControlConnection *control_connection;
 MainLoop *main_loop;
+MainLoopOptions main_loop_options;
 
 void
 setup(void)
 {
-  MainLoopOptions main_loop_options = {0};
   app_startup();
 
   main_loop = main_loop_get_instance();

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -136,6 +136,7 @@ struct _MainLoop
    * would be gone.
    */
   gboolean _is_terminating;
+  gboolean cfg_inited;
   gboolean last_config_reload_successful;
   time_t last_config_reload_time;
 
@@ -183,6 +184,12 @@ MainLoop *
 main_loop_get_instance(void)
 {
   return &main_loop;
+}
+
+MainLoopOptions *
+main_loop_get_options(void)
+{
+  return main_loop_get_instance()->options;
 }
 
 /* called when syslog-ng first starts up */
@@ -443,6 +450,7 @@ main_loop_exit_finish(gpointer user_data)
    * threads are running.  This will unregister ivykis tasks and timers
    * that could fire while the configuration is being destructed */
   cfg_deinit(self->current_configuration);
+  self->cfg_inited = FALSE;
   iv_quit();
 }
 
@@ -452,6 +460,16 @@ main_loop_exit_timer_elapsed(gpointer user_data)
   MainLoop *self = (MainLoop *) user_data;
 
   main_loop_worker_sync_call(main_loop_exit_finish, self);
+}
+
+static void
+main_loop_deinit_cfg(MainLoop *self)
+{
+  app_pre_shutdown();
+  cfg_deinit(self->current_configuration);
+  self->cfg_inited = FALSE;
+
+  self->_is_terminating = TRUE;
 }
 
 static void
@@ -701,6 +719,10 @@ main_loop_read_and_init_config(MainLoop *self)
     {
       return 2;
     }
+  self->cfg_inited = TRUE;
+
+  if (options->check_startup)
+    return 0;
 
   self->control_server = control_init(resolved_configurable_paths.ctlfilename);
 
@@ -724,6 +746,9 @@ main_loop_free_config(MainLoop *self)
 void
 main_loop_deinit(MainLoop *self)
 {
+  if (main_loop_is_dry_run(self->options) && self->cfg_inited)
+    main_loop_deinit_cfg(self);
+
   main_loop_free_config(self);
 
   if (self->cfg_monitor)
@@ -732,7 +757,8 @@ main_loop_deinit(MainLoop *self)
       file_monitor_free(self->cfg_monitor);
     }
 
-  control_deinit(self->control_server);
+  if (self->control_server)
+    control_deinit(self->control_server);
 
   iv_event_unregister(&self->exit_requested);
   main_loop_call_deinit();

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -786,12 +786,6 @@ main_loop_thread_resource_deinit(void)
   g_cond_clear(&thread_halt_cond);
 }
 
-gboolean
-main_loop_is_control_server_running(MainLoop *self)
-{
-  return self->control_server != NULL;
-}
-
 GQuark
 main_loop_error_quark(void)
 {

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -748,6 +748,9 @@ main_loop_deinit(MainLoop *self)
 void
 main_loop_run(MainLoop *self)
 {
+  if (main_loop_is_dry_run(self->options))
+    return;
+
   msg_notice("syslog-ng starting up",
              evt_tag_str("version", SYSLOG_NG_VERSION));
 

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -43,6 +43,9 @@ typedef struct _MainLoopOptions
 static inline gboolean
 main_loop_is_dry_run(const MainLoopOptions *options)
 {
+  if (!options)
+    return FALSE;
+
   return options->syntax_only || options->preprocess_into || options->config_id || options->check_startup;
 }
 
@@ -78,6 +81,7 @@ gboolean main_loop_was_last_reload_successful(MainLoop *self);
 void main_loop_run(MainLoop *self);
 
 MainLoop *main_loop_get_instance(void);
+MainLoopOptions *main_loop_get_options(void);
 GlobalConfig *main_loop_get_current_config(MainLoop *self);
 GlobalConfig *main_loop_get_pending_new_config(MainLoop *self);
 void main_loop_init(MainLoop *self, MainLoopOptions *options);

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -90,8 +90,6 @@ gboolean main_loop_initialize_state(GlobalConfig *cfg, const gchar *persist_file
 void main_loop_thread_resource_init(void);
 void main_loop_thread_resource_deinit(void);
 
-gboolean main_loop_is_control_server_running(MainLoop *self);
-
 #define MAIN_LOOP_ERROR main_loop_error_quark()
 
 GQuark main_loop_error_quark(void);

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -40,6 +40,12 @@ typedef struct _MainLoopOptions
   gboolean disable_module_discovery;
 } MainLoopOptions;
 
+static inline gboolean
+main_loop_is_dry_run(const MainLoopOptions *options)
+{
+  return options->syntax_only || options->preprocess_into || options->config_id || options->check_startup;
+}
+
 extern ThreadId main_thread_handle;
 extern GCond thread_halt_cond;
 extern GMutex workers_running_lock;

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -328,10 +328,7 @@ main(int argc, char *argv[])
               "The -d/--debug option no longer implies -e/--stderr, if you want to redirect internal() source to stderr please also include -e/--stderr option\n");
     }
 
-  gboolean exit_before_main_loop_run = main_loop_options.syntax_only
-                                       || main_loop_options.preprocess_into
-                                       || main_loop_options.config_id
-                                       || main_loop_options.check_startup;
+  gboolean exit_before_main_loop_run = main_loop_is_dry_run(&main_loop_options);
 
   if (exit_before_main_loop_run)
     interactive_mode();

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -351,6 +351,7 @@ main(int argc, char *argv[])
     {
       main_loop_deinit(main_loop);
       app_shutdown();
+      console_global_deinit();
       reloc_deinit();
       g_process_startup_failed(rc, TRUE);
       return rc;


### PR DESCRIPTION
Fixes #1150

Before this PR, `deinit()` was not called at all during `--check-startup`, only `init()`; but once I started calling `deinit()`, more problems arose.

This PR fixes everything functionally, but it looks bad. I couldn't come up with a cleaner fix without reimplemeting how a real shutdown is done.