### PR TITLE
`disk-buffer`: fix fd leak

### DIFF
--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -223,6 +223,7 @@ _release_dirlock(gint fd)
 {
   flock(fd, LOCK_UN);
   g_mutex_unlock(&filename_lock);
+  close(fd);
 }
 
 gchar *

--- a/news/bugfix-1188.md
+++ b/news/bugfix-1188.md
@@ -1,0 +1,1 @@
+`disk-buffer()`: fix leaking a file descriptor per disk-buffer file allocation


### PR DESCRIPTION
A nice catch by @petek.

Fixes syslog-ng/syslog-ng#5747