### PR TITLE
filterx/json-repr: do not bypass the integer cache

### DIFF
--- a/lib/filterx/json-repr.c
+++ b/lib/filterx/json-repr.c
@@ -153,7 +153,16 @@ _convert_from_json_number(const gchar *json_text, gsize json_len, jsmntok_t *tok
   if (!parse_generic_number(buf, &gn))
     return NULL;
 
-  return filterx_primitive_new_from_gn(&gn);
+  switch (gn.type)
+    {
+    case GN_DOUBLE:
+    case GN_NAN:
+      return filterx_double_new_with_prec(gn_as_double(&gn), gn.precision);
+    case GN_INT64:
+      return filterx_integer_new(gn_as_int64(&gn));
+    default:
+      g_assert_not_reached();
+    }
 }
 
 static FilterXObject *

--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -316,29 +316,6 @@ filterx_primitive_get_value(FilterXObject *s)
 }
 
 FilterXObject *
-filterx_primitive_new_from_gn(const GenericNumber *gn)
-{
-  FilterXType *type;
-
-  switch (gn->type)
-    {
-    case GN_DOUBLE:
-    case GN_NAN:
-      type = &FILTERX_TYPE_NAME(double);
-      break;
-    case GN_INT64:
-      type = &FILTERX_TYPE_NAME(integer);
-      break;
-    default:
-      g_assert_not_reached();
-    }
-  FilterXPrimitive *self = filterx_primitive_new(type);
-  self->value = *gn;
-  return &self->super;
-
-}
-
-FilterXObject *
 filterx_typecast_boolean(FilterXExpr *s, FilterXObject *args[], gsize args_len)
 {
   FilterXObject *object = filterx_typecast_get_arg(s, args, args_len);

--- a/lib/filterx/object-primitive.h
+++ b/lib/filterx/object-primitive.h
@@ -56,7 +56,6 @@ FilterXObject *filterx_double_new(gdouble value);
 FilterXObject *filterx_double_new_with_prec(gdouble value, gint prec);
 FilterXObject *filterx_enum_new(GlobalConfig *cfg, const gchar *namespace_name, const gchar *enum_name);
 GenericNumber filterx_primitive_get_value(FilterXObject *s);
-FilterXObject *filterx_primitive_new_from_gn(const GenericNumber *gn);
 
 FilterXObject *filterx_typecast_boolean(FilterXExpr *s, FilterXObject *args[], gsize args_len);
 FilterXObject *filterx_typecast_integer(FilterXExpr *s, FilterXObject *args[], gsize args_len);


### PR DESCRIPTION
As JSON parsing turned GenericNumbers to FilterXPrimitive instances, it bypassed the integer cache. Let's not do that.

no news needed, probably only matters when we are loading JSONs with lots of integers at runtime.
