### PR TITLE
feat: support gauge like metrics with update_metric

### DIFF
--- a/modules/metrics-probe/filterx/func-update-metric.c
+++ b/modules/metrics-probe/filterx/func-update-metric.c
@@ -40,34 +40,34 @@ typedef struct FilterXFunctionUpdateMetric_
   struct
   {
     FilterXExpr *expr;
-    gint64 value;
-  } increment;
+    gint64 literal;
+  } value;
 } FilterXFunctionUpdateMetric;
 
 static gboolean
-_get_increment(FilterXFunctionUpdateMetric *self, gint64 *increment)
+_get_value(FilterXFunctionUpdateMetric *self, gint64 *value)
 {
-  if (!self->increment.expr)
+  if (!self->value.expr)
     {
-      *increment = self->increment.value;
+      *value = self->value.literal;
       return TRUE;
     }
 
-  FilterXObject *increment_obj = filterx_expr_eval_typed(self->increment.expr);
-  if (!increment_obj)
+  FilterXObject *value_obj = filterx_expr_eval_typed(self->value.expr);
+  if (!value_obj)
     {
       return FALSE;
     }
 
-  gboolean success = filterx_integer_unwrap(increment_obj, increment);
+  gboolean success = filterx_integer_unwrap(value_obj, value);
   if (!success)
     {
       filterx_eval_push_error_info_printf("Failed to evaluate update_metric()",
                                           "Metric increment must be an integer, got: %s",
-                                          filterx_object_get_type_name(increment_obj));
+                                          filterx_object_get_type_name(value_obj));
     }
 
-  filterx_object_unref(increment_obj);
+  filterx_object_unref(value_obj);
   return success;
 }
 
@@ -78,15 +78,15 @@ _eval(FilterXExpr *s)
 
   gboolean success = FALSE;
 
-  gint64 increment;
-  if (!_get_increment(self, &increment))
+  gint64 value;
+  if (!_get_value(self, &value))
     goto exit;
 
   StatsCounterItem *counter;
   if (!filterx_metrics_get_stats_counter(self->metrics, &counter))
     goto exit;
 
-  stats_counter_add(counter, increment);
+  stats_counter_add(counter, value);
   success = TRUE;
 
 exit:
@@ -100,22 +100,22 @@ exit:
 }
 
 static void
-_optimize_increment(FilterXFunctionUpdateMetric *self)
+_optimize_value(FilterXFunctionUpdateMetric *self)
 {
-  if (!self->increment.expr || !filterx_expr_is_literal(self->increment.expr))
+  if (!self->value.expr || !filterx_expr_is_literal(self->value.expr))
     return;
 
-  FilterXObject *increment_obj = filterx_literal_get_value(self->increment.expr);
-  if (!increment_obj)
+  FilterXObject *value_obj = filterx_literal_get_value(self->value.expr);
+  if (!value_obj)
     return;
 
-  gboolean success = filterx_object_extract_integer(increment_obj, &self->increment.value);
-  filterx_object_unref(increment_obj);
+  gboolean success = filterx_object_extract_integer(value_obj, &self->value.literal);
+  filterx_object_unref(value_obj);
   if (!success)
     return;
 
-  filterx_expr_unref(self->increment.expr);
-  self->increment.expr = NULL;
+  filterx_expr_unref(self->value.expr);
+  self->value.expr = NULL;
 }
 
 static FilterXExpr *
@@ -123,7 +123,7 @@ _optimize(FilterXExpr *s)
 {
   FilterXFunctionUpdateMetric *self = (FilterXFunctionUpdateMetric *) s;
 
-  _optimize_increment(self);
+  _optimize_value(self);
   filterx_metrics_optimize(self->metrics);
 
   return filterx_function_optimize_method(&self->super);
@@ -136,7 +136,7 @@ _init(FilterXExpr *s, GlobalConfig *cfg)
 
   if (!filterx_metrics_init(self->metrics, cfg))
     {
-      filterx_expr_deinit(self->increment.expr, cfg);
+      filterx_expr_deinit(self->value.expr, cfg);
       return FALSE;
     }
 
@@ -158,16 +158,16 @@ _free(FilterXExpr *s)
 
   if (self->metrics)
     filterx_metrics_free(self->metrics);
-  filterx_expr_unref(self->increment.expr);
+  filterx_expr_unref(self->value.expr);
 
   filterx_function_free_method(&self->super);
 }
 
 static gboolean
-_extract_increment_arg(FilterXFunctionUpdateMetric *self, FilterXFunctionArgs *args, GError **error)
+_extract_value_arg(FilterXFunctionUpdateMetric *self, FilterXFunctionArgs *args, GError **error)
 {
-  self->increment.value = 1;
-  self->increment.expr = filterx_function_args_get_named_expr(args, "increment");
+  self->value.literal = 1;
+  self->value.expr = filterx_function_args_get_named_expr(args, "increment");
 
   return TRUE;
 }
@@ -216,7 +216,7 @@ _extract_args(FilterXFunctionUpdateMetric *self, FilterXFunctionArgs *args, GErr
       return FALSE;
     }
 
-  if (!_extract_increment_arg(self, args, error))
+  if (!_extract_value_arg(self, args, error))
     return FALSE;
 
   if (!_extract_level_arg(self, args, error))
@@ -233,7 +233,7 @@ _update_metric_walk(FilterXExpr *s, FilterXExprWalkFunc f, gpointer user_data)
 {
   FilterXFunctionUpdateMetric *self = (FilterXFunctionUpdateMetric *) s;
 
-  if (!filterx_expr_visit(s, &self->increment.expr, f, user_data))
+  if (!filterx_expr_visit(s, &self->value.expr, f, user_data))
     return FALSE;
 
   if (!filterx_metrics_walk_children(self->metrics, s, f, user_data))

--- a/modules/metrics-probe/filterx/func-update-metric.c
+++ b/modules/metrics-probe/filterx/func-update-metric.c
@@ -29,13 +29,14 @@
 #include "filterx/object-primitive.h"
 #include "stats/stats.h"
 
-#define FILTERX_FUNC_UPDATE_METRIC_USAGE "update_metric(\"key\", labels={\"key\": \"value\"}, increment=1, level=0)"
+#define FILTERX_FUNC_UPDATE_METRIC_USAGE "update_metric(\"key\", labels={\"key\": \"value\"}, increment=1|set=20, level=0)"
 
 typedef struct FilterXFunctionUpdateMetric_
 {
   FilterXFunction super;
   FilterXMetrics *metrics;
   gint level;
+  gboolean assign_mode;
 
   struct
   {
@@ -63,7 +64,7 @@ _get_value(FilterXFunctionUpdateMetric *self, gint64 *value)
   if (!success)
     {
       filterx_eval_push_error_info_printf("Failed to evaluate update_metric()",
-                                          "Metric increment must be an integer, got: %s",
+                                          "Metric value must be an integer, got: %s",
                                           filterx_object_get_type_name(value_obj));
     }
 
@@ -82,11 +83,23 @@ _eval(FilterXExpr *s)
   if (!_get_value(self, &value))
     goto exit;
 
+  /* stats_counter_set does not support negative values */
+  if (self->assign_mode && value < 0)
+    {
+      filterx_eval_push_error_info_printf("Failed to evaluate update_metric()",
+                                          "Metric value must be non-negative, got: %" G_GINT64_FORMAT,
+                                          value);
+      goto exit;
+    }
+
   StatsCounterItem *counter;
   if (!filterx_metrics_get_stats_counter(self->metrics, &counter))
     goto exit;
 
-  stats_counter_add(counter, value);
+  if (self->assign_mode)
+    stats_counter_set(counter, (gsize) value);
+  else
+    stats_counter_add(counter, value);
   success = TRUE;
 
 exit:
@@ -166,8 +179,27 @@ _free(FilterXExpr *s)
 static gboolean
 _extract_value_arg(FilterXFunctionUpdateMetric *self, FilterXFunctionArgs *args, GError **error)
 {
+  FilterXExpr *increment = filterx_function_args_get_named_expr(args, "increment");
+  FilterXExpr *set = filterx_function_args_get_named_expr(args, "set");
+
+  if (increment && set)
+    {
+      filterx_expr_unref(increment);
+      filterx_expr_unref(set);
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "increment and set are mutually exclusive. " FILTERX_FUNC_UPDATE_METRIC_USAGE);
+      return FALSE;
+    }
+
+  if (set)
+    {
+      self->assign_mode = TRUE;
+      self->value.expr = set;
+      return TRUE;
+    }
+
   self->value.literal = 1;
-  self->value.expr = filterx_function_args_get_named_expr(args, "increment");
+  self->value.expr = increment;
 
   return TRUE;
 }

--- a/modules/metrics-probe/tests/test_filterx_func_update_metric.c
+++ b/modules/metrics-probe/tests/test_filterx_func_update_metric.c
@@ -24,6 +24,7 @@
 #include <criterion/criterion.h>
 #include "metrics-probe-test.h"
 #include "libtest/filterx-lib.h"
+#include "libtest/grab-logging.h"
 
 #include "filterx/func-update-metric.h"
 #include "filterx/expr-literal.h"
@@ -49,7 +50,8 @@ _add_label(FilterXExpr *labels_expr, const gchar *name, const gchar *value)
 }
 
 static FilterXExpr *
-_create_func(FilterXExpr *key, FilterXExpr *labels, FilterXExpr *increment, FilterXExpr *level)
+_create_func(FilterXExpr *key, FilterXExpr *labels, FilterXExpr *increment, FilterXExpr *set,
+             FilterXExpr *level, GError **error)
 {
   GList *args_list = NULL;
 
@@ -62,12 +64,34 @@ _create_func(FilterXExpr *key, FilterXExpr *labels, FilterXExpr *increment, Filt
   if (increment)
     args_list = g_list_append(args_list, filterx_function_arg_new("increment", increment));
 
+  if (set)
+    args_list = g_list_append(args_list, filterx_function_arg_new("set", set));
+
   if (level)
     args_list = g_list_append(args_list, filterx_function_arg_new("level", level));
 
+  return filterx_function_update_metric_new(filterx_function_args_new(args_list, error), error);
+}
+
+static FilterXExpr *
+_create_increment_func(FilterXExpr *key, FilterXExpr *labels, FilterXExpr *increment, FilterXExpr *level)
+{
   GError *error = NULL;
-  FilterXExpr *func = filterx_function_update_metric_new(filterx_function_args_new(args_list, &error), &error);
+  FilterXExpr *func = _create_func(key, labels, increment, NULL, level, &error);
+
   cr_assert(!error, "Failed to create update_metric(): %s", error->message);
+  cr_assert(func);
+
+  return func;
+}
+
+static FilterXExpr *
+_create_set_func(FilterXExpr *key, FilterXExpr *value, FilterXExpr *labels, FilterXExpr *level)
+{
+  GError *error = NULL;
+  FilterXExpr *func = _create_func(key, labels, NULL, value, level, &error);
+
+  cr_assert(!error, "Failed to create update_metric(set=): %s", error->message);
   cr_assert(func);
 
   return func;
@@ -94,7 +118,7 @@ Test(filterx_func_update_metric, key_and_labels)
   _add_label(labels, "test_label_3", "baz");
   _add_label(labels, "test_label_1", "foo");
   _add_label(labels, "test_label_2", "bar");
-  FilterXExpr *func = _create_func(key, labels, NULL, NULL);
+  FilterXExpr *func = _create_increment_func(key, labels, NULL, NULL);
   cr_assert(filterx_expr_init(func, configuration));
 
   StatsClusterLabel expected_labels[] =
@@ -123,7 +147,7 @@ Test(filterx_func_update_metric, key_and_labels)
 Test(filterx_func_update_metric, increment)
 {
   FilterXExpr *key = filterx_literal_new(filterx_string_new("test_key", -1));
-  FilterXExpr *func = _create_func(key, NULL, filterx_object_expr_new(filterx_integer_new(42)), NULL);
+  FilterXExpr *func = _create_increment_func(key, NULL, filterx_object_expr_new(filterx_integer_new(42)), NULL);
   cr_assert(filterx_expr_init(func, configuration));
 
   StatsClusterLabel expected_labels[] = {};
@@ -151,8 +175,8 @@ Test(filterx_func_update_metric, level)
 
   configuration->stats_options.level = STATS_LEVEL0;
   cr_assert(cfg_init(configuration));
-  func = _create_func(filterx_literal_new(filterx_string_new("test_key", -1)), NULL, NULL,
-                      filterx_literal_new(filterx_integer_new(2)));
+  func = _create_increment_func(filterx_literal_new(filterx_string_new("test_key", -1)), NULL, NULL,
+                                filterx_literal_new(filterx_integer_new(2)));
   cr_assert(filterx_expr_init(func, configuration));
   cr_assert(_eval(func));
   filterx_expr_deinit(func, configuration);
@@ -162,8 +186,8 @@ Test(filterx_func_update_metric, level)
 
   configuration->stats_options.level = STATS_LEVEL1;
   cr_assert(cfg_init(configuration));
-  func = _create_func(filterx_literal_new(filterx_string_new("test_key", -1)), NULL, NULL,
-                      filterx_literal_new(filterx_integer_new(2)));
+  func = _create_increment_func(filterx_literal_new(filterx_string_new("test_key", -1)), NULL, NULL,
+                                filterx_literal_new(filterx_integer_new(2)));
   cr_assert(filterx_expr_init(func, configuration));
   cr_assert(_eval(func));
   filterx_expr_deinit(func, configuration);
@@ -173,8 +197,8 @@ Test(filterx_func_update_metric, level)
 
   configuration->stats_options.level = STATS_LEVEL2;
   cr_assert(cfg_init(configuration));
-  func = _create_func(filterx_literal_new(filterx_string_new("test_key", -1)), NULL, NULL,
-                      filterx_literal_new(filterx_integer_new(2)));
+  func = _create_increment_func(filterx_literal_new(filterx_string_new("test_key", -1)), NULL, NULL,
+                                filterx_literal_new(filterx_integer_new(2)));
   cr_assert(filterx_expr_init(func, configuration));
   cr_assert(_eval(func));
   filterx_expr_deinit(func, configuration);
@@ -184,6 +208,104 @@ Test(filterx_func_update_metric, level)
                                           G_N_ELEMENTS(expected_labels),
                                           1);
   cr_assert(cfg_deinit(configuration));
+}
+
+Test(filterx_func_update_metric, set)
+{
+  StatsClusterLabel expected_labels[] = {};
+
+  FilterXExpr *func = _create_set_func(filterx_literal_new(filterx_string_new("test_key", -1)),
+                                       filterx_object_expr_new(filterx_integer_new(42)),
+                                       NULL,
+                                       NULL);
+  cr_assert(filterx_expr_init(func, configuration));
+
+  cr_assert(_eval(func));
+  metrics_probe_test_assert_counter_value("test_key",
+                                          expected_labels,
+                                          G_N_ELEMENTS(expected_labels),
+                                          42);
+
+  /* unlike increment=, a second eval must not accumulate */
+  cr_assert(_eval(func));
+  metrics_probe_test_assert_counter_value("test_key",
+                                          expected_labels,
+                                          G_N_ELEMENTS(expected_labels),
+                                          42);
+
+  filterx_expr_deinit(func, configuration);
+  filterx_expr_unref(func);
+
+  FilterXExpr *lower = _create_set_func(filterx_literal_new(filterx_string_new("test_key", -1)),
+                                        filterx_object_expr_new(filterx_integer_new(7)),
+                                        NULL,
+                                        NULL);
+  cr_assert(filterx_expr_init(lower, configuration));
+
+  cr_assert(_eval(lower));
+  metrics_probe_test_assert_counter_value("test_key",
+                                          expected_labels,
+                                          G_N_ELEMENTS(expected_labels),
+                                          7);
+
+  filterx_expr_deinit(lower, configuration);
+  filterx_expr_unref(lower);
+}
+
+Test(filterx_func_update_metric, set_rejects_negative)
+{
+  StatsClusterLabel expected_labels[] = {};
+
+  FilterXExpr *func = _create_set_func(filterx_literal_new(filterx_string_new("test_key", -1)),
+                                       filterx_object_expr_new(filterx_integer_new(5)),
+                                       NULL,
+                                       NULL);
+  cr_assert(filterx_expr_init(func, configuration));
+  cr_assert(_eval(func));
+  metrics_probe_test_assert_counter_value("test_key",
+                                          expected_labels,
+                                          G_N_ELEMENTS(expected_labels),
+                                          5);
+  filterx_expr_deinit(func, configuration);
+  filterx_expr_unref(func);
+
+  /* the counter is read out unsigned, so a negative is refused and the value kept */
+  FilterXExpr *negative = _create_set_func(filterx_literal_new(filterx_string_new("test_key", -1)),
+                                           filterx_object_expr_new(filterx_integer_new(-1)),
+                                           NULL,
+                                           NULL);
+  cr_assert(filterx_expr_init(negative, configuration));
+
+  /* filterx_eval_dump_errors() only logs the pushed error when debug_flag is set */
+  debug_flag = TRUE;
+  start_grabbing_messages();
+  cr_assert(_eval(negative));
+  stop_grabbing_messages();
+  debug_flag = FALSE;
+
+  assert_grabbed_log_contains("Metric value must be non-negative, got: -1");
+  reset_grabbed_messages();
+
+  metrics_probe_test_assert_counter_value("test_key",
+                                          expected_labels,
+                                          G_N_ELEMENTS(expected_labels),
+                                          5);
+  filterx_expr_deinit(negative, configuration);
+  filterx_expr_unref(negative);
+}
+
+Test(filterx_func_update_metric, set_and_increment_are_mutually_exclusive)
+{
+  GError *error = NULL;
+  FilterXExpr *func = _create_func(filterx_literal_new(filterx_string_new("test_key", -1)),
+                                   NULL,
+                                   filterx_object_expr_new(filterx_integer_new(1)),
+                                   filterx_object_expr_new(filterx_integer_new(5)),
+                                   NULL,
+                                   &error);
+  cr_assert_not(func);
+  cr_assert(error);
+  g_error_free(error);
 }
 
 void setup(void)

--- a/news/feature-1224.md
+++ b/news/feature-1224.md
@@ -1,0 +1,9 @@
+`update_metric()`: added a new `set` parameter, which assigns an absolute value
+to the metric instead of incrementing it, making the function usable for
+gauge-like metrics:
+
+    update_metric("demo_gauge", set=int($MSG), labels={"host": "demo"});
+
+`set` and `increment` are mutually exclusive, specifying both is a configuration
+error. The value must be non-negative. Negative values are rejected at evaluation
+time and the metric is left unchanged.

--- a/tests/light/functional_tests/filterx/test_filterx_update_metric.py
+++ b/tests/light/functional_tests/filterx/test_filterx_update_metric.py
@@ -236,3 +236,59 @@ def test_filterx_update_metric_skip_empty_labels(config, port_allocator, syslog_
     assert int(samples[0].value) == 1
 
     syslog_ng.stop()
+
+
+def test_filterx_update_metric_set(config, port_allocator, syslog_ng):
+    network_source, file_destination = create_config(
+        config,
+        port_allocator,
+        r"""
+            update_metric("gauge", set=int($MSG));
+            update_metric("labeled", set=int($MSG), labels={"foo": "foovalue"});
+        """,
+    )
+
+    syslog_ng.start(config)
+    network_source.write_logs(["3", "2", "1", "0"])
+    file_destination.read_logs(4)
+
+    # the last value wins, it is not accumulated like increment=
+
+    samples = config.get_prometheus_samples([MetricFilter("syslogng_gauge", {})])
+    assert len(samples) == 1
+    assert int(samples[0].value) == 0
+
+    samples = config.get_prometheus_samples([MetricFilter("syslogng_labeled", {"foo": "foovalue"})])
+    assert len(samples) == 1
+    assert int(samples[0].value) == 0
+
+    syslog_ng.stop()
+
+
+def test_filterx_update_metric_set_negative_is_rejected(config, port_allocator, syslog_ng):
+    network_source, file_destination = create_config(
+        config,
+        port_allocator,
+        r"""
+            update_metric("gauge", set=int($MSG));
+        """,
+    )
+
+    syslog_ng.start(config)
+    network_source.write_logs(["5"])
+    file_destination.read_logs(1)
+
+    samples = config.get_prometheus_samples([MetricFilter("syslogng_gauge", {})])
+    assert len(samples) == 1
+    assert int(samples[0].value) == 5
+
+    # the counter is scraped unsigned, so a negative is refused and the previous value kept
+
+    network_source.write_logs(["-1"])
+    file_destination.read_logs(1)
+
+    samples = config.get_prometheus_samples([MetricFilter("syslogng_gauge", {})])
+    assert len(samples) == 1
+    assert int(samples[0].value) == 5
+
+    syslog_ng.stop()


### PR DESCRIPTION
This patchset extends the already existing `update_metric` with a new `set=42` parameter. Instead of incrementing a counter, `set` will assign a value to the counter.

```
    update_metric("demo_gauge", set=int($MSG), labels={"host": "demo"});
```

When `set` is omitted, we fall back to increment, exactly the way `update_metric` is used to behave earlier. 

Only nonnegative values are supported. Setting negative values result in error evaluation time:
```
[2026-09-05T11:55:46.251764] FilterX: update_metric() eval error, skipping; err_idx='[1/1]', expr='n/a', error='Failed to evaluate update_metric(): Metric value must be non-negative, got: -100'
```