### PR TITLE
docker/axosyslog-builder: add criterion build

### DIFF
--- a/docker/apkbuild/axoflow/criterion/APKBUILD
+++ b/docker/apkbuild/axoflow/criterion/APKBUILD
@@ -1,0 +1,65 @@
+# Contributor: Balazs Scheidler <balazs.scheidler@axoflow.com>
+# Maintainer: Balazs Scheidler <balazs.scheidler@axoflow.com>
+pkgname=criterion
+pkgver=2.4.3
+pkgrel=0
+pkgdesc="A cross-platform C and C++ unit testing framework for the 21st century"
+url="https://github.com/Snaipe/Criterion"
+arch="all"
+license="MIT"
+makedepends="
+	cmake
+	git
+	meson
+	ninja
+	linux-headers
+	libffi-dev
+	libgit2-dev
+	nanomsg-dev
+	"
+checkdepends=""
+subpackages="$pkgname-dev $pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/Snaipe/Criterion/archive/v$pkgver.tar.gz"
+builddir="$srcdir/Criterion-$pkgver"
+
+prepare() {
+	default_prepare
+
+	# Use system packages for these instead.
+	rm -v \
+		subprojects/libffi.wrap \
+		subprojects/libgit2-cmake.wrap \
+		subprojects/nanomsg-cmake.wrap
+
+	# Download of nanopb produces an error as it does not contain a
+	# meson.build file. A meson.build file is not necessary, so ignore
+	# the error.
+	meson subprojects download || true
+
+	# Fix FTBS
+	sed -i '/#ifdef __cplusplus/a # include <cstdint>' \
+		include/criterion/alloc.h
+}
+
+build() {
+	meson setup build \
+		--prefix=/usr \
+		--buildtype=release \
+		-Db_lto=false \
+		-Dwrap_mode=nodownload
+	meson compile -C build
+}
+
+check() {
+	meson test -C build --print-errorlogs
+}
+
+package() {
+	meson install -C build --destdir "$pkgdir"
+	install -Dm644 LICENSE \
+		"$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+}
+
+sha512sums="
+4699144627b6637a10b1602763f6220fdb52ea280cff9fe1f5eecbe941a828bae0a877d344bf9d661a0ec62bc5fcf51ebdfc843d6455af0a372a1e0b8a2c41b6  criterion-2.4.3.tar.gz
+"

--- a/docker/axosyslog-builder.dockerfile
+++ b/docker/axosyslog-builder.dockerfile
@@ -50,6 +50,13 @@ ADD --chown=builder:builder apkbuild .
 
 ENV CFLAGS=-fno-omit-frame-pointer CXXFLAGS=-fno-omit-frame-pointer REBUILD_DEPS=$REBUILD_DEPS
 
+RUN mkdir packages || true \
+    && USER=builder abuild-keygen -n -a -i \
+    && cd axoflow/criterion \
+    && export MAKEFLAGS="-j$(nproc)" \
+    && abuild checksum \
+    && abuild -r
+
 RUN \
     mkdir packages || true \
     && USER=builder abuild-keygen -n -a -i \


### PR DESCRIPTION
To be able to compile our unit tests. This needs to go in before the actual unit tests fixes, so that the axosyslog-builder image is produced.

