### PR TITLE
affile, afsql: fix a lost wildcard file and an sql() memory leak

### DIFF
--- a/modules/affile/directory-monitor.c
+++ b/modules/affile/directory-monitor.c
@@ -216,12 +216,12 @@ directory_monitor_start(DirectoryMonitor *self)
       g_error_free(error);
       return;
     }
-  _collect_all_files(self, directory);
-  g_dir_close(directory);
   if (self->start_watches)
     {
       self->start_watches(self);
     }
+  _collect_all_files(self, directory);
+  g_dir_close(directory);
   self->watches_running = TRUE;
   return;
 }

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1299,6 +1299,7 @@ afsql_dd_free(LogPipe *s)
   g_free(self->password);
   g_free(self->database);
   g_free(self->encoding);
+  g_free(self->quote_as_string);
   g_free(self->create_statement_append);
   if (self->null_value)
     g_free(self->null_value);

--- a/news/bugfix-1204-1.md
+++ b/news/bugfix-1204-1.md
@@ -1,0 +1,2 @@
+`wildcard-file()`: Fixed a race where a file created while the source was starting to watch its directory could be
+missed until the next restart.

--- a/news/bugfix-1204-2.md
+++ b/news/bugfix-1204-2.md
@@ -1,0 +1,1 @@
+`sql()`: Fixed a small memory leak that happened once for every configured destination.


### PR DESCRIPTION
Preparation step for porting all the `func-test`s to `light`.
