### PR TITLE
light: force IPv4 by default to OTel source clients

### DIFF
--- a/tests/light/pyproject.toml
+++ b/tests/light/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "axosyslog-light"
-version = "1.19.0"
+version = "1.20.0"
 description = "Lightweight End-to-End Test Framework for AxoSyslog."
 authors = ["Andras Mitzki <andras.mitzki@axoflow.com>", "Attila Szakacs <attila.szakacs@axoflow.com>"]
 readme = "README.md"

--- a/tests/light/src/axosyslog_light/driver_io/opentelemetry/opentelemetry_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/opentelemetry/opentelemetry_io.py
@@ -204,7 +204,7 @@ class OTelResourceScopeLog:
 
 
 class OpenTelemetryIO():
-    def __init__(self, port: int, address: str = "localhost") -> None:
+    def __init__(self, port: int, address: str = "127.0.0.1") -> None:
         self.__port = port
         self.__address = address
         self.__credentials = None

--- a/tests/light/src/axosyslog_light/driver_io/opentelemetry/opentelemetry_io.py
+++ b/tests/light/src/axosyslog_light/driver_io/opentelemetry/opentelemetry_io.py
@@ -204,8 +204,9 @@ class OTelResourceScopeLog:
 
 
 class OpenTelemetryIO():
-    def __init__(self, port: int) -> None:
+    def __init__(self, port: int, address: str = "localhost") -> None:
         self.__port = port
+        self.__address = address
         self.__credentials = None
 
     def set_tls(
@@ -221,7 +222,7 @@ class OpenTelemetryIO():
         )
 
     def __create_channel(self):
-        target = f"localhost:{self.__port}"
+        target = f"{self.__address}:{self.__port}"
         if self.__credentials:
             return secure_channel(target, self.__credentials)
         return insecure_channel(target)


### PR DESCRIPTION
`"localhost"` resolves to `::1` first, and the reverse name of `::1` differs from host to host, so `$HOST` of the received messages was not stable. `127.0.0.1` keeps `$HOST` stable.

This is a breaking change.