### PR TITLE
CLI flag --filterx-only and --print-ast

### DIFF
--- a/doc/man/syslog-ng.8.xml
+++ b/doc/man/syslog-ng.8.xml
@@ -144,6 +144,21 @@
           </listitem>
         </varlistentry>
         <varlistentry>
+          <term>
+            <command>--filterx-only</command>
+            <indexterm type="parameter">
+              <primary>--filterx-only</primary>
+            </indexterm>
+            <indexterm type="parameter">
+              <primary>filterx-only</primary>
+            </indexterm>
+          </term>
+          <listitem>
+            <para>Compile the file specified with <parameter>--cfgfile</parameter> as a standalone filterx script instead of a syslog-ng configuration, then exit. The entire file is parsed as filterx code, as if its contents were the body of a <parameter>filterx {}</parameter> block, so it must not contain sources, destinations or log paths. Useful for validating filterx code from CI or an editor.</para>
+            <para>Add <parameter>--print-ast</parameter> to print the abstract syntax tree of the compiled script to the standard output as JSON. The tree is the one that would be evaluated, e.g. it is already optimized, and nothing is printed if the script fails to compile.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
           <term><command>--foreground</command> or <command>-F</command>
                         <indexterm type="parameter"><primary>--foreground</primary></indexterm>
                         <indexterm type="parameter"><primary>foreground</primary></indexterm>

--- a/doc/man/syslog-ng.8.xml
+++ b/doc/man/syslog-ng.8.xml
@@ -236,6 +236,23 @@
         </varlistentry>
         <varlistentry>
           <term>
+            <command>--print-ast</command>
+            <indexterm type="parameter">
+              <primary>--print-ast</primary>
+            </indexterm>
+            <indexterm type="parameter">
+              <primary>print-ast</primary>
+            </indexterm>
+          </term>
+          <listitem>
+            <para>Parse the configuration file, print its abstract syntax tree to the standard output as JSON, and exit. The configuration is not initialized, so this is as cheap and as side effect free as <parameter>--syntax-only</parameter>. Nothing is printed if the configuration fails to parse.</para>
+            <para>The <parameter>statements</parameter> array contains every root level statement of the configuration in source order, including the ones that are not log expressions (<parameter>options</parameter>, <parameter>template</parameter>, <parameter>template-function</parameter>, <parameter>block</parameter> and root context plugins such as <parameter>python</parameter>). Log expression statements also carry an <parameter>expr</parameter> member describing the tree of the expression, and <parameter>filterx {}</parameter> blocks carry a <parameter>filterx</parameter> member describing the parsed filterx expression.</para>
+            <para>Every expression node carries a <parameter>layout</parameter> and a <parameter>content</parameter> member, using the same terms as the configuration tree: a <parameter>content</parameter> of <parameter>log</parameter> with a <parameter>layout</parameter> of <parameter>sequence</parameter> is a log statement, while a <parameter>layout</parameter> of <parameter>single</parameter> is an individual driver or pipe, in which case the <parameter>plugin</parameter> member names the plugin it was created from, if it came from one.</para>
+            <para>This makes it possible to validate what the parser actually built, for example that a snippet of generated configuration did not escape the block it was embedded into.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
             <command>--process-mode &lt;mode&gt;</command>
             <indexterm type="parameter">
               <primary>--process-mode</primary>

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -94,6 +94,7 @@ set (LIB_HEADERS
     cfg-source.h
     cfg-tree.h
     cfg-graph.h
+    cfg-ast.h
     cfg-persist.h
     children.h
     crypto.h
@@ -195,6 +196,7 @@ set(LIB_SOURCES
     cfg-source.c
     cfg-tree.c
     cfg-graph.c
+    cfg-ast.c
     cfg-persist.c
     children.c
     dnscache.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -118,6 +118,7 @@ pkginclude_HEADERS			+= \
 	lib/cfg-source.h		\
 	lib/cfg-tree.h			\
 	lib/cfg-graph.h		\
+	lib/cfg-ast.h			\
 	lib/cfg-persist.h		\
 	lib/children.h			\
 	lib/crypto.h			\
@@ -216,6 +217,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/cfg-source.c		\
 	lib/cfg-tree.c			\
 	lib/cfg-graph.c		\
+	lib/cfg-ast.c			\
 	lib/cfg-persist.c		\
 	lib/children.c			\
 	lib/dnscache.c			\

--- a/lib/cfg-ast.c
+++ b/lib/cfg-ast.c
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "cfg-ast.h"
+#include "cfg.h"
+#include "logpipe.h"
+#include "filterx/filterx-ast.h"
+#include "filterx/filterx-pipe.h"
+#include "compat/json.h"
+
+static struct json_object *
+_format_location(const gchar *filename, gint line, gint column)
+{
+  struct json_object *location = json_object_new_object();
+
+  json_object_object_add(location, "file", filename ? json_object_new_string(filename) : NULL);
+  json_object_object_add(location, "line", json_object_new_int(line));
+  json_object_object_add(location, "column", json_object_new_int(column));
+
+  return location;
+}
+
+static struct json_object *
+_format_flags(guint32 flags)
+{
+  static const struct
+  {
+    guint32 flag;
+    const gchar *name;
+  } flag_names[] =
+  {
+    { LC_CATCHALL, "catch-all" },
+    { LC_FALLBACK, "fallback" },
+    { LC_FINAL, "final" },
+    { LC_FLOW_CONTROL, "flow-control" },
+    { LC_NO_FLOW_CONTROL, "no-flow-control" },
+  };
+
+  struct json_object *result = json_object_new_array();
+
+  for (gsize i = 0; i < G_N_ELEMENTS(flag_names); i++)
+    {
+      if (flags & flag_names[i].flag)
+        json_object_array_add(result, json_object_new_string(flag_names[i].name));
+    }
+
+  return result;
+}
+
+static struct json_object *_format_expr_node(LogExprNode *node);
+
+static struct json_object *
+_format_expr_node_list(LogExprNode *node)
+{
+  struct json_object *result = json_object_new_array();
+
+  for (LogExprNode *child = node; child; child = child->next)
+    json_object_array_add(result, _format_expr_node(child));
+
+  return result;
+}
+
+static void
+_add_pipe_members(struct json_object *result, LogPipe *pipe)
+{
+  json_object_object_add(result, "plugin", pipe->plugin_name ? json_object_new_string(pipe->plugin_name) : NULL);
+
+  FilterXExpr *filterx_block = log_filterx_pipe_get_block(pipe);
+
+  if (filterx_block)
+    json_object_object_add(result, "filterx", filterx_expr_format_ast(filterx_block));
+}
+
+static struct json_object *
+_format_expr_node(LogExprNode *node)
+{
+  struct json_object *result = json_object_new_object();
+
+  json_object_object_add(result, "layout", json_object_new_string(log_expr_node_get_layout_name(node->layout)));
+  json_object_object_add(result, "content", json_object_new_string(log_expr_node_get_content_name(node->content)));
+  json_object_object_add(result, "name", node->name ? json_object_new_string(node->name) : NULL);
+  json_object_object_add(result, "flags", _format_flags(node->flags));
+  json_object_object_add(result, "location", _format_location(node->filename, node->line, node->column));
+
+  if (node->content == ENC_PIPE && node->layout == ENL_SINGLE && node->object)
+    _add_pipe_members(result, (LogPipe *) node->object);
+
+  if (node->children)
+    json_object_object_add(result, "children", _format_expr_node_list(node->children));
+
+  return result;
+}
+
+static struct json_object *
+_format_statement(LogExprNode *node)
+{
+  struct json_object *result = json_object_new_object();
+
+  json_object_object_add(result, "kind", json_object_new_string(log_expr_node_get_content_name(node->content)));
+  json_object_object_add(result, "expr", _format_expr_node(node));
+
+  return result;
+}
+
+static gint
+_compare_statements(gconstpointer a, gconstpointer b)
+{
+  const LogExprNode *n1 = *((LogExprNode **) a);
+  const LogExprNode *n2 = *((LogExprNode **) b);
+
+  gint result = g_strcmp0(n1->filename, n2->filename);
+
+  if (result == 0)
+    result = n1->line - n2->line;
+  if (result == 0)
+    result = n1->column - n2->column;
+
+  return result;
+}
+
+static GPtrArray *
+_collect_statements(CfgTree *tree)
+{
+  GPtrArray *statements = g_ptr_array_new();
+
+  for (guint i = 0; i < tree->rules->len; i++)
+    g_ptr_array_add(statements, g_ptr_array_index(tree->rules, i));
+
+  GList *objects = cfg_tree_get_objects(tree);
+  for (GList *object = objects; object; object = object->next)
+    g_ptr_array_add(statements, object->data);
+  g_list_free(objects);
+
+  g_ptr_array_sort(statements, _compare_statements);
+
+  return statements;
+}
+
+static struct json_object *
+_format_statements(GlobalConfig *cfg)
+{
+  struct json_object *result = json_object_new_array();
+  GPtrArray *statements = _collect_statements(&cfg->tree);
+
+  for (guint i = 0; i < statements->len; i++)
+    json_object_array_add(result, _format_statement(g_ptr_array_index(statements, i)));
+
+  g_ptr_array_free(statements, TRUE);
+
+  return result;
+}
+
+GString *
+cfg_ast_format(GlobalConfig *cfg)
+{
+  struct json_object *root = json_object_new_object();
+
+  json_object_object_add(root, "statements", _format_statements(cfg));
+
+  GString *result = g_string_new(json_object_to_json_string_ext(root, JSON_C_TO_STRING_PRETTY));
+  json_object_put(root);
+
+  return result;
+}

--- a/lib/cfg-ast.h
+++ b/lib/cfg-ast.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef CFG_AST_H_INCLUDED
+#define CFG_AST_H_INCLUDED
+
+#include "cfg-tree.h"
+
+/* Format the abstract syntax tree of an already parsed configuration as JSON.
+ * The returned GString is owned by the caller.
+ *
+ * The statements of the dump are the root level log expressions of the CfgTree
+ * (sorted by their source location, as the tree itself only keeps the order of
+ * the log statements), each with its expression tree and the parsed filterx
+ * expressions inside.  The statements that are not part of the CfgTree are not
+ * reported: options{}, template{}, template-function, block{} definitions and
+ * root level plugins such as python{}.
+ *
+ * The configuration must not be initialized yet, as cfg_init() rewrites the
+ * nodes of the tree: log paths with flags(catch-all) get their sources
+ * substituted and the anonymous expressions are named.
+ */
+GString *cfg_ast_format(GlobalConfig *cfg);
+
+#endif

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -31,6 +31,7 @@
 #include "atomic.h"
 
 const gchar *log_expr_node_get_content_name(gint content);
+const gchar *log_expr_node_get_layout_name(gint layout);
 
 #define LC_CATCHALL       1
 #define LC_FALLBACK       2

--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -33,6 +33,7 @@ set(FILTERX_HEADERS
     filterx/expr-variable.h
     filterx/expr-string-operators.h
     filterx/filterx-allocator.h
+    filterx/filterx-ast.h
     filterx/filterx-config.h
     filterx/filterx-error.h
     filterx/filterx-eval.h
@@ -126,6 +127,7 @@ set(FILTERX_SOURCES
     filterx/expr-variable.c
     filterx/expr-string-operators.c
     filterx/filterx-allocator.c
+    filterx/filterx-ast.c
     filterx/filterx-config.c
     filterx/filterx-error.c
     filterx/filterx-eval.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -35,6 +35,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/expr-variable.h \
 	lib/filterx/expr-string-operators.h \
 	lib/filterx/filterx-allocator.h \
+	lib/filterx/filterx-ast.h \
 	lib/filterx/filterx-config.h \
 	lib/filterx/filterx-error.h \
 	lib/filterx/filterx-eval.h \
@@ -131,6 +132,7 @@ lib_filterx_libfilterx_la_SOURCES = \
 	$(filterx_expr_sources) \
 	$(filterxjit_sources) \
 	lib/filterx/filterx-allocator.c \
+	lib/filterx/filterx-ast.c \
 	lib/filterx/filterx-config.c \
 	lib/filterx/filterx-dpath.c \
 	lib/filterx/filterx-env.c \

--- a/lib/filterx/filterx-ast.c
+++ b/lib/filterx/filterx-ast.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/filterx-ast.h"
+
+static struct json_object *
+_format_location(const CFG_LTYPE *lloc)
+{
+  struct json_object *location = json_object_new_object();
+
+  json_object_object_add(location, "file", lloc->name ? json_object_new_string(lloc->name) : NULL);
+  json_object_object_add(location, "line", json_object_new_int(lloc->first_line));
+  json_object_object_add(location, "column", json_object_new_int(lloc->first_column));
+
+  return location;
+}
+
+static gboolean
+_add_child(FilterXExpr *parent, FilterXExpr **child, gpointer user_data)
+{
+  struct json_object *children = (struct json_object *) user_data;
+
+  if (*child)
+    json_object_array_add(children, filterx_expr_format_ast(*child));
+
+  return TRUE;
+}
+
+static struct json_object *
+_format_children(FilterXExpr *expr)
+{
+  struct json_object *children = json_object_new_array();
+
+  filterx_expr_walk_children(expr, _add_child, children);
+
+  return children;
+}
+
+struct json_object *
+filterx_expr_format_ast(FilterXExpr *expr)
+{
+  if (!expr)
+    return NULL;
+
+  struct json_object *result = json_object_new_object();
+
+  json_object_object_add(result, "type", expr->type ? json_object_new_string(expr->type) : NULL);
+  json_object_object_add(result, "text", expr->expr_text ? json_object_new_string(expr->expr_text) : NULL);
+  json_object_object_add(result, "location", expr->lloc ? _format_location(expr->lloc) : NULL);
+  json_object_object_add(result, "children", _format_children(expr));
+
+  return result;
+}
+
+GString *
+filterx_expr_format_ast_string(FilterXExpr *expr)
+{
+  struct json_object *root = filterx_expr_format_ast(expr);
+  GString *result = g_string_new(json_object_to_json_string_ext(root, JSON_C_TO_STRING_PRETTY));
+
+  json_object_put(root);
+
+  return result;
+}

--- a/lib/filterx/filterx-ast.h
+++ b/lib/filterx/filterx-ast.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_AST_H_INCLUDED
+#define FILTERX_AST_H_INCLUDED
+
+#include "filterx/filterx-expr.h"
+#include "compat/json.h"
+
+/* Format the abstract syntax tree of a filterx expression as JSON: each node
+ * reports its type, its verbatim source text, its location and the list of its
+ * children. */
+struct json_object *filterx_expr_format_ast(FilterXExpr *expr);
+
+/* The pretty printed form of filterx_expr_format_ast(), the returned GString is
+ * owned by the caller. */
+GString *filterx_expr_format_ast_string(FilterXExpr *expr);
+
+#endif

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -128,6 +128,9 @@ _assign_location(FilterXExpr *expr, CfgLexer *lexer, CFG_LTYPE *lloc)
 %token KW_DEFAULT
 %token KW_DPATH
 
+/* only used/injected by filterx_compile_script() */
+%token LL_FILTERX_VIRTUAL_TOPLEVEL
+
 %type <ptr> block
 %type <ptr> stmts
 %type <node> stmt
@@ -187,6 +190,14 @@ _assign_location(FilterXExpr *expr, CfgLexer *lexer, CFG_LTYPE *lloc)
 
 start
         : block					{ *result = $1; if (yychar != FILTERX_EMPTY) { cfg_lexer_unput_token(lexer, &yylval); } YYACCEPT; }
+	| LL_FILTERX_VIRTUAL_TOPLEVEL stmts		{
+						  /* used when entire file is filterx code.
+						   * NOTE: no YYACCEPT here -> expecting end-of-input to ensure complete statements */
+						  FilterXExpr *block = filterx_compound_expr_new(FALSE);
+						  filterx_compound_expr_add_list_ref(block, $2);
+						  filterx_expr_set_location_with_text(block, &@$, "<toplevel>");
+						  *result = block;
+						}
 	;
 
 block

--- a/lib/filterx/filterx-parser.c
+++ b/lib/filterx/filterx-parser.c
@@ -22,6 +22,12 @@
 
 #include "filterx/filterx-parser.h"
 #include "filterx/filterx-grammar.h"
+#include "filterx/filterx-ast.h"
+#include "filterx/filterx-eval.h"
+#include "filterx/filterx-pipe.h"
+#include "cfg.h"
+#include "cfg-lexer.h"
+#include "messages.h"
 
 extern int filterx_debug;
 int filterx_parse(CfgLexer *lexer, FilterXExpr **expr, gpointer arg);
@@ -73,3 +79,86 @@ CfgParser filterx_parser =
 };
 
 CFG_PARSER_IMPLEMENT_LEXER_BINDING(filterx_, FILTERX_, FilterXExpr **)
+
+/* for parsing the whole as a brace-less filterx statement list */
+static void
+_inject_toplevel_token(CfgLexer *lexer)
+{
+  CfgTokenBlock *block = cfg_token_block_new();
+  CFG_STYPE token;
+
+  memset(&token, 0, sizeof(token));
+  token.type = LL_TOKEN;
+  token.token = LL_FILTERX_VIRTUAL_TOPLEVEL;
+  cfg_token_block_add_and_consume_token(block, &token);
+
+  cfg_lexer_inject_token_block(lexer, block);
+}
+
+static gboolean
+_parse_script(GlobalConfig *cfg, CfgLexer *lexer, FilterXExpr **block)
+{
+  FilterXEvalContext compile_context;
+
+  _inject_toplevel_token(lexer);
+
+  filterx_eval_begin_compile(&compile_context, cfg);
+  gboolean result = cfg_run_parser(cfg, lexer, &filterx_parser, (gpointer *) block, NULL);
+  filterx_eval_end_compile(&compile_context);
+
+  return result;
+}
+
+/* To obtain errors beyond compilability. */
+static gboolean
+_compile_block(GlobalConfig *cfg, FilterXExpr *block, GString **ast)
+{
+  /* the pipe takes over @block and optimizes it as part of its initialization */
+  LogPipe *pipe = log_filterx_pipe_new(block, cfg);
+
+  gboolean result = log_pipe_init(pipe);
+  if (result)
+    {
+      /* dump the tree that would actually be evaluated, e.g. the optimized one */
+      if (ast)
+        *ast = filterx_expr_format_ast_string(log_filterx_pipe_get_block(pipe));
+      log_pipe_deinit(pipe);
+    }
+
+  log_pipe_unref(pipe);
+  return result;
+}
+
+gboolean
+filterx_compile_script(GlobalConfig *cfg, CfgLexer *lexer, GString **ast)
+{
+  FilterXExpr *block = NULL;
+
+  if (!_parse_script(cfg, lexer, &block))
+    return FALSE;
+
+  return _compile_block(cfg, block, ast);
+}
+
+gboolean
+filterx_compile_script_file(GlobalConfig *cfg, const gchar *fname, GString **ast)
+{
+  FILE *script_file;
+
+  cfg_discover_candidate_modules(cfg);
+
+  cfg->filename = fname;
+
+  if ((script_file = fopen(fname, "r")) == NULL)
+    {
+      msg_error("Error opening filterx script file",
+                evt_tag_str(EVT_TAG_FILENAME, fname),
+                evt_tag_error(EVT_TAG_OSERROR));
+      return FALSE;
+    }
+
+  gboolean result = filterx_compile_script(cfg, cfg_lexer_new(cfg, script_file, fname, NULL), ast);
+  fclose(script_file);
+
+  return result;
+}

--- a/lib/filterx/filterx-parser.h
+++ b/lib/filterx/filterx-parser.h
@@ -30,4 +30,12 @@ extern CfgParser filterx_parser;
 
 CFG_PARSER_DECLARE_LEXER_BINDING(filterx_, FILTERX_, FilterXExpr **)
 
+/* Compile an entire input as filterx code, e.g. as if it were the body of a
+ * filterx {} block, and throw away the result: this only validates that the code
+ * compiles.  @lexer is consumed.  If @ast is not NULL, the abstract syntax tree
+ * of the compiled script is returned there as JSON (owned by the caller), it is
+ * left intact unless the script compiles. */
+gboolean filterx_compile_script(GlobalConfig *cfg, CfgLexer *lexer, GString **ast);
+gboolean filterx_compile_script_file(GlobalConfig *cfg, const gchar *fname, GString **ast);
+
 #endif

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -210,6 +210,15 @@ log_filterx_pipe_free(LogPipe *s)
   log_pipe_free_method(s);
 }
 
+FilterXExpr *
+log_filterx_pipe_get_block(LogPipe *s)
+{
+  if (!s || s->queue != log_filterx_pipe_queue)
+    return NULL;
+
+  return ((LogFilterXPipe *) s)->block;
+}
+
 LogPipe *
 log_filterx_pipe_new(FilterXExpr *block, GlobalConfig *cfg)
 {

--- a/lib/filterx/filterx-pipe.h
+++ b/lib/filterx/filterx-pipe.h
@@ -28,4 +28,6 @@
 
 LogPipe *log_filterx_pipe_new(FilterXExpr *expr, GlobalConfig *cfg);
 
+FilterXExpr *log_filterx_pipe_get_block(LogPipe *s);
+
 #endif

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -41,5 +41,6 @@ add_unit_test(LIBTEST CRITERION TARGET test_object_ip DEPENDS json-plugin ${JSON
 add_unit_test(LIBTEST CRITERION TARGET test_expr_arithmetic_operators DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_func_set_pri DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_json_repr DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_filterx_script DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_filterx_plist DEPENDS syslogformat json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_tuple DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -45,7 +45,8 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_object_ip \
 		lib/filterx/tests/test_expr_arithmetic_operators \
 		lib/filterx/tests/test_func_set_pri \
-		lib/filterx/tests/test_json_repr
+		lib/filterx/tests/test_json_repr \
+		lib/filterx/tests/test_filterx_script
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt
 
@@ -185,3 +186,6 @@ lib_filterx_tests_test_func_set_pri_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_json_repr_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_json_repr_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_filterx_script_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_filterx_script_LDADD   = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/test_filterx_script.c
+++ b/lib/filterx/tests/test_filterx_script.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+
+#include "filterx/filterx-parser.h"
+#include "cfg.h"
+#include "apphook.h"
+#include "scratch-buffers.h"
+#include "compat/json.h"
+
+static gboolean
+_compile(const gchar *script)
+{
+  CfgLexer *lexer = cfg_lexer_new_buffer(configuration, script, strlen(script));
+
+  return filterx_compile_script(configuration, lexer, NULL);
+}
+
+static struct json_object *
+_compile_ast(const gchar *script)
+{
+  CfgLexer *lexer = cfg_lexer_new_buffer(configuration, script, strlen(script));
+  GString *ast = NULL;
+
+  if (!filterx_compile_script(configuration, lexer, &ast))
+    {
+      cr_assert_null(ast, "no AST is expected for a script that failed to compile");
+      return NULL;
+    }
+
+  cr_assert_not_null(ast);
+  struct json_object *result = json_tokener_parse(ast->str);
+
+  cr_assert_not_null(result, "the AST is not valid JSON: %s", ast->str);
+  g_string_free(ast, TRUE);
+
+  return result;
+}
+
+static struct json_object *
+_get(struct json_object *object, const gchar *key)
+{
+  struct json_object *value = NULL;
+
+  cr_assert(json_object_object_get_ex(object, key, &value), "missing key: %s", key);
+  return value;
+}
+
+static const gchar *
+_get_str(struct json_object *object, const gchar *key)
+{
+  return json_object_get_string(_get(object, key));
+}
+
+static struct json_object *
+_get_children(struct json_object *node, gsize expected_length)
+{
+  struct json_object *children = _get(node, "children");
+
+  cr_assert(json_object_is_type(children, json_type_array));
+  cr_assert_eq(json_object_array_length(children), expected_length,
+               "unexpected number of children: %s", json_object_to_json_string(children));
+  return children;
+}
+
+static struct json_object *
+_get_child(struct json_object *node, gsize index, gsize expected_length)
+{
+  return json_object_array_get_idx(_get_children(node, expected_length), index);
+}
+
+Test(filterx_script, empty_input_compiles_to_an_empty_block)
+{
+  cr_assert(_compile(""));
+  cr_assert(_compile("\n\n# just a comment\n"));
+}
+
+Test(filterx_script, brace_less_statement_list_compiles)
+{
+  cr_assert(_compile("$MSG = \"foo\";\n"
+                     "$MSG2 = $MSG + \"bar\";\n"));
+}
+
+Test(filterx_script, multi_statement_script_with_control_flow_compiles)
+{
+  cr_assert(_compile("$MSG = json({\"a\": 1});\n"
+                     "if (isset($MSG.a)) {\n"
+                     "  $MSG.b = $MSG.a + 1;\n"
+                     "} else {\n"
+                     "  $MSG.b = 0;\n"
+                     "};\n"
+                     "$LEN = len($MSG);\n"));
+}
+
+Test(filterx_script, trailing_statement_without_semicolon_is_rejected)
+{
+  cr_assert_not(_compile("$MSG = \"foo\"\n"));
+}
+
+Test(filterx_script, unterminated_conditional_is_rejected)
+{
+  cr_assert_not(_compile("if (isset($MSG.foo)) {\n"
+                         "  $MSG.bar = 1;\n"));
+}
+
+Test(filterx_script, stray_closing_brace_is_rejected)
+{
+  cr_assert_not(_compile("$MSG = \"foo\";\n}\n"));
+}
+
+Test(filterx_script, unknown_function_is_rejected)
+{
+  cr_assert_not(_compile("$MSG = there_is_no_such_filterx_function();\n"));
+}
+
+Test(filterx_script, invalid_regexp_is_rejected)
+{
+  cr_assert_not(_compile("$MSG =~ /(/;\n"));
+}
+
+Test(filterx_script, ast_of_an_empty_script_is_an_empty_toplevel_block)
+{
+  struct json_object *ast = _compile_ast("\n# nothing to see here\n");
+
+  cr_assert_str_eq(_get_str(ast, "type"), "compound");
+  cr_assert_str_eq(_get_str(ast, "text"), "<toplevel>");
+  _get_children(ast, 0);
+
+  json_object_put(ast);
+}
+
+Test(filterx_script, ast_lists_the_toplevel_statements_as_children)
+{
+  struct json_object *ast = _compile_ast("$MSG = \"foo\";\n"
+                                         "if (isset($MSG)) {\n"
+                                         "  $MSG2 = $MSG;\n"
+                                         "};\n");
+
+  cr_assert_str_eq(_get_str(ast, "type"), "compound");
+  _get_children(ast, 2);
+  cr_assert_str_eq(_get_str(_get_child(ast, 0, 2), "type"), "assign");
+  cr_assert_str_eq(_get_str(_get_child(ast, 1, 2), "type"), "conditional");
+
+  json_object_put(ast);
+}
+
+Test(filterx_script, ast_nodes_carry_their_source_text_and_location)
+{
+  struct json_object *ast = _compile_ast("\n"
+                                         "$MSG = \"foo\";\n");
+  struct json_object *assign = _get_child(ast, 0, 1);
+  struct json_object *location = _get(assign, "location");
+
+  cr_assert_str_eq(_get_str(assign, "text"), "$MSG = \"foo\"");
+  cr_assert_eq(json_object_get_int(_get(location, "line")), 2);
+  cr_assert_gt(json_object_get_int(_get(location, "column")), 0);
+
+  json_object_put(ast);
+}
+
+Test(filterx_script, ast_is_dumped_after_optimization)
+{
+  struct json_object *ast = _compile_ast("$MSG = 1 + 2;\n");
+  struct json_object *assign = _get_child(ast, 0, 1);
+  struct json_object *rhs = _get_child(assign, 1, 2);
+
+  cr_assert_str_eq(_get_str(rhs, "type"), "literal");
+  /* leaf expressions have no children of their own */
+  _get_children(rhs, 0);
+
+  json_object_put(ast);
+}
+
+Test(filterx_script, no_ast_is_produced_for_a_script_that_does_not_compile)
+{
+  cr_assert_null(_compile_ast("$MSG = there_is_no_such_filterx_function();\n"));
+  cr_assert_null(_compile_ast("$MSG = \"foo\"\n"));
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  configuration = cfg_new_snippet();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  cfg_free(configuration);
+  configuration = NULL;
+  app_shutdown();
+}
+
+TestSuite(filterx_script, .init = setup, .fini = teardown);

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -48,6 +48,7 @@
 #include "healthcheck/healthcheck-control.h"
 #include "signal-handler.h"
 #include "file-monitor.h"
+#include "filterx/filterx-parser.h"
 
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -687,6 +688,28 @@ _init_reload_metrics(MainLoop *self)
 }
 
 /*
+ * Returns: 0 when filterx compilation is successful.
+ */
+static int
+_compile_filterx_script(MainLoop *self)
+{
+  GString *ast = NULL;
+
+  if (!filterx_compile_script_file(self->current_configuration, resolved_configurable_paths.cfgfilename,
+                                   self->options->print_ast ? &ast : NULL))
+    return 1;
+
+  /* @ast is only filled in if the script compiled and --print-ast was given */
+  if (ast)
+    {
+      fprintf(stdout, "%s\n", ast->str);
+      g_string_free(ast, TRUE);
+    }
+
+  return 0;
+}
+
+/*
  * Returns: exit code to be returned to the calling process, 0 on success.
  */
 int
@@ -695,6 +718,9 @@ main_loop_read_and_init_config(MainLoop *self)
   MainLoopOptions *options = self->options;
 
   _init_reload_metrics(self);
+
+  if (options->filterx_only)
+    return _compile_filterx_script(self);
 
   if (!cfg_read_config(self->current_configuration, resolved_configurable_paths.cfgfilename, options->preprocess_into))
     {

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -27,6 +27,7 @@
 #include "mainloop-control.h"
 #include "apphook.h"
 #include "cfg.h"
+#include "cfg-ast.h"
 #include "stats/stats-registry.h"
 #include "stats/stats-counter.h"
 #include "stats/stats-cluster-single.h"
@@ -706,6 +707,14 @@ main_loop_read_and_init_config(MainLoop *self)
       cfg_format_id(self->current_configuration, config_id);
       fprintf(stdout, "%s\n", config_id->str);
       g_string_free(config_id, TRUE);
+      return 0;
+    }
+
+  if (options->print_ast)
+    {
+      GString *ast = cfg_ast_format(self->current_configuration);
+      fprintf(stdout, "%s\n", ast->str);
+      g_string_free(ast, TRUE);
       return 0;
     }
 

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -36,6 +36,7 @@ typedef struct _MainLoopOptions
   gboolean syntax_only;
   gboolean check_startup;
   gboolean config_id;
+  gboolean print_ast;
   gboolean interactive_mode;
   gboolean disable_module_discovery;
 } MainLoopOptions;
@@ -46,7 +47,8 @@ main_loop_is_dry_run(const MainLoopOptions *options)
   if (!options)
     return FALSE;
 
-  return options->syntax_only || options->preprocess_into || options->config_id || options->check_startup;
+  return options->syntax_only || options->preprocess_into || options->config_id
+         || options->print_ast || options->check_startup;
 }
 
 extern ThreadId main_thread_handle;

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -34,6 +34,7 @@ typedef struct _MainLoopOptions
 {
   gchar *preprocess_into;
   gboolean syntax_only;
+  gboolean filterx_only;
   gboolean check_startup;
   gboolean config_id;
   gboolean print_ast;
@@ -47,7 +48,7 @@ main_loop_is_dry_run(const MainLoopOptions *options)
   if (!options)
     return FALSE;
 
-  return options->syntax_only || options->preprocess_into || options->config_id
+  return options->syntax_only || options->filterx_only || options->preprocess_into || options->config_id
          || options->print_ast || options->check_startup;
 }
 

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_unit_test(CRITERION TARGET test_cfg_lexer_subst)
 add_unit_test(CRITERION TARGET test_cfg_tree)
+add_unit_test(CRITERION LIBTEST TARGET test_cfg_ast)
 add_unit_test(CRITERION TARGET test_parse_number)
 add_unit_test(CRITERION TARGET test_reloc)
 add_unit_test(CRITERION TARGET test_hostname)

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -2,6 +2,7 @@ lib_tests_TESTS		= \
 	lib/tests/test_cfg_lexer_subst	\
 	lib/tests/test_lexer_block	\
 	lib/tests/test_cfg_tree		\
+	lib/tests/test_cfg_ast		\
 	lib/tests/test_parse_number	\
 	lib/tests/test_generic_number	\
 	lib/tests/test_reloc		\
@@ -63,6 +64,11 @@ lib_tests_test_lexer_block_LDADD	=	\
 lib_tests_test_cfg_tree_CFLAGS		=	\
 	$(TEST_CFLAGS)
 lib_tests_test_cfg_tree_LDADD		=	\
+	$(TEST_LDADD)
+
+lib_tests_test_cfg_ast_CFLAGS		=	\
+	$(TEST_CFLAGS)
+lib_tests_test_cfg_ast_LDADD		=	\
 	$(TEST_LDADD)
 
 

--- a/lib/tests/test_cfg_ast.c
+++ b/lib/tests/test_cfg_ast.c
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026 Axoflow
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/config_parse_lib.h"
+
+#include "cfg.h"
+#include "cfg-ast.h"
+#include "cfg-grammar.h"
+#include "apphook.h"
+#include "compat/json.h"
+
+static struct json_object *
+_parse_ast(const gchar *config)
+{
+  cr_assert(parse_config(config, LL_CONTEXT_ROOT, NULL, NULL), "Parsing the configuration failed: %s", config);
+
+  GString *ast = cfg_ast_format(configuration);
+  struct json_object *result = json_tokener_parse(ast->str);
+
+  cr_assert_not_null(result, "cfg_ast_format() did not produce valid JSON: %s", ast->str);
+  g_string_free(ast, TRUE);
+
+  return result;
+}
+
+static struct json_object *
+_get(struct json_object *object, const gchar *key)
+{
+  struct json_object *value = NULL;
+
+  cr_assert(json_object_object_get_ex(object, key, &value), "missing key: %s", key);
+  return value;
+}
+
+static const gchar *
+_get_str(struct json_object *object, const gchar *key)
+{
+  return json_object_get_string(_get(object, key));
+}
+
+static struct json_object *
+_get_idx(struct json_object *array, gsize index)
+{
+  cr_assert(json_object_is_type(array, json_type_array));
+  cr_assert(index < json_object_array_length(array), "index %" G_GSIZE_FORMAT " is out of range", index);
+  return json_object_array_get_idx(array, index);
+}
+
+static struct json_object *
+_get_statements(struct json_object *ast, gsize expected_length)
+{
+  struct json_object *statements = _get(ast, "statements");
+
+  cr_assert_eq(json_object_array_length(statements), expected_length,
+               "unexpected number of statements: %s", json_object_to_json_string(statements));
+  return statements;
+}
+
+Test(cfg_ast, root_statements_are_reported_in_source_order)
+{
+  /* the log statement is stored in the rules of the cfg-tree, the source in the
+   * hash table of the named objects, still they are reported in source order */
+  struct json_object *ast = _parse_ast("log { source(s_in); };\n"
+                                       "source s_in { internal(); };\n");
+  struct json_object *statements = _get_statements(ast, 2);
+
+  cr_assert_str_eq(_get_str(_get_idx(statements, 0), "kind"), "log");
+  cr_assert_str_eq(_get_str(_get_idx(statements, 1), "kind"), "source");
+  cr_assert_str_eq(_get_str(_get(_get_idx(statements, 1), "expr"), "name"), "s_in");
+
+  json_object_put(ast);
+}
+
+Test(cfg_ast, statements_that_are_not_log_expressions_are_not_reported)
+{
+  /* options{}, template{}, template-function and block{} definitions are not
+   * part of the cfg-tree, so they are invisible in the AST */
+  struct json_object *ast = _parse_ast("options { keep-hostname(yes); };\n"
+                                       "template t_x { template(\"$MSG\\n\"); };\n"
+                                       "template-function tf_x \"$MSG\";\n"
+                                       "block source my_source() { internal(); };\n"
+                                       "source s_in { internal(); };\n");
+  struct json_object *statements = _get_statements(ast, 1);
+
+  cr_assert_str_eq(_get_str(_get_idx(statements, 0), "kind"), "source");
+
+  json_object_put(ast);
+}
+
+Test(cfg_ast, statements_carry_their_source_location)
+{
+  struct json_object *ast = _parse_ast("source s_in { internal(); };\n"
+                                       "\n"
+                                       "log { source(s_in); };\n");
+  struct json_object *statements = _get_statements(ast, 2);
+  struct json_object *location = _get(_get(_get_idx(statements, 1), "expr"), "location");
+
+  cr_assert_eq(json_object_get_int(_get(location, "line")), 3);
+  cr_assert_gt(json_object_get_int(_get(location, "column")), 0);
+
+  json_object_put(ast);
+}
+
+Test(cfg_ast, named_objects_are_dumped_as_expression_trees)
+{
+  struct json_object *ast = _parse_ast("source s_in { internal(); };\n");
+  struct json_object *expr = _get(_get_idx(_get_statements(ast, 1), 0), "expr");
+
+  cr_assert_str_eq(_get_str(expr, "layout"), "sequence");
+  cr_assert_str_eq(_get_str(expr, "content"), "source");
+  cr_assert_str_eq(_get_str(expr, "name"), "s_in");
+
+  /* source { ... } is compiled into a junction of the drivers listed inside */
+  struct json_object *junction = _get_idx(_get(expr, "children"), 0);
+  cr_assert_str_eq(_get_str(junction, "layout"), "junction");
+
+  /* internal() is built into the grammar instead of being a plugin, so it has
+   * no plugin name, but it is still a single pipe in the tree */
+  struct json_object *driver = _get_idx(_get(junction, "children"), 0);
+  cr_assert_str_eq(_get_str(driver, "layout"), "single");
+  cr_assert(json_object_is_type(_get(driver, "plugin"), json_type_null));
+
+  json_object_put(ast);
+}
+
+Test(cfg_ast, log_path_flags_are_dumped)
+{
+  struct json_object *ast = _parse_ast("source s_in { internal(); };\n"
+                                       "log { source(s_in); flags(final, flow-control); };\n");
+  struct json_object *expr = _get(_get_idx(_get_statements(ast, 2), 1), "expr");
+  struct json_object *flags = _get(expr, "flags");
+
+  cr_assert_eq(json_object_array_length(flags), 2);
+  cr_assert_str_eq(json_object_get_string(_get_idx(flags, 0)), "final");
+  cr_assert_str_eq(json_object_get_string(_get_idx(flags, 1)), "flow-control");
+
+  json_object_put(ast);
+}
+
+Test(cfg_ast, filterx_blocks_are_dumped_as_filterx_expressions)
+{
+  struct json_object *ast = _parse_ast("source s_in { internal(); };\n"
+                                       "log { source(s_in); filterx { $MSG = \"hello\"; }; };\n");
+  struct json_object *log_expr = _get(_get_idx(_get_statements(ast, 2), 1), "expr");
+
+  /* filterx {} is wrapped into a filter expression holding a single pipe */
+  struct json_object *filter = _get_idx(_get(log_expr, "children"), 1);
+  cr_assert_str_eq(_get_str(filter, "content"), "filter");
+
+  struct json_object *pipe = _get_idx(_get(filter, "children"), 0);
+  cr_assert_str_eq(_get_str(pipe, "layout"), "single");
+  cr_assert_str_eq(_get_str(pipe, "plugin"), "filterx");
+
+  struct json_object *filterx = _get(pipe, "filterx");
+  cr_assert_str_eq(_get_str(filterx, "type"), "compound");
+
+  struct json_object *stmt = _get_idx(_get(filterx, "children"), 0);
+  cr_assert_str_eq(_get_str(stmt, "text"), "$MSG = \"hello\"");
+  cr_assert_gt(json_object_get_int(_get(_get(stmt, "location"), "line")), 0);
+
+  json_object_put(ast);
+}
+
+Test(cfg_ast, unsafe_characters_in_the_config_are_escaped)
+{
+  /* the JSON would be malformed if the quote or the backslash were not escaped,
+   * _parse_ast() asserts on that */
+  struct json_object *ast = _parse_ast("source \"s_\\\"quote\\\\\" { internal(); };\n");
+  struct json_object *expr = _get(_get_idx(_get_statements(ast, 1), 0), "expr");
+
+  cr_assert_str_eq(_get_str(expr, "name"), "s_\"quote\\");
+
+  json_object_put(ast);
+}
+
+Test(cfg_ast, a_filterx_block_escaped_by_a_snippet_shows_up_as_extra_statements)
+{
+  /* the config below is what a generated configuration looks like once the
+   * snippet embedded into its filterx block has closed the block and injected
+   * statements of its own: the extra statements are visible in the AST */
+  struct json_object *ast = _parse_ast("source s_in { internal(); };\n"
+                                       "log { source(s_in); filterx {\n"
+                                       "  $MSG = \"x\";\n"
+                                       "}; };\n"
+                                       "log { source(s_in); };\n");
+  struct json_object *statements = _get_statements(ast, 3);
+
+  cr_assert_str_eq(_get_str(_get_idx(statements, 2), "kind"), "log");
+
+  json_object_put(ast);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  configuration = cfg_new_snippet();
+}
+
+static void
+teardown(void)
+{
+  cfg_free(configuration);
+  configuration = NULL;
+  app_shutdown();
+}
+
+TestSuite(cfg_ast, .init = setup, .fini = teardown);

--- a/news/feature-1189-1.md
+++ b/news/feature-1189-1.md
@@ -1,0 +1,5 @@
+`syslog-ng`: added a new `--print-ast` command line option, which parses the configuration, prints its abstract
+syntax tree to the standard output as JSON and exits, without initializing the configuration. The dump lists every
+root level log expression (`source`, `destination`, `filter`, `parser`, `rewrite` and `log` statements) in source
+order, the expression tree of each one and the parsed `filterx` expressions inside them, so that a generated
+configuration can be validated against what the parser actually built.

--- a/news/feature-1189-2.md
+++ b/news/feature-1189-2.md
@@ -1,0 +1,5 @@
+`filterx`: added a new `--filterx-only` command line option, which compiles the file specified with `--cfgfile` as a
+standalone filterx script instead of a syslog-ng configuration, then exits. The entire file is parsed as filterx code,
+as if its contents were the body of a `filterx {}` block, which makes it possible to validate filterx code without
+wrapping it into a full configuration. Combined with `--print-ast`, the abstract syntax tree of the compiled script is
+printed to the standard output as JSON.

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -85,6 +85,7 @@ static GOptionEntry syslogng_options[] =
   { "persist-file",      'R',         0, G_OPTION_ARG_STRING, &resolved_configurable_paths.persist_file, "Set the name of the persistent configuration file, default=" PATH_PERSIST_CONFIG, "<fname>" },
   { "preprocess-into",     0,         0, G_OPTION_ARG_STRING, &main_loop_options.preprocess_into, "Write the preprocessed configuration file to the file specified and quit", "output" },
   { "syntax-only",       's',         0, G_OPTION_ARG_NONE, &main_loop_options.syntax_only, "Only read and parse config file", NULL},
+  { "filterx-only",        0,         0, G_OPTION_ARG_NONE, &main_loop_options.filterx_only, "Compile the given file provided by --cfgfile as a filterx script and quit", NULL},
   { "check-startup",       0,         0, G_OPTION_ARG_NONE, &main_loop_options.check_startup, "Check if syslog-ng would start up and then exit", NULL},
   { "config-id",           0,         0, G_OPTION_ARG_NONE, &main_loop_options.config_id, "Parse config file, print configuration ID, and quit", NULL},
   { "print-ast",           0,         0, G_OPTION_ARG_NONE, &main_loop_options.print_ast, "Parse config file, print its abstract syntax tree as JSON, and quit", NULL},

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -87,6 +87,7 @@ static GOptionEntry syslogng_options[] =
   { "syntax-only",       's',         0, G_OPTION_ARG_NONE, &main_loop_options.syntax_only, "Only read and parse config file", NULL},
   { "check-startup",       0,         0, G_OPTION_ARG_NONE, &main_loop_options.check_startup, "Check if syslog-ng would start up and then exit", NULL},
   { "config-id",           0,         0, G_OPTION_ARG_NONE, &main_loop_options.config_id, "Parse config file, print configuration ID, and quit", NULL},
+  { "print-ast",           0,         0, G_OPTION_ARG_NONE, &main_loop_options.print_ast, "Parse config file, print its abstract syntax tree as JSON, and quit", NULL},
   { "control",           'c',         0, G_OPTION_ARG_STRING, &resolved_configurable_paths.ctlfilename, "Set syslog-ng control socket, default=" PATH_CONTROL_SOCKET, "<ctlpath>" },
   { "interactive",       'i',         0, G_OPTION_ARG_NONE, &main_loop_options.interactive_mode, "Enable interactive mode" },
   { NULL },

--- a/tests/light/functional_tests/Makefile.am
+++ b/tests/light/functional_tests/Makefile.am
@@ -4,6 +4,7 @@ EXTRA_DIST += \
 	tests/light/functional_tests/config_change/test_backtick_substitution.py \
 	tests/light/functional_tests/config_change/test_confgen_network_load_balancer.py \
 	tests/light/functional_tests/config_change/test_manipulating_config_between_reload.py \
+	tests/light/functional_tests/config_change/test_print_ast.py \
 	tests/light/functional_tests/config_change/test_python_custom_options.py \
 	tests/light/functional_tests/conftest.py \
 	tests/light/functional_tests/destination_drivers/arrow_flight_destination/test_arrow_flight_destination.py \

--- a/tests/light/functional_tests/config_change/test_print_ast.py
+++ b/tests/light/functional_tests/config_change/test_print_ast.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import pytest
+
+
+def _set_raw_config(config, body):
+    config.set_raw_config("@version: {}\n".format(config.get_version()) + body)
+
+
+def test_print_ast_reports_every_log_expression(config, syslog_ng):
+    _set_raw_config(
+        config,
+        """
+options { keep-hostname(yes); };
+template t_x { template("$MSG\\n"); };
+source s_in { internal(); };
+log {
+    source(s_in);
+    filterx {
+        $MSG = "hello";
+    };
+    destination { file("/dev/null"); };
+};
+""",
+    )
+
+    ast = syslog_ng.print_ast(config)
+
+    statements = ast["statements"]
+    # options {} and template {} are not part of the cfg-tree, so they are not
+    # reported, not even the options {} the light config renderer appends
+    assert [statement["kind"] for statement in statements] == ["source", "log"]
+    assert statements[0]["expr"]["name"] == "s_in"
+
+    log_path = statements[1]
+    assert log_path["expr"]["layout"] == "sequence"
+
+    # source(s_in); filterx {}; destination {};
+    children = log_path["expr"]["children"]
+    assert len(children) == 3
+    assert children[0]["layout"] == "reference"
+    assert children[0]["content"] == "source"
+    assert children[1]["content"] == "filter"
+
+    filterx_pipe = children[1]["children"][0]
+    assert filterx_pipe["plugin"] == "filterx"
+    assert filterx_pipe["filterx"]["type"] == "compound"
+    assert filterx_pipe["filterx"]["children"][0]["text"] == '$MSG = "hello"'
+
+
+def test_print_ast_of_a_broken_config_fails(config, syslog_ng):
+    _set_raw_config(config, "log { this-is-not-a-driver(); };\n")
+
+    with pytest.raises(Exception, match="--print-ast failed"):
+        syslog_ng.print_ast(config)

--- a/tests/light/src/axosyslog_light/syslog_ng/syslog_ng.py
+++ b/tests/light/src/axosyslog_light/syslog_ng/syslog_ng.py
@@ -20,6 +20,7 @@
 # COPYING for details.
 #
 #############################################################################
+import json
 import logging
 import typing
 from copy import copy
@@ -126,6 +127,28 @@ class SyslogNg(object):
     def restart(self, config: SyslogNgConfig) -> None:
         self.stop()
         self.start(config)
+
+    def print_ast(self, config: SyslogNgConfig) -> dict:
+        config.write_config(self.instance_paths.get_config_path())
+
+        stdout_path = self.instance_paths.get_stdout_path_with_postfix("print_ast")
+        stderr_path = self.instance_paths.get_stderr_path_with_postfix("print_ast")
+
+        start_params = copy(self.start_params)
+        start_params.print_ast = True
+
+        process = self._syslog_ng_executor.run_process(
+            start_params=start_params,
+            stderr_path=stderr_path,
+            stdout_path=stdout_path,
+        )
+        returncode = process.wait()
+        if returncode == 1:
+            raise Exception(f"syslog-ng --print-ast failed. See {stderr_path.absolute()} for details")
+        if returncode != 0:
+            self.__validate_crash_returncode(returncode)
+
+        return json.loads(stdout_path.read_text())
 
     def _get_version_info(self, keyword: str) -> str:
         stdout_path = Path(f"syslog_ng_{self.instance_paths.get_instance_name()}_version_stdout")

--- a/tests/light/src/axosyslog_light/syslog_ng/syslog_ng_executor.py
+++ b/tests/light/src/axosyslog_light/syslog_ng/syslog_ng_executor.py
@@ -41,6 +41,7 @@ class SyslogNgStartParams:
     startup_debug: bool = True
     no_caps: bool = True
     syntax_only: bool = False
+    print_ast: bool = False
     version: bool = False
     config_path: typing.Optional[Path] = None
     persist_path: typing.Optional[Path] = None
@@ -68,6 +69,8 @@ class SyslogNgStartParams:
             params += ["--no-caps"]
         if self.syntax_only:
             params += ["--syntax-only"]
+        if self.print_ast:
+            params += ["--print-ast"]
         if self.version:
             params += ["--version"]
         if self.config_path is not None:


### PR DESCRIPTION
My intention is to have a way to
- check filterx code without running it
  - ensuring a legal syntax
  - having the AST to be able to perform further external checks

Feel free to discard my implementation. I ask for suggestions to reach my goal.