### PR TITLE
`filterx/format_kv`: add `quote_char` and `always_quote` options

### DIFF
--- a/modules/kvformat/filterx-func-format-kv.c
+++ b/modules/kvformat/filterx-func-format-kv.c
@@ -31,7 +31,8 @@
 #include "scratch-buffers.h"
 #include "utf8utils.h"
 
-#define FILTERX_FUNC_FORMAT_KV_USAGE "Usage: format_kv(kvs_dict, value_separator=\"=\", pair_separator=\", \")"
+#define FILTERX_FUNC_FORMAT_KV_USAGE "Usage: format_kv(kvs_dict, value_separator=\"=\", pair_separator=\", \", " \
+  "quote_char=\"\\\"\")"
 
 typedef struct FilterXFunctionFormatKV_
 {
@@ -39,6 +40,7 @@ typedef struct FilterXFunctionFormatKV_
   FilterXExpr *kvs;
   gchar value_separator;
   gchar *pair_separator;
+  gchar quote_char;
 } FilterXFunctionFormatKV;
 
 static gboolean
@@ -84,9 +86,10 @@ _append_kv_to_buffer(FilterXObject *key, FilterXObject *value, gpointer user_dat
 
       g_string_assign(value_buffer, buffer->str + len_before_value);
       g_string_truncate(buffer, len_before_value);
-      g_string_append_c(buffer, '"');
-      append_unsafe_utf8_as_escaped_binary(buffer, value_buffer->str, value_buffer->len, AUTF8_UNSAFE_QUOTE);
-      g_string_append_c(buffer, '"');
+      g_string_append_c(buffer, self->quote_char);
+      append_unsafe_utf8_as_escaped_binary(buffer, value_buffer->str, value_buffer->len,
+                                           self->quote_char == '\'' ? AUTF8_UNSAFE_APOSTROPHE : AUTF8_UNSAFE_QUOTE);
+      g_string_append_c(buffer, self->quote_char);
 
       scratch_buffers_reclaim_marked(marker);
     }
@@ -191,6 +194,34 @@ _extract_pair_separator_arg(FilterXFunctionFormatKV *self, FilterXFunctionArgs *
 }
 
 static gboolean
+_extract_quote_char_arg(FilterXFunctionFormatKV *self, FilterXFunctionArgs *args, GError **error)
+{
+  gboolean exists;
+  gsize quote_char_len;
+  const gchar *quote_char = filterx_function_args_get_named_literal_string(args, "quote_char", &quote_char_len,
+                            &exists);
+  if (!exists)
+    return TRUE;
+
+  if (!quote_char)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "quote_char must be a string literal. " FILTERX_FUNC_FORMAT_KV_USAGE);
+      return FALSE;
+    }
+
+  if (quote_char_len != 1 || (quote_char[0] != '"' && quote_char[0] != '\''))
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "quote_char must be a single \" or ' character. " FILTERX_FUNC_FORMAT_KV_USAGE);
+      return FALSE;
+    }
+
+  self->quote_char = quote_char[0];
+  return TRUE;
+}
+
+static gboolean
 _extract_arguments(FilterXFunctionFormatKV *self, FilterXFunctionArgs *args, GError **error)
 {
   gsize args_len = filterx_function_args_len(args);
@@ -213,6 +244,9 @@ _extract_arguments(FilterXFunctionFormatKV *self, FilterXFunctionArgs *args, GEr
     return FALSE;
 
   if (!_extract_pair_separator_arg(self, args, error))
+    return FALSE;
+
+  if (!_extract_quote_char_arg(self, args, error))
     return FALSE;
 
   return TRUE;
@@ -245,6 +279,7 @@ filterx_function_format_kv_new(FilterXFunctionArgs *args, GError **error)
   self->super.super.free_fn = _free;
   self->value_separator = '=';
   self->pair_separator = g_strdup(", ");
+  self->quote_char = '"';
 
   if (!_extract_arguments(self, args, error) ||
       !filterx_function_args_check(args, error))

--- a/modules/kvformat/filterx-func-format-kv.c
+++ b/modules/kvformat/filterx-func-format-kv.c
@@ -32,7 +32,7 @@
 #include "utf8utils.h"
 
 #define FILTERX_FUNC_FORMAT_KV_USAGE "Usage: format_kv(kvs_dict, value_separator=\"=\", pair_separator=\", \", " \
-  "quote_char=\"\\\"\")"
+  "quote_char=\"\\\"\", always_quote=false)"
 
 typedef struct FilterXFunctionFormatKV_
 {
@@ -41,6 +41,7 @@ typedef struct FilterXFunctionFormatKV_
   gchar value_separator;
   gchar *pair_separator;
   gchar quote_char;
+  gboolean always_quote;
 } FilterXFunctionFormatKV;
 
 static gboolean
@@ -79,7 +80,8 @@ _append_kv_to_buffer(FilterXObject *key, FilterXObject *value, gpointer user_dat
     }
 
   /* TODO: make the characters here configurable. */
-  if (memchr(buffer->str + len_before_value, ' ', buffer->len - len_before_value) != NULL)
+  if (self->always_quote ||
+      memchr(buffer->str + len_before_value, ' ', buffer->len - len_before_value) != NULL)
     {
       ScratchBuffersMarker marker;
       GString *value_buffer = scratch_buffers_alloc_and_mark(&marker);
@@ -222,6 +224,25 @@ _extract_quote_char_arg(FilterXFunctionFormatKV *self, FilterXFunctionArgs *args
 }
 
 static gboolean
+_extract_always_quote_arg(FilterXFunctionFormatKV *self, FilterXFunctionArgs *args, GError **error)
+{
+  gboolean exists, eval_error;
+  gboolean always_quote = filterx_function_args_get_named_literal_boolean(args, "always_quote", &exists, &eval_error);
+  if (!exists)
+    return TRUE;
+
+  if (eval_error)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "always_quote must be a boolean literal. " FILTERX_FUNC_FORMAT_KV_USAGE);
+      return FALSE;
+    }
+
+  self->always_quote = always_quote;
+  return TRUE;
+}
+
+static gboolean
 _extract_arguments(FilterXFunctionFormatKV *self, FilterXFunctionArgs *args, GError **error)
 {
   gsize args_len = filterx_function_args_len(args);
@@ -247,6 +268,9 @@ _extract_arguments(FilterXFunctionFormatKV *self, FilterXFunctionArgs *args, GEr
     return FALSE;
 
   if (!_extract_quote_char_arg(self, args, error))
+    return FALSE;
+
+  if (!_extract_always_quote_arg(self, args, error))
     return FALSE;
 
   return TRUE;

--- a/modules/kvformat/tests/test_filterx_func_format_kv.c
+++ b/modules/kvformat/tests/test_filterx_func_format_kv.c
@@ -169,6 +169,35 @@ Test(filterx_func_format_kv, test_space_gets_double_quoted)
   _assert_format_kv(args, "foo=bar, bar=\"almafa korte\\\"fa\"");
 }
 
+Test(filterx_func_format_kv, test_apostrophe_quote_char)
+{
+  FilterXExpr *kvs = filterx_literal_new(
+                       filterx_object_from_json("{\"foo\":\"bar\",\"bar\": \"almafa korte\'fa\"}", -1, NULL));
+  GList *args = NULL;
+
+  args = g_list_append(args, filterx_function_arg_new(NULL, kvs));
+  args = g_list_append(args, filterx_function_arg_new("quote_char", filterx_literal_new(filterx_string_new("\'", -1))));
+  _assert_format_kv(args, "foo=bar, bar=\'almafa korte\\\'fa\'");
+}
+
+Test(filterx_func_format_kv, test_invalid_quote_char)
+{
+  GList *args = NULL;
+
+  /* a quote the escaper has no rule for */
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new("quote_char", filterx_literal_new(filterx_string_new("|", -1))));
+  _assert_format_kv_init_fail(args);
+  args = NULL;
+
+  /* more than one character */
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new("quote_char", filterx_literal_new(filterx_string_new("\"\"",
+                                                      -1))));
+  _assert_format_kv_init_fail(args);
+  args = NULL;
+}
+
 static void
 setup(void)
 {

--- a/modules/kvformat/tests/test_filterx_func_format_kv.c
+++ b/modules/kvformat/tests/test_filterx_func_format_kv.c
@@ -198,6 +198,29 @@ Test(filterx_func_format_kv, test_invalid_quote_char)
   args = NULL;
 }
 
+Test(filterx_func_format_kv, test_always_quote)
+{
+  FilterXExpr *kvs = filterx_literal_new(
+                       filterx_object_from_json("{\"foo\":\"bar\",\"baz\":42}", -1, NULL));
+  GList *args = NULL;
+
+  /* neither value holds a space, so nothing here would be quoted otherwise */
+  args = g_list_append(args, filterx_function_arg_new(NULL, kvs));
+  args = g_list_append(args, filterx_function_arg_new("always_quote", filterx_literal_new(filterx_boolean_new(TRUE))));
+  _assert_format_kv(args, "foo=\"bar\", baz=\"42\"");
+}
+
+Test(filterx_func_format_kv, test_invalid_always_quote)
+{
+  GList *args = NULL;
+
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new("always_quote",
+                                                      filterx_object_expr_new(filterx_boolean_new(TRUE))));
+  _assert_format_kv_init_fail(args);
+  args = NULL;
+}
+
 static void
 setup(void)
 {

--- a/news/feature-1208.md
+++ b/news/feature-1208.md
@@ -1,0 +1,1 @@
+`format_kv` FilterX function: add `quote_char` and `always_quote` options


### PR DESCRIPTION
<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
