### PR TITLE
`opentelemetry()` dest: fix crash when sending more than one type of data in one batch

### DIFF
--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -87,6 +87,12 @@ DestWorker::DestWorker(GrpcDestWorker *s)
 {
 }
 
+DestWorker::~DestWorker()
+{
+  if (batch_first_msg)
+    log_msg_unref(batch_first_msg);
+}
+
 void
 DestWorker::clear_current_msg_metadata()
 {
@@ -368,11 +374,8 @@ DestWorker::insert(LogMessage *msg)
       g_assert_not_reached();
     }
 
-  if (!client_context.get())
-    {
-      client_context = std::make_unique<::grpc::ClientContext>();
-      prepare_context_dynamic(*client_context, msg);
-    }
+  if (!batch_first_msg)
+    batch_first_msg = log_msg_ref(msg);
 
   if (should_initiate_flush())
     return log_threaded_dest_worker_flush(&super->super, LTF_FLUSH_NORMAL);
@@ -438,7 +441,10 @@ permanent_error:
 LogThreadedResult
 DestWorker::flush_log_records()
 {
-  ::grpc::Status status = logs_service_stub->Export(client_context.get(), *logs_service_request,
+  ::grpc::ClientContext client_context;
+  prepare_context_dynamic(client_context, batch_first_msg);
+
+  ::grpc::Status status = logs_service_stub->Export(&client_context, *logs_service_request,
                                                     logs_service_response);
   owner.metrics.insert_grpc_request_stats(status);
 
@@ -458,7 +464,10 @@ DestWorker::flush_log_records()
 LogThreadedResult
 DestWorker::flush_metrics()
 {
-  ::grpc::Status status = metrics_service_stub->Export(client_context.get(), *metrics_service_request,
+  ::grpc::ClientContext client_context;
+  prepare_context_dynamic(client_context, batch_first_msg);
+
+  ::grpc::Status status = metrics_service_stub->Export(&client_context, *metrics_service_request,
                                                        metrics_service_response);
   owner.metrics.insert_grpc_request_stats(status);
 
@@ -478,7 +487,10 @@ DestWorker::flush_metrics()
 LogThreadedResult
 DestWorker::flush_spans()
 {
-  ::grpc::Status status = trace_service_stub->Export(client_context.get(), *trace_service_request,
+  ::grpc::ClientContext client_context;
+  prepare_context_dynamic(client_context, batch_first_msg);
+
+  ::grpc::Status status = trace_service_stub->Export(&client_context, *trace_service_request,
                                                      trace_service_response);
   owner.metrics.insert_grpc_request_stats(status);
 
@@ -525,7 +537,11 @@ DestWorker::flush(LogThreadedFlushMode mode)
     }
 
 exit:
-  client_context.reset();
+  if (batch_first_msg)
+    {
+      log_msg_unref(batch_first_msg);
+      batch_first_msg = nullptr;
+    }
   fallback_msg_scope_logs = nullptr;
 
   arena.Reset();

--- a/modules/grpc/otel/otel-dest-worker.hpp
+++ b/modules/grpc/otel/otel-dest-worker.hpp
@@ -56,6 +56,7 @@ class DestWorker : public syslogng::grpc::DestWorker
 {
 public:
   DestWorker(GrpcDestWorker *s);
+  ~DestWorker();
 
   LogThreadedResult insert(LogMessage *msg) override;
   LogThreadedResult flush(LogThreadedFlushMode mode) override;
@@ -85,7 +86,6 @@ protected:
   LogThreadedResult flush_spans();
 
 protected:
-  std::unique_ptr<::grpc::ClientContext> client_context;
   std::unique_ptr<LogsService::Stub> logs_service_stub;
   std::unique_ptr<MetricsService::Stub> metrics_service_stub;
   std::unique_ptr<TraceService::Stub> trace_service_stub;
@@ -111,6 +111,7 @@ protected:
   } current_msg_metadata;
 
   ScopeLogs *fallback_msg_scope_logs = nullptr;
+  LogMessage *batch_first_msg = nullptr;
 };
 
 }

--- a/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
+++ b/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
@@ -57,11 +57,8 @@ SyslogNgDestWorker::insert(LogMessage *msg)
   logs_current_batch_bytes += log_record_bytes;
   log_threaded_dest_driver_insert_msg_length_stats(super->super.owner, log_record_bytes);
 
-  if (!client_context.get())
-    {
-      client_context = std::make_unique<::grpc::ClientContext>();
-      prepare_context_dynamic(*client_context, msg);
-    }
+  if (!batch_first_msg)
+    batch_first_msg = log_msg_ref(msg);
 
   if (should_initiate_flush())
     return log_threaded_dest_worker_flush(&super->super, LTF_FLUSH_NORMAL);

--- a/news/bugfix-1224.md
+++ b/news/bugfix-1224.md
@@ -1,0 +1,3 @@
+`opentelemetry()` destination: Fixed a crash when a batch held more than one signal type, for example a log and a
+metric. The batch reused one gRPC client context for its logs, metrics and traces requests, which gRPC does not
+allow, so the process aborted on the second request.

--- a/tests/light/functional_tests/Makefile.am
+++ b/tests/light/functional_tests/Makefile.am
@@ -11,6 +11,7 @@ EXTRA_DIST += \
 	tests/light/functional_tests/destination_drivers/example_destination/test_example_destination.py \
 	tests/light/functional_tests/destination_drivers/network_destination/test_kept_alive_tls_connection_doing_handshake_after_reload.py \
 	tests/light/functional_tests/destination_drivers/network_destination/test_network_destination_transport.py \
+	tests/light/functional_tests/destination_drivers/opentelemetry_destination/test_opentelemetry_destination_batching.py \
 	tests/light/functional_tests/destination_drivers/python_destination/test_python_destination.py \
 	tests/light/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_acceptance.py \
 	tests/light/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_missing_snmp_obj.py \

--- a/tests/light/functional_tests/destination_drivers/opentelemetry_destination/test_opentelemetry_destination_batching.py
+++ b/tests/light/functional_tests/destination_drivers/opentelemetry_destination/test_opentelemetry_destination_batching.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+# Copyright (c) 2026 Attila Szakacs-Bertok <attila.szakacs@axoflow.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from axosyslog_light.syslog_ng.syslog_ng import SyslogNg
+from axosyslog_light.syslog_ng_config.statements.sources.opentelemetry_source import OTelLog
+from axosyslog_light.syslog_ng_config.syslog_ng_config import SyslogNgConfig
+from grpc import insecure_channel
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2_grpc import MetricsServiceStub
+from opentelemetry.proto.metrics.v1.metrics_pb2 import Metric
+
+
+def _send_metric(port: int, metric: Metric) -> None:
+    request = ExportMetricsServiceRequest()
+    request.resource_metrics.add().scope_metrics.add().metrics.append(metric)
+    with insecure_channel(f"127.0.0.1:{port}") as channel:
+        MetricsServiceStub(channel).Export(request)
+
+
+def test_opentelemetry_destination_mixed_signal_batch(
+    syslog_ng: SyslogNg,
+    config: SyslogNgConfig,
+    port_allocator,
+) -> None:
+    sender_port = port_allocator()
+    receiver_port = port_allocator()
+
+    sender_source = config.create_opentelemetry_source(port=sender_port)
+    # without batch-timeout() the worker flushes whenever its queue runs empty,
+    # so the two signals could go out in two batches
+    opentelemetry_destination = config.create_opentelemetry_destination(
+        port=receiver_port,
+        batch_lines=2,
+        batch_timeout=10000,
+    )
+    config.create_logpath(statements=[sender_source, opentelemetry_destination])
+
+    receiver_source = config.create_opentelemetry_source(port=receiver_port)
+    file_destination = config.create_file_destination(file_name="output.log", template='"${.otel_raw.type}\\n"')
+    config.create_logpath(statements=[receiver_source, file_destination])
+
+    syslog_ng.start(config)
+    sender_source.write_log(log=OTelLog(body="log"))
+    _send_metric(sender_port, Metric(name="metric"))
+
+    assert sorted(file_destination.read_logs(2)) == ["log", "metric"]
+    assert syslog_ng.is_process_running()

--- a/tests/light/src/axosyslog_light/Makefile.am
+++ b/tests/light/src/axosyslog_light/Makefile.am
@@ -63,6 +63,7 @@ EXTRA_DIST += \
 	tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/bigquery_destination.py \
 	tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/destination_driver.py \
 	tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/example_destination.py \
+	tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/opentelemetry_destination.py \
 	tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/file_destination.py \
 	tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/__init__.py \
 	tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/network_destination.py \

--- a/tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/opentelemetry_destination.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/statements/destinations/opentelemetry_destination.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2026 Axoflow
+# Copyright (c) 2026 Attila Szakacs-Bertok <attila.szakacs@axoflow.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from axosyslog_light.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
+from axosyslog_light.syslog_ng_ctl.legacy_stats_handler import LegacyStatsHandler
+from axosyslog_light.syslog_ng_ctl.prometheus_stats_handler import PrometheusStatsHandler
+
+
+class OpenTelemetryDestination(DestinationDriver):
+    def __init__(
+        self,
+        stats_handler: LegacyStatsHandler,
+        prometheus_stats_handler: PrometheusStatsHandler,
+        port: int,
+        **options,
+    ) -> None:
+        self.driver_name = "opentelemetry"
+        options.setdefault("url", '"127.0.0.1:{}"'.format(port))
+        options.setdefault("batch_lines", 1)
+        super(OpenTelemetryDestination, self).__init__(stats_handler, prometheus_stats_handler, [], options)

--- a/tests/light/src/axosyslog_light/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/axosyslog_light/syslog_ng_config/syslog_ng_config.py
@@ -36,6 +36,7 @@ from axosyslog_light.syslog_ng_config.statements.destinations.example_destinatio
 from axosyslog_light.syslog_ng_config.statements.destinations.file_destination import FileDestination
 from axosyslog_light.syslog_ng_config.statements.destinations.http_destination import HttpDestination
 from axosyslog_light.syslog_ng_config.statements.destinations.network_destination import NetworkDestination
+from axosyslog_light.syslog_ng_config.statements.destinations.opentelemetry_destination import OpenTelemetryDestination
 from axosyslog_light.syslog_ng_config.statements.destinations.python_destination import PythonDestination
 from axosyslog_light.syslog_ng_config.statements.destinations.snmp_destination import SnmpDestination
 from axosyslog_light.syslog_ng_config.statements.destinations.sql_destination import SqlDestination
@@ -287,6 +288,9 @@ class SyslogNgConfig(object):
 
     def create_sql_destination(self, **options):
         return SqlDestination(self._stats_handler, self._prometheus_stats_handler, **options)
+
+    def create_opentelemetry_destination(self, **options):
+        return OpenTelemetryDestination(self._stats_handler, self._prometheus_stats_handler, **options)
 
     def create_network_destination(self, **options):
         network_destination = NetworkDestination(self._stats_handler, self._prometheus_stats_handler, **options)


### PR DESCRIPTION
gRPC allows a single RPC per `ClientContext`.

The batch shared one context between the logs, metrics and traces `Export()` calls, so a batch that held two signal types aborted the process on the second call with `Check failed: call_ == nullptr`.