### PR TITLE
dbld: install libdbd-sqlite3 in the devshell image

### DIFF
--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -113,6 +113,7 @@ libmongoc-dev               [debian]
 # added as comments.
 #############################################################################
 
+libdbd-sqlite3                  [devshell]
 
 #############################################################################
 # Development tools in our devshell.


### PR DESCRIPTION
Preparation step for replacing the `funct-test` framework with `light`.