### PR TITLE
arrow-flight: deprecate broken timeout(), introduce keep-alive() options

### DIFF
--- a/modules/arrow-flight/arrow-flight-dest.cpp
+++ b/modules/arrow-flight/arrow-flight-dest.cpp
@@ -158,6 +158,27 @@ arrow_flight_dd_set_batch_bytes(LogDriver *d, glong b)
 }
 
 void
+arrow_flight_dd_set_keepalive_time(LogDriver *d, gint t)
+{
+  ArrowFlightDestDriver *self = (ArrowFlightDestDriver *) d;
+  self->cpp->set_keepalive_time(t);
+}
+
+void
+arrow_flight_dd_set_keepalive_timeout(LogDriver *d, gint t)
+{
+  ArrowFlightDestDriver *self = (ArrowFlightDestDriver *) d;
+  self->cpp->set_keepalive_timeout(t);
+}
+
+void
+arrow_flight_dd_set_keepalive_max_pings(LogDriver *d, gint p)
+{
+  ArrowFlightDestDriver *self = (ArrowFlightDestDriver *) d;
+  self->cpp->set_keepalive_max_pings(p);
+}
+
+void
 arrow_flight_dd_add_string_schema_field(LogDriver *d, const gchar *name, LogTemplate *value)
 {
   ArrowFlightDestDriver *self = (ArrowFlightDestDriver *) d;

--- a/modules/arrow-flight/arrow-flight-dest.cpp
+++ b/modules/arrow-flight/arrow-flight-dest.cpp
@@ -158,13 +158,6 @@ arrow_flight_dd_set_batch_bytes(LogDriver *d, glong b)
 }
 
 void
-arrow_flight_dd_set_timeout(LogDriver *d, glong timeout)
-{
-  ArrowFlightDestDriver *self = (ArrowFlightDestDriver *) d;
-  self->cpp->set_timeout(timeout);
-}
-
-void
 arrow_flight_dd_add_string_schema_field(LogDriver *d, const gchar *name, LogTemplate *value)
 {
   ArrowFlightDestDriver *self = (ArrowFlightDestDriver *) d;

--- a/modules/arrow-flight/arrow-flight-dest.h
+++ b/modules/arrow-flight/arrow-flight-dest.h
@@ -43,6 +43,9 @@ void arrow_flight_dd_add_bool_schema_field(LogDriver *d, const gchar *name, LogT
 void arrow_flight_dd_add_timestamp_schema_field(LogDriver *d, const gchar *name, LogTemplate *value);
 void arrow_flight_dd_add_map_string_string_schema_field(LogDriver *d, const gchar *name, LogTemplate *value);
 void arrow_flight_dd_set_batch_bytes(LogDriver *d, glong b);
+void arrow_flight_dd_set_keepalive_time(LogDriver *d, gint t);
+void arrow_flight_dd_set_keepalive_timeout(LogDriver *d, gint t);
+void arrow_flight_dd_set_keepalive_max_pings(LogDriver *d, gint p);
 
 LogTemplateOptions *arrow_flight_dd_get_template_options(LogDriver *d);
 

--- a/modules/arrow-flight/arrow-flight-dest.h
+++ b/modules/arrow-flight/arrow-flight-dest.h
@@ -43,7 +43,6 @@ void arrow_flight_dd_add_bool_schema_field(LogDriver *d, const gchar *name, LogT
 void arrow_flight_dd_add_timestamp_schema_field(LogDriver *d, const gchar *name, LogTemplate *value);
 void arrow_flight_dd_add_map_string_string_schema_field(LogDriver *d, const gchar *name, LogTemplate *value);
 void arrow_flight_dd_set_batch_bytes(LogDriver *d, glong b);
-void arrow_flight_dd_set_timeout(LogDriver *d, glong timeout);
 
 LogTemplateOptions *arrow_flight_dd_get_template_options(LogDriver *d);
 

--- a/modules/arrow-flight/arrow-flight-dest.hpp
+++ b/modules/arrow-flight/arrow-flight-dest.hpp
@@ -107,16 +107,6 @@ public:
     return this->batch_bytes;
   }
 
-  void set_timeout(glong t)
-  {
-    this->timeout = t;
-  }
-
-  glong get_timeout() const
-  {
-    return this->timeout;
-  }
-
   LogTemplateOptions &get_template_options()
   {
     return this->template_options;
@@ -171,7 +161,6 @@ private:
   std::vector<SchemaField> schema_fields;
   std::shared_ptr<arrow::Schema> arrow_schema;
   size_t batch_bytes = 0;
-  glong timeout = 0;
 };
 
 }

--- a/modules/arrow-flight/arrow-flight-dest.hpp
+++ b/modules/arrow-flight/arrow-flight-dest.hpp
@@ -107,6 +107,36 @@ public:
     return this->batch_bytes;
   }
 
+  void set_keepalive_time(gint t)
+  {
+    this->keepalive_time = t;
+  }
+
+  gint get_keepalive_time() const
+  {
+    return this->keepalive_time;
+  }
+
+  void set_keepalive_timeout(gint t)
+  {
+    this->keepalive_timeout = t;
+  }
+
+  gint get_keepalive_timeout() const
+  {
+    return this->keepalive_timeout;
+  }
+
+  void set_keepalive_max_pings(gint p)
+  {
+    this->keepalive_max_pings_without_data = p;
+  }
+
+  gint get_keepalive_max_pings() const
+  {
+    return this->keepalive_max_pings_without_data;
+  }
+
   LogTemplateOptions &get_template_options()
   {
     return this->template_options;
@@ -161,6 +191,9 @@ private:
   std::vector<SchemaField> schema_fields;
   std::shared_ptr<arrow::Schema> arrow_schema;
   size_t batch_bytes = 0;
+  gint keepalive_time = -1;
+  gint keepalive_timeout = -1;
+  gint keepalive_max_pings_without_data = -1;
 };
 
 }

--- a/modules/arrow-flight/arrow-flight-grammar.ym
+++ b/modules/arrow-flight/arrow-flight-grammar.ym
@@ -32,6 +32,7 @@
 #include "cfg-grammar-internal.h"
 #include "plugin.h"
 #include "syslog-names.h"
+#include "messages.h"
 
 #include "arrow-flight-dest.h"
 
@@ -63,6 +64,9 @@
 %token KW_CAP_MAP
 %token KW_BATCH_BYTES
 %token KW_TIMEOUT
+%token KW_KEEP_ALIVE
+%token KW_TIME
+%token KW_MAX_PINGS_WITHOUT_DATA
 
 %type <ptr> arrow_flight_dest
 
@@ -89,12 +93,28 @@ arrow_flight_dest_option
   : KW_URL '(' string ')' { arrow_flight_dd_set_url(last_driver, $3); free($3); }
   | KW_PATH '(' template_content ')' { arrow_flight_dd_set_path(last_driver, $3); log_template_unref($3); }
   | KW_BATCH_BYTES '(' positive_integer ')' { arrow_flight_dd_set_batch_bytes(last_driver, $3); }
-  | KW_TIMEOUT '(' nonnegative_integer ')' { }
+  | KW_TIMEOUT '(' nonnegative_integer ')'
+    {
+      msg_warning("WARNING: The arrow-flight timeout() option is deprecated and was broken, "
+                  "use the keep-alive() options instead");
+    }
+  | KW_KEEP_ALIVE '(' arrow_flight_keepalive_options ')'
   | KW_SCHEMA '(' arrow_flight_schema_fields ')'
   | threaded_dest_driver_general_option
   | threaded_dest_driver_workers_option
   | threaded_dest_driver_batch_option
   | { last_template_options = arrow_flight_dd_get_template_options(last_driver); } template_option
+  ;
+
+arrow_flight_keepalive_options
+  : arrow_flight_keepalive_option arrow_flight_keepalive_options
+  |
+  ;
+
+arrow_flight_keepalive_option
+  : KW_TIME '(' nonnegative_integer ')' { arrow_flight_dd_set_keepalive_time(last_driver, $3); }
+  | KW_TIMEOUT '(' nonnegative_integer ')' { arrow_flight_dd_set_keepalive_timeout(last_driver, $3); }
+  | KW_MAX_PINGS_WITHOUT_DATA '(' nonnegative_integer ')' { arrow_flight_dd_set_keepalive_max_pings(last_driver, $3); }
   ;
 
 arrow_flight_schema_fields

--- a/modules/arrow-flight/arrow-flight-grammar.ym
+++ b/modules/arrow-flight/arrow-flight-grammar.ym
@@ -89,7 +89,7 @@ arrow_flight_dest_option
   : KW_URL '(' string ')' { arrow_flight_dd_set_url(last_driver, $3); free($3); }
   | KW_PATH '(' template_content ')' { arrow_flight_dd_set_path(last_driver, $3); log_template_unref($3); }
   | KW_BATCH_BYTES '(' positive_integer ')' { arrow_flight_dd_set_batch_bytes(last_driver, $3); }
-  | KW_TIMEOUT '(' nonnegative_integer ')' { arrow_flight_dd_set_timeout(last_driver, $3); }
+  | KW_TIMEOUT '(' nonnegative_integer ')' { }
   | KW_SCHEMA '(' arrow_flight_schema_fields ')'
   | threaded_dest_driver_general_option
   | threaded_dest_driver_workers_option

--- a/modules/arrow-flight/arrow-flight-parser.c
+++ b/modules/arrow-flight/arrow-flight-parser.c
@@ -45,7 +45,10 @@ static CfgLexerKeyword arrow_flight_keywords[] =
   { "TIMESTAMP",     KW_CAP_TIMESTAMP },
   { "MAP",           KW_CAP_MAP },
   { "batch_bytes",   KW_BATCH_BYTES },
-  { "timeout",       KW_TIMEOUT, KWS_OBSOLETE, "The timeout() option is deprecated and was broken, use the keep-alive() options instead." },
+  { "timeout",       KW_TIMEOUT },
+  { "keep_alive",    KW_KEEP_ALIVE },
+  { "time",          KW_TIME },
+  { "max_pings_without_data", KW_MAX_PINGS_WITHOUT_DATA },
   { NULL }
 };
 

--- a/modules/arrow-flight/arrow-flight-parser.c
+++ b/modules/arrow-flight/arrow-flight-parser.c
@@ -45,7 +45,7 @@ static CfgLexerKeyword arrow_flight_keywords[] =
   { "TIMESTAMP",     KW_CAP_TIMESTAMP },
   { "MAP",           KW_CAP_MAP },
   { "batch_bytes",   KW_BATCH_BYTES },
-  { "timeout",       KW_TIMEOUT },
+  { "timeout",       KW_TIMEOUT, KWS_OBSOLETE, "The timeout() option is deprecated and was broken, use the keep-alive() options instead." },
   { NULL }
 };
 

--- a/modules/arrow-flight/arrow-flight-worker.cpp
+++ b/modules/arrow-flight/arrow-flight-worker.cpp
@@ -407,10 +407,6 @@ DestinationWorker::open_stream(const gchar *path)
   DestinationDriver *owner = this->get_owner();
 
   arrow::flight::FlightCallOptions call_options;
-  glong timeout = owner->get_timeout();
-  if (timeout > 0)
-    call_options.timeout = arrow::flight::TimeoutDuration{(double) timeout};
-
   auto descriptor = arrow::flight::FlightDescriptor::Path({path});
   auto put_result = this->client->DoPut(call_options, descriptor, owner->get_arrow_schema());
   if (!put_result.ok())

--- a/modules/arrow-flight/arrow-flight-worker.cpp
+++ b/modules/arrow-flight/arrow-flight-worker.cpp
@@ -116,7 +116,17 @@ DestinationWorker::connect()
 {
   DestinationDriver *owner = this->get_owner();
 
-  auto client_result = arrow::flight::FlightClient::Connect(this->location);
+  auto client_options = arrow::flight::FlightClientOptions::Defaults();
+  if (owner->get_keepalive_time() != -1)
+    client_options.generic_options.emplace_back("grpc.keepalive_time_ms", owner->get_keepalive_time());
+  if (owner->get_keepalive_timeout() != -1)
+    client_options.generic_options.emplace_back("grpc.keepalive_timeout_ms", owner->get_keepalive_timeout());
+  if (owner->get_keepalive_max_pings() != -1)
+    client_options.generic_options.emplace_back("grpc.http2.max_pings_without_data",
+                                                owner->get_keepalive_max_pings());
+  client_options.generic_options.emplace_back("grpc.keepalive_permit_without_calls", 1);
+
+  auto client_result = arrow::flight::FlightClient::Connect(this->location, client_options);
   if (!client_result.ok())
     {
       msg_error("arrow-flight: Failed to connect to server",

--- a/tests/light/functional_tests/destination_drivers/arrow_flight_destination/test_arrow_flight_destination.py
+++ b/tests/light/functional_tests/destination_drivers/arrow_flight_destination/test_arrow_flight_destination.py
@@ -447,33 +447,3 @@ def test_arrow_flight_destination_temporary_error(config, syslog_ng, port_alloca
     assert wait_until_true(lambda: arrow_flight_destination.get_stats().get("written", 0) == num_messages)
     assert arrow_flight_destination.get_stats()["dropped"] == 0
     assert arrow_flight_destination.get_row_count(ARROW_FLIGHT_PATH) == num_messages
-
-
-def test_arrow_flight_destination_timeout(config, syslog_ng, port_allocator):
-    num_messages = 5
-    custom_msg = f"test message {uuid.uuid4()}"
-    file_source = config.create_file_source(file_name="input.log", flags="no-parse")
-    options = {
-        **ARROW_FLIGHT_OPTIONS,
-        "batch-lines": 1,
-        "time-reopen": 1,
-        "timeout": 1,
-    }
-    arrow_flight_destination = config.create_arrow_flight_destination(port=port_allocator(), **options)
-    config.create_logpath(statements=[file_source, arrow_flight_destination])
-
-    arrow_flight_destination.start_listener()
-    arrow_flight_destination.start_hanging()
-    syslog_ng.start(config)
-
-    file_source.write_logs([custom_msg] * num_messages)
-
-    assert wait_until_true(lambda: syslog_ng.is_message_in_console_log("temporary error status code"))
-    assert arrow_flight_destination.get_stats().get("written", 0) == 0
-    assert arrow_flight_destination.get_stats()["dropped"] == 0
-
-    arrow_flight_destination.stop_hanging()
-
-    assert wait_until_true(lambda: arrow_flight_destination.get_stats().get("written", 0) == num_messages)
-    assert arrow_flight_destination.get_stats()["dropped"] == 0
-    assert arrow_flight_destination.get_row_count(ARROW_FLIGHT_PATH) == num_messages


### PR DESCRIPTION
AxoSyslog uses long-running DoPut streams.

The timeout() option was not a per-WriteRecordBatch() timeout, it was
for the whole stream, which ideally closes only on reload or shutdown,
which implies that the timeout() option should not exist as it always
causes errors if we wait the configured number of seconds.

The option can be reintroduced if we decide to use shorter DoPut sessions
(based on the API docs, this would be the recommended path).