### PR TITLE
Filterx remove more redundant errors

### DIFF
--- a/lib/filterx/expr-arithmetic-operators.c
+++ b/lib/filterx/expr-arithmetic-operators.c
@@ -354,8 +354,6 @@ static FilterXObject *
 _do_plus(FilterXObject *lhs, FilterXObject *rhs, FilterXExpr *expr)
 {
   FilterXObject *result = filterx_object_add(lhs, rhs);
-  if (!result)
-    filterx_eval_push_error_static_info("Failed to add values", "add() method failed");
 
   filterx_object_unref(lhs);
   filterx_object_unref(rhs);

--- a/lib/filterx/expr-plus-assign.c
+++ b/lib/filterx/expr-plus-assign.c
@@ -40,12 +40,6 @@ _eval_plus_assign(FilterXExpr *s)
 
   FilterXObject *res = filterx_expr_plus_assign(self->super.lhs, rhs_object);
   filterx_object_unref(rhs_object);
-  if (!res)
-    {
-      filterx_eval_push_error_static_info("Failed to add values in place", "plus_assign() method failed");
-      return NULL;
-    }
-
   return res;
 }
 

--- a/lib/filterx/filterx-dpath.c
+++ b/lib/filterx/filterx-dpath.c
@@ -233,7 +233,7 @@ filterx_dpath_lvalue_plus_assign(FilterXExpr *s, FilterXObject *new_value)
   FilterXObject *dict = _dpath_touch(self, TRUE, &last_object);
 
   if (!dict)
-    return FALSE;
+    return NULL;
 
   FilterXObject *result = filterx_object_add_inplace(last_object, new_value);
   if (result && result != last_object)

--- a/lib/filterx/filterx-mapping.c
+++ b/lib/filterx/filterx-mapping.c
@@ -46,7 +46,12 @@ filterx_mapping_merge(FilterXObject *s, FilterXObject *other)
 {
   other = filterx_ref_unwrap_ro(other);
   if (!filterx_object_is_type(other, &FILTERX_TYPE_NAME(mapping)))
-    return FALSE;
+    {
+      filterx_eval_push_error_info_printf("Failed to merge mapping",
+                                          "argument must be a mapping, got: %s",
+                                          filterx_object_get_type_name(other));
+      return FALSE;
+    }
 
   return filterx_object_iter(other, _add_elem, s);
 }

--- a/lib/filterx/filterx-sequence.c
+++ b/lib/filterx/filterx-sequence.c
@@ -76,7 +76,12 @@ filterx_sequence_merge(FilterXObject *s, FilterXObject *other)
 {
   other = filterx_ref_unwrap_ro(other);
   if (!filterx_object_is_type(other, &FILTERX_TYPE_NAME(sequence)))
-    return FALSE;
+    {
+      filterx_eval_push_error_info_printf("Failed to merge sequence",
+                                          "argument must be a sequence, got: %s",
+                                          filterx_object_get_type_name(other));
+      return FALSE;
+    }
 
   return filterx_object_iter(other, _add_elem, s);
 }

--- a/lib/filterx/func-digest.c
+++ b/lib/filterx/func-digest.c
@@ -141,7 +141,7 @@ _filterx_function_digest_eval(FilterXExpr *s)
     {
       filterx_eval_push_error_info_printf(FILTERX_FUNC_DIGEST_USAGE,
                                           "Argument must be a string or bytes, got type: %s",
-                                          input_obj->type->name);
+                                          filterx_object_get_type_name(input_obj));
       filterx_object_unref(input_obj);
       return NULL;
     }

--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -304,6 +304,9 @@ _add(FilterXObject *s, FilterXObject *object)
       goto success;
     }
 
+  filterx_eval_push_error_info_printf("Failed to add to datetime",
+                                      "rhs requires an integer or double, got: %s",
+                                      filterx_object_get_type_name(object));
   return NULL;
 
 success:

--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -58,7 +58,11 @@ static FilterXObject *
 _double_add_result(gdouble value)
 {
   if (!isfinite(value))
-    return NULL;
+    {
+      filterx_eval_push_error_static_info("Failed to perform addition",
+                                          "double overflow");
+      return NULL;
+    }
   return filterx_double_new(value);
 }
 
@@ -72,7 +76,11 @@ _integer_add(FilterXObject *s, FilterXObject *object)
     {
       gint64 res;
       if (__builtin_add_overflow(gn_as_int64(&self->value), i, &res))
-        return NULL;
+        {
+          filterx_eval_push_error_static_info("Failed to perform addition",
+                                              "integer overflow");
+          return NULL;
+        }
       return filterx_integer_new(res);
     }
 

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -515,7 +515,12 @@ _bytes_add(FilterXObject *s, FilterXObject *object)
   const gchar *other_str;
   gsize other_str_len;
   if (!filterx_object_extract_bytes_ref(object, &other_str, &other_str_len))
-    return NULL;
+    {
+      filterx_eval_push_error_info_printf("Failed to add object to bytes",
+                                          "Right hand side must be bytes, got: %s",
+                                          filterx_object_get_type_name(object));
+      return NULL;
+    }
 
   gsize buffer_len = self->str_len + other_str_len;
   gchar *buffer = g_malloc(buffer_len);


### PR DESCRIPTION
This PR should further clean up our filterx error stack in case of add() and add_inplace(), as we delegate the responsibility to
push the error entry to the objects themselves, meaning we will only have a single error in our stack pointing to the right statement, with specific error descriptions.
