### PR TITLE
cmake: fix UTs, enable ASAN

### DIFF
--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -69,6 +69,7 @@ jobs:
             -DCMAKE_C_FLAGS=-Werror
             -DCMAKE_INSTALL_PREFIX=${HOME}/install/syslog-ng
             -DPYTHON_VERSION=3
+            `[ $CC = clang ] && echo '-DSANITIZER=address' || true`
           "
           PYTEST_XDIST_AUTO_NUM_WORKERS=16
           gh_export COREFILES_DIR PYTHONUSERBASE CC CXX SYSLOG_NG_INSTALL_DIR CONFIGURE_FLAGS CMAKE_FLAGS PYTEST_XDIST_AUTO_NUM_WORKERS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,8 +534,10 @@ if (SANITIZER)
   if (SANITIZER MATCHES address-all)
     SET(SANITIZE_MODE "address")
     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize-address-use-after-scope -fsanitize-address-use-after-return=runtime")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize-address-use-after-scope -fsanitize-address-use-after-return=runtime")
   endif()
   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O1 -fsanitize=${SANITIZE_MODE} -fno-omit-frame-pointer -fno-optimize-sibling-calls")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O1 -fsanitize=${SANITIZE_MODE} -fno-omit-frame-pointer -fno-optimize-sibling-calls")
 endif()
 
 

--- a/cmake/Modules/ExternalIVYKIS.cmake
+++ b/cmake/Modules/ExternalIVYKIS.cmake
@@ -34,6 +34,7 @@ if (EXISTS ${PROJECT_SOURCE_DIR}/lib/ivykis/src/include/iv.h.in)
         BUILD_COMMAND     make
         INSTALL_COMMAND   make install
         CONFIGURE_COMMAND autoreconf -i ${PROJECT_SOURCE_DIR}/lib/ivykis && ${PROJECT_SOURCE_DIR}/lib/ivykis/configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/ivykis-install/
+        BUILD_BYPRODUCTS  ${CMAKE_CURRENT_BINARY_DIR}/ivykis-install/lib/libivykis${CMAKE_SHARED_LIBRARY_SUFFIX}
     )
 
     set(${LIB_NAME}_INTERNAL TRUE)

--- a/cmake/add_tests.cmake
+++ b/cmake/add_tests.cmake
@@ -28,6 +28,15 @@ if (BUILD_TESTING)
   check_pie_supported()
 endif()
 
+# Tests with known sanitizer findings, excluded from the leak/ASan error check.
+# The cmake counterpart of the sanitizer_exception_list in scripts/test-grep.sh.
+# TODO fix them.
+set(SANITIZER_EXCEPTION_LIST
+  test_patterndb
+  test_secure_logging
+  test-mongodb-config
+)
+
 function (add_unit_test)
 
   if (NOT BUILD_TESTING)
@@ -76,7 +85,9 @@ function (add_unit_test)
   add_test (${ADD_UNIT_TEST_TARGET} ${ADD_UNIT_TEST_TARGET})
   add_dependencies(check ${ADD_UNIT_TEST_TARGET})
   set_tests_properties(${ADD_UNIT_TEST_TARGET} PROPERTIES ENVIRONMENT "CRITERION_TEST_PATTERN=!(*/*performance*);LSAN_OPTIONS=suppressions=${PROJECT_SOURCE_DIR}/tests/axosyslog-lsan.supp")
-  set_tests_properties(${ADD_UNIT_TEST_TARGET} PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR: (LeakSanitizer|AddressSanitizer)")
+  if (NOT "${ADD_UNIT_TEST_TARGET}" IN_LIST SANITIZER_EXCEPTION_LIST)
+    set_tests_properties(${ADD_UNIT_TEST_TARGET} PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR: (LeakSanitizer|AddressSanitizer)")
+  endif()
 endfunction ()
 
 macro (add_test_subdirectory SUBDIR)

--- a/cmake/add_tests.cmake
+++ b/cmake/add_tests.cmake
@@ -75,7 +75,7 @@ function (add_unit_test)
 
   add_test (${ADD_UNIT_TEST_TARGET} ${ADD_UNIT_TEST_TARGET})
   add_dependencies(check ${ADD_UNIT_TEST_TARGET})
-  set_tests_properties(${ADD_UNIT_TEST_TARGET} PROPERTIES ENVIRONMENT "CRITERION_TEST_PATTERN=!(*/*performance*)")
+  set_tests_properties(${ADD_UNIT_TEST_TARGET} PROPERTIES ENVIRONMENT "CRITERION_TEST_PATTERN=!(*/*performance*);LSAN_OPTIONS=suppressions=${PROJECT_SOURCE_DIR}/tests/axosyslog-lsan.supp")
   set_tests_properties(${ADD_UNIT_TEST_TARGET} PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR: (LeakSanitizer|AddressSanitizer)")
 endfunction ()
 

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -41,3 +41,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_object_ip DEPENDS json-plugin ${JSON
 add_unit_test(LIBTEST CRITERION TARGET test_expr_arithmetic_operators DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_func_set_pri DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_json_repr DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_filterx_plist DEPENDS syslogformat json-plugin ${JSONC_LIBRARY})

--- a/lib/transport/tests/CMakeLists.txt
+++ b/lib/transport/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_unit_test(CRITERION TARGET test_aux_data)
+add_unit_test(LIBTEST CRITERION TARGET test_transport)
 add_unit_test(CRITERION TARGET test_transport_stack)
 add_unit_test(CRITERION TARGET test_tls_wildcard_match)
 add_unit_test(LIBTEST CRITERION TARGET test_transport_haproxy)

--- a/modules/grpc/common/CMakeLists.txt
+++ b/modules/grpc/common/CMakeLists.txt
@@ -31,4 +31,5 @@ add_module(
   SOURCES ${GRPC_COMMON_CPP_SOURCES}
   INCLUDES ${PROJECT_SOURCE_DIR}/modules/grpc/common
   LIBRARY_TYPE STATIC
+  COMPILE_OPTIONS -fvisibility=hidden
 )

--- a/modules/grpc/otel/tests/test-otel-protobuf-parser.cpp
+++ b/modules/grpc/otel/tests/test-otel-protobuf-parser.cpp
@@ -304,6 +304,7 @@ Test(otel_protobuf_parser, log_record_body_types)
   std::string serialized_kvlist_value = log_record.body().SerializeAsString();
   _assert_log_msg_value(msg, ".otel.log.body", serialized_kvlist_value.c_str(), serialized_kvlist_value.length(),
                         LM_VT_PROTOBUF);
+  log_msg_unref(msg);
 
   msg = _create_dummy_log_msg();
   ArrayValue *protobuf_list_value = log_record.mutable_body()->mutable_array_value();

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -26,7 +26,6 @@
 #include "logpipe.h"
 #include "messages.h"
 #include "poll-fd-events.h"
-#include "mainloop-io-worker.h"
 #include "persist-state.h"
 #include "persistable-state-header.h"
 #include "ack-tracker/ack_tracker.h"

--- a/modules/systemd-journal/journal-reader.h
+++ b/modules/systemd-journal/journal-reader.h
@@ -25,6 +25,7 @@
 #define JOURNAL_READER_H_
 
 #include "logsource.h"
+#include "mainloop-io-worker.h"
 #include "journald-subsystem.h"
 #include "journald-helper.h"
 #include "stats/stats-cluster-key-builder.h"
@@ -49,6 +50,7 @@ typedef struct _JournalReaderOptions
 } JournalReaderOptions;
 
 JournalReader *journal_reader_new(GlobalConfig *cfg);
+sd_journal *journal_reader_get_sd_journal(JournalReader *self);
 void journal_reader_set_options(LogPipe *s, LogPipe *control, JournalReaderOptions *options, const gchar *stats_id,
                                 StatsClusterKeyBuilder *kb);
 

--- a/modules/systemd-journal/tests/Makefile.am
+++ b/modules/systemd-journal/tests/Makefile.am
@@ -13,7 +13,7 @@ modules_systemd_journal_tests_test_systemd_journal_SOURCES = \
 	modules/systemd-journal/tests/test-source.c
 
 modules_systemd_journal_tests_test_systemd_journal_CFLAGS = $(TEST_CFLAGS) $(libsystemd_CFLAGS) -I$(top_srcdir)/modules/systemd-journal
-modules_systemd_journal_tests_test_systemd_journal_LDADD = $(TEST_LDADD) $(IVYKIS_LIBS)
+modules_systemd_journal_tests_test_systemd_journal_LDADD = $(TEST_LDADD) $(IVYKIS_LIBS) -dlpreopen $(top_builddir)/modules/systemd-journal/libsdjournal.la
 
 modules_systemd_journal_tests_test_journald_mock_SOURCES = \
 	modules/systemd-journal/tests/test-journald-mock.c \

--- a/modules/systemd-journal/tests/test_systemd_journal.c
+++ b/modules/systemd-journal/tests/test_systemd_journal.c
@@ -25,8 +25,8 @@
 #include "test-source.h"
 #include "journald-mock.h"
 
-#include "journald-helper.c"
-#include "journal-reader.c"
+#include "journald-helper.h"
+#include "journal-reader.h"
 #include "apphook.h"
 
 static GlobalConfig *cfg;

--- a/scripts/test-grep.sh
+++ b/scripts/test-grep.sh
@@ -27,7 +27,6 @@ sanitizer_exception_list=(
   "modules/correlation/tests/test_patterndb"
   "modules/secure-logging/tests/test_secure_logging"
   "modules/afmongodb/tests/test-mongodb-config"
-  "modules/grpc/otel/tests/test_otel_protobuf_parser"
 )
 
 on_exception_list() {

--- a/tests/axosyslog-lsan.supp
+++ b/tests/axosyslog-lsan.supp
@@ -1,5 +1,6 @@
 leak:^dlopen
 leak:^set_argv_space
+leak:^g_process_set_argv_space
 leak:^python_evaluate_global_code
 leak:libpython*.so
 leak:^netsnmp_parse_args

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_custom_target(func-test
   ${CMAKE_COMMAND} -E env "top_srcdir=${PROJECT_SOURCE_DIR}" "top_builddir=${PROJECT_BINARY_DIR}" "PYTHON=${PYTHON_EXECUTABLE}"
+  "LSAN_OPTIONS=suppressions=${PROJECT_SOURCE_DIR}/tests/axosyslog-lsan.supp"
   "${CMAKE_CURRENT_SOURCE_DIR}/runtests.sh")

--- a/tests/light/CMakeLists.txt
+++ b/tests/light/CMakeLists.txt
@@ -9,10 +9,12 @@ add_custom_target(light-self-check
    COMMAND ${LIGHT_POETRY_CMD} install
    COMMAND ${LIGHT_PYTEST_CMD} ${LIGHT_SOURCE_DIR}/src/axosyslog_light)
 
+set(LIGHT_LSAN_OPTIONS LSAN_OPTIONS=suppressions=${PROJECT_SOURCE_DIR}/tests/axosyslog-lsan.supp)
+
 add_custom_target(light-check
    COMMAND ${LIGHT_POETRY_CMD} install
-   COMMAND ${LIGHT_PYTEST_CMD} ${LIGHT_SOURCE_DIR}/functional_tests -m "not timing" -n auto --installdir=${CMAKE_INSTALL_PREFIX} $$EXTRA_ARGS
-   COMMAND ${LIGHT_PYTEST_CMD} ${LIGHT_SOURCE_DIR}/functional_tests -m "timing" -n0 --installdir=${CMAKE_INSTALL_PREFIX} $$EXTRA_ARGS)
+   COMMAND ${CMAKE_COMMAND} -E env ${LIGHT_LSAN_OPTIONS} ${LIGHT_PYTEST_CMD} ${LIGHT_SOURCE_DIR}/functional_tests -m "not timing" -n auto --installdir=${CMAKE_INSTALL_PREFIX} $$EXTRA_ARGS
+   COMMAND ${CMAKE_COMMAND} -E env ${LIGHT_LSAN_OPTIONS} ${LIGHT_PYTEST_CMD} ${LIGHT_SOURCE_DIR}/functional_tests -m "timing" -n0 --installdir=${CMAKE_INSTALL_PREFIX} $$EXTRA_ARGS)
 
 add_custom_target(light-linters
    COMMAND ${LIGHT_POETRY_CMD} install


### PR DESCRIPTION
I am not that familiar with using `cmake` for development, but it heavily outperforms autotools.
I recently set up a build guide for `claude`, which uses `cmake` for the sake of performance.
However some features are missing from it.

I am fixing them in this PR and in #1157.