### PR TITLE
almalinux-9: `sql()` destination support

### DIFF
--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -43,5 +43,5 @@ ubuntu-resolute	python3
 
 fedora			python3
 almalinux-8		python3,noriemann,nokafka,nomqtt,nojava,nogrpc,nobpf
-almalinux-9		python3,nojava,nosql
+almalinux-9		python3,nojava
 almalinux-10		python3,nojava,nosql

--- a/news/packaging-1230.md
+++ b/news/packaging-1230.md
@@ -1,0 +1,3 @@
+`sql()` destination: The AlmaLinux 9 packages now include it in the `axosyslog-sql` package.
+
+EPEL 9 ships libdbi and its `libdbi-dbd-*` drivers, so the module is available on EL 9.

--- a/packaging/rhel/axosyslog.spec
+++ b/packaging/rhel/axosyslog.spec
@@ -78,7 +78,7 @@ BuildRequires: json-c-devel
 BuildRequires: llvm-devel
 BuildRequires: clang
 BuildRequires: libcap-devel
-%if 0%{?rhel} <= 8
+%if %{with sql}
 BuildRequires: libdbi-devel
 %endif
 BuildRequires: libnet-devel


### PR DESCRIPTION
* EPEL 9 ships `libdbi-devel` and `libdbi-drivers`.
* EPEL 10 ships `libdbi-devel` but not `libdbi-drivers`.