### PR TITLE
logmatcher: fix GLib-CRITICAL on the first glob pattern compile

### DIFF
--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -259,7 +259,8 @@ static void
 log_matcher_glob_free(LogMatcher *s)
 {
   LogMatcherGlob *self = (LogMatcherGlob *)s;
-  g_pattern_spec_free(self->pattern);
+  if (self->pattern)
+    g_pattern_spec_free(self->pattern);
   log_matcher_free_method(s);
 }
 

--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -219,7 +219,8 @@ log_matcher_glob_compile(LogMatcher *s, const gchar *pattern, GError **error)
   g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
   log_matcher_store_pattern(s, pattern);
 
-  g_pattern_spec_free(self->pattern);
+  if (self->pattern)
+    g_pattern_spec_free(self->pattern);
   self->pattern = g_pattern_spec_new(pattern);
   return TRUE;
 }

--- a/news/bugfix-1214.md
+++ b/news/bugfix-1214.md
@@ -1,0 +1,2 @@
+`type(glob)`: Fixed a `GLib-CRITICAL` assertion warning that was printed at
+startup for every glob matcher.


### PR DESCRIPTION
Fixes #1213