### PR TITLE
distcheck: fix on latest devshell image

### DIFF
--- a/lib/compat/cpp-start.h
+++ b/lib/compat/cpp-start.h
@@ -90,10 +90,6 @@
 
 #ifdef __cplusplus
 
-#ifndef __STDC_VERSION__
-#define __STDC_VERSION__ 0
-#endif
-
 #define this this_
 
 extern "C" {

--- a/lib/compat/json.h
+++ b/lib/compat/json.h
@@ -23,7 +23,12 @@
 #define COMPAT_JSON_C_H_INCLUDED 1
 
 #include "compat/compat.h"
+
+/* json-c < 0.16 tests __STDC_VERSION__ unguarded, C++ never defines it */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundef"
 #include <json.h>
+#pragma GCC diagnostic pop
 
 #if JSON_C_MAJOR_VERSION == 0 && JSON_C_MINOR_VERSION < 15
 


### PR DESCRIPTION
GCC 16 implements C++26 P2843R3 and warns on any `#define` of a cpp.predefined macro in C++ mode:

```
  warning: '__STDC_VERSION__' defined
```

No `-W` option controls the warning, so every `CXXFLAGS=-Werror` build fails, including the Distcheck CI job since the devshell image moved to GCC 16.

The define only silenced `-Wundef` in json-c < 0.16, whose `json_object.h` tests `__STDC_VERSION__` without `defined()`.
The pragma around the include covers that case.

Source: https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=cdd015c4ddbb

Assisted-by: Claude:claude-fable-5-1

<!--
Thank you for contributing to AxoSyslog. Please make sure you:
- Read our Contribution guideline: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/axoflow/axosyslog/tree/main/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/axoflow/axosyslog/blob/main/CONTRIBUTING.md#pr-description
-->
