### PR TITLE
dbld: mount the worktree gitdir into the build container

### DIFF
--- a/dbld/rules
+++ b/dbld/rules
@@ -31,6 +31,7 @@ DOCKER_RUN_ARGS=-e USER_NAME_ON_HOST=$(shell whoami)	\
         --network=host \
 	--ulimit nofile=1024:1024 \
 	-v $(ROOT_DIR):/source \
+	$(GIT_WORKTREE_MOUNT) \
         -v $(DBLD_DIR):/dbld \
 	-v $(DBLD_DIR)/build:/build \
 	-v $(DBLD_DIR)/install:/install \
@@ -46,6 +47,7 @@ DOCKER_RUN_ARGS=-e USER_NAME_ON_HOST=$(shell whoami)	\
 DOCKER_BUILD_ARGS=
 ROOT_DIR=$(shell pwd)
 DBLD_DIR=$(ROOT_DIR)/dbld
+GIT_WORKTREE_MOUNT=$(shell if [ -f "$(ROOT_DIR)/.git" ]; then d=$$(git -C "$(ROOT_DIR)" rev-parse --path-format=absolute --git-common-dir 2>/dev/null); [ -n "$$d" ] && echo "-v $$d:$$d"; fi)
 BUILD_DIR=$(DBLD_DIR)/build
 RELEASE_DIR=$(DBLD_DIR)/release
 TARBALL_BASENAME=axosyslog-$(VERSION).tar.gz


### PR DESCRIPTION
When the `dbld` devshell or build is launched from a linked git worktree, `$(ROOT_DIR)/.git` is a file pointing to the main repository's gitdir under `.git/worktrees/<name>`.

Only the worktree itself is mounted as `/source`, so that gitdir is invisible inside the container and every git operation fails: the cmake build aborts at `git submodule update --init --recursive` and `scripts/version.sh` cannot read the revision.

Detect the worktree case and bind-mount the main repository's common gitdir at its host path so git resolves the worktree fully inside the container.

A normal checkout has a `.git` directory and adds no extra mount, leaving the CI and packaging builds unchanged.

Assisted-by: Claude:claude-opus-4-8[1m]

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
