### PR TITLE
Light: Support to run light tests on local build

### DIFF
--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -78,6 +78,7 @@ docker/.*$
 tests/light/functional_tests/filterx/cache_json_file\.json
 tests/light/shared_files/.*\.sh
 tests/light/shared_files/.*\.proto
+tests/light/docker/.*\.dockerfile$
 
 ###########################################################################
 # These files are GPLd contributions.

--- a/tests/light/Makefile.am
+++ b/tests/light/Makefile.am
@@ -3,6 +3,7 @@ export abs_top_srcdir
 EXTRA_DIST += \
 	tests/light/CMakeLists.txt \
 	tests/light/Makefile.am \
+	tests/light/docker \
 	tests/light/pytest.ini \
 	tests/light/shared_files \
 	tests/light/tox.ini
@@ -19,6 +20,9 @@ PYTEST_VERBOSE ?= false
 PYTEST_OPTS ?=
 PYTEST_WORKERS ?= -n auto
 
+LIGHT_CLICKHOUSE_IMAGE ?= clickhouse/clickhouse-server:latest
+LIGHT_SNMPTRAPD_IMAGE ?= axosyslog-light-snmptrapd:latest
+
 LIGHT_SRC_DIR=$(abs_top_srcdir)/tests/light
 LIGHT_POETRY_CMD=$(POETRY) -C $(LIGHT_SRC_DIR)
 LIGHT_PYTHON_CMD=$(LIGHT_POETRY_CMD) run python
@@ -26,6 +30,11 @@ LIGHT_PYTEST_CMD=$(LIGHT_PYTHON_CMD) -m pytest --showlocals --verbosity=3
 
 light-venv:
 	@$(LIGHT_POETRY_CMD) install
+
+light-third-party-deps:
+	docker build -t $(LIGHT_SNMPTRAPD_IMAGE) -f $(LIGHT_SRC_DIR)/docker/snmptrapd.dockerfile $(LIGHT_SRC_DIR)/docker
+	docker pull $(LIGHT_CLICKHOUSE_IMAGE)
+	$(prefix)/bin/syslog-ng-update-virtualenv -y
 
 light-self-check pytest-self-check: light-venv
 	@$(LIGHT_PYTEST_CMD) $(LIGHT_SRC_DIR)/src/axosyslog_light
@@ -48,11 +57,11 @@ light-linters pytest-linters: light-venv
 
 else
 
-light-venv light-self-check pytest-self-check light-check pytest-check light-linters pytest-linters:
+light-venv light-third-party-deps light-self-check pytest-self-check light-check pytest-check light-linters pytest-linters:
 	@echo "Poetry is missing, cannot execute E2E tests."
 	@exit 1
 
 endif
 
 
-.PHONY: light-venv light-self-check light-check light-linters pytest-self-check pytest-check pytest-linters
+.PHONY: light-venv light-third-party-deps light-self-check light-check light-linters pytest-self-check pytest-check pytest-linters

--- a/tests/light/README.md
+++ b/tests/light/README.md
@@ -11,6 +11,32 @@ It is designed to facilitate the testing of AxoSyslog components and ensure thei
 - **Integration with Poetry**: Simplified dependency management and packaging.
 - **Support for Valgrind, GDB, and Strace**: Advanced debugging and profiling tools.
 
+## Running 3rd party services in containers
+
+Some tests need 3rd party services (`clickhouse-server`, `snmptrapd`). By default
+(`--third-party-runner local`) these are expected to be installed on the host.
+
+To run them in containers instead — so they don't need to be installed locally —
+pass `--third-party-runner docker`:
+
+```
+make light-check PYTEST_OPTS="--third-party-runner docker"
+```
+
+This is independent of `--runner` (which selects how AxoSyslog itself runs), so a
+locally installed AxoSyslog can be tested against containerized 3rd party services.
+
+The images are hardcoded:
+- ClickHouse: `clickhouse/clickhouse-server:latest` (pulled).
+- snmptrapd: `axosyslog-light-snmptrapd:latest`, built from `tests/light/docker/snmptrapd.dockerfile`:
+
+```
+docker build -t axosyslog-light-snmptrapd:latest -f tests/light/docker/snmptrapd.dockerfile tests/light/docker
+```
+
+The containers run with `--network host`, so the services stay reachable on `localhost`
+exactly as with local binaries.
+
 ## License
 
 This project is licensed under the GNU General Public License version 3 or later.

--- a/tests/light/README.md
+++ b/tests/light/README.md
@@ -14,10 +14,12 @@ It is designed to facilitate the testing of AxoSyslog components and ensure thei
 ## Running 3rd party services in containers
 
 Some tests need 3rd party services (`clickhouse-server`, `snmptrapd`). By default
-(`--third-party-runner local`) these are expected to be installed on the host.
+(`--third-party-runner auto`) each service runs from the host binary when it is
+installed, and falls back to a container otherwise — so tests work out of the box
+both on a host with the services installed and on one without them.
 
-To run them in containers instead — so they don't need to be installed locally —
-pass `--third-party-runner docker`:
+To force one mode for all services, pass `--third-party-runner local` (host
+binaries only) or `--third-party-runner docker` (containers only):
 
 ```
 make light-check PYTEST_OPTS="--third-party-runner docker"

--- a/tests/light/docker/snmptrapd.dockerfile
+++ b/tests/light/docker/snmptrapd.dockerfile
@@ -1,0 +1,19 @@
+# Minimal image providing snmptrapd (NET-SNMP) for the light E2E tests.
+#
+# Build:
+#   docker build -t axosyslog-light-snmptrapd:latest -f tests/light/docker/snmptrapd.dockerfile tests/light/docker
+#
+# Used by SnmpTrapdDockerExecutor when pytest is invoked with:
+#   --third-party-runner docker [--snmptrapd-image axosyslog-light-snmptrapd:latest]
+#
+# Note: no MIBs are installed. The tests use numeric OIDs (snmptrapd runs with
+# "-On"), so "-m ALL" simply finds no extra MIBs and snmptrapd still starts and
+# logs traps -- exactly as a default Debian/Ubuntu host install would.
+FROM debian:stable-slim
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        snmptrapd \
+    && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["snmptrapd"]

--- a/tests/light/docker/snmptrapd.dockerfile
+++ b/tests/light/docker/snmptrapd.dockerfile
@@ -1,0 +1,42 @@
+#############################################################################
+# Copyright (c) 2026 Axoflow
+# Copyright (c) 2026 Andras Mitzki <andras.mitzki@axoflow.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+# Minimal image providing snmptrapd (NET-SNMP) for the light E2E tests.
+#
+# Build:
+#   docker build -t axosyslog-light-snmptrapd:latest -f tests/light/docker/snmptrapd.dockerfile tests/light/docker
+#
+# Used by SnmpTrapdDockerExecutor when pytest is invoked with:
+#   --third-party-runner docker [--snmptrapd-image axosyslog-light-snmptrapd:latest]
+#
+# Note: no MIBs are installed. The tests use numeric OIDs (snmptrapd runs with
+# "-On"), so "-m ALL" simply finds no extra MIBs and snmptrapd still starts and
+# logs traps -- exactly as a default Debian/Ubuntu host install would.
+FROM debian:stable-slim
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        snmptrapd \
+    && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["snmptrapd"]

--- a/tests/light/src/axosyslog_light/Makefile.am
+++ b/tests/light/src/axosyslog_light/Makefile.am
@@ -48,6 +48,9 @@ EXTRA_DIST += \
 	tests/light/src/axosyslog_light/helpers/secure_logging/conftest.py \
 	tests/light/src/axosyslog_light/helpers/secure_logging/__init__.py \
 	tests/light/src/axosyslog_light/helpers/snmptrapd/conftest.py \
+	tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_docker_executor.py \
+	tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_executor.py \
+	tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_local_executor.py \
 	tests/light/src/axosyslog_light/helpers/snmptrapd/__init__.py \
 	tests/light/src/axosyslog_light/__init__.py \
 	tests/light/src/axosyslog_light/message_builder/bsd_format.py \

--- a/tests/light/src/axosyslog_light/Makefile.am
+++ b/tests/light/src/axosyslog_light/Makefile.am
@@ -3,6 +3,7 @@
 EXTRA_DIST += \
 	tests/light/src/axosyslog_light/common/asynchronous.py \
 	tests/light/src/axosyslog_light/common/blocking.py \
+	tests/light/src/axosyslog_light/common/docker_operations.py \
 	tests/light/src/axosyslog_light/common/file.py \
 	tests/light/src/axosyslog_light/common/__init__.py \
 	tests/light/src/axosyslog_light/common/network_operations.py \

--- a/tests/light/src/axosyslog_light/Makefile.am
+++ b/tests/light/src/axosyslog_light/Makefile.am
@@ -37,6 +37,9 @@ EXTRA_DIST += \
 	tests/light/src/axosyslog_light/executors/tests/test_process_executor.py \
 	tests/light/src/axosyslog_light/fixtures.py \
 	tests/light/src/axosyslog_light/helpers/__init__.py \
+	tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_docker_executor.py \
+	tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_executor.py \
+	tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_local_executor.py \
 	tests/light/src/axosyslog_light/helpers/loggen/__init__.py \
 	tests/light/src/axosyslog_light/helpers/loggen/loggen_docker_executor.py \
 	tests/light/src/axosyslog_light/helpers/loggen/loggen_executor.py \

--- a/tests/light/src/axosyslog_light/Makefile.am
+++ b/tests/light/src/axosyslog_light/Makefile.am
@@ -52,6 +52,9 @@ EXTRA_DIST += \
 	tests/light/src/axosyslog_light/helpers/secure_logging/conftest.py \
 	tests/light/src/axosyslog_light/helpers/secure_logging/__init__.py \
 	tests/light/src/axosyslog_light/helpers/snmptrapd/conftest.py \
+	tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_docker_executor.py \
+	tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_executor.py \
+	tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_local_executor.py \
 	tests/light/src/axosyslog_light/helpers/snmptrapd/__init__.py \
 	tests/light/src/axosyslog_light/__init__.py \
 	tests/light/src/axosyslog_light/message_builder/bsd_format.py \

--- a/tests/light/src/axosyslog_light/Makefile.am
+++ b/tests/light/src/axosyslog_light/Makefile.am
@@ -41,6 +41,9 @@ EXTRA_DIST += \
 	tests/light/src/axosyslog_light/executors/tests/test_process_executor.py \
 	tests/light/src/axosyslog_light/fixtures.py \
 	tests/light/src/axosyslog_light/helpers/__init__.py \
+	tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_docker_executor.py \
+	tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_executor.py \
+	tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_local_executor.py \
 	tests/light/src/axosyslog_light/helpers/loggen/__init__.py \
 	tests/light/src/axosyslog_light/helpers/loggen/loggen_docker_executor.py \
 	tests/light/src/axosyslog_light/helpers/loggen/loggen_executor.py \

--- a/tests/light/src/axosyslog_light/common/docker_operations.py
+++ b/tests/light/src/axosyslog_light/common/docker_operations.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+# Copyright (c) 2026 Andras Mitzki <andras.mitzki@axoflow.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from subprocess import DEVNULL
+from subprocess import Popen
+
+
+def ensure_image_exists(image: str) -> None:
+    if Popen(["docker", "image", "inspect", image], stdout=DEVNULL, stderr=DEVNULL).wait() != 0:
+        raise RuntimeError(f"Docker image {image} is not available, run 'make light-third-party-deps' to prepare the 3rd party service images.")

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -26,6 +26,7 @@ import argparse
 import logging
 import os
 import re
+import shutil
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -102,9 +103,9 @@ def pytest_addoption(parser):
 
     parser.addoption(
         "--third-party-runner",
-        default="local",
-        choices=["local", "docker"],
-        help="How to run 3rd party services (ClickHouse server, snmptrapd): as host binaries ('local') or in containers ('docker'). Default: local.",
+        default="auto",
+        choices=["auto", "local", "docker"],
+        help="How to run 3rd party services (ClickHouse server, snmptrapd): as host binaries ('local') or in containers ('docker'). 'auto' uses the host binary when installed and falls back to a container. Default: auto.",
     )
 
     parser.addoption(
@@ -261,9 +262,16 @@ def dqtool(testcase_parameters):
     yield instance
 
 
+def third_party_runner_uses_docker(request, binary: str) -> bool:
+    runner = request.config.getoption("--third-party-runner")
+    if runner == "auto":
+        return shutil.which(binary) is None
+    return runner == "docker"
+
+
 @pytest.fixture
 def clickhouse_server(request, testcase_parameters, container_name):
-    if request.config.getoption("--third-party-runner") == "docker":
+    if third_party_runner_uses_docker(request, "clickhouse-server"):
         clickhouse_server_instance = ClickhouseServerDockerExecutor(
             testcase_parameters,
             f"clickhouse_{container_name}",

--- a/tests/light/src/axosyslog_light/fixtures.py
+++ b/tests/light/src/axosyslog_light/fixtures.py
@@ -39,7 +39,8 @@ from axosyslog_light.common.file import copy_file
 from axosyslog_light.common.pytest_operations import calculate_testcase_name
 from axosyslog_light.common.session_data import get_session_data
 from axosyslog_light.common.session_data import SessionData
-from axosyslog_light.helpers.clickhouse.clickhouse_server_executor import ClickhouseServerExecutor
+from axosyslog_light.helpers.clickhouse.clickhouse_server_docker_executor import ClickhouseServerDockerExecutor
+from axosyslog_light.helpers.clickhouse.clickhouse_server_local_executor import ClickhouseServerLocalExecutor
 from axosyslog_light.helpers.dqtool.dqtool import DqTool
 from axosyslog_light.helpers.dqtool.dqtool_docker_executor import DqToolDockerExecutor
 from axosyslog_light.helpers.dqtool.dqtool_executor import DqToolExecutor
@@ -97,6 +98,13 @@ def pytest_addoption(parser):
         "--docker-image",
         default="ghcr.io/axoflow/axosyslog:latest",
         help="Docker image to use for running syslog-ng. Used when 'runner' is 'docker'. Default: ghcr.io/axoflow/axosyslog:latest",
+    )
+
+    parser.addoption(
+        "--third-party-runner",
+        default="local",
+        choices=["local", "docker"],
+        help="How to run 3rd party services (ClickHouse server, snmptrapd): as host binaries ('local') or in containers ('docker'). Default: local.",
     )
 
     parser.addoption(
@@ -254,8 +262,14 @@ def dqtool(testcase_parameters):
 
 
 @pytest.fixture
-def clickhouse_server(request, testcase_parameters):
-    clickhouse_server_instance = ClickhouseServerExecutor(testcase_parameters)
+def clickhouse_server(request, testcase_parameters, container_name):
+    if request.config.getoption("--third-party-runner") == "docker":
+        clickhouse_server_instance = ClickhouseServerDockerExecutor(
+            testcase_parameters,
+            f"clickhouse_{container_name}",
+        )
+    else:
+        clickhouse_server_instance = ClickhouseServerLocalExecutor(testcase_parameters)
     yield clickhouse_server_instance
     if clickhouse_server_instance.process is not None:
         clickhouse_server_instance.stop()

--- a/tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_docker_executor.py
+++ b/tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_docker_executor.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+# Copyright (c) 2026 Andras Mitzki <andras.mitzki@axoflow.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import logging
+import os
+from pathlib import Path
+from subprocess import DEVNULL
+from subprocess import Popen
+
+from axosyslog_light.common.blocking import wait_until_true
+from axosyslog_light.executors.process_executor import ProcessExecutor
+from axosyslog_light.helpers.clickhouse.clickhouse_server_executor import ClickhouseServerExecutor
+from axosyslog_light.helpers.clickhouse.clickhouse_server_executor import CONFIG_FILE
+
+logger = logging.getLogger(__name__)
+
+CLICKHOUSE_IMAGE = "clickhouse/clickhouse-server:latest"
+
+
+class ClickhouseServerDockerExecutor(ClickhouseServerExecutor):
+    def __init__(self, testcase_parameters, container_name: str) -> None:
+        super().__init__(testcase_parameters)
+        self.__container_name = container_name
+        self.__image = CLICKHOUSE_IMAGE
+
+    def _start_server(self):
+        Popen(["docker", "rm", "-f", self.__container_name], stdout=DEVNULL, stderr=DEVNULL).wait()
+
+        cwd = Path.cwd().absolute()
+        command = ["docker", "run", "--rm", "-i"]
+        command += ["--entrypoint", "clickhouse-server"]
+        command += ["--name", self.__container_name]
+        command += ["--workdir", str(cwd)]
+        command += ["--user", f"{os.getuid()}:{os.getgid()}"]
+        command += ["-e", f"PUID={os.getuid()}", "-e", f"PGID={os.getgid()}"]
+        command += ["--network", "host"]
+        command += ["-v", f"{cwd}:{cwd}"]
+        command += [self.__image]
+        command += ["--config-file", CONFIG_FILE]
+
+        return ProcessExecutor().start(command, "clickhouse_server.stdout", "clickhouse_server.stderr")
+
+    def stop(self) -> None:
+        Popen(["docker", "rm", "-f", self.__container_name], stdout=DEVNULL, stderr=DEVNULL).wait()
+        wait_until_true(lambda: not self.process.is_running())
+        logger.info("Clickhouse server container %s removed.", self.__container_name)

--- a/tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_docker_executor.py
+++ b/tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_docker_executor.py
@@ -28,6 +28,7 @@ from subprocess import DEVNULL
 from subprocess import Popen
 
 from axosyslog_light.common.blocking import wait_until_true
+from axosyslog_light.common.docker_operations import ensure_image_exists
 from axosyslog_light.executors.process_executor import ProcessExecutor
 from axosyslog_light.helpers.clickhouse.clickhouse_server_executor import ClickhouseServerExecutor
 from axosyslog_light.helpers.clickhouse.clickhouse_server_executor import CONFIG_FILE
@@ -44,6 +45,7 @@ class ClickhouseServerDockerExecutor(ClickhouseServerExecutor):
         self.__image = CLICKHOUSE_IMAGE
 
     def _start_server(self):
+        ensure_image_exists(self.__image)
         Popen(["docker", "rm", "-f", self.__container_name], stdout=DEVNULL, stderr=DEVNULL).wait()
 
         cwd = Path.cwd().absolute()

--- a/tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_executor.py
+++ b/tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_executor.py
@@ -22,16 +22,14 @@
 #
 #############################################################################
 import logging
+from abc import ABC
+from abc import abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 import clickhouse_connect
-import psutil
-from axosyslog_light.common.blocking import wait_until_true
-from axosyslog_light.common.blocking import wait_until_true_custom
 from axosyslog_light.common.file import copy_shared_file
-from axosyslog_light.executors.process_executor import ProcessExecutor
 from axosyslog_light.syslog_ng_config.__init__ import destringify
 from axosyslog_light.syslog_ng_config.__init__ import stringify
 from tenacity import retry
@@ -39,6 +37,8 @@ from tenacity import stop_after_delay
 from tenacity import wait_fixed
 
 logger = logging.getLogger(__name__)
+
+CONFIG_FILE = "clickhouse_server_config.xml"
 
 CLICKHOUSE_OPTIONS = {
     "database": "default",
@@ -61,12 +61,12 @@ class ClickhouseServerTLS:
     require_client_auth: bool = False
 
 
-class ClickhouseServerExecutor():
+class ClickhouseServerExecutor(ABC):
     def __init__(self, testcase_parameters) -> None:
         self.process = None
         self.clickhouse_server_ports = []
         self.hostname = "localhost"
-        copy_shared_file(testcase_parameters, "clickhouse_server_config.xml")
+        copy_shared_file(testcase_parameters, CONFIG_FILE)
         copy_shared_file(testcase_parameters, "clickhouse_users.xml")
 
     @staticmethod
@@ -88,37 +88,26 @@ class ClickhouseServerExecutor():
         }
 
     def start(self, clickhouse_ports, tls: Optional[ClickhouseServerTLS] = None) -> None:
-        command = [
-            "clickhouse-server", "start",
-            "--config-file", "clickhouse_server_config.xml",
-        ]
-
         self.clickhouse_server_ports.append(clickhouse_ports.http_port)
         self.clickhouse_server_ports.append(clickhouse_ports.grpc_port)
+        self._apply_ports_to_config(clickhouse_ports, tls)
 
+        self.process = self._start_server()
+        self.wait_for_server_start(port=clickhouse_ports.http_port)
+        logger.info("Clickhouse server started with PID: %s", self.process.pid)
+
+    def _apply_ports_to_config(self, clickhouse_ports, tls: Optional[ClickhouseServerTLS] = None) -> None:
         substitutions = {
             "ALLOCATED_HTTP_PORT": str(clickhouse_ports.http_port),
             "ALLOCATED_INTERSERVER_GRPC_PORT": str(clickhouse_ports.grpc_port),
             **self._grpc_ssl_substitutions(tls),
         }
-        with open("clickhouse_server_config.xml", "r", encoding="utf-8") as file:
+        with open(CONFIG_FILE, "r", encoding="utf-8") as file:
             config = file.read()
         for placeholder, value in substitutions.items():
             config = config.replace(placeholder, value)
-        with open("clickhouse_server_config.xml", "w", encoding="utf-8") as file:
+        with open(CONFIG_FILE, "w", encoding="utf-8") as file:
             file.write(config)
-
-        self.process = ProcessExecutor().start(command, "clickhouse_server.stdout", "clickhouse_server.stderr")
-        if wait_until_true_custom(lambda: psutil.Process(self.process.pid).children(), timeout=0.5):
-            logger.info("Clickhouse server started with child process.")
-            self.process = psutil.Process(self.process.pid).children()[0]
-        self.wait_for_server_start(port=clickhouse_ports.http_port)
-        logger.info("Clickhouse server started with PID: %s", self.process.pid)
-
-    def stop(self) -> None:
-        self.process.terminate()
-        self.wait_for_server_stop()
-        logger.info("Clickhouse server with PID %s terminated.", self.process.pid)
 
     @retry(wait=wait_fixed(0.1), reraise=True, stop=stop_after_delay(10))
     def wait_for_server_start(self, port) -> None:
@@ -133,5 +122,10 @@ class ClickhouseServerExecutor():
         except Exception as e:
             raise RuntimeError("Clickhouse server is not ready yet.") from e
 
-    def wait_for_server_stop(self) -> None:
-        wait_until_true(lambda: not self.process.is_running())
+    @abstractmethod
+    def _start_server(self):
+        ...
+
+    @abstractmethod
+    def stop(self) -> None:
+        ...

--- a/tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_local_executor.py
+++ b/tests/light/src/axosyslog_light/helpers/clickhouse/clickhouse_server_local_executor.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+# Copyright (c) 2026 Andras Mitzki <andras.mitzki@axoflow.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import logging
+
+import psutil
+from axosyslog_light.common.blocking import wait_until_true
+from axosyslog_light.common.blocking import wait_until_true_custom
+from axosyslog_light.executors.process_executor import ProcessExecutor
+from axosyslog_light.helpers.clickhouse.clickhouse_server_executor import ClickhouseServerExecutor
+from axosyslog_light.helpers.clickhouse.clickhouse_server_executor import CONFIG_FILE
+
+logger = logging.getLogger(__name__)
+
+
+class ClickhouseServerLocalExecutor(ClickhouseServerExecutor):
+    def _start_server(self):
+        command = [
+            "clickhouse-server", "start",
+            "--config-file", CONFIG_FILE,
+        ]
+        process = ProcessExecutor().start(command, "clickhouse_server.stdout", "clickhouse_server.stderr")
+        if wait_until_true_custom(lambda: psutil.Process(process.pid).children(), timeout=0.5):
+            logger.info("Clickhouse server started with child process.")
+            process = psutil.Process(process.pid).children()[0]
+        return process
+
+    def stop(self) -> None:
+        self.process.terminate()
+        wait_until_true(lambda: not self.process.is_running())
+        logger.info("Clickhouse server with PID %s terminated.", self.process.pid)

--- a/tests/light/src/axosyslog_light/helpers/snmptrapd/conftest.py
+++ b/tests/light/src/axosyslog_light/helpers/snmptrapd/conftest.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import pytest
 from axosyslog_light.common.blocking import wait_until_true
 from axosyslog_light.common.file import File
+from axosyslog_light.fixtures import third_party_runner_uses_docker
 from axosyslog_light.helpers.snmptrapd.snmptrapd_docker_executor import SnmpTrapdDockerExecutor
 from axosyslog_light.helpers.snmptrapd.snmptrapd_local_executor import SnmpTrapdLocalExecutor
 
@@ -116,7 +117,7 @@ class SNMPtrapd(object):
 
 @pytest.fixture
 def snmptrapd(request, port_allocator, container_name):
-    if request.config.getoption("--third-party-runner") == "docker":
+    if third_party_runner_uses_docker(request, "snmptrapd"):
         executor = SnmpTrapdDockerExecutor(
             f"snmptrapd_{container_name}",
         )

--- a/tests/light/src/axosyslog_light/helpers/snmptrapd/conftest.py
+++ b/tests/light/src/axosyslog_light/helpers/snmptrapd/conftest.py
@@ -27,16 +27,17 @@ from pathlib import Path
 import pytest
 from axosyslog_light.common.blocking import wait_until_true
 from axosyslog_light.common.file import File
-from axosyslog_light.executors.process_executor import ProcessExecutor
-from psutil import TimeoutExpired
+from axosyslog_light.helpers.snmptrapd.snmptrapd_docker_executor import SnmpTrapdDockerExecutor
+from axosyslog_light.helpers.snmptrapd.snmptrapd_local_executor import SnmpTrapdLocalExecutor
 
 
 class SNMPtrapd(object):
     TRAP_LOG_PREFIX = 'LIGHT_TEST_SNMP_TRAP_RECEIVED:'
 
-    def __init__(self, port):
-        self.snmptrapd_proc = None
+    def __init__(self, executor, port):
+        self.executor = executor
         self.port = port
+        self.started = False
 
         self.snmptrapd_log = Path("snmptrapd_log")
         self.snmptrapd_stdout_path = Path("snmptrapd_stdout")
@@ -49,43 +50,37 @@ class SNMPtrapd(object):
         return "NET-SNMP version" in self.snmptrapd_log.read_text()
 
     def start(self):
-        if self.snmptrapd_proc is not None:
+        if self.started:
             return
 
-        self.snmptrapd_proc = ProcessExecutor().start(
-            [
-                "snmptrapd", "-f",
-                "--disableAuthorization=yes",
-                "-C",
-                "-m ALL",
-                "-A",
-                "-Ddump",
-                "-On",
-                "--doNotLogTraps=no",
-                "--authCommunity=log public",
-                self.port,
-                "-d",
-                "-Lf", os.path.relpath(str(self.snmptrapd_log)),
-                "-F", "{}%v\n".format(self.TRAP_LOG_PREFIX),
-            ],
-            self.snmptrapd_stdout_path,
-            self.snmptrapd_stderr_path,
-        )
+        snmptrapd_options = [
+            "-f",
+            "--disableAuthorization=yes",
+            "-C",
+            "-m ALL",
+            "-A",
+            "-Ddump",
+            "-On",
+            "--doNotLogTraps=no",
+            "--authCommunity=log public",
+            self.port,
+            "-d",
+            "-Lf", os.path.relpath(str(self.snmptrapd_log)),
+            "-F", "{}%v\n".format(self.TRAP_LOG_PREFIX),
+        ]
+        proc = self.executor.start(snmptrapd_options, self.snmptrapd_stdout_path, self.snmptrapd_stderr_path)
+        self.started = True
+
         wait_until_true(self.wait_for_snmptrapd_log_creation)
         wait_until_true(self.wait_for_snmptrapd_startup)
-        return self.snmptrapd_proc.is_running()
+        return proc.is_running()
 
     def stop(self):
-        if self.snmptrapd_proc is None:
+        if not self.started:
             return
 
-        self.snmptrapd_proc.terminate()
-        try:
-            self.snmptrapd_proc.wait(4)
-        except TimeoutExpired:
-            self.snmptrapd_proc.kill()
-
-        self.snmptrapd_proc = None
+        self.executor.stop()
+        self.started = False
 
     def get_port(self):
         return self.port
@@ -120,8 +115,14 @@ class SNMPtrapd(object):
 
 
 @pytest.fixture
-def snmptrapd(port_allocator):
-    server = SNMPtrapd(port_allocator())
+def snmptrapd(request, port_allocator, container_name):
+    if request.config.getoption("--third-party-runner") == "docker":
+        executor = SnmpTrapdDockerExecutor(
+            f"snmptrapd_{container_name}",
+        )
+    else:
+        executor = SnmpTrapdLocalExecutor()
+    server = SNMPtrapd(executor, port_allocator())
     server.start()
     yield server
     server.stop()

--- a/tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_docker_executor.py
+++ b/tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_docker_executor.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+# Copyright (c) 2026 Andras Mitzki <andras.mitzki@axoflow.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import os
+import typing
+from pathlib import Path
+from subprocess import DEVNULL
+from subprocess import Popen as subprocess_Popen
+
+from axosyslog_light.executors.process_executor import ProcessExecutor
+from axosyslog_light.helpers.snmptrapd.snmptrapd_executor import SnmpTrapdExecutor
+from psutil import Popen
+
+SNMPTRAPD_IMAGE = "axosyslog-light-snmptrapd:latest"
+
+
+class SnmpTrapdDockerExecutor(SnmpTrapdExecutor):
+    def __init__(self, container_name: str) -> None:
+        self.__container_name = container_name
+        self.__image = SNMPTRAPD_IMAGE
+        self.__proc = None
+
+    def start(self, snmptrapd_options: typing.List, stdout_path: Path, stderr_path: Path) -> Popen:
+        subprocess_Popen(["docker", "rm", "-f", self.__container_name], stdout=DEVNULL, stderr=DEVNULL).wait()
+
+        cwd = Path.cwd().absolute()
+        command = ["docker", "run", "--rm", "-i"]
+        command += ["--entrypoint", "snmptrapd"]
+        command += ["--name", self.__container_name]
+        command += ["--workdir", str(cwd)]
+        command += ["--user", f"{os.getuid()}:{os.getgid()}"]
+        command += ["-e", f"PUID={os.getuid()}", "-e", f"PGID={os.getgid()}"]
+        command += ["--network", "host"]
+        command += ["-v", f"{cwd}:{cwd}"]
+        command += [self.__image]
+        command += snmptrapd_options
+
+        self.__proc = ProcessExecutor().start(command, stdout_path, stderr_path)
+        return self.__proc
+
+    def stop(self) -> None:
+        subprocess_Popen(["docker", "rm", "-f", self.__container_name], stdout=DEVNULL, stderr=DEVNULL).wait()
+        self.__proc = None

--- a/tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_docker_executor.py
+++ b/tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_docker_executor.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from subprocess import DEVNULL
 from subprocess import Popen as subprocess_Popen
 
+from axosyslog_light.common.docker_operations import ensure_image_exists
 from axosyslog_light.executors.process_executor import ProcessExecutor
 from axosyslog_light.helpers.snmptrapd.snmptrapd_executor import SnmpTrapdExecutor
 from psutil import Popen
@@ -41,6 +42,7 @@ class SnmpTrapdDockerExecutor(SnmpTrapdExecutor):
         self.__proc = None
 
     def start(self, snmptrapd_options: typing.List, stdout_path: Path, stderr_path: Path) -> Popen:
+        ensure_image_exists(self.__image)
         subprocess_Popen(["docker", "rm", "-f", self.__container_name], stdout=DEVNULL, stderr=DEVNULL).wait()
 
         cwd = Path.cwd().absolute()

--- a/tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_executor.py
+++ b/tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_executor.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+# Copyright (c) 2026 Andras Mitzki <andras.mitzki@axoflow.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import typing
+from abc import ABC
+from abc import abstractmethod
+from pathlib import Path
+
+from psutil import Popen
+
+
+class SnmpTrapdExecutor(ABC):
+    @abstractmethod
+    def start(self, snmptrapd_options: typing.List, stdout_path: Path, stderr_path: Path) -> Popen:
+        ...
+
+    @abstractmethod
+    def stop(self) -> None:
+        ...

--- a/tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_local_executor.py
+++ b/tests/light/src/axosyslog_light/helpers/snmptrapd/snmptrapd_local_executor.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+# Copyright (c) 2026 Andras Mitzki <andras.mitzki@axoflow.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import typing
+from pathlib import Path
+
+from axosyslog_light.executors.process_executor import ProcessExecutor
+from axosyslog_light.helpers.snmptrapd.snmptrapd_executor import SnmpTrapdExecutor
+from psutil import Popen
+from psutil import TimeoutExpired
+
+
+class SnmpTrapdLocalExecutor(SnmpTrapdExecutor):
+    def __init__(self) -> None:
+        self.__proc = None
+
+    def start(self, snmptrapd_options: typing.List, stdout_path: Path, stderr_path: Path) -> Popen:
+        self.__proc = ProcessExecutor().start(["snmptrapd"] + snmptrapd_options, stdout_path, stderr_path)
+        return self.__proc
+
+    def stop(self) -> None:
+        if self.__proc is None:
+            return
+
+        self.__proc.terminate()
+        try:
+            self.__proc.wait(4)
+        except TimeoutExpired:
+            self.__proc.kill()
+
+        self.__proc = None


### PR DESCRIPTION
After this PR we can execute `make light-check PYTEST_OPTS="--third-party-runner docker"`
- this will start clickhouse-server and snmptrad service from docker containers -> so we do not have to install them on our local host
