### PR TITLE
filterx/filterx-ref: fix copy-on-write handling for sibling xrefs pointing to the same underlying object

### DIFF
--- a/lib/filterx/filterx-ref.c
+++ b/lib/filterx/filterx-ref.c
@@ -132,7 +132,7 @@
  *      old and new.  They also handle filterx_object_cow_prepare() if an
  *      object is not yet wrapped.
  *
- *   2) filterx_object_copy() does not explicitly wrap a bare object,
+ *   3) filterx_object_copy() does not explicitly wrap a bare object,
  *      but will clone the xref if it is already wrapped.
  *
  * The number of copies for objects are tracked by the
@@ -193,17 +193,19 @@
  *
  * Sharing of xrefs
  * ----------------
+ *
  * The idea of FilterXRefs (or xrefs) is to represent a distinct copy of a
- * mutable data structure.  There's an exception to everything though: and
- * that is the potential sharing of xrefs between multiple shared object
- * hierarchies.
+ * mutable data structure.  There's an exception to everything though:
+ * sometimes the same xref instance can represent multiple copies, when they
+ * end up being shared in multiple object hierarchies.
  *
  * FilterXRef instances can be shared when we have a dict embedded in
  * another dict (e.g.  top-level and a child) and the top-level dict is
  * being shared by two xrefs.  In this case, while the xref to the top-level
- * is distinct (kept in two variables for example), the xref to the child
- * (contained in the top-level as a value) is shared, and the child dict
- * itself may contain additional xrefs to further mutable data objects.
+ * is distinct (kept in two variables for example), but the xref to the
+ * child (contained in the top-level as a value) is shared (as the value is
+ * still shared), and the child dict itself may contain additional xrefs to
+ * further mutable data objects.
  *
  * When manipulating data structures through xrefs we have to know if those
  * xrefs are shared or not.  Actually we can't mutate objects through shared
@@ -213,8 +215,8 @@
  *
  * To avoid this, xref sharing needs to be eliminated.
  *
- * Floating xrefs
- * --------------
+ * Shadow xrefs
+ * ------------
  * As we navigate and change the hierarchy of dict/list instances while
  * interpreting the filterx statements, we need to notice and eliminate the
  * use of shared xrefs.  If an xref is shared, that means that `fx_ref_cnt`
@@ -228,13 +230,19 @@
  *
  * Any expr that evaluates to an object in a hierarchical structure (e.g.
  * getattr or get_subscript) must check for shared xrefs and actively
- * replace them with a "floating xref" instead of returning the stored xref.
+ * replace them with a "shadow xref" instead of returning the stored xref.
  * See the function
- * `_filterx_ref_replace_shared_xref_with_a_floating_one()`.
+ * `_filterx_ref_replace_shared_xref_with_a_shadow()`.
  *
- * A floating xref is a temporary FilterXRef that is explicitly marked as
- * floating using the `filterx_ref_floating()` function (and the associated
- * FILTERX_REF_FLAG_FLOATING flag).
+ * A shadow xref is a temporary FilterXRef that is explicitly marked as a
+ * shadow using the `filterx_ref_create_shadow()` function. A shadow xref
+ * is also a floating xref (see Floating xrefs below).
+ *
+ * Floating xrefs
+ * --------------
+ * Sometimes we have an xref that is not yet stored anywhere (such as a
+ * shadow xref, or an xref that has just been unplugged from its storage
+ * mechanism using `move()`). We call xrefs in this state as "floating xrefs".
  *
  * Floating xrefs are yet to be stored somewhere or be discarded at the end
  * of the FilterX statement unless they are actually needed.  A floating xref
@@ -250,13 +258,14 @@
  * -----------------------------------
  *
  *   1) when a hierarchical structure is sharing an xref with another, then
- *      the getattr/get_subscript operation returns a floating xref instead of
- *      the stored (& shared) one.
+ *      the getattr/get_subscript operation returns a shadow xref instead of
+ *      the stored (& shared) one.  A shadow xref is always floating when it
+ *      is created.
  *
  *   2) `filterx_object_cow_fork2()` generates a floating ref as the new copy
  *
- *   3) the new `move()` FilterX "function" retrieves the stored xref, unsets
- *      it and returns it as a floating xref.
+ *   3) the new `move()` FilterX "function" retrieves the stored xref,
+ *      unplugs it from its container, and returns it as a floating xref.
  *
  * When do we ground floating xrefs
  * --------------------------------
@@ -266,6 +275,9 @@
  *   2) filterx_object_copy() turns the floating xref into a simple xref,
  *      without generating a new clone.
  *
+ *   3) in dict/list copy-on-write operations, when the contents of the
+ *      dict/list are cloned.  This is actually a special case for
+ *      filterx_object_copy().
  */
 static FilterXObject *
 _filterx_ref_clone(FilterXObject *s)
@@ -426,7 +438,7 @@ _filterx_ref_truthy(FilterXObject *s)
  * parent itself is shared.
  *
  * In these cases, we need a new ref instance, which has the proper
- * parent_container value, while still cotinuing to share the dict (e.g.
+ * parent_container value, while still continuing to share the dict (e.g.
  * self->value).
  *
  * In case we are just using the values in a read-only manner, the dicts
@@ -438,7 +450,7 @@ _filterx_ref_truthy(FilterXObject *s)
  * "child_of_interest" argument we are passing to clone_container().
  */
 static FilterXObject *
-_filterx_ref_replace_shared_xref_with_a_floating_one(FilterXObject *s, FilterXObject *c)
+_filterx_ref_replace_shared_xref_with_a_shadow(FilterXObject *s, FilterXObject *c)
 {
   if (!s || !filterx_object_is_ref(s))
     return s;
@@ -450,7 +462,7 @@ _filterx_ref_replace_shared_xref_with_a_floating_one(FilterXObject *s, FilterXOb
       g_atomic_counter_get(_get_fx_ref_cnt(container)) <= 1)
     return s;
 
-  FilterXObject *result = filterx_ref_float(_filterx_ref_new(filterx_object_ref(self->value)));
+  FilterXObject *result = filterx_ref_create_shadow(&self->super);
   filterx_object_unref(&self->super);
   filterx_ref_set_parent_container(result, &container->super);
   return result;
@@ -461,7 +473,7 @@ _filterx_ref_getattr(FilterXObject *s, FilterXObject *attr)
 {
   FilterXRef *self = (FilterXRef *) s;
   FilterXObject *result = filterx_object_getattr(self->value, attr);
-  return _filterx_ref_replace_shared_xref_with_a_floating_one(result, s);
+  return _filterx_ref_replace_shared_xref_with_a_shadow(result, s);
 }
 
 static FilterXObject *
@@ -469,7 +481,7 @@ _filterx_ref_get_subscript(FilterXObject *s, FilterXObject *key)
 {
   FilterXRef *self = (FilterXRef *) s;
   FilterXObject *result = filterx_object_get_subscript(self->value, key);
-  return _filterx_ref_replace_shared_xref_with_a_floating_one(result, s);
+  return _filterx_ref_replace_shared_xref_with_a_shadow(result, s);
 }
 
 static gboolean

--- a/lib/filterx/filterx-ref.h
+++ b/lib/filterx/filterx-ref.h
@@ -48,9 +48,15 @@ struct _FilterXRef
   FilterXObject super;
   FilterXObject *value;
   FilterXWeakRef parent_container;
+
+  /* NOTE: this pointer is only set on shadow xrefs. It identifies (but does
+   * not reference) the xref we are shadowing for, so clone_container() can
+   * properly identify which entry triggered the copy-on-write. */
+  gpointer shadowed_xref;
 };
 
 gboolean _filterx_ref_cow_recurse(FilterXObject *s, gpointer user_data);
+FilterXObject *_filterx_ref_new(FilterXObject *value);
 
 static inline void
 _filterx_ref_cow(FilterXRef *self)
@@ -89,15 +95,6 @@ filterx_ref_add_inplace(FilterXObject *s, FilterXObject *o)
   return self->value->type->add_inplace(self->value, s, o);
 }
 
-static inline gboolean
-filterx_ref_values_equal(FilterXObject *r1, FilterXObject *r2)
-{
-  if (filterx_object_is_ref(r1))
-    r1 = ((FilterXRef *) r1)->value;
-  if (filterx_object_is_ref(r2))
-    r2 = ((FilterXRef *) r2)->value;
-  return r1 == r2;
-}
 
 static inline void
 filterx_ref_set_parent_container(FilterXObject *s, FilterXObject *parent)
@@ -145,6 +142,28 @@ filterx_ref_float(FilterXObject *s)
   return s;
 }
 
+/* TRUE iff the floating xref @s is the stand-in for the stored xref */
+static inline gboolean
+filterx_ref_shadows(FilterXObject *s, FilterXObject *stored)
+{
+  if (!s || !filterx_object_is_ref(s))
+    return FALSE;
+
+  FilterXRef *self = (FilterXRef *) s;
+  return self->shadowed_xref == stored;
+}
+
+/* Creates a new shadow xref wrapping the same value as the stored xref
+ * @original, marked as the stand-in for @original (see
+ * filterx_ref_shadows()). */
+static inline FilterXObject *
+filterx_ref_create_shadow(FilterXObject *original)
+{
+  FilterXRef *orig = (FilterXRef *) original;
+  FilterXObject *s = filterx_ref_float_unchecked(_filterx_ref_new(filterx_object_ref(orig->value)));
+  ((FilterXRef *) s)->shadowed_xref = original;
+  return s;
+}
 
 /* ground this xref (e.g.  make it not floating), the reverse of
  * filterx_ref_float().  This is to be used when the xref is stored
@@ -156,6 +175,7 @@ filterx_ref_ground_unchecked(FilterXObject *s)
 
   s->floating_ref = FALSE;
   filterx_weakref_set(&self->parent_container, NULL);
+  self->shadowed_xref = NULL;
   return s;
 }
 
@@ -170,6 +190,5 @@ filterx_ref_ground(FilterXObject *s)
 }
 
 FilterXObject *filterx_ref_dup(FilterXObject *s);
-FilterXObject *_filterx_ref_new(FilterXObject *value);
 
 #endif

--- a/lib/filterx/object-dict.c
+++ b/lib/filterx/object-dict.c
@@ -483,7 +483,7 @@ _table_clone_index(FilterXDictTable *target, FilterXDictTable *source, FilterXOb
         continue;
 
       ep->key = _object_clone(ep->key, dup);
-      if (child_of_interest && filterx_ref_values_equal(ep->value, child_of_interest))
+      if (child_of_interest && filterx_ref_shadows(child_of_interest, ep->value))
         {
           /* child_of_interest is a movable, floating xref, which is grounded by this copy */
           ep->value = _object_clone(child_of_interest, dup);

--- a/lib/filterx/object-list.c
+++ b/lib/filterx/object-list.c
@@ -235,7 +235,7 @@ _filterx_list_clone_container(FilterXObject *s, FilterXObject *container, Filter
     {
       FilterXObject *el = g_ptr_array_index(self->array, i);
 
-      if (child_of_interest && filterx_ref_values_equal(el, child_of_interest))
+      if (child_of_interest && filterx_ref_shadows(child_of_interest, el))
         {
           /* child_of_interest is a movable, floating xref, which is grounded by this clone */
           el = _object_clone(child_of_interest, dup);

--- a/lib/filterx/tests/test_object_cow.c
+++ b/lib/filterx/tests/test_object_cow.c
@@ -24,6 +24,7 @@
 
 #include "filterx/filterx-eval.h"
 #include "filterx/object-string.h"
+#include "filterx/object-primitive.h"
 #include "filterx/object-dict.h"
 #include "filterx/json-repr.h"
 #include "scratch-buffers.h"
@@ -51,6 +52,12 @@ static FilterXObject *
 _value_string(const gchar *attr)
 {
   return filterx_string_new_frozen(attr);
+}
+
+static gboolean
+_unwrapped_values_equal(FilterXObject *r1, FilterXObject *r2)
+{
+  return filterx_ref_unwrap_ro(r1) == filterx_ref_unwrap_ro(r2);
 }
 
 Test(filterx_cow, test_filterx_cow_child_objects_are_refs_too)
@@ -105,8 +112,8 @@ Test(filterx_cow, test_filterx_cow_fork_creates_a_second_reference_to_the_same_o
   cr_assert(filterx_object_is_type(c_comma_cc, &FILTERX_TYPE_NAME(string)));
 
   /* access through c and c_comma still refers to the same dict, so all objects are equal */
-  cr_assert(filterx_ref_values_equal(c_comma_c, cc));
-  cr_assert(filterx_ref_values_equal(c_comma_cc, ccc));
+  cr_assert(_unwrapped_values_equal(c_comma_c, cc));
+  cr_assert(_unwrapped_values_equal(c_comma_cc, ccc));
 
   filterx_object_unref(c_comma_cc);
   filterx_object_unref(c_comma_c);
@@ -202,6 +209,75 @@ Test(filterx_cow, test_filterx_cow_make_grandchild_writable_creates_an_unshared_
 
   filterx_object_unref(c_comma_c);
   filterx_object_unref(c_comma);
+  filterx_object_unref(r);
+}
+
+Test(filterx_cow, test_filterx_cow_write_through_floating_ref_lands_in_its_own_slot_despite_aliasing_siblings)
+{
+  FilterXObject *r = filterx_object_from_json("{\"a\":{\"dataset\":\"ds\"}}", -1, NULL);
+  cr_assert(filterx_object_is_ref(r));
+
+  /* d.b = d.a: "a" and "b" become sibling xrefs sharing the same dict */
+  FilterXObject *a = filterx_object_getattr(r, _attr_string("a"));
+  FilterXObject *b_value = filterx_object_cow_fork2(a, NULL);
+  cr_assert(filterx_object_setattr(r, _attr_string("b"), &b_value) == TRUE);
+  filterx_object_unref(b_value);
+
+  /* simulate an assignment (e.g. the variable copy at a log path fork point) */
+  FilterXObject *r_comma = filterx_object_copy(r);
+
+  /* the first write through d.b: getattr returns a floating stand-in for the
+   * stored xref as r_comma is shared, the write must land in "b", not "a" */
+  FilterXObject *b = filterx_object_getattr(r_comma, _attr_string("b"));
+  FilterXObject *changed_string = _value_string("changed");
+  cr_assert(filterx_object_setattr(b, _attr_string("dataset"), &changed_string) == TRUE);
+  filterx_object_unref(changed_string);
+  filterx_object_unref(b);
+
+  GString *r_comma_json = scratch_buffers_alloc();
+  GString *r_json = scratch_buffers_alloc();
+  cr_assert(filterx_object_to_json(r_comma, r_comma_json) == TRUE);
+  cr_assert(filterx_object_to_json(r, r_json) == TRUE);
+
+  cr_assert_str_eq(r_comma_json->str, "{\"a\":{\"dataset\":\"ds\"},\"b\":{\"dataset\":\"changed\"}}");
+  cr_assert_str_eq(r_json->str, "{\"a\":{\"dataset\":\"ds\"},\"b\":{\"dataset\":\"ds\"}}");
+
+  filterx_object_unref(r_comma);
+  filterx_object_unref(r);
+}
+
+Test(filterx_cow, test_filterx_cow_write_through_floating_ref_lands_in_its_own_index_despite_aliasing_siblings)
+{
+  FilterXObject *r = filterx_object_from_json("[{\"dataset\":\"ds\"}]", -1, NULL);
+  cr_assert(filterx_object_is_ref(r));
+
+  /* l[1] = l[0]: the two elements become sibling xrefs sharing the same dict */
+  FilterXObject *zero = filterx_integer_new(0);
+  FilterXObject *one = filterx_integer_new(1);
+  FilterXObject *first = filterx_object_get_subscript(r, zero);
+  FilterXObject *second_value = filterx_object_cow_fork2(first, NULL);
+  cr_assert(filterx_object_set_subscript(r, one, &second_value) == TRUE);
+  filterx_object_unref(second_value);
+
+  FilterXObject *r_comma = filterx_object_copy(r);
+
+  FilterXObject *second = filterx_object_get_subscript(r_comma, one);
+  FilterXObject *changed_string = _value_string("changed");
+  cr_assert(filterx_object_setattr(second, _attr_string("dataset"), &changed_string) == TRUE);
+  filterx_object_unref(changed_string);
+  filterx_object_unref(second);
+
+  GString *r_comma_json = scratch_buffers_alloc();
+  GString *r_json = scratch_buffers_alloc();
+  cr_assert(filterx_object_to_json(r_comma, r_comma_json) == TRUE);
+  cr_assert(filterx_object_to_json(r, r_json) == TRUE);
+
+  cr_assert_str_eq(r_comma_json->str, "[{\"dataset\":\"ds\"},{\"dataset\":\"changed\"}]");
+  cr_assert_str_eq(r_json->str, "[{\"dataset\":\"ds\"},{\"dataset\":\"ds\"}]");
+
+  filterx_object_unref(one);
+  filterx_object_unref(zero);
+  filterx_object_unref(r_comma);
   filterx_object_unref(r);
 }
 


### PR DESCRIPTION
When two keys in a dict point to the same underlying object (which can happen with the config below), the mechanism we used to identify the "child_of_interest" in clone_container() methods went side-ways.

The original implementation checked if the child_of_interest and the stored xref contained a pointer to the same underlying object. (using filterx_ref_values_equal). This breaks down, if there are multiple children that point to the same value.

This patch changes the implementation by introducing "shadow xrefs", that are basically floating xrefs the same way, but implement a 1:1 identification to pick the right child.

The new mechanism adds a new pointer to FilterXRef, the "shadowed_xref", which records exactly which xref is being shadowed.

Then at clone_container time, we are just comparing the two pointers.

NOTES:
 * the shadowed_xref is a generic pointer on purpose, NEVER deref that pointer. We don't have a real reference (or even a weak reference) to it
 * the "shadowing" is short lived, we set the pointer to NULL as soon as we ground the shadow.

The reproducing config is below. It will fail an assertion in debug builds or would produce unexpected results in production builds.

```
source s_gen { example-msg-generator(num(1) template("seed")); };

destination d_out { file("out.log" template("$MSG\n")); };

log {
    source(s_gen);
    filterx {
        declare d = {"a": {"dataset": "ds"}};
        d.b = d.a;
    };
    if {
        filterx {
            d.b.dataset = "first";
            d.m1 = d.b.dataset;
            d.b.dataset = "second";
            d.m2 = d.b.dataset;
        };
    };
    filterx { $MSG = "after-1st-write=" + d.m1 + "  after-2nd-write=" + d.m2; };
    destination(d_out);
};

```

