### PR TITLE
filterx: uuid7()

### DIFF
--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -123,6 +123,7 @@ _simple_init(void)
   g_assert(filterx_builtin_simple_function_register("str_rstrip", filterx_simple_function_str_rstrip));
   g_assert(filterx_builtin_simple_function_register("str_replace", filterx_simple_function_str_replace));
   g_assert(filterx_builtin_simple_function_register("uuid", filterx_simple_function_uuid));
+  g_assert(filterx_builtin_simple_function_register("uuid7", filterx_simple_function_uuid7));
   g_assert(filterx_builtin_simple_function_register("md5", filterx_simple_function_md5));
   g_assert(filterx_builtin_simple_function_register("sha1", filterx_simple_function_sha1));
   g_assert(filterx_builtin_simple_function_register("sha256", filterx_simple_function_sha256));

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -122,7 +122,8 @@ _simple_init(void)
   g_assert(filterx_builtin_simple_function_register("str_lstrip", filterx_simple_function_str_lstrip));
   g_assert(filterx_builtin_simple_function_register("str_rstrip", filterx_simple_function_str_rstrip));
   g_assert(filterx_builtin_simple_function_register("str_replace", filterx_simple_function_str_replace));
-  g_assert(filterx_builtin_simple_function_register("uuid", filterx_simple_function_uuid));
+  g_assert(filterx_builtin_simple_function_register("uuid", filterx_simple_function_uuid4));
+  g_assert(filterx_builtin_simple_function_register("uuid4", filterx_simple_function_uuid4));
   g_assert(filterx_builtin_simple_function_register("uuid7", filterx_simple_function_uuid7));
   g_assert(filterx_builtin_simple_function_register("md5", filterx_simple_function_md5));
   g_assert(filterx_builtin_simple_function_register("sha1", filterx_simple_function_sha1));

--- a/lib/filterx/func-uuid.c
+++ b/lib/filterx/func-uuid.c
@@ -28,7 +28,7 @@
 #include "uuid.h"
 
 FilterXObject *
-filterx_simple_function_uuid(FilterXExpr *s, FilterXObject *args[], gsize args_len)
+filterx_simple_function_uuid4(FilterXExpr *s, FilterXObject *args[], gsize args_len)
 {
   if (args_len != 0)
     {

--- a/lib/filterx/func-uuid.c
+++ b/lib/filterx/func-uuid.c
@@ -40,3 +40,17 @@ filterx_simple_function_uuid(FilterXExpr *s, FilterXObject *args[], gsize args_l
   uuid_gen_random(uuid_str, sizeof(uuid_str));
   return filterx_string_new(uuid_str, 36);
 }
+
+FilterXObject *
+filterx_simple_function_uuid7(FilterXExpr *s, FilterXObject *args[], gsize args_len)
+{
+  if (args_len != 0)
+    {
+      filterx_simple_function_argument_error(s, "Requires no arguments");
+      return NULL;
+    }
+
+  gchar uuid_str[37];
+  uuid_gen_v7(uuid_str, sizeof(uuid_str));
+  return filterx_string_new(uuid_str, 36);
+}

--- a/lib/filterx/func-uuid.h
+++ b/lib/filterx/func-uuid.h
@@ -27,7 +27,7 @@
 #include "filterx/filterx-object.h"
 #include "filterx/filterx-expr.h"
 
-FilterXObject *filterx_simple_function_uuid(FilterXExpr *s, FilterXObject *args[], gsize args_len);
+FilterXObject *filterx_simple_function_uuid4(FilterXExpr *s, FilterXObject *args[], gsize args_len);
 FilterXObject *filterx_simple_function_uuid7(FilterXExpr *s, FilterXObject *args[], gsize args_len);
 
 #endif

--- a/lib/filterx/func-uuid.h
+++ b/lib/filterx/func-uuid.h
@@ -28,5 +28,6 @@
 #include "filterx/filterx-expr.h"
 
 FilterXObject *filterx_simple_function_uuid(FilterXExpr *s, FilterXObject *args[], gsize args_len);
+FilterXObject *filterx_simple_function_uuid7(FilterXExpr *s, FilterXObject *args[], gsize args_len);
 
 #endif

--- a/lib/filterx/tests/test_func_uuid.c
+++ b/lib/filterx/tests/test_func_uuid.c
@@ -34,6 +34,7 @@
 
 #include "apphook.h"
 #include "scratch-buffers.h"
+#include "timeutils/cache.h"
 
 static FilterXExpr *
 _create_uuid_expr(void)
@@ -119,6 +120,90 @@ Test(filterx_func_uuid, rejects_arguments)
   cr_assert_null(res);
 
   filterx_expr_unref(fn);
+}
+
+static FilterXExpr *
+_create_uuid7_expr(void)
+{
+  GError *error = NULL;
+  FilterXExpr *fn = filterx_simple_function_new("uuid7", filterx_function_args_new(NULL, NULL),
+                                                filterx_simple_function_uuid7, &error);
+  cr_assert_null(error);
+  return fn;
+}
+
+Test(filterx_func_uuid, uuid7_format_version_and_variant)
+{
+  FilterXExpr *fn = _create_uuid7_expr();
+  FilterXObject *res = init_and_eval_expr(fn);
+
+  cr_assert_not_null(res);
+  cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
+
+  gsize len;
+  const gchar *uuid = filterx_string_get_value_ref(res, &len);
+  cr_assert_not_null(uuid);
+
+  cr_assert_eq(len, 36);
+  cr_assert_eq(uuid[8], '-');
+  cr_assert_eq(uuid[13], '-');
+  cr_assert_eq(uuid[18], '-');
+  cr_assert_eq(uuid[23], '-');
+  cr_assert_eq(uuid[14], '7');
+  cr_assert(uuid[19] == '8' || uuid[19] == '9' || uuid[19] == 'a' || uuid[19] == 'b');
+
+  filterx_object_unref(res);
+  filterx_expr_unref(fn);
+}
+
+Test(filterx_func_uuid, uuid7_embeds_current_timestamp)
+{
+  invalidate_cached_realtime();
+  gint64 before_ms = g_get_real_time() / 1000;
+
+  FilterXExpr *fn = _create_uuid7_expr();
+  FilterXObject *res = init_and_eval_expr(fn);
+  cr_assert_not_null(res);
+
+  gint64 after_ms = g_get_real_time() / 1000;
+
+  gsize len;
+  const gchar *uuid = filterx_string_get_value_ref(res, &len);
+
+  gchar ts_hex[13];
+  memcpy(ts_hex, uuid, 8);
+  memcpy(ts_hex + 8, uuid + 9, 4);
+  ts_hex[12] = '\0';
+  gint64 ts_ms = g_ascii_strtoll(ts_hex, NULL, 16);
+
+  cr_assert_geq(ts_ms, before_ms);
+  cr_assert_leq(ts_ms, after_ms);
+
+  filterx_object_unref(res);
+  filterx_expr_unref(fn);
+}
+
+Test(filterx_func_uuid, uuid7_burst_is_strictly_monotonic)
+{
+  gchar prev[37] = "";
+
+  for (gint i = 0; i < 64; i++)
+    {
+      FilterXExpr *fn = _create_uuid7_expr();
+      FilterXObject *res = init_and_eval_expr(fn);
+      cr_assert_not_null(res);
+
+      gsize len;
+      const gchar *uuid = filterx_string_get_value_ref(res, &len);
+      cr_assert_eq(len, 36);
+      cr_assert(strcmp(prev, uuid) < 0);
+
+      memcpy(prev, uuid, 36);
+      prev[36] = '\0';
+
+      filterx_object_unref(res);
+      filterx_expr_unref(fn);
+    }
 }
 
 static void

--- a/lib/filterx/tests/test_func_uuid.c
+++ b/lib/filterx/tests/test_func_uuid.c
@@ -41,7 +41,7 @@ _create_uuid_expr(void)
 {
   GError *error = NULL;
   FilterXExpr *fn = filterx_simple_function_new("uuid", filterx_function_args_new(NULL, NULL),
-                                                filterx_simple_function_uuid, &error);
+                                                filterx_simple_function_uuid4, &error);
   cr_assert_null(error);
   return fn;
 }
@@ -113,7 +113,7 @@ Test(filterx_func_uuid, rejects_arguments)
 
   GError *error = NULL;
   FilterXExpr *fn = filterx_simple_function_new("uuid", filterx_function_args_new(args, NULL),
-                                                filterx_simple_function_uuid, &error);
+                                                filterx_simple_function_uuid4, &error);
   cr_assert_null(error);
 
   FilterXObject *res = init_and_eval_expr(fn);

--- a/lib/uuid.c
+++ b/lib/uuid.c
@@ -22,6 +22,7 @@
  */
 
 #include "uuid.h"
+#include "timeutils/unixtime.h"
 
 #include <openssl/rand.h>
 
@@ -51,4 +52,59 @@ uuid_gen_random(gchar *buf, gsize buflen)
   rnd[8] = (rnd[8] & 0x3F) | 0x80; /* RFC 4122 variant: top two bits of byte 8 */
 
   _format_uuid(rnd, buf, buflen);
+}
+
+#define UUID_V7_COUNTER_LIMIT (G_GUINT64_CONSTANT(1) << 42)
+
+static GMutex uuid_v7_lock;
+static guint64 uuid_v7_ms;
+static guint64 uuid_v7_counter;
+
+static guint64
+_uuid_v7_counter_seed(void)
+{
+  guint64 seed;
+  RAND_bytes((guchar *) &seed, sizeof(seed));
+  return seed >> 23;
+}
+
+void
+uuid_gen_v7(gchar *buf, gsize buflen)
+{
+  UnixTime now;
+  unix_time_set_now(&now);
+  guint64 unix_ms = unix_time_to_unix_epoch_usec(now) / 1000;
+
+  g_mutex_lock(&uuid_v7_lock);
+  if (unix_ms > uuid_v7_ms)
+    {
+      uuid_v7_ms = unix_ms;
+      uuid_v7_counter = _uuid_v7_counter_seed();
+    }
+  else if (++uuid_v7_counter == UUID_V7_COUNTER_LIMIT)
+    {
+      uuid_v7_ms++;
+      uuid_v7_counter = _uuid_v7_counter_seed();
+    }
+  guint64 ms = uuid_v7_ms;
+  guint64 counter = uuid_v7_counter;
+  g_mutex_unlock(&uuid_v7_lock);
+
+  guchar bytes[16];
+  RAND_bytes(bytes + 12, 4);
+
+  bytes[0] = (ms >> 40) & 0xFF;
+  bytes[1] = (ms >> 32) & 0xFF;
+  bytes[2] = (ms >> 24) & 0xFF;
+  bytes[3] = (ms >> 16) & 0xFF;
+  bytes[4] = (ms >> 8) & 0xFF;
+  bytes[5] = ms & 0xFF;
+  bytes[6] = 0x70 | ((counter >> 38) & 0x0F);
+  bytes[7] = (counter >> 30) & 0xFF;
+  bytes[8] = 0x80 | ((counter >> 24) & 0x3F);
+  bytes[9] = (counter >> 16) & 0xFF;
+  bytes[10] = (counter >> 8) & 0xFF;
+  bytes[11] = counter & 0xFF;
+
+  _format_uuid(bytes, buf, buflen);
 }

--- a/lib/uuid.c
+++ b/lib/uuid.c
@@ -25,6 +25,18 @@
 
 #include <openssl/rand.h>
 
+static void
+_format_uuid(const guchar *bytes, gchar *buf, gsize buflen)
+{
+  g_snprintf(buf, buflen,
+             "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+             bytes[0], bytes[1], bytes[2], bytes[3],
+             bytes[4], bytes[5],
+             bytes[6], bytes[7],
+             bytes[8], bytes[9],
+             bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]);
+}
+
 void
 uuid_gen_random(gchar *buf, gsize buflen)
 {
@@ -38,11 +50,5 @@ uuid_gen_random(gchar *buf, gsize buflen)
   rnd[6] = (rnd[6] & 0x0F) | 0x40; /* version 4: top nibble of byte 6 */
   rnd[8] = (rnd[8] & 0x3F) | 0x80; /* RFC 4122 variant: top two bits of byte 8 */
 
-  g_snprintf(buf, buflen,
-             "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-             rnd[0], rnd[1], rnd[2], rnd[3],
-             rnd[4], rnd[5],
-             rnd[6], rnd[7],
-             rnd[8], rnd[9],
-             rnd[10], rnd[11], rnd[12], rnd[13], rnd[14], rnd[15]);
+  _format_uuid(rnd, buf, buflen);
 }

--- a/lib/uuid.h
+++ b/lib/uuid.h
@@ -27,5 +27,6 @@
 #include "syslog-ng.h"
 
 void uuid_gen_random(gchar *buf, gsize buflen);
+void uuid_gen_v7(gchar *buf, gsize buflen);
 
 #endif

--- a/news/feature-1168.md
+++ b/news/feature-1168.md
@@ -1,0 +1,6 @@
+`filterx`: add the `uuid7()` function
+
+`uuid7()` generates RFC 9562 UUIDv7 identifiers, which embed a millisecond-precision Unix timestamp, so
+they sort lexically by creation time.
+
+For consistency with `uuid7()`, `uuid()` now has an alias: `uuid4()`.

--- a/tests/light/functional_tests/filterx/test_filterx_funcs.py
+++ b/tests/light/functional_tests/filterx/test_filterx_funcs.py
@@ -1160,6 +1160,19 @@ def test_uuid(config, syslog_ng):
     assert re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", uuid_str)
 
 
+def test_uuid7(config, syslog_ng):
+    (file_final,) = create_config(
+        config, r"""
+    $MSG = string(uuid7());
+    """,
+    )
+    syslog_ng.start(config)
+
+    assert file_final.get_stats()["processed"] == 1
+    uuid_str = file_final.read_log().strip()
+    assert re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", uuid_str)
+
+
 def test_digest(config, syslog_ng):
     (file_final,) = create_config(
         config, r"""


### PR DESCRIPTION
RFC 9562 UUIDv7, similar to the Rust's Uuid::now_v7().

The implementation uses cached time "now" (unix_time_set_now()),
in order not to complicate the counter implementation further by 
supporting timestamps in the past or future.