### PR TITLE
`s3`: two more small fixes

### DIFF
--- a/modules/python-modules/syslogng/modules/s3/s3_object.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_object.py
@@ -25,7 +25,12 @@ from __future__ import annotations
 from .compressable_file_buffer import CompressableFileBuffer
 
 try:
-    from botocore.exceptions import ClientError, EndpointConnectionError
+    from botocore.exceptions import ClientError, ConnectionError as BotocoreConnectionError, HTTPClientError
+
+    # botocore raises these when its own retries did not get past a network failure, like a refused
+    # connection, a timeout or a closed connection.  Errors raised without a network call, like
+    # ParamValidationError, are left out, as the next attempt fails the same way.
+    TRANSIENT_ERRORS = (BotocoreConnectionError, HTTPClientError)
 except ImportError:
     pass
 
@@ -657,7 +662,7 @@ class S3Object:
                     **extra_args,
                 )
                 self.__logger.debug(f"Multipart upload created for {self.bucket}/{self.key}")
-            except (ClientError, EndpointConnectionError) as e:
+            except (ClientError, *TRANSIENT_ERRORS) as e:
                 self.__logger.error(f"Failed to create multipart upload: {self.bucket}/{self.key} => {e}")
                 return False
 
@@ -697,8 +702,9 @@ class S3Object:
                 Body=chunk.buffer.getvalue(),
             )
             self.__logger.debug(f"Multipart upload finished for {self.bucket}/{self.key}")
-        except EndpointConnectionError as e:
+        except TRANSIENT_ERRORS as e:
             self.__logger.error(f"Failed to upload part: {self.bucket}/{self.key} ({chunk.part_number}) => {e}")
+            # no retry cap here: a network failure carries no verdict on the part, unlike a status code
             self.__upload_chunk(chunk, is_retry=True)
             return
         except ClientError as e:
@@ -818,7 +824,7 @@ class S3Object:
                 UploadId=self.__persist.upload_id,
             )
             self.__logger.debug(f"Multipart upload aborted for {self.bucket}/{self.key}")
-        except EndpointConnectionError as e:
+        except TRANSIENT_ERRORS as e:
             self.__logger.error(f"Failed to abort multipart upload: {self.bucket}/{self.key} => {e}")
             return False
         except ClientError as e:
@@ -873,7 +879,7 @@ class S3Object:
                 UploadId=self.__persist.upload_id,
             )
             self.__logger.info(f"Object created {self.bucket}/{self.key}")
-        except EndpointConnectionError as e:
+        except TRANSIENT_ERRORS as e:
             self.__logger.error(f"Failed to complete multipart upload: {self.bucket}/{self.key} => {e}")
             self.__complete_multipart(is_retry=True)
             return
@@ -974,7 +980,7 @@ class S3Object:
                     Prefix=self.target_key,
                     **pagination_options,
                 )
-            except (ClientError, EndpointConnectionError) as e:
+            except (ClientError, *TRANSIENT_ERRORS) as e:
                 self.__logger.error(f"Failed to list multipart uploads: {self.bucket}/{self.key} => {e}")
                 return None
 
@@ -1006,7 +1012,7 @@ class S3Object:
                     Prefix=self.target_key,
                     **pagination_options,
                 )
-            except (ClientError, EndpointConnectionError) as e:
+            except (ClientError, *TRANSIENT_ERRORS) as e:
                 self.__logger.error(f"Failed to list objects: {self.bucket}/{self.key} => {e}")
                 return None
 

--- a/modules/python-modules/syslogng/modules/s3/s3_object.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_object.py
@@ -777,42 +777,34 @@ class S3Object:
         """Raises OSError on write failure. Cannot be called from multiple threads."""
         with self.__lock:
             chunk = self.__current_chunk
-        if chunk is None:
-            with self.__lock:
+            if chunk is None:
                 if self.__prev_chunk is None:
                     # the flush timer can finish this object between the caller selecting it and this write
                     raise AlreadyFinishedError()
-                self.__current_chunk = self.__prev_chunk.create_next()
+                chunk = self.__current_chunk = self.__prev_chunk.create_next()
                 self.__prev_chunk = None
-                self.__persist.add_pending_part(self.__current_chunk.buffer.path, self.__current_chunk.part_number)
-                chunk = self.__current_chunk
+                self.__persist.add_pending_part(chunk.buffer.path, chunk.part_number)
 
-        old_size = chunk.buffer.tell()
-        chunk.buffer.write(data)
-        new_size = chunk.buffer.tell()
-        self.__size += new_size - old_size
+            # the lock must cover the write, or finish() closes the buffer underneath
+            old_size = chunk.buffer.tell()
+            chunk.buffer.write(data)
+            new_size = chunk.buffer.tell()
+            self.__size += new_size - old_size
+            self.__modified_at = monotonic()
 
-        self.__modified_at = monotonic()
-
-        if new_size > self.__persist.chunk_size:
-            self.__lock.acquire()
-
-            if self.__current_chunk is None:
-                # finish() was called while we were writing the buffer (part upload failure or the flush timer).
-                self.__lock.release()
-                raise AlreadyFinishedError()
-
-            if self.__current_chunk.part_number == S3Chunk.MAX_PART_NUMBER:
-                self.__lock.release()
-                self.finish()
+            if new_size <= self.__persist.chunk_size:
                 return
 
-            self.__prev_chunk = self.__current_chunk
-            self.__current_chunk = None
+            next_part_number_available = chunk.part_number < S3Chunk.MAX_PART_NUMBER
+            if next_part_number_available:
+                self.__prev_chunk = chunk
+                self.__current_chunk = None
 
-            self.__lock.release()
-
+        # both take the lock themselves
+        if next_part_number_available:
             self.__upload_chunk(chunk)
+        else:
+            self.finish()
 
     def __abort_multipart(self) -> bool:
         assert self.__persist.upload_id

--- a/modules/python-modules/syslogng/modules/s3/tests/test_s3_object.py
+++ b/modules/python-modules/syslogng/modules/s3/tests/test_s3_object.py
@@ -28,6 +28,7 @@ import pytest
 pytest.importorskip("botocore")
 
 from botocore.exceptions import ClientError, EndpointConnectionError, ReadTimeoutError  # noqa: E402
+from syslogng.modules.s3.compressable_file_buffer import CompressableFileBuffer  # noqa: E402
 from syslogng.modules.s3.s3_object import PART_UPLOAD_MAX_RETRIES, AlreadyFinishedError, S3Object, S3ObjectPersist  # noqa: E402
 
 LOGGER = getLogger(__name__)
@@ -36,6 +37,9 @@ CHUNK_SIZE = S3Object.MIN_CHUNK_SIZE_BYTES
 # A part upload must never wait for another task of the same pool.  Every wait below is bounded, so
 # a regression fails the test instead of hanging the whole test run.
 WAIT_TIMEOUT_SECONDS = 30
+
+# A negative probe: finish() must still be blocked when it expires, so it is short on purpose.
+BLOCKED_PROBE_SECONDS = 0.5
 
 
 class FakeS3Client:
@@ -199,6 +203,46 @@ def test_finish_after_a_chunk_rollover_closes_the_object(tmp_path):
     assert wait_for_uploads([s3_object])
     assert client.completed_parts == {"test-key-0.log": [1]}
     assert leftover_files(tmp_path) == []
+
+
+def test_finish_waits_for_an_in_flight_write(tmp_path, monkeypatch):
+    """Regression test: write() released the lock before writing the buffer, so a finish() from the
+    flush timer closed the chunk underneath and the write failed with an AssertionError."""
+    client = FakeS3Client()
+    s3_object = create_s3_object(tmp_path, ThreadPoolExecutor(max_workers=8), client, Event())
+    in_write = Event()
+    release_write = Event()
+    real_write = CompressableFileBuffer.write
+
+    def gated_write(buffer, data):
+        in_write.set()
+        assert release_write.wait(WAIT_TIMEOUT_SECONDS)
+        return real_write(buffer, data)
+
+    monkeypatch.setattr(CompressableFileBuffer, "write", gated_write)
+    errors = []
+
+    def write_while_gated():
+        try:
+            s3_object.write(b"data")
+        except Exception as e:
+            errors.append(e)
+
+    writer = Thread(target=write_while_gated)
+    writer.start()
+    assert in_write.wait(WAIT_TIMEOUT_SECONDS)
+    finisher = Thread(target=s3_object.finish)
+    finisher.start()
+    finisher.join(BLOCKED_PROBE_SECONDS)
+    finish_returned_early = not finisher.is_alive()
+    release_write.set()
+    writer.join(WAIT_TIMEOUT_SECONDS)
+    finisher.join(WAIT_TIMEOUT_SECONDS)
+
+    assert not finish_returned_early, "finish() closed the chunk while write() was still writing it"
+    assert errors == []
+    assert wait_for_uploads([s3_object])
+    assert client.completed_parts == {"test-key-0.log": [1]}
 
 
 def test_transient_part_upload_failure_is_retried(tmp_path):

--- a/modules/python-modules/syslogng/modules/s3/tests/test_s3_object.py
+++ b/modules/python-modules/syslogng/modules/s3/tests/test_s3_object.py
@@ -27,7 +27,7 @@ import pytest
 
 pytest.importorskip("botocore")
 
-from botocore.exceptions import ClientError, EndpointConnectionError  # noqa: E402
+from botocore.exceptions import ClientError, EndpointConnectionError, ReadTimeoutError  # noqa: E402
 from syslogng.modules.s3.s3_object import PART_UPLOAD_MAX_RETRIES, AlreadyFinishedError, S3Object, S3ObjectPersist  # noqa: E402
 
 LOGGER = getLogger(__name__)
@@ -44,6 +44,7 @@ class FakeS3Client:
     def __init__(
         self,
         transient_failure_part=None,
+        transient_failure_error=None,
         retryable_failure_part=None,
         retryable_failures=1,
         permanent_failure_part=None,
@@ -51,6 +52,7 @@ class FakeS3Client:
         failure_gate=None,
     ):
         self.transient_failure_part = transient_failure_part
+        self.transient_failure_error = transient_failure_error or EndpointConnectionError(endpoint_url="http://localhost")
         self.retryable_failure_part = retryable_failure_part
         self.retryable_failures = retryable_failures
         self.permanent_failure_part = permanent_failure_part
@@ -72,7 +74,7 @@ class FakeS3Client:
 
     def __injected_failure(self, part_number, attempt):
         if part_number == self.transient_failure_part and attempt == 1:
-            return EndpointConnectionError(endpoint_url="http://localhost")
+            return self.transient_failure_error
         if part_number == self.retryable_failure_part and attempt <= self.retryable_failures:
             return ClientError(
                 {"Error": {"Code": "InternalError"}, "ResponseMetadata": {"HTTPStatusCode": 500}},
@@ -201,6 +203,18 @@ def test_finish_after_a_chunk_rollover_closes_the_object(tmp_path):
 
 def test_transient_part_upload_failure_is_retried(tmp_path):
     client = FakeS3Client(transient_failure_part=2)
+    s3_object = create_s3_object(tmp_path, ThreadPoolExecutor(max_workers=8), client, Event())
+    write_parts(s3_object, 3)
+    s3_object.finish()
+
+    assert wait_for_uploads([s3_object])
+    assert client.completed_parts == {"test-key-0.log": [1, 2, 3]}
+
+
+def test_read_timeout_on_a_part_upload_is_retried(tmp_path):
+    """Regression test: only EndpointConnectionError was retried, every other botocore network error
+    abandoned the part."""
+    client = FakeS3Client(transient_failure_part=2, transient_failure_error=ReadTimeoutError(endpoint_url="http://localhost"))
     s3_object = create_s3_object(tmp_path, ThreadPoolExecutor(max_workers=8), client, Event())
     write_parts(s3_object, 3)
     s3_object.finish()

--- a/news/bugfix-1228-1.md
+++ b/news/bugfix-1228-1.md
@@ -1,0 +1,5 @@
+`s3`: retry part uploads on every network error
+
+Only a refused connection was retried. A timeout or a closed connection during a part upload was
+treated as an unexpected error, which left the part on disk until the next start and crashed the
+destination on shutdown.

--- a/news/bugfix-1228-2.md
+++ b/news/bugfix-1228-2.md
@@ -1,0 +1,4 @@
+`s3`: fixed an `AssertionError` when the flush timer finished an object during a write
+
+The flush timer could close the chunk while a message was being written to it. The write then
+failed with an assertion that was logged as an unhandled exception and the message was retried.


### PR DESCRIPTION
Two bugs that predate #1211.

---

Only a refused connection was retried on a part upload.

`botocore` raises:
* `ReadTimeoutError`
* `ConnectTimeoutError`
* `ConnectionClosedError`
* `SSLError`

after its own retries give up, and none of them is an `EndpointConnectionError` subclass, so they escaped the retry and abandoned the part until the next start.

Every S3 call now treats `botocore`'s `ConnectionError` and `HTTPClientError` families as transient.

---

`write()` picked the chunk under the object lock and wrote its buffer after releasing it.

A `finish()` from the flush timer in between closed the buffer, and the write failed with an `AssertionError` that `send()` does not catch.

The buffer is now written under the lock.

---

Depends on #1211.
