### PR TITLE
filterx: dynamically allocate the jsmn token array in JSON parsing

### DIFF
--- a/lib/filterx/json-repr.c
+++ b/lib/filterx/json-repr.c
@@ -262,7 +262,6 @@ FilterXObject *
 filterx_object_from_json(const gchar *repr, gssize repr_len, GError **error)
 {
   const gint min_tokens = 256;
-  const gint max_tokens = 65536;
 
   g_return_val_if_fail(error == NULL || (*error) == NULL, NULL);
 
@@ -278,6 +277,12 @@ filterx_object_from_json(const gchar *repr, gssize repr_len, GError **error)
       jsmn_tokens = g_new(jsmntok_t, jsmn_tokens_len);
     }
 
+  /* NOTE: a token consumes at least one byte of input, so the number of
+   * tokens can never exceed the length of the JSON text.  This gives us a
+   * natural, input-driven ceiling for the doubling loop below, without
+   * resorting to an arbitrary hardcoded limit. */
+  gint64 max_tokens = MAX(repr_len, min_tokens);
+
   gint r;
   gboolean try_again;
   do
@@ -287,8 +292,18 @@ filterx_object_from_json(const gchar *repr, gssize repr_len, GError **error)
       r = jsmn_parse(&parser, repr, repr_len, jsmn_tokens, jsmn_tokens_len);
       if (r == JSMN_ERROR_NOMEM && jsmn_tokens_len < max_tokens)
         {
-          jsmn_tokens_len *= 2;
-          jsmn_tokens = g_renew(jsmntok_t, jsmn_tokens, jsmn_tokens_len);
+          gint64 new_tokens_len = MIN((gint64) jsmn_tokens_len * 2, max_tokens);
+          jsmntok_t *new_tokens = g_try_renew(jsmntok_t, jsmn_tokens, new_tokens_len);
+          if (!new_tokens)
+            {
+              g_set_error(error, FILTERX_JSON_ERROR, FILTERX_JSON_ERROR_TOO_LARGE,
+                          "JSON text too large, could not allocate memory for %"
+                          G_GINT64_FORMAT " tokens (size %" G_GSSIZE_FORMAT " bytes)",
+                          new_tokens_len, repr_len);
+              return NULL;
+            }
+          jsmn_tokens = new_tokens;
+          jsmn_tokens_len = new_tokens_len;
           try_again = TRUE;
         }
     }
@@ -300,7 +315,8 @@ filterx_object_from_json(const gchar *repr, gssize repr_len, GError **error)
         {
         case JSMN_ERROR_NOMEM:
           g_set_error(error, FILTERX_JSON_ERROR, FILTERX_JSON_ERROR_TOO_LARGE,
-                      "JSON text too large, number of tokens exceeds the maximum of %d tokens (size %ld bytes)",
+                      "JSON text too large, number of tokens exceeds the maximum of %"
+                      G_GINT64_FORMAT " tokens (size %" G_GSSIZE_FORMAT " bytes)",
                       max_tokens, repr_len);
           break;
         case JSMN_ERROR_INVAL:

--- a/lib/filterx/tests/test_json_repr.c
+++ b/lib/filterx/tests/test_json_repr.c
@@ -50,6 +50,35 @@ Test(filterx_json_repr, deeply_nested_array_does_not_overflow_stack)
   cr_assert(TRUE);
 }
 
+/* the legacy hardcoded jsmn token limit was 65536, use a token count comfortably above that */
+#define LARGE_ARRAY_ELEMENT_COUNT 100000
+
+Test(filterx_json_repr, array_exceeding_legacy_max_tokens_is_parsed_successfully)
+{
+  GString *large = g_string_sized_new(LARGE_ARRAY_ELEMENT_COUNT * 2 + 2);
+  g_string_append_c(large, '[');
+  for (gint i = 0; i < LARGE_ARRAY_ELEMENT_COUNT; i++)
+    {
+      if (i > 0)
+        g_string_append_c(large, ',');
+      g_string_append_c(large, '1');
+    }
+  g_string_append_c(large, ']');
+
+  GError *error = NULL;
+  FilterXObject *obj = filterx_object_from_json(large->str, large->len, &error);
+
+  cr_assert_null(error, "%s", error ? error->message : "");
+  cr_assert_not_null(obj);
+
+  guint64 len = 0;
+  cr_assert(filterx_object_len(obj, &len));
+  cr_assert_eq(len, LARGE_ARRAY_ELEMENT_COUNT);
+
+  filterx_object_unref(obj);
+  g_string_free(large, TRUE);
+}
+
 static void
 setup(void)
 {

--- a/news/bugfix-1181.md
+++ b/news/bugfix-1181.md
@@ -1,0 +1,3 @@
+`filterx`: JSON parsing (`parse_json()`, `cache_json_file()`) no longer fails on JSON documents that need more
+than 65536 jsmn tokens. The token array is now grown dynamically until parsing succeeds or memory is
+actually exhausted, instead of being capped at a hardcoded token count.


### PR DESCRIPTION
filterx_object_from_json() capped the jsmn token buffer at a hardcoded 65536 tokens, so any JSON document requiring more tokens (e.g. large cache_json_file() datasets) failed to parse with a "JSON text too large" error, blocking upgrades for users with such data.

Replace the fixed ceiling with a bound derived from the input size itself (a token consumes at least one byte, so token count can never exceed the text length), and keep doubling the buffer with g_try_renew() until parsing succeeds or the allocation genuinely fails, reporting a clear error only in that case.

Fixes axoflow/axosyslog#1181

Assisted-by: Claude:claude-fable-5[1m]
