### PR TITLE
filterx: end the compile context even when parsing the block fails

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -726,8 +726,9 @@ filterx_content
             FilterXEvalContext compile_context;
 
             filterx_eval_begin_compile(&compile_context, configuration);
-	    CHECK_ERROR_WITHOUT_MESSAGE(cfg_parser_parse(&filterx_parser, lexer, (gpointer *) &filterx_block, NULL), @$);
+	    gboolean parse_result = cfg_parser_parse(&filterx_parser, lexer, (gpointer *) &filterx_block, NULL);
             filterx_eval_end_compile(&compile_context);
+	    CHECK_ERROR_WITHOUT_MESSAGE(parse_result, @$);
 
             $$ = log_expr_node_new_pipe(log_filterx_pipe_new(filterx_block, configuration), &@$);
 	  } _filterx_context_pop			{ $$ = $2; }


### PR DESCRIPTION
The filterx_content grammar rule sets the thread-local eval context to a stack-local `FilterXEvalContext` via `filterx_eval_begin_compile()`, then parses the block.

When the parse failed, `CHECK_ERROR_WITHOUT_MESSAGE()` jumped to the bison error handler before
`filterx_eval_end_compile()` ran, leaving the eval context pointing at the stack frame after it unwound.

A later read of the context (e.g. `filterx_eval_context_is_production()` during shutdown) then dereferenced freed stack memory, crashing under ASan.

Assisted-by: Claude:claude-opus-4-8[1m]

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
