### PR TITLE
github-actions: call local reusable workflows via the self-repository syntax

### DIFF
--- a/.github/workflows/axosyslog-image-snapshot.yml
+++ b/.github/workflows/axosyslog-image-snapshot.yml
@@ -102,7 +102,7 @@ jobs:
     permissions:
       contents: read  # checkout source
       packages: write  # push image to GHCR
-    uses: ./.github/workflows/axosyslog-docker.yml
+    uses: $/.github/workflows/axosyslog-docker.yml
     needs: [prepare, tarball]
     with:
       type: snapshot

--- a/.github/workflows/axosyslog-image-stable-rebuild.yml
+++ b/.github/workflows/axosyslog-image-stable-rebuild.yml
@@ -26,7 +26,7 @@ jobs:
           fi
 
   publish-image:
-    uses: ./.github/workflows/axosyslog-docker.yml
+    uses: $/.github/workflows/axosyslog-docker.yml
     needs: pre-check
     permissions:
       contents: read  # checkout source

--- a/.github/workflows/axosyslog-nightly.yml
+++ b/.github/workflows/axosyslog-nightly.yml
@@ -74,14 +74,14 @@ jobs:
 
   create-packages:
     needs: tarball
-    uses: ./.github/workflows/create-packages.yml
+    uses: $/.github/workflows/create-packages.yml
     with:
       source-tarball-artifact-name: source-tarball
       dbld-image-mode: cache
 
   upload-packages:
     needs: create-packages
-    uses: ./.github/workflows/upload-packages.yml
+    uses: $/.github/workflows/upload-packages.yml
     with:
       pkg-type: nightly
     secrets:
@@ -91,7 +91,7 @@ jobs:
 
   index-packages:
     needs: upload-packages
-    uses: ./.github/workflows/index-packages.yml
+    uses: $/.github/workflows/index-packages.yml
     with:
       pkg-type: nightly
     secrets:
@@ -101,12 +101,12 @@ jobs:
 
   test-packages:
     needs: index-packages
-    uses: ./.github/workflows/test-apt-packages.yml
+    uses: $/.github/workflows/test-apt-packages.yml
     with:
       pkg-type: nightly
 
   publish-image:
-    uses: ./.github/workflows/axosyslog-docker.yml
+    uses: $/.github/workflows/axosyslog-docker.yml
     needs: tarball
     permissions:
       contents: read  # checkout source

--- a/.github/workflows/axosyslog-stable.yml
+++ b/.github/workflows/axosyslog-stable.yml
@@ -63,7 +63,7 @@ jobs:
 
   index-packages:
     needs: find-draft-release-run
-    uses: ./.github/workflows/index-packages.yml
+    uses: $/.github/workflows/index-packages.yml
     with:
       pkg-type: stable
       run-id: ${{ needs.find-draft-release-run.outputs.DRAFT_RELEASE_RUN_ID }}
@@ -74,12 +74,12 @@ jobs:
 
   test-packages:
     needs: index-packages
-    uses: ./.github/workflows/test-apt-packages.yml
+    uses: $/.github/workflows/test-apt-packages.yml
     with:
       pkg-type: stable
 
   publish-image:
-    uses: ./.github/workflows/axosyslog-docker.yml
+    uses: $/.github/workflows/axosyslog-docker.yml
     needs: find-draft-release-run
     permissions:
       contents: read  # checkout source

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -88,14 +88,14 @@ jobs:
 
   create-packages:
     needs: create-release-tarball
-    uses: ./.github/workflows/create-packages.yml
+    uses: $/.github/workflows/create-packages.yml
     with:
       source-tarball-artifact-name: release-tarball
       dbld-image-mode: build
 
   upload-packages:
     needs: create-packages
-    uses: ./.github/workflows/upload-packages.yml
+    uses: $/.github/workflows/upload-packages.yml
     with:
       pkg-type: stable
     secrets:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -37,7 +37,7 @@ jobs:
 
   create-packages:
     needs: create-source-tarball
-    uses: ./.github/workflows/create-packages.yml
+    uses: $/.github/workflows/create-packages.yml
     with:
       source-tarball-artifact-name: source-tarball
       dbld-image-mode: cache

--- a/.github/workflows/trigger-index-packages.yml
+++ b/.github/workflows/trigger-index-packages.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   index-packages:
-    uses: ./.github/workflows/index-packages.yml
+    uses: $/.github/workflows/index-packages.yml
     with:
       pkg-type: ${{ github.event.inputs.pkg-type }}
       run-id: ${{ github.event.inputs.run-id }}

--- a/.github/workflows/trigger-tests-on-packages.yml
+++ b/.github/workflows/trigger-tests-on-packages.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   test-packages:
-    uses: ./.github/workflows/test-apt-packages.yml
+    uses: $/.github/workflows/test-apt-packages.yml
     with:
       pkg-type: ${{ github.event.inputs.pkg-type }}


### PR DESCRIPTION
The workspace-relative form resolves through the checked out tree, so an earlier step can replace the file before Actions loads it. The `$/` form resolves against the repository at the triggering ref.

This syntax is not available on GitHub Enterprise Server.

Source: https://docs.zizmor.sh/audits/#self-repository

Assisted-by: Claude:claude-opus-5[1m]