### PR TITLE
Filterx tuple unpacking

### DIFF
--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -61,6 +61,34 @@ exit:
 }
 
 static gboolean
+_assign(FilterXExpr *s, FilterXObject **new_value)
+{
+  FilterXGetSubscript *self = (FilterXGetSubscript *) s;
+  gboolean success = FALSE;
+  FilterXObject *key = NULL;
+
+  FilterXObject *variable = filterx_expr_eval_typed(self->operand);
+  if (!variable)
+    goto error;
+
+  key = filterx_expr_eval_typed(self->key);
+  if (!key)
+    goto error;
+
+  if (!filterx_object_set_subscript(variable, key, new_value))
+    {
+      filterx_eval_push_error_static_info("Failed to assign to object",
+                                          "set_subscript() method failed");
+      goto error;
+    }
+  success = TRUE;
+error:
+  filterx_object_unref(variable);
+  filterx_object_unref(key);
+  return success;
+}
+
+static gboolean
 _isset(FilterXExpr *s)
 {
   FilterXGetSubscript *self = (FilterXGetSubscript *) s;
@@ -195,6 +223,7 @@ filterx_get_subscript_new(FilterXExpr *operand, FilterXExpr *key)
   filterx_expr_init_instance(&self->super, FILTERX_EXPR_TYPE_NAME(get_subscript), FXE_READ);
   self->super.eval = _eval_get_subscript;
   self->super.is_set = _isset;
+  self->super.assign = _assign;
   self->super.unset = _unset;
   self->super.walk_children = _get_subscript_walk;
   self->super.move = _move;

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -56,6 +56,27 @@ _eval_getattr(FilterXExpr *s)
 }
 
 static gboolean
+_assign(FilterXExpr *s, FilterXObject **new_value)
+{
+  FilterXGetAttr *self = (FilterXGetAttr *) s;
+  gboolean success = FALSE;
+
+  FilterXObject *variable = filterx_expr_eval_typed(self->operand);
+  if (!variable)
+    return FALSE;
+  if (!filterx_object_setattr(variable, self->attr, new_value))
+    {
+      filterx_eval_push_error_static_info("Failed to assign to object",
+                                          "setattr() method failed");
+      goto error;
+    }
+  success = TRUE;
+error:
+  filterx_object_unref(variable);
+  return success;
+}
+
+static gboolean
 _unset(FilterXExpr *s)
 {
   FilterXGetAttr *self = (FilterXGetAttr *) s;
@@ -193,6 +214,7 @@ filterx_getattr_new(FilterXExpr *operand, FilterXObject *attr_name)
 
   filterx_expr_init_instance(&self->super, FILTERX_EXPR_TYPE_NAME(getattr), FXE_READ);
   self->super.eval = _eval_getattr;
+  self->super.assign = _assign;
   self->super.unset = _unset;
   self->super.move = _move;
   self->super.is_set = _isset;

--- a/lib/filterx/expr-literal-container.c
+++ b/lib/filterx/expr-literal-container.c
@@ -272,8 +272,14 @@ static gboolean
 _literal_container_assign(FilterXExpr *s, FilterXObject **new_value)
 {
   FilterXLiteralContainer *self = (FilterXLiteralContainer *) s;
-  FilterXObject *rhs = *new_value;
 
+  if (filterx_object_is_type(*new_value, &FILTERX_TYPE_NAME(message_value)))
+    {
+      FilterXObject *unmarshalled = filterx_object_unmarshal(*new_value);
+      filterx_object_unref(*new_value);
+      *new_value = unmarshalled;
+    }
+  FilterXObject *rhs = *new_value;
   if (!filterx_object_is_type_or_ref(rhs, &FILTERX_TYPE_NAME(sequence)))
     {
       filterx_eval_push_error("Unpacking assignment requires a sequence (tuple or list) on the right hand side", rhs);

--- a/lib/filterx/expr-literal-container.c
+++ b/lib/filterx/expr-literal-container.c
@@ -32,6 +32,7 @@
 #include "filterx/object-message-value.h"
 #include "filterx/object-extractor.h"
 #include "filterx/filterx-plist.h"
+#include "filterx/filterx-sequence.h"
 
 /* Object Members (e.g. key-value) */
 
@@ -264,6 +265,61 @@ _literal_list_infer_types(FilterXExpr *s, FilterXTypeEnv *env)
 }
 
 #endif
+
+/* implements destructuring assignment, e.g. "(a, b) = expr;" or
+ * "[a, b] = expr;" */
+static gboolean
+_literal_container_assign(FilterXExpr *s, FilterXObject **new_value)
+{
+  FilterXLiteralContainer *self = (FilterXLiteralContainer *) s;
+  FilterXObject *rhs = *new_value;
+
+  if (!filterx_object_is_type_or_ref(rhs, &FILTERX_TYPE_NAME(sequence)))
+    {
+      filterx_eval_push_error("Unpacking assignment requires a sequence (tuple or list) on the right hand side", rhs);
+      return FALSE;
+    }
+
+  guint64 rhs_len;
+  if (!filterx_object_len(rhs, &rhs_len))
+    {
+      filterx_eval_push_error("Failed to determine the length of the value to unpack", rhs);
+      return FALSE;
+    }
+
+  gsize lhs_len = filterx_pointer_list_get_length(&self->elements);
+  if ((guint64) lhs_len != rhs_len)
+    {
+      filterx_eval_push_error_info_printf("Unpacking assignment element count mismatch",
+                                          "expected %" G_GSIZE_FORMAT " values, got %" G_GUINT64_FORMAT,
+                                          lhs_len, rhs_len);
+      return FALSE;
+    }
+
+  for (gsize i = 0; i < lhs_len; i++)
+    {
+      FilterXLiteralElement *elem = (FilterXLiteralElement *) filterx_pointer_list_index_fast(&self->elements, i);
+
+      FilterXObject *slot_value = filterx_sequence_get_subscript(rhs, i);
+      if (!slot_value)
+        {
+          filterx_eval_push_error_info_printf("Unpacking assignment failed",
+                                              "failed to retrieve element %" G_GSIZE_FORMAT, i);
+          return FALSE;
+        }
+
+      gboolean ok = filterx_expr_assign(elem->value, &slot_value);
+      filterx_object_unref(slot_value);
+      if (!ok)
+        {
+          filterx_eval_push_error_info_printf("Unpacking assignment failed",
+                                              "cannot assign to unpacking target %" G_GSIZE_FORMAT, i);
+          return FALSE;
+        }
+    }
+
+  return TRUE;
+}
 
 static void
 _literal_container_init_instance(FilterXLiteralContainer *self, const gchar *type)
@@ -584,6 +640,7 @@ filterx_literal_list_new(GList *elements)
 #if SYSLOG_NG_ENABLE_JIT
   self->super.infer_types = _literal_list_infer_types;
 #endif
+  self->super.assign = _literal_container_assign;
   self->eval_early = _literal_list_eval_early;
   filterx_pointer_list_add_list(&self->elements, elements);
 
@@ -681,6 +738,7 @@ filterx_literal_tuple_new(GList *elements)
 
   _literal_container_init_instance(self, FILTERX_EXPR_TYPE_NAME(literal_tuple));
   self->super.eval = _literal_tuple_eval;
+  self->super.assign = _literal_container_assign;
   self->eval_early = _literal_tuple_eval_early;
   filterx_pointer_list_add_list(&self->elements, elements);
 

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -227,6 +227,8 @@ assignment
 	| expr '[' expr ']' KW_ASSIGN expr	{ $$ = filterx_set_subscript_new($1, $3, $6); }
 	| expr '[' ']' KW_ASSIGN expr  		{ $$ = filterx_set_subscript_new($1, NULL, $5); }
 	| dpath_lvalue KW_ASSIGN expr { $$ = filterx_assign_new($1, $3); }
+	| tuple_literal KW_ASSIGN expr		{ $$ = filterx_assign_new($1, $3); }
+	| list_literal KW_ASSIGN expr		{ $$ = filterx_assign_new($1, $3); }
 	| plus_assignment
 	| nullv_assignment
 	;

--- a/lib/filterx/object-tuple.c
+++ b/lib/filterx/object-tuple.c
@@ -87,7 +87,27 @@ _filterx_tuple_get_subscript(FilterXObject *s, FilterXObject *key)
       return NULL;
     }
 
-  return filterx_object_ref(g_ptr_array_index(self->array, normalized_index));
+  FilterXObject *el = g_ptr_array_index(self->array, normalized_index);
+
+  /* Tuples are immutable but may contain mutable objects as children.
+   * Also, since tuples are immutable, they are not wrapped in an xref to
+   * facilitate copy-on-write (as immutable objects do not need that).
+   *
+   * This code here is similar to what FilterXRef does in
+   * _filterx_ref_replace_shared_xref_with_a_floating_one(), whenever we
+   * return an xref, we make sure that xref is a separate copy, so in case
+   * it is changed, the element in the tuple does not change with it.
+   */
+  if (filterx_object_is_ref(el))
+    {
+      /* the element is a mutable child, create an implicit copy of the xref */
+      FilterXRef *xref = (FilterXRef *) el;
+      return filterx_ref_float(_filterx_ref_new(filterx_object_ref(xref->value)));
+    }
+  else
+    {
+      return filterx_object_ref(el);
+    }
 }
 
 static gboolean

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -55,6 +55,12 @@ _assert_int_value_and_unref(FilterXObject *object, gint64 expected_value)
   filterx_object_unref(object);
 }
 
+static FilterXExpr *
+_int_literal(gint64 value)
+{
+  return filterx_literal_new(filterx_integer_new(value));
+}
+
 Test(filterx_expr, test_filterx_expr_construction_and_free)
 {
   FilterXExpr *fexpr = filterx_expr_new();
@@ -154,28 +160,19 @@ Test(filterx_expr, test_filterx_literal_list_with_embedded_list)
 
 Test(filterx_expr, test_filterx_dict_immutable_values)
 {
-  FilterXExpr *dict_expr = NULL;
   FilterXObject *result = NULL;
-  GList *values = NULL;
   guint64 len;
 
   FilterXObject *foo = filterx_string_new("foo", -1);
   FilterXObject *bar = filterx_string_new("bar", -1);
   FilterXObject *baz = filterx_string_new("baz", -1);
 
-
-  values = g_list_append(values,
-                         filterx_literal_element_new(filterx_literal_new(filterx_object_ref(foo)),
-                                                     filterx_literal_new(filterx_integer_new(42))));
-  values = g_list_append(values,
-                         filterx_literal_element_new(filterx_literal_new(filterx_object_ref(bar)),
-                                                     filterx_literal_new(filterx_integer_new(43))));
-  values = g_list_append(values,
-                         filterx_literal_element_new(filterx_literal_new(filterx_object_ref(baz)),
-                                                     filterx_literal_new(filterx_integer_new(44))));
-  dict_expr = filterx_literal_dict_new(values);
-
   // result = {"foo": 42, "bar": 43, "baz": 44};
+  FilterXExpr *dict_expr = filterx_literal_dict_of(filterx_literal_new(filterx_object_ref(foo)), _int_literal(42),
+                                                   filterx_literal_new(filterx_object_ref(bar)), _int_literal(43),
+                                                   filterx_literal_new(filterx_object_ref(baz)), _int_literal(44),
+                                                   NULL);
+
   result = init_and_eval_expr(dict_expr);
   cr_assert(result);
   cr_assert(filterx_object_truthy(result));
@@ -193,31 +190,22 @@ Test(filterx_expr, test_filterx_dict_immutable_values)
 
 Test(filterx_expr, test_filterx_dict_with_embedded_dict)
 {
-  FilterXExpr *dict_expr = NULL;
   FilterXObject *result = NULL;
-  GList *values = NULL, *inner_values = NULL;
   guint64 len;
 
   FilterXObject *foo = filterx_string_new("foo", -1);
   FilterXObject *bar = filterx_string_new("bar", -1);
   FilterXObject *baz = filterx_string_new("baz", -1);
 
-  // {"foo": 1};
-  inner_values = g_list_append(inner_values,
-                               filterx_literal_element_new(filterx_literal_new(filterx_object_ref(foo)),
-                                                           filterx_literal_new(filterx_integer_new(1))));
-  // result = {"foo": 420, "bar": 1337", "baz": {"foo":1}};
-  values = g_list_append(values,
-                         filterx_literal_element_new(filterx_literal_new(filterx_object_ref(foo)),
-                                                     filterx_literal_new(filterx_integer_new(420))));
-  values = g_list_append(values,
-                         filterx_literal_element_new(filterx_literal_new(filterx_object_ref(bar)),
-                                                     filterx_literal_new(filterx_integer_new(1337))));
-  values = g_list_append(values,
-                         filterx_literal_element_new(filterx_literal_new(filterx_object_ref(baz)),
-                                                     filterx_literal_dict_new(inner_values)));
+  // inner = {"foo": 1};
+  FilterXExpr *inner_dict_expr = filterx_literal_dict_of(filterx_literal_new(filterx_object_ref(foo)), _int_literal(1),
+                                                         NULL);
 
-  dict_expr = filterx_literal_dict_new(values);
+  // result = {"foo": 420, "bar": 1337", "baz": inner};
+  FilterXExpr *dict_expr = filterx_literal_dict_of(filterx_literal_new(filterx_object_ref(foo)), _int_literal(420),
+                                                   filterx_literal_new(filterx_object_ref(bar)), _int_literal(1337),
+                                                   filterx_literal_new(filterx_object_ref(baz)), inner_dict_expr,
+                                                   NULL);
 
   result = init_and_eval_expr(dict_expr);
   cr_assert(result);

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -261,6 +261,77 @@ Test(filterx_expr, test_filterx_assign)
   filterx_scope_variable_layout_free(l);
 }
 
+/* destructuring assignment, e.g. "(a, b) = expr;" or "[a, b] = expr;" --
+ * exercised end-to-end (tuple/list targets, nesting, message-field targets)
+ * by tests/light/functional_tests/filterx/test_filterx_destructuring_assignment.py;
+ * these unit tests stick to the parts that need direct expr-tree access:
+ * a representative happy path plus the two runtime failure branches of
+ * _literal_container_assign(). */
+Test(filterx_expr, test_filterx_tuple_unpack_assignment)
+{
+  FilterXExpr *var_a = filterx_msg_variable_expr_new("a");
+  FilterXExpr *var_b = filterx_msg_variable_expr_new("b");
+  FilterXExpr *var_c = filterx_msg_variable_expr_new("c");
+
+  /* (a, (b, c)) = (1, (2, 3)); -- nesting exercises the same code path
+   * recursively, covering both the tuple and list container types in one
+   * go since _literal_container_assign() is shared between them. */
+  FilterXExpr *lhs = filterx_literal_tuple_of(var_a, filterx_literal_list_of(var_b, var_c, NULL), NULL);
+  FilterXExpr *rhs = filterx_literal_tuple_of(_int_literal(1),
+                                              filterx_literal_list_of(_int_literal(2), _int_literal(3), NULL), NULL);
+  FilterXExpr *assign = filterx_assign_new(lhs, rhs);
+
+  FilterXScopeVariableLayout *l = filterx_scope_variable_layout_new(assign);
+  set_libtest_filterx_scope(filterx_scope_new(NULL, l));
+
+  FilterXObject *res = init_and_eval_expr(assign);
+  cr_assert_not_null(res);
+  filterx_object_unref(res);
+
+  _assert_int_value_and_unref(init_and_eval_expr(var_a), 1);
+  _assert_int_value_and_unref(init_and_eval_expr(var_b), 2);
+  _assert_int_value_and_unref(init_and_eval_expr(var_c), 3);
+
+  filterx_expr_unref(assign);
+  filterx_scope_variable_layout_free(l);
+}
+
+Test(filterx_expr, test_filterx_tuple_unpack_assignment_element_count_mismatch)
+{
+  FilterXExpr *lhs = filterx_literal_tuple_of(filterx_msg_variable_expr_new("a"), filterx_msg_variable_expr_new("b"),
+                                              NULL);
+  FilterXExpr *rhs = filterx_literal_tuple_of(_int_literal(1), _int_literal(2), _int_literal(3), NULL);
+  FilterXExpr *assign = filterx_assign_new(lhs, rhs);
+
+  FilterXScopeVariableLayout *l = filterx_scope_variable_layout_new(assign);
+  set_libtest_filterx_scope(filterx_scope_new(NULL, l));
+
+  FilterXObject *res = init_and_eval_expr(assign);
+  cr_assert_null(res);
+  filterx_eval_clear_errors();
+
+  filterx_expr_unref(assign);
+  filterx_scope_variable_layout_free(l);
+}
+
+Test(filterx_expr, test_filterx_tuple_unpack_assignment_rejects_non_sequence_rhs)
+{
+  FilterXExpr *lhs = filterx_literal_tuple_of(filterx_msg_variable_expr_new("a"), filterx_msg_variable_expr_new("b"),
+                                              NULL);
+  FilterXExpr *rhs = filterx_literal_new(filterx_string_new("xy", -1));
+  FilterXExpr *assign = filterx_assign_new(lhs, rhs);
+
+  FilterXScopeVariableLayout *l = filterx_scope_variable_layout_new(assign);
+  set_libtest_filterx_scope(filterx_scope_new(NULL, l));
+
+  FilterXObject *res = init_and_eval_expr(assign);
+  cr_assert_null(res);
+  filterx_eval_clear_errors();
+
+  filterx_expr_unref(assign);
+  filterx_scope_variable_layout_free(l);
+}
+
 Test(filterx_expr, test_filterx_setattr)
 {
   FilterXObject *dict = filterx_dict_new();

--- a/lib/filterx/tests/test_func_unset_empties.c
+++ b/lib/filterx/tests/test_func_unset_empties.c
@@ -74,24 +74,6 @@ _assert_unset_empties(GList *args, const gchar *expected_repr)
   filterx_expr_unref(modifiable_object_expr);
 }
 
-FilterXExpr *
-_list_generator_helper(FilterXObject *first, ...)
-{
-  GList *target_vals = NULL;
-  va_list va;
-
-  va_start(va, first);
-  FilterXObject *arg = first;
-  while (arg)
-    {
-      target_vals = g_list_append(target_vals, filterx_literal_element_new(NULL, filterx_literal_new(arg)));
-      arg = va_arg(va, FilterXObject *);
-    }
-  va_end(va);
-
-  return filterx_literal_list_new(target_vals);
-}
-
 Test(filterx_func_unset_empties, invalid_args)
 {
   GList *args = NULL;
@@ -162,7 +144,7 @@ Test(filterx_func_unset_empties, target_resets_defaults)
   const gchar *input = "[\"\",null,[],{}]";
   GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
                                                              filterx_object_expr_new(filterx_object_from_json(input, -1, NULL))));
-  FilterXExpr *targets = _list_generator_helper(filterx_string_new("anything", -1), NULL);
+  FilterXExpr *targets = filterx_literal_list_of_objects(filterx_string_new("anything", -1), NULL);
   args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
                                                       targets));
   _assert_unset_empties(args, input);
@@ -173,7 +155,7 @@ Test(filterx_func_unset_empties, target_null_only)
   const gchar *input = "[\"\",null,[],{}]";
   GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
                                                              filterx_object_expr_new(filterx_object_from_json(input, -1, NULL))));
-  FilterXExpr *targets = _list_generator_helper(filterx_null_new(), NULL);
+  FilterXExpr *targets = filterx_literal_list_of_objects(filterx_null_new(), NULL);
   args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
                                                       targets));
   _assert_unset_empties(args, "[\"\",[],{}]");
@@ -184,7 +166,7 @@ Test(filterx_func_unset_empties, target_empty_string_only)
   const gchar *input = "[\"\",null,[],{}]";
   GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
                                                              filterx_object_expr_new(filterx_object_from_json(input, -1, NULL))));
-  FilterXExpr *targets = _list_generator_helper(filterx_string_new("", -1), NULL);
+  FilterXExpr *targets = filterx_literal_list_of_objects(filterx_string_new("", -1), NULL);
   args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
                                                       targets));
   _assert_unset_empties(args, "[null,[],{}]");
@@ -195,7 +177,7 @@ Test(filterx_func_unset_empties, target_empty_list_only)
   const gchar *input = "[\"\",null,[],{}]";
   GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
                                                              filterx_object_expr_new(filterx_object_from_json(input, -1, NULL))));
-  FilterXExpr *targets = _list_generator_helper(filterx_list_new(), NULL);
+  FilterXExpr *targets = filterx_literal_list_of_objects(filterx_list_new(), NULL);
   args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
                                                       targets));
   _assert_unset_empties(args, "[\"\",null,{}]");
@@ -206,7 +188,7 @@ Test(filterx_func_unset_empties, target_empty_dict_only)
   const gchar *input = "[\"\",null,[],{}]";
   GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
                                                              filterx_object_expr_new(filterx_object_from_json(input, -1, NULL))));
-  FilterXExpr *targets = _list_generator_helper(filterx_dict_new(), NULL);
+  FilterXExpr *targets = filterx_literal_list_of_objects(filterx_dict_new(), NULL);
   args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
                                                       targets));
   _assert_unset_empties(args, "[\"\",null,[]]");
@@ -217,10 +199,10 @@ Test(filterx_func_unset_empties, target_empties_manual)
   const gchar *input = "[\"\",null,[],{}]";
   GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
                                                              filterx_object_expr_new(filterx_object_from_json(input, -1, NULL))));
-  FilterXExpr *targets = _list_generator_helper(filterx_dict_new(),
-                                                filterx_list_new(),
-                                                filterx_string_new("", -1),
-                                                filterx_null_new(), NULL);
+  FilterXExpr *targets = filterx_literal_list_of_objects(filterx_dict_new(),
+                                                         filterx_list_new(),
+                                                         filterx_string_new("", -1),
+                                                         filterx_null_new(), NULL);
   args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
                                                       targets));
   _assert_unset_empties(args, "[]");
@@ -231,13 +213,13 @@ Test(filterx_func_unset_empties, target_empties_manual_and_strings)
   const gchar *input = "[\"bar\",\"\",null,[],{},\"foo\",\"bar\",\"baz\"]";
   GList *args = g_list_append(NULL, filterx_function_arg_new(NULL,
                                                              filterx_object_expr_new(filterx_object_from_json(input, -1, NULL))));
-  FilterXExpr *targets = _list_generator_helper(filterx_dict_new(),
-                                                filterx_list_new(),
-                                                filterx_string_new("", -1),
-                                                filterx_null_new(),
-                                                filterx_string_new("foo", -1),
-                                                filterx_string_new("bar", -1),
-                                                NULL);
+  FilterXExpr *targets = filterx_literal_list_of_objects(filterx_dict_new(),
+                                                         filterx_list_new(),
+                                                         filterx_string_new("", -1),
+                                                         filterx_null_new(),
+                                                         filterx_string_new("foo", -1),
+                                                         filterx_string_new("bar", -1),
+                                                         NULL);
   args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
                                                       targets));
   _assert_unset_empties(args, "[\"baz\"]");
@@ -249,8 +231,8 @@ Test(filterx_func_unset_empties, string_targets)
   FilterXExpr *targets = NULL;
 
   /* dict */
-  targets = _list_generator_helper(filterx_string_new("baz", -1),
-                                   NULL);
+  targets = filterx_literal_list_of_objects(filterx_string_new("baz", -1),
+                                            NULL);
   args = g_list_append(args, filterx_function_arg_new(NULL,
                                                       filterx_object_expr_new(filterx_object_from_json("{\"foo\":{\"bar\":\"baz\",\"tik\":\"tak\"}}", -1, NULL))));
   args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
@@ -259,10 +241,10 @@ Test(filterx_func_unset_empties, string_targets)
   args = NULL;
 
 
-  targets = _list_generator_helper(filterx_string_new("baz", -1),
-                                   filterx_string_new("tak", -1),
-                                   filterx_dict_new(), //also remove empty dict
-                                   NULL);
+  targets = filterx_literal_list_of_objects(filterx_string_new("baz", -1),
+                                            filterx_string_new("tak", -1),
+                                            filterx_dict_new(), //also remove empty dict
+                                            NULL);
   args = g_list_append(args, filterx_function_arg_new(NULL,
                                                       filterx_object_expr_new(filterx_object_from_json("{\"foo\":{\"bar\":\"baz\",\"tik\":\"tak\"}}", -1, NULL))));
   args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
@@ -272,9 +254,9 @@ Test(filterx_func_unset_empties, string_targets)
 
   // /* list */
 
-  targets = _list_generator_helper(filterx_string_new("baz", -1),
-                                   filterx_null_new(), // also remove null values
-                                   NULL);
+  targets = filterx_literal_list_of_objects(filterx_string_new("baz", -1),
+                                            filterx_null_new(), // also remove null values
+                                            NULL);
   args = g_list_append(args, filterx_function_arg_new(NULL,
                                                       filterx_object_expr_new(filterx_object_from_json("[\"foo\",\"bar\",null,\"baz\"]",
                                                         -1, NULL))));
@@ -284,10 +266,10 @@ Test(filterx_func_unset_empties, string_targets)
   args = NULL;
 
 
-  targets = _list_generator_helper(filterx_string_new("baz", -1),
-                                   filterx_string_new("foo", -1),
-                                   filterx_null_new(), // also remove null values
-                                   NULL);
+  targets = filterx_literal_list_of_objects(filterx_string_new("baz", -1),
+                                            filterx_string_new("foo", -1),
+                                            filterx_null_new(), // also remove null values
+                                            NULL);
   args = g_list_append(args, filterx_function_arg_new(NULL,
                                                       filterx_object_expr_new(filterx_object_from_json("[\"foo\",\"bar\",null,\"baz\"]",
                                                         -1, NULL))));
@@ -304,9 +286,9 @@ Test(filterx_func_unset_empties, replacement)
 
   /* dict */
 
-  targets = _list_generator_helper(filterx_string_new("baz", -1),
-                                   filterx_string_new("tak", -1),
-                                   NULL);
+  targets = filterx_literal_list_of_objects(filterx_string_new("baz", -1),
+                                            filterx_string_new("tak", -1),
+                                            NULL);
   args = g_list_append(args, filterx_function_arg_new(NULL,
                                                       filterx_object_expr_new(filterx_object_from_json("{\"foo\":{\"bar\":\"baz\",\"tik\":\"tak\"}}", -1, NULL))));
   args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
@@ -318,10 +300,10 @@ Test(filterx_func_unset_empties, replacement)
 
   /* list */
 
-  targets = _list_generator_helper(filterx_string_new("baz", -1),
-                                   filterx_string_new("foo", -1),
-                                   filterx_null_new(), //also replace null
-                                   NULL);
+  targets = filterx_literal_list_of_objects(filterx_string_new("baz", -1),
+                                            filterx_string_new("foo", -1),
+                                            filterx_null_new(), //also replace null
+                                            NULL);
   args = g_list_append(args, filterx_function_arg_new(NULL,
                                                       filterx_object_expr_new(filterx_object_from_json("[\"foo\",\"bar\",null,\"baz\"]",
                                                         -1, NULL))));
@@ -340,8 +322,8 @@ Test(filterx_func_unset_empties, ignorecase)
 
   /* dict */
 
-  targets = _list_generator_helper(filterx_string_new("BAZ", -1),
-                                   NULL);
+  targets = filterx_literal_list_of_objects(filterx_string_new("BAZ", -1),
+                                            NULL);
   args = g_list_append(args, filterx_function_arg_new(NULL,
                                                       filterx_object_expr_new(filterx_object_from_json("{\"foo\":{\"bar\":\"baz\",\"tik\":\"tak\"}}", -1, NULL))));
   args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
@@ -352,8 +334,8 @@ Test(filterx_func_unset_empties, ignorecase)
   args = NULL;
 
 
-  targets = _list_generator_helper(filterx_string_new("BAZ", -1),
-                                   NULL);
+  targets = filterx_literal_list_of_objects(filterx_string_new("BAZ", -1),
+                                            NULL);
   args = g_list_append(args, filterx_function_arg_new(NULL,
                                                       filterx_object_expr_new(filterx_object_from_json("{\"foo\":{\"bar\":\"baz\",\"tik\":\"tak\"}}", -1, NULL))));
   args = g_list_append(args, filterx_function_arg_new(FILTERX_FUNC_UNSET_EMPTIES_ARG_NAME_TARGETS,
@@ -365,9 +347,9 @@ Test(filterx_func_unset_empties, ignorecase)
 
   /* list */
 
-  targets = _list_generator_helper(filterx_string_new("BAR", -1),
-                                   filterx_null_new(), // also remove null
-                                   NULL);
+  targets = filterx_literal_list_of_objects(filterx_string_new("BAR", -1),
+                                            filterx_null_new(), // also remove null
+                                            NULL);
   args = g_list_append(args, filterx_function_arg_new(NULL,
                                                       filterx_object_expr_new(filterx_object_from_json("[\"foo\",\"bar\",null,\"baz\"]",
                                                         -1, NULL))));
@@ -378,9 +360,9 @@ Test(filterx_func_unset_empties, ignorecase)
   _assert_unset_empties(args, "[\"foo\",\"bar\",\"baz\"]");
   args = NULL;
 
-  targets = _list_generator_helper(filterx_string_new("BAR", -1),
-                                   filterx_null_new(), // also remove null
-                                   NULL);
+  targets = filterx_literal_list_of_objects(filterx_string_new("BAR", -1),
+                                            filterx_null_new(), // also remove null
+                                            NULL);
   args = g_list_append(args, filterx_function_arg_new(NULL,
                                                       filterx_object_expr_new(filterx_object_from_json("[\"foo\",\"bar\",null,\"baz\"]",
                                                         -1, NULL))));

--- a/lib/filterx/tests/test_metrics_labels.c
+++ b/lib/filterx/tests/test_metrics_labels.c
@@ -33,12 +33,6 @@
 #include "scratch-buffers.h"
 #include "apphook.h"
 
-static GList *
-_add_label_expr(GList *label_exprs, FilterXExpr *key, FilterXExpr *value)
-{
-  return g_list_append(label_exprs, filterx_literal_element_new(key, value));
-}
-
 Test(filterx_metrics_labels, null_labels)
 {
   FilterXMetricsLabels *metrics_labels = filterx_metrics_labels_new(NULL);
@@ -108,15 +102,10 @@ Test(filterx_metrics_labels, non_literal_empty_labels)
 
 Test(filterx_metrics_labels, const_literal_generator_labels)
 {
-  GList *label_exprs = NULL;
-  label_exprs = _add_label_expr(label_exprs,
-                                filterx_literal_new(filterx_string_new("foo", -1)),
-                                filterx_literal_new(filterx_string_new("foovalue", -1)));
-  label_exprs = _add_label_expr(label_exprs,
-                                filterx_literal_new(filterx_string_new("bar", -1)),
-                                filterx_literal_new(filterx_string_new("barvalue", -1)));
-
-  FilterXExpr *labels_expr = filterx_literal_dict_new(label_exprs);
+  FilterXExpr *labels_expr = filterx_literal_dict_of(
+                               filterx_literal_new(filterx_string_new("foo", -1)), filterx_literal_new(filterx_string_new("foovalue", -1)),
+                               filterx_literal_new(filterx_string_new("bar", -1)), filterx_literal_new(filterx_string_new("barvalue", -1)),
+                               NULL);
 
   FilterXMetricsLabels *metrics_labels = filterx_metrics_labels_new(labels_expr);
   filterx_expr_unref(labels_expr);
@@ -145,15 +134,10 @@ Test(filterx_metrics_labels, const_literal_generator_labels)
 
 Test(filterx_metrics_labels, non_const_literal_generator_labels)
 {
-  GList *label_exprs = NULL;
-  label_exprs = _add_label_expr(label_exprs,
-                                filterx_literal_new(filterx_string_new("foo", -1)),
-                                filterx_object_expr_new(filterx_string_new("foovalue", -1)));
-  label_exprs = _add_label_expr(label_exprs,
-                                filterx_literal_new(filterx_string_new("bar", -1)),
-                                filterx_literal_new(filterx_string_new("barvalue", -1)));
-
-  FilterXExpr *labels_expr = filterx_literal_dict_new(label_exprs);
+  FilterXExpr *labels_expr = filterx_literal_dict_of(
+                               filterx_literal_new(filterx_string_new("foo", -1)), filterx_object_expr_new(filterx_string_new("foovalue", -1)),
+                               filterx_literal_new(filterx_string_new("bar", -1)), filterx_literal_new(filterx_string_new("barvalue", -1)),
+                               NULL);
 
   FilterXMetricsLabels *metrics_labels = filterx_metrics_labels_new(labels_expr);
   filterx_expr_unref(labels_expr);
@@ -182,12 +166,9 @@ Test(filterx_metrics_labels, non_const_literal_generator_labels)
 
 Test(filterx_metrics_labels, non_literal_key_in_literal_generator_labels)
 {
-  GList *label_exprs = NULL;
-  label_exprs = _add_label_expr(label_exprs,
-                                filterx_object_expr_new(filterx_string_new("foo", -1)),
-                                filterx_literal_new(filterx_string_new("foovalue", -1)));
-
-  FilterXExpr *labels_expr = filterx_literal_dict_new(label_exprs);
+  FilterXExpr *labels_expr = filterx_literal_dict_of(
+                               filterx_object_expr_new(filterx_string_new("foo", -1)), filterx_literal_new(filterx_string_new("foovalue", -1)),
+                               NULL);
 
   FilterXMetricsLabels *metrics_labels = filterx_metrics_labels_new(labels_expr);
   filterx_expr_unref(labels_expr);

--- a/libtest/filterx-lib.c
+++ b/libtest/filterx-lib.c
@@ -21,6 +21,7 @@
  */
 
 #include <criterion/criterion.h>
+#include <stdarg.h>
 #include "filterx-lib.h"
 #include "cr_template.h"
 #include "filterx/json-repr.h"
@@ -29,6 +30,7 @@
 #include "filterx/object-string.h"
 #include "filterx/expr-compound.h"
 #include "filterx/expr-literal.h"
+#include "filterx/expr-literal-container.h"
 #include "filterx/filterx-eval.h"
 
 void
@@ -364,6 +366,66 @@ deinit_libtest_filterx(void)
   filterx_eval_clear_errors();
   filterx_eval_end_context(&filterx_world.context);
   filterx_env_clear(&filterx_world.test_env);
+}
+
+static FilterXExpr *
+_literal_container_of_va(FilterXExpr *(*ctor)(GList *elements), FilterXExpr *first, va_list args)
+{
+  GList *elements = NULL;
+  for (FilterXExpr *elem = first; elem != NULL; elem = va_arg(args, FilterXExpr *))
+    elements = g_list_append(elements, filterx_literal_element_new(NULL, elem));
+  return ctor(elements);
+}
+
+FilterXExpr *
+filterx_literal_tuple_of(FilterXExpr *first, ...)
+{
+  va_list args;
+  va_start(args, first);
+  FilterXExpr *result = _literal_container_of_va(filterx_literal_tuple_new, first, args);
+  va_end(args);
+  return result;
+}
+
+FilterXExpr *
+filterx_literal_list_of(FilterXExpr *first, ...)
+{
+  va_list args;
+  va_start(args, first);
+  FilterXExpr *result = _literal_container_of_va(filterx_literal_list_new, first, args);
+  va_end(args);
+  return result;
+}
+
+FilterXExpr *
+filterx_literal_list_of_objects(FilterXObject *first, ...)
+{
+  GList *elements = NULL;
+  va_list args;
+  va_start(args, first);
+  for (FilterXObject *obj = first; obj != NULL; obj = va_arg(args, FilterXObject *))
+    elements = g_list_append(elements, filterx_literal_element_new(NULL, filterx_literal_new(obj)));
+  va_end(args);
+  return filterx_literal_list_new(elements);
+}
+
+FilterXExpr *
+filterx_literal_dict_of(FilterXExpr *first_key, FilterXExpr *first_value, ...)
+{
+  GList *elements = NULL;
+  va_list args;
+  va_start(args, first_value);
+  FilterXExpr *key = first_key;
+  FilterXExpr *value = first_value;
+  while (key != NULL)
+    {
+      elements = g_list_append(elements, filterx_literal_element_new(key, value));
+      key = va_arg(args, FilterXExpr *);
+      if (key != NULL)
+        value = va_arg(args, FilterXExpr *);
+    }
+  va_end(args);
+  return filterx_literal_dict_new(elements);
 }
 
 FILTERX_DEFINE_TYPE(test_dict, FILTERX_TYPE_NAME(object), .is_abstract = TRUE);

--- a/libtest/filterx-lib.h
+++ b/libtest/filterx-lib.h
@@ -57,4 +57,11 @@ void deinit_libtest_filterx(void);
 
 FilterXObject *init_and_eval_expr(FilterXExpr *expr);
 
+/* build a literal tuple/list/dict expr out of a NULL-terminated list of element
+ * expressions */
+FilterXExpr *filterx_literal_tuple_of(FilterXExpr *first, ...);
+FilterXExpr *filterx_literal_list_of(FilterXExpr *first, ...);
+FilterXExpr *filterx_literal_list_of_objects(FilterXObject *first, ...);
+FilterXExpr *filterx_literal_dict_of(FilterXExpr *first_key, FilterXExpr *first_value, ...);
+
 #endif

--- a/news/feature-1209.md
+++ b/news/feature-1209.md
@@ -1,0 +1,4 @@
+`tuple()` unpacking in filterx: added Python-like tuple unpacking, e.g.
+assignments like this:
+
+     (a, b, c) = (1, 2, 3)

--- a/tests/light/functional_tests/filterx/test_filterx_cow.py
+++ b/tests/light/functional_tests/filterx/test_filterx_cow.py
@@ -535,7 +535,7 @@ def test_list_unset_causes_clone(config, syslog_ng):
     assert file_true.read_log() == """[1,2,3,[4,5,6,{"foo":"foovalue","bar":"barvalue"}]]--[1,2,3,[4,5,6]]"""
 
 
-def test_list_mutable_elements_appended_from_another_list_cause_clone_when_whanged_through_l1(config, syslog_ng):
+def test_list_mutable_elements_appended_from_another_list_cause_clone_when_changed_through_l1(config, syslog_ng):
     (file_true, file_false, _) = create_config(
         config, [
             """
@@ -555,7 +555,7 @@ def test_list_mutable_elements_appended_from_another_list_cause_clone_when_whang
     assert file_true.read_log() == """[1,2,3,4,5,6,{"bar":"barvalue"}]--[4,5,6,{"foo":"foovalue","bar":"barvalue"}]"""
 
 
-def test_list_mutable_elements_appended_from_another_list_cause_clone_when_whanged_through_l2(config, syslog_ng):
+def test_list_mutable_elements_appended_from_another_list_cause_clone_when_changed_through_l2(config, syslog_ng):
     (file_true, file_false, _) = create_config(
         config, [
             """
@@ -592,13 +592,15 @@ def test_plus_on_child_of_shared_hierarchy(config, syslog_ng):
     assert file_true.read_log() == """["foo","bar","foobar"]--{"child":["foo","bar"]}"""
 
 
-def test_list_mutable_elements_from_tuple_cause_clone_when_whanged_through_tuple(config, syslog_ng):
+def test_list_mutable_elements_from_tuple_cause_changes_to_be_dropped_when_mutated_through_tuple(config, syslog_ng):
     (file_true, file_false, _) = create_config(
         config, [
             """
                 d = {'foo':'foovalue','bar':'barvalue'};
                 t = tuple([1,2,3,d]);
                 l = list(t);
+                # this change is lost as we mutate a copy we extract from the tuple
+                # we could probably raise an error when the top-level xref (parent == NULL) is floating
                 unset(t[3].foo);
                 $MSG = string(t) + '--' + string(l);
             """,
@@ -608,10 +610,10 @@ def test_list_mutable_elements_from_tuple_cause_clone_when_whanged_through_tuple
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """(1,2,3,{"bar":"barvalue"})--[1,2,3,{"foo":"foovalue","bar":"barvalue"}]"""
+    assert file_true.read_log() == """(1,2,3,{"foo":"foovalue","bar":"barvalue"})--[1,2,3,{"foo":"foovalue","bar":"barvalue"}]"""
 
 
-def test_list_mutable_elements_from_tuple_cause_clone_when_whanged_through_list(config, syslog_ng):
+def test_list_mutable_elements_from_tuple_cause_clone_when_changed_through_list(config, syslog_ng):
     (file_true, file_false, _) = create_config(
         config, [
             """

--- a/tests/light/functional_tests/filterx/test_filterx_destructuring_assignment.py
+++ b/tests/light/functional_tests/filterx/test_filterx_destructuring_assignment.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+# Copyright (c) 2026 Balazs Scheidler <balazs.scheidler@axoflow.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from axosyslog_light.syslog_ng_config.renderer import render_statement
+
+
+def create_config(config, filterx_expr):
+    file_true = config.create_file_destination(file_name="dest-true.log", template="'$MSG\n'")
+    file_false = config.create_file_destination(file_name="dest-false.log", template="'$MSG\n'")
+
+    raw_config = f"""
+@version: {config.get_version()}
+
+options {{ stats(level(1)); }};
+
+source genmsg {{
+    example-msg-generator(num(1) template("foobar"));
+}};
+
+destination dest_true {{
+    {render_statement(file_true)};
+}};
+
+destination dest_false {{
+    {render_statement(file_false)};
+}};
+
+log {{
+    source(genmsg);
+    if {{
+        filterx {{ {filterx_expr} }};
+        destination(dest_true);
+    }} else {{
+        destination(dest_false);
+    }};
+}};
+"""
+    config.set_raw_config(raw_config)
+    return (file_true, file_false)
+
+
+def test_tuple_unpack_assignment(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+        (a, b) = (1, 2);
+        $MSG = string(a) + "," + string(b);
+        """,
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "1,2"
+
+
+def test_list_unpack_assignment(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+        [a, b] = [3, 4];
+        $MSG = string(a) + "," + string(b);
+        """,
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "3,4"
+
+
+def test_mixed_tuple_and_list_unpack_assignment(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+        [a, b] = (5, 6);
+        (c, d) = [7, 8];
+        $MSG = string(a) + "," + string(b) + "," + string(c) + "," + string(d);
+        """,
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "5,6,7,8"
+
+
+def test_nested_unpack_assignment(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+        (a, [b, c]) = (1, [2, 3]);
+        $MSG = string(a) + "," + string(b) + "," + string(c);
+        """,
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "1,2,3"
+
+
+def test_unpack_assignment_into_message_fields(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+        ($first, $second) = ("foo", "bar");
+        $MSG = $first + "," + $second;
+        """,
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "foo,bar"
+
+
+def test_unpack_assignment_element_count_mismatch(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+        (a, b) = (1, 2, 3);
+        """,
+    )
+    syslog_ng.start(config)
+
+    assert "processed" not in file_true.get_stats()
+    assert file_false.get_stats()["processed"] == 1
+
+
+def test_unpack_assignment_rejects_non_sequence_rhs(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+        (a, b) = "xy";
+        """,
+    )
+    syslog_ng.start(config)
+
+    assert "processed" not in file_true.get_stats()
+    assert file_false.get_stats()["processed"] == 1


### PR DESCRIPTION

This implements:

```
(a, b, c) = function_returning_tuple();
```

like in Python. My aggregate() work (in #1193) is going to return a tuple. This simplifies processing the return value a lot.
