### PR TITLE
Logproto drop handshake method

### DIFF
--- a/lib/logproto/logproto-auto-server.c
+++ b/lib/logproto/logproto-auto-server.c
@@ -103,9 +103,13 @@ log_proto_auto_server_poll_prepare(LogProtoServer *s, GIOCondition *cond, gint *
 }
 
 static LogProtoStatus
-log_proto_auto_handshake(LogProtoServer *s, gboolean *handshake_finished, LogProtoServer **proto_replacement)
+log_proto_auto_server_fetch(LogProtoServer *s, const guchar **msg, gsize *msg_len,
+                            gboolean *may_read, LogTransportAuxData *aux, Bookmark *bookmark)
 {
   LogProtoAutoServer *self = (LogProtoAutoServer *) s;
+
+  *msg = NULL;
+  *msg_len = 0;
 
   gint rc;
   const gchar *detect_buffer = log_transport_stack_look_ahead(&self->super.transport_stack, &rc);
@@ -119,11 +123,9 @@ log_proto_auto_handshake(LogProtoServer *s, gboolean *handshake_finished, LogPro
       return LPS_ERROR;
     }
 
-  *proto_replacement = _construct_detected_proto(self, detect_buffer, rc);
-  if (!*proto_replacement)
-    return LPS_AGAIN;
+  self->super.proto_replacement = _construct_detected_proto(self, detect_buffer, rc);
 
-  return LPS_SUCCESS;
+  return LPS_AGAIN;
 }
 
 static void
@@ -147,7 +149,7 @@ log_proto_auto_server_new(LogTransport *transport, const LogProtoServerOptions *
    * the LogProto implementation once we finished with detection */
 
   log_proto_server_init(&self->super, transport, options);
-  self->super.handshake = log_proto_auto_handshake;
+  self->super.fetch = log_proto_auto_server_fetch;
   self->super.poll_prepare = log_proto_auto_server_poll_prepare;
   self->super.free_fn = log_proto_auto_server_free;
   self->kb = kb ? stats_cluster_key_builder_clone(kb) : NULL;

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -72,7 +72,6 @@ struct _LogProtoClient
   LogProtoStatus (*process_in)(LogProtoClient *s);
   LogProtoStatus (*flush)(LogProtoClient *s);
   gboolean (*validate_options)(LogProtoClient *s);
-  LogProtoStatus (*handshake)(LogProtoClient *s, gboolean *handshake_finished);
   gboolean (*restart_with_state)(LogProtoClient *s, PersistState *state, const gchar *persist_name);
   void (*free_fn)(LogProtoClient *s);
   LogProtoClientFlowControlFuncs flow_control_funcs;
@@ -109,17 +108,6 @@ static inline gboolean
 log_proto_client_validate_options(LogProtoClient *self)
 {
   return self->validate_options(self);
-}
-
-static inline LogProtoStatus
-log_proto_client_handshake(LogProtoClient *s, gboolean *handshake_finished)
-{
-  if (s->handshake)
-    {
-      return s->handshake(s, handshake_finished);
-    }
-  *handshake_finished = TRUE;
-  return LPS_SUCCESS;
 }
 
 static inline gboolean

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -95,7 +95,6 @@ struct _LogProtoServer
                           LogTransportAuxData *aux, Bookmark *bookmark);
   LogProtoStatus (*fetch_structured)(LogProtoServer *s, LogMessage **msg, LogTransportAuxData *aux, Bookmark *bookmark);
   gboolean (*validate_options)(LogProtoServer *s);
-  LogProtoStatus (*handshake)(LogProtoServer *s, gboolean *handshake_finished, LogProtoServer **proto_replacement);
   void (*free_fn)(LogProtoServer *s);
 };
 
@@ -103,25 +102,6 @@ static inline gboolean
 log_proto_server_validate_options(LogProtoServer *self)
 {
   return self->validate_options(self);
-}
-
-static inline LogProtoStatus
-log_proto_server_handshake(LogProtoServer *s, gboolean *handshake_finished, LogProtoServer **proto_replacement)
-{
-  if (s->handshake)
-    {
-      LogProtoStatus status;
-
-      g_assert(*proto_replacement == NULL);
-      status = s->handshake(s, handshake_finished, proto_replacement);
-      if (*proto_replacement)
-        {
-          g_assert(status == LPS_SUCCESS || status == LPS_AGAIN);
-        }
-      return status;
-    }
-  *handshake_finished = TRUE;
-  return LPS_SUCCESS;
 }
 
 static inline void

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -83,6 +83,12 @@ struct _LogProtoServer
   AckTracker *ack_tracker;
 
   LogProtoServerWakeupCallback wakeup_callback;
+
+  /* To change from one proto implementation to another, store the new one
+   * here and return LPS_AGAIN from fetch().
+   */
+  LogProtoServer *proto_replacement;
+
   LogProtoPrepareAction (*poll_prepare)(LogProtoServer *s, GIOCondition *cond, gint *timeout);
   gboolean (*restart_with_state)(LogProtoServer *s, PersistState *state, const gchar *persist_name);
   LogProtoStatus (*fetch)(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read,
@@ -208,6 +214,28 @@ log_proto_server_set_ack_tracker(LogProtoServer *s, AckTracker *ack_tracker)
 {
   g_assert(ack_tracker);
   s->ack_tracker = ack_tracker;
+}
+
+/* Perform the replacement a fetch() asked for, should be called when fetch
+ * returns LPS_AGAIN.  */
+static inline gboolean
+log_proto_server_apply_replacement(LogProtoServer **proto)
+{
+  LogProtoServer *old_proto = *proto;
+  LogProtoServer *replacement = old_proto->proto_replacement;
+
+  if (!replacement)
+    return FALSE;
+
+  old_proto->proto_replacement = NULL;
+  log_transport_stack_move(&replacement->transport_stack, &old_proto->transport_stack);
+  if (old_proto->ack_tracker)
+    log_proto_server_set_ack_tracker(replacement, old_proto->ack_tracker);
+  replacement->wakeup_callback = old_proto->wakeup_callback;
+  log_proto_server_free(old_proto);
+
+  *proto = replacement;
+  return TRUE;
 }
 
 #define DEFINE_LOG_PROTO_SERVER(prefix, options...) \

--- a/lib/logproto/tests/test-auto-server.c
+++ b/lib/logproto/tests/test-auto-server.c
@@ -30,6 +30,27 @@
 
 #include <errno.h>
 
+/* a single fetch that returned neither a message nor a replacement */
+static void
+assert_detection_pending(LogProtoServer *proto)
+{
+  const guchar *msg = NULL;
+  gsize msg_len = 0;
+  LogTransportAuxData aux = {0};
+  Bookmark bookmark;
+  gboolean may_read = TRUE;
+  LogProtoStatus status;
+
+  log_transport_aux_data_init(&aux);
+  status = log_proto_server_fetch(proto, &msg, &msg_len, &may_read, &aux, &bookmark);
+  log_transport_aux_data_destroy(&aux);
+
+  assert_proto_server_status(proto, status, LPS_AGAIN);
+  cr_assert_null(msg, "the auto server must never return a message of its own");
+  cr_assert_null(proto->proto_replacement,
+                 "detection must not conclude before it has enough data to tell the framing apart");
+}
+
 Test(log_proto, test_log_proto_initial_framing_too_long)
 {
   LogProtoServer *proto;
@@ -41,8 +62,8 @@ Test(log_proto, test_log_proto_initial_framing_too_long)
             get_inited_proto_server_options(),
             NULL);
 
-  assert_proto_server_handshake_failure(&proto, LPS_SUCCESS);
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, NULL);
+  assert_proto_server_replacement(&proto, "Auto-detected octet-counted-framing");
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, NULL);
   log_proto_server_free(proto);
 }
 
@@ -56,7 +77,21 @@ Test(log_proto, test_log_proto_error_in_initial_frame)
             get_inited_proto_server_options(),
             NULL);
 
-  assert_proto_server_handshake_failure(&proto, LPS_ERROR);
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, NULL);
+  log_proto_server_free(proto);
+}
+
+Test(log_proto, test_log_proto_eof_before_detection)
+{
+  LogProtoServer *proto;
+
+  proto = log_proto_auto_server_new(
+            log_transport_mock_stream_new(
+              LTM_EOF),
+            get_inited_proto_server_options(),
+            NULL);
+
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }
 
@@ -74,12 +109,12 @@ Test(log_proto, test_log_proto_auto_server_no_framing)
             get_inited_proto_server_options(),
             NULL);
 
-  assert_proto_server_handshake(&proto);
-  assert_proto_server_fetch(proto, "abcdefghijklmnopqstuvwxyz", -1);
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch(proto, "01234567", 8);
-  assert_proto_server_fetch(proto, "abcdef", -1);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_replacement(&proto, "Unable to detect framing");
+  assert_proto_server_fetch(&proto, "abcdefghijklmnopqstuvwxyz", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "01234567", 8);
+  assert_proto_server_fetch(&proto, "abcdef", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }
 
@@ -97,12 +132,12 @@ Test(log_proto, test_log_proto_auto_server_opening_bracket)
             get_inited_proto_server_options(),
             NULL);
 
-  assert_proto_server_handshake(&proto);
-  assert_proto_server_fetch(proto, "<55> abcdefghijklmnopqstuvwxyz", -1);
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch(proto, "01234567", 8);
-  assert_proto_server_fetch(proto, "abcdef", -1);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_replacement(&proto, "Auto-detected non-transparent-framing");
+  assert_proto_server_fetch(&proto, "<55> abcdefghijklmnopqstuvwxyz", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "01234567", 8);
+  assert_proto_server_fetch(&proto, "abcdef", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }
 
@@ -127,17 +162,19 @@ Test(log_proto, test_log_proto_auto_server_with_framing)
             get_inited_proto_server_options(),
             NULL);
 
-  assert_proto_server_handshake(&proto);
-  assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", -1);
-  assert_proto_server_fetch(proto, "01234567\n\n", -1);
-  assert_proto_server_fetch(proto, "01234567\0\0", 10);
-  assert_proto_server_fetch(proto, "árvíztűrőtükörfúrógép", -1);
-  assert_proto_server_fetch(proto,
+  /* the mock hands out one byte per read, so the first fetch only sees "3" */
+  assert_detection_pending(proto);
+  assert_proto_server_replacement(&proto, "Auto-detected octet-counted-framing");
+  assert_proto_server_fetch(&proto, "0123456789ABCDEF0123456789ABCDEF", -1);
+  assert_proto_server_fetch(&proto, "01234567\n\n", -1);
+  assert_proto_server_fetch(&proto, "01234567\0\0", 10);
+  assert_proto_server_fetch(&proto, "árvíztűrőtükörfúrógép", -1);
+  assert_proto_server_fetch(&proto,
                             "\xe1\x72\x76\xed\x7a\x74\xfb\x72\xf5\x74\xfc\x6b\xf6\x72\x66\xfa"        /*  |.rv.zt.r.t.k.rf.| */
                             "\x72\xf3\x67\xe9\x70", -1);                                              /*  |r.g.p|            */
-  assert_proto_server_fetch(proto,
+  assert_proto_server_fetch(&proto,
                             "\x00\x00\x00\xe1\x00\x00\x00\x72\x00\x00\x00\x76\x00\x00\x00\xed"        /* |...á...r...v...í| */
                             "\x00\x00\x00\x7a\x00\x00\x00\x74\x00\x00\x01\x71\x00\x00\x00\x72", 32);  /* |...z...t...q...r|  */
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }

--- a/lib/logproto/tests/test-dgram-server.c
+++ b/lib/logproto/tests/test-dgram-server.c
@@ -51,24 +51,24 @@ Test(log_proto, test_log_proto_dgram_server_no_encoding)
               "01234", 5,
               LTM_EOF),
             get_inited_proto_server_options());
-  assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", -1);
-  assert_proto_server_fetch(proto, "01234567\n", -1);
-  assert_proto_server_fetch(proto, "01234567\0", 9);
+  assert_proto_server_fetch(&proto, "0123456789ABCDEF0123456789ABCDEF", -1);
+  assert_proto_server_fetch(&proto, "01234567\n", -1);
+  assert_proto_server_fetch(&proto, "01234567\0", 9);
 
   /* no encoding: utf8 remains utf8 */
-  assert_proto_server_fetch(proto, "árvíztűrőtükörfúrógép\n\n", -1);
+  assert_proto_server_fetch(&proto, "árvíztűrőtükörfúrógép\n\n", -1);
 
   /* no encoding: iso-8859-2 remains iso-8859-2 */
-  assert_proto_server_fetch(proto,
+  assert_proto_server_fetch(&proto,
                             "\xe1\x72\x76\xed\x7a\x74\xfb\x72\xf5\x74\xfc\x6b\xf6\x72\x66\xfa" /*  |.rv.zt.r.t.k.rf.| */
                             "\x72\xf3\x67\xe9\x70\n",                                          /*  |r.g.p|            */
                             -1);
   /* no encoding, ucs4 becomes a string with embedded NULs */
-  assert_proto_server_fetch(proto,
+  assert_proto_server_fetch(&proto,
                             "\x00\x00\x00\xe1\x00\x00\x00\x72\x00\x00\x00\x76\x00\x00\x00\xed"       /* |...á...r...v...í| */
                             "\x00\x00\x00\x7a\x00\x00\x00\x74\x00\x00\x01\x71\x00\x00\x00\x72", 32); /* |...z...t...ű...r|  */
 
-  assert_proto_server_fetch(proto, "01234", -1);
+  assert_proto_server_fetch(&proto, "01234", -1);
 
   log_proto_server_free(proto);
 }
@@ -92,8 +92,8 @@ Test(log_proto, test_log_proto_dgram_server_ucs4)
 
               LTM_EOF),
             get_inited_proto_server_options());
-  assert_proto_server_fetch(proto, "árvíztűr", -1);
-  assert_proto_server_fetch(proto, "árvíztű\n", -1);
+  assert_proto_server_fetch(&proto, "árvíztűr", -1);
+  assert_proto_server_fetch(&proto, "árvíztű\n", -1);
   log_proto_server_free(proto);
 }
 
@@ -111,7 +111,7 @@ Test(log_proto, test_log_proto_dgram_server_invalid_ucs4)
               "\x00\x00\x00\x7a\x00\x00\x00\x74\x00\x00\x01\x71\x00\x00\x00", 31, /* |...z...t...ű...r|  */
               LTM_EOF),
             get_inited_proto_server_options());
-  assert_proto_server_fetch_failure(proto, LPS_ERROR,
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR,
                                     "Byte sequence too short, cannot convert an individual frame in its entirety");
   log_proto_server_free(proto);
 }
@@ -132,8 +132,8 @@ Test(log_proto, test_log_proto_dgram_server_iso_8859_2)
               "\x72\xf3\x67\xe9\x70\xe9\xe9\xe9\xe9\xe9\xe9\xe9\xe9\xe9\xe9\xe9", -1,  /*  |rógépééééééééééé| */
               LTM_EOF),
             get_inited_proto_server_options());
-  assert_proto_server_fetch(proto, "árvíztűrőtükörfúrógépééééééééééé", -1);
-  assert_proto_server_fetch_ignored_eof(proto);
+  assert_proto_server_fetch(&proto, "árvíztűrőtükörfúrógépééééééééééé", -1);
+  assert_proto_server_fetch_ignored_eof(&proto);
   log_proto_server_free(proto);
 }
 
@@ -149,9 +149,9 @@ Test(log_proto, test_log_proto_dgram_server_eof_handling)
 
               LTM_EOF),
             get_inited_proto_server_options());
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch_ignored_eof(proto);
-  assert_proto_server_fetch_ignored_eof(proto);
-  assert_proto_server_fetch_ignored_eof(proto);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch_ignored_eof(&proto);
+  assert_proto_server_fetch_ignored_eof(&proto);
+  assert_proto_server_fetch_ignored_eof(&proto);
   log_proto_server_free(proto);
 }

--- a/lib/logproto/tests/test-framed-server.c
+++ b/lib/logproto/tests/test-framed-server.c
@@ -50,17 +50,17 @@ Test(log_proto, test_log_proto_framed_server_simple_messages)
               "\x00\x00\x00\x7a\x00\x00\x00\x74\x00\x00\x01\x71\x00\x00\x00\x72", 35,    /* |...z...t...ű...r|  */
               LTM_EOF),
             get_inited_proto_server_options(), NULL);
-  assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", -1);
-  assert_proto_server_fetch(proto, "01234567\n\n", -1);
-  assert_proto_server_fetch(proto, "01234567\0\0", 10);
-  assert_proto_server_fetch(proto, "árvíztűrőtükörfúrógép", -1);
-  assert_proto_server_fetch(proto,
+  assert_proto_server_fetch(&proto, "0123456789ABCDEF0123456789ABCDEF", -1);
+  assert_proto_server_fetch(&proto, "01234567\n\n", -1);
+  assert_proto_server_fetch(&proto, "01234567\0\0", 10);
+  assert_proto_server_fetch(&proto, "árvíztűrőtükörfúrógép", -1);
+  assert_proto_server_fetch(&proto,
                             "\xe1\x72\x76\xed\x7a\x74\xfb\x72\xf5\x74\xfc\x6b\xf6\x72\x66\xfa"        /*  |.rv.zt.r.t.k.rf.| */
                             "\x72\xf3\x67\xe9\x70", -1);                                              /*  |r.g.p|            */
-  assert_proto_server_fetch(proto,
+  assert_proto_server_fetch(&proto,
                             "\x00\x00\x00\xe1\x00\x00\x00\x72\x00\x00\x00\x76\x00\x00\x00\xed"        /* |...á...r...v...í| */
                             "\x00\x00\x00\x7a\x00\x00\x00\x74\x00\x00\x01\x71\x00\x00\x00\x72", 32);  /* |...z...t...q...r|  */
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }
 
@@ -75,8 +75,8 @@ Test(log_proto, test_log_proto_framed_server_io_error)
               LTM_INJECT_ERROR(EIO),
               LTM_EOF),
             get_inited_proto_server_options(), NULL);
-  assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", -1);
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, "Error reading RFC6587 style framed data");
+  assert_proto_server_fetch(&proto, "0123456789ABCDEF0123456789ABCDEF", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, "Error reading RFC6587 style framed data");
   log_proto_server_free(proto);
 }
 
@@ -91,7 +91,7 @@ Test(log_proto, test_log_proto_framed_server_invalid_header)
               "1q 0123456789ABCDEF0123456789ABCDEF", -1,
               LTM_EOF),
             get_inited_proto_server_options(), NULL);
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, "Invalid frame header");
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, "Invalid frame header");
   log_proto_server_free(proto);
 }
 
@@ -105,7 +105,7 @@ Test(log_proto, test_log_proto_framed_server_too_long_line)
               "48 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF", -1,
               LTM_EOF),
             get_inited_proto_server_options(), NULL);
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, "Incoming frame larger than log_msg_size()");
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, "Incoming frame larger than log_msg_size()");
   log_proto_server_free(proto);
 }
 
@@ -122,8 +122,8 @@ Test(log_proto, test_log_proto_framed_server_too_long_line_trimmed)
               "48 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF", -1,
               LTM_EOF),
             get_inited_proto_server_options(), NULL);
-  assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", 32);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch(&proto, "0123456789ABCDEF0123456789ABCDEF", 32);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }
 
@@ -145,10 +145,10 @@ Test(log_proto, test_log_proto_framed_server_too_long_line_trimmed_multiple_cycl
               "1 2", -1,
               LTM_EOF),
             get_inited_proto_server_options(), NULL);
-  assert_proto_server_fetch(proto, "0",  1);
-  assert_proto_server_fetch(proto, "1a", 2);
-  assert_proto_server_fetch(proto, "2",  1);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch(&proto, "0",  1);
+  assert_proto_server_fetch(&proto, "1a", 2);
+  assert_proto_server_fetch(&proto, "2",  1);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }
 
@@ -176,11 +176,11 @@ Test(log_proto, test_log_proto_framed_server_too_long_line_trimmed_frame_at_the_
               " 2abc",     -1,
               LTM_EOF),
             get_inited_proto_server_options(), NULL);
-  assert_proto_server_fetch(proto, "01\n",     3);
-  assert_proto_server_fetch(proto, "1abcdefg", 8);
+  assert_proto_server_fetch(&proto, "01\n",     3);
+  assert_proto_server_fetch(&proto, "1abcdefg", 8);
   // dropping: 1234567
-  assert_proto_server_fetch(proto, "2abc",  4);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch(&proto, "2abc",  4);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }
 
@@ -197,8 +197,8 @@ Test(log_proto, test_log_proto_framed_server_too_long_line_trimmed_one_big_messa
               "2 ab16 0123456789ABCDEF", -1,
               LTM_EOF),
             get_inited_proto_server_options(), NULL);
-  assert_proto_server_fetch(proto, "ab",          2);
-  assert_proto_server_fetch(proto, "0123456789", 10);
+  assert_proto_server_fetch(&proto, "ab",          2);
+  assert_proto_server_fetch(&proto, "0123456789", 10);
   log_proto_server_free(proto);
 }
 
@@ -215,8 +215,8 @@ Test(log_proto, test_log_proto_framed_server_message_exceeds_buffer)
               "16 0123456789ABCDE\n16 0123456789ABCDE\n", -1,
               LTM_EOF),
             get_inited_proto_server_options(), NULL);
-  assert_proto_server_fetch(proto, "0123456789ABCDE\n", -1);
-  assert_proto_server_fetch(proto, "0123456789ABCDE\n", -1);
+  assert_proto_server_fetch(&proto, "0123456789ABCDE\n", -1);
+  assert_proto_server_fetch(&proto, "0123456789ABCDE\n", -1);
   log_proto_server_free(proto);
 }
 
@@ -235,8 +235,8 @@ Test(log_proto, test_log_proto_framed_server_buffer_shift_before_fetch)
               " 123\n", -1,
               LTM_EOF),
             get_inited_proto_server_options(), NULL);
-  assert_proto_server_fetch(proto, "012345\n", -1);
-  assert_proto_server_fetch(proto, "123\n", -1);
+  assert_proto_server_fetch(&proto, "012345\n", -1);
+  assert_proto_server_fetch(&proto, "123\n", -1);
   log_proto_server_free(proto);
 }
 
@@ -255,8 +255,8 @@ Test(log_proto, test_log_proto_framed_server_buffer_shift_to_make_space_for_a_fr
               "123\n", -1,
               LTM_EOF),
             get_inited_proto_server_options(), NULL);
-  assert_proto_server_fetch(proto, "01234\n", -1);
-  assert_proto_server_fetch(proto, "123\n", -1);
+  assert_proto_server_fetch(&proto, "01234\n", -1);
+  assert_proto_server_fetch(&proto, "123\n", -1);
   log_proto_server_free(proto);
 }
 
@@ -273,9 +273,9 @@ Test(log_proto, test_log_proto_framed_server_multi_read)
               LTM_INJECT_ERROR(EIO),
               LTM_EOF),
             get_inited_proto_server_options(), NULL);
-  assert_proto_server_fetch(proto, "foobar\n", -1);
+  assert_proto_server_fetch(&proto, "foobar\n", -1);
   /* with multi-read, we get the injected failure at the 2nd fetch */
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, "Error reading RFC6587 style framed data");
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, "Error reading RFC6587 style framed data");
   log_proto_server_free(proto);
 
   /* NOTE: LPBS_NOMREAD is not implemented for framed protocol */

--- a/lib/logproto/tests/test-indented-multiline-server.c
+++ b/lib/logproto/tests/test-indented-multiline-server.c
@@ -54,9 +54,9 @@ test_proper_multiline(LogTransportMockConstructor log_transport_mock_new)
               LTM_EOF),
             get_inited_proto_server_options());
 
-  assert_proto_server_fetch(proto, "0\n"
-                                   " 1=2\n"
-                                   " 3=4", -1);
+  assert_proto_server_fetch(&proto, "0\n"
+                                    " 1=2\n"
+                                    " 3=4", -1);
 
   log_proto_server_free(proto);
 }
@@ -84,8 +84,8 @@ test_line_without_continuation(LogTransportMockConstructor log_transport_mock_ne
               LTM_EOF),
             get_inited_proto_server_options());
 
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch(proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
 
   log_proto_server_free(proto);
 }
@@ -113,8 +113,8 @@ test_input_starts_with_continuation(LogTransportMockConstructor log_transport_mo
               LTM_EOF),
             get_inited_proto_server_options());
 
-  assert_proto_server_fetch(proto, " 01234567", -1);
-  assert_proto_server_fetch(proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, " 01234567", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
 
   log_proto_server_free(proto);
 }
@@ -141,10 +141,10 @@ test_multiline_at_eof(LogTransportMockConstructor log_transport_mock_new)
               LTM_EOF),
             get_inited_proto_server_options());
 
-  assert_proto_server_fetch(proto, "01234567\n"
-                                   " 01234567\n"
-                                   " end", -1);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch(&proto, "01234567\n"
+                                    " 01234567\n"
+                                    " end", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
 
   log_proto_server_free(proto);
 }

--- a/lib/logproto/tests/test-record-server.c
+++ b/lib/logproto/tests/test-record-server.c
@@ -50,17 +50,17 @@ Test(log_proto, test_log_proto_binary_record_server_no_encoding)
               "01234", 5,
               LTM_EOF),
             get_inited_proto_server_options(), 32);
-  assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", -1);
-  assert_proto_server_fetch(proto, "01234567\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n", -1);
-  assert_proto_server_fetch(proto, "01234567\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 32);
-  assert_proto_server_fetch(proto, "árvíztűrőtükörfúrógép\n\n", -1);
-  assert_proto_server_fetch(proto,
+  assert_proto_server_fetch(&proto, "0123456789ABCDEF0123456789ABCDEF", -1);
+  assert_proto_server_fetch(&proto, "01234567\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n", -1);
+  assert_proto_server_fetch(&proto, "01234567\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 32);
+  assert_proto_server_fetch(&proto, "árvíztűrőtükörfúrógép\n\n", -1);
+  assert_proto_server_fetch(&proto,
                             "\xe1\x72\x76\xed\x7a\x74\xfb\x72\xf5\x74\xfc\x6b\xf6\x72\x66\xfa"        /*  |.rv.zt.r.t.k.rf.| */
                             "\x72\xf3\x67\xe9\x70\n\n\n\n\n\n\n\n\n\n\n", -1);                        /*  |r.g.p|            */
-  assert_proto_server_fetch(proto,
+  assert_proto_server_fetch(&proto,
                             "\x00\x00\x00\xe1\x00\x00\x00\x72\x00\x00\x00\x76\x00\x00\x00\xed"        /* |...á...r...v...í| */
                             "\x00\x00\x00\x7a\x00\x00\x00\x74\x00\x00\x01\x71\x00\x00\x00\x72", 32);  /* |...z...t...q...r|  */
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, "Record size was set, and couldn't read enough bytes");
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, "Record size was set, and couldn't read enough bytes");
   log_proto_server_free(proto);
 }
 
@@ -85,21 +85,21 @@ Test(log_proto, test_log_proto_padded_record_server_no_encoding)
               "01234", 5,
               LTM_EOF),
             get_inited_proto_server_options(), 32);
-  assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", -1);
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch(proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "0123456789ABCDEF0123456789ABCDEF", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
 
   /* no encoding: utf8 remains utf8 */
-  assert_proto_server_fetch(proto, "árvíztűrőtükörfúrógép", -1);
+  assert_proto_server_fetch(&proto, "árvíztűrőtükörfúrógép", -1);
 
   /* no encoding: iso-8859-2 remains iso-8859-2 */
-  assert_proto_server_fetch(proto,
+  assert_proto_server_fetch(&proto,
                             "\xe1\x72\x76\xed\x7a\x74\xfb\x72\xf5\x74\xfc\x6b\xf6\x72\x66\xfa" /*  |.rv.zt.r.t.k.rf.| */
                             "\x72\xf3\x67\xe9\x70",                                            /*  |r.g.p|            */
                             -1);
   /* no encoding, ucs4 becomes an empty string as it starts with a zero byte */
-  assert_proto_server_fetch(proto, "", -1);
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, "Record size was set, and couldn't read enough bytes");
+  assert_proto_server_fetch(&proto, "", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, "Record size was set, and couldn't read enough bytes");
   log_proto_server_free(proto);
 }
 
@@ -122,9 +122,9 @@ Test(log_proto, test_log_proto_padded_record_server_ucs4)
               "01234", 5,
               LTM_EOF),
             get_inited_proto_server_options(), 32);
-  assert_proto_server_fetch(proto, "árvíztűr", -1);
-  assert_proto_server_fetch(proto, "árvíztű", -1);
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, "Record size was set, and couldn't read enough bytes");
+  assert_proto_server_fetch(&proto, "árvíztűr", -1);
+  assert_proto_server_fetch(&proto, "árvíztű", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, "Record size was set, and couldn't read enough bytes");
   log_proto_server_free(proto);
 }
 
@@ -141,7 +141,7 @@ Test(log_proto, test_log_proto_padded_record_server_invalid_ucs4)
               "\x00\x00\x00\x7a\x00\x00\x00\x74\x00\x00\x01\x71\x00\x00\x00", 31, /* |...z...t...ű...r|  */
               LTM_EOF),
             get_inited_proto_server_options(), 31);
-  assert_proto_server_fetch_failure(proto, LPS_ERROR,
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR,
                                     "Byte sequence too short, cannot convert an individual frame in its entirety");
   log_proto_server_free(proto);
 }
@@ -162,7 +162,7 @@ Test(log_proto, test_log_proto_padded_record_server_iso_8859_2)
               "\x72\xf3\x67\xe9\x70\xe9\xe9\xe9\xe9\xe9\xe9\xe9\xe9\xe9\xe9\xe9", -1,  /*  |rógépééééééééééé| */
               LTM_EOF),
             get_inited_proto_server_options(), 32);
-  assert_proto_server_fetch(proto, "árvíztűrőtükörfúrógépééééééééééé", -1);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch(&proto, "árvíztűrőtükörfúrógépééééééééééé", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }

--- a/lib/logproto/tests/test-regexp-multiline-server.c
+++ b/lib/logproto/tests/test-regexp-multiline-server.c
@@ -99,10 +99,10 @@ StaticParameterizedTest(LogTransportMockConstructor *log_transport_mock_new, log
               LTM_EOF),
             "^Foo", NULL);
 
-  assert_proto_server_fetch(proto, "Foo First Line", -1);
-  assert_proto_server_fetch(proto, "Foo Second Line", -1);
-  assert_proto_server_fetch(proto, "Foo Third Line", -1);
-  assert_proto_server_fetch(proto, "Foo Multiline\nmulti", -1);
+  assert_proto_server_fetch(&proto, "Foo First Line", -1);
+  assert_proto_server_fetch(&proto, "Foo Second Line", -1);
+  assert_proto_server_fetch(&proto, "Foo Third Line", -1);
+  assert_proto_server_fetch(&proto, "Foo Multiline\nmulti", -1);
 
   log_proto_server_free(proto);
 }
@@ -127,10 +127,10 @@ StaticParameterizedTest(LogTransportMockConstructor *log_transport_mock_new, log
               LTM_EOF),
             "^Foo", " Bar$");
 
-  assert_proto_server_fetch(proto, "Foo First Line", -1);
-  assert_proto_server_fetch(proto, "Foo Second Line", -1);
-  assert_proto_server_fetch(proto, "Foo Third Line", -1);
-  assert_proto_server_fetch(proto, "Foo Multiline\nmulti", -1);
+  assert_proto_server_fetch(&proto, "Foo First Line", -1);
+  assert_proto_server_fetch(&proto, "Foo Second Line", -1);
+  assert_proto_server_fetch(&proto, "Foo Third Line", -1);
+  assert_proto_server_fetch(&proto, "Foo Multiline\nmulti", -1);
 
   log_proto_server_free(proto);
 }
@@ -153,8 +153,8 @@ StaticParameterizedTest(LogTransportMockConstructor *log_transport_mock_new, log
               LTM_EOF),
             "^prefix", "suffix");
 
-  assert_proto_server_fetch(proto, "prefix first suffix", -1);
-  assert_proto_server_fetch(proto, "prefix multi\nsuffix", -1);
+  assert_proto_server_fetch(&proto, "prefix first suffix", -1);
+  assert_proto_server_fetch(&proto, "prefix multi\nsuffix", -1);
 
   log_proto_server_free(proto);
 }
@@ -179,10 +179,10 @@ StaticParameterizedTest(LogTransportMockConstructor *log_transport_mock_new, log
               LTM_EOF),
             NULL, " Bar$");
 
-  assert_proto_server_fetch(proto, "Foo First Line", -1);
-  assert_proto_server_fetch(proto, "Foo Second Line", -1);
-  assert_proto_server_fetch(proto, "Foo Third Line", -1);
-  assert_proto_server_fetch(proto, "Foo Multiline\nmulti", -1);
+  assert_proto_server_fetch(&proto, "Foo First Line", -1);
+  assert_proto_server_fetch(&proto, "Foo Second Line", -1);
+  assert_proto_server_fetch(&proto, "Foo Third Line", -1);
+  assert_proto_server_fetch(&proto, "Foo Multiline\nmulti", -1);
 
   log_proto_server_free(proto);
 }
@@ -207,10 +207,10 @@ StaticParameterizedTest(LogTransportMockConstructor *log_transport_mock_new, log
               LTM_EOF),
             "^Foo", NULL);
 
-  assert_proto_server_fetch(proto, "First Line", -1);
-  assert_proto_server_fetch(proto, "Foo Second Line", -1);
-  assert_proto_server_fetch(proto, "Foo Third Line", -1);
-  assert_proto_server_fetch(proto, "Foo Multiline\nmulti", -1);
+  assert_proto_server_fetch(&proto, "First Line", -1);
+  assert_proto_server_fetch(&proto, "Foo Second Line", -1);
+  assert_proto_server_fetch(&proto, "Foo Third Line", -1);
+  assert_proto_server_fetch(&proto, "Foo Multiline\nmulti", -1);
 
   log_proto_server_free(proto);
 }

--- a/lib/logproto/tests/test-text-server.c
+++ b/lib/logproto/tests/test-text-server.c
@@ -116,30 +116,30 @@ test_log_proto_text_server_no_encoding(LogTransportMockConstructor log_transport
 
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
 
   /* input split due to an oversized input line */
-  assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", -1);
-  assert_proto_server_fetch(proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "0123456789ABCDEF0123456789ABCDEF", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
 
-  assert_proto_server_fetch(proto, "árvíztűrőtükörfúrógép", -1);
-  assert_proto_server_fetch(proto,
+  assert_proto_server_fetch(&proto, "árvíztűrőtükörfúrógép", -1);
+  assert_proto_server_fetch(&proto,
                             "\xe1\x72\x76\xed\x7a\x74\xfb\x72\xf5\x74\xfc\x6b\xf6\x72\x66\xfa"    /*  |árvíztűrőtükörfú| */
                             "\x72\xf3\x67\xe9\x70",                                               /*  |rógép|            */
                             -1);
-  assert_proto_server_fetch(proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
 
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch(proto, "", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "", -1);
 
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch(proto, "", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "", -1);
 
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch(proto, "", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "", -1);
 
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch(proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
   log_proto_server_free(proto);
 }
 
@@ -160,8 +160,8 @@ Test(log_proto, test_log_proto_text_server_no_eol_before_eof)
 
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 
 }
@@ -176,9 +176,9 @@ Test(log_proto, test_log_proto_text_server_eols_are_removed_from_the_front_as_we
               "\r01234567\r\n", -1,
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }
 
@@ -194,9 +194,9 @@ Test(log_proto, test_log_proto_text_with_embedded_nuls)
 
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch(proto, "alma\x00korte", 10);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch(&proto, "alma\x00korte", 10);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }
 
@@ -212,9 +212,9 @@ Test(log_proto, test_log_proto_nul_terminated_records)
 
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "01234\n567", -1);
-  assert_proto_server_fetch(proto, "alma\nkorte", -1);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch(&proto, "01234\n567", -1);
+  assert_proto_server_fetch(&proto, "alma\nkorte", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }
 
@@ -229,10 +229,10 @@ Test(log_proto, test_log_proto_text_server_eol_before_eof)
               LTM_INJECT_ERROR(EIO),
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "01234", -1);
-  assert_proto_server_fetch(proto, "567", -1);
-  assert_proto_server_fetch(proto, "890", -1);
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, NULL);
+  assert_proto_server_fetch(&proto, "01234", -1);
+  assert_proto_server_fetch(&proto, "567", -1);
+  assert_proto_server_fetch(&proto, "890", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, NULL);
   log_proto_server_free(proto);
 }
 
@@ -246,8 +246,8 @@ Test(log_proto, test_log_proto_text_server_io_error_before_eof)
               LTM_INJECT_ERROR(EIO),
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "01234567", -1);
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, NULL);
+  assert_proto_server_fetch(&proto, "01234567", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, NULL);
   log_proto_server_free(proto);
 }
 
@@ -264,7 +264,7 @@ Test(log_proto, test_log_proto_text_server_partial_chars_before_eof)
 
   cr_assert(log_proto_server_validate_options(proto),
             "validate_options() returned failure but it should have succeeded");
-  assert_proto_server_fetch_failure(proto, LPS_EOF,
+  assert_proto_server_fetch_failure(&proto, LPS_EOF,
                                     "EOF read on a channel with leftovers from previous character conversion, dropping input");
   log_proto_server_free(proto);
 }
@@ -281,7 +281,7 @@ Test(log_proto, test_log_proto_text_server_invalid_char_with_encoding)
 
   cr_assert(log_proto_server_validate_options(proto),
             "validate_options() returned failure but it should have succeeded");
-  assert_proto_server_fetch(proto, "foobarbaz", -1);
+  assert_proto_server_fetch(&proto, "foobarbaz", -1);
   log_proto_server_free(proto);
 }
 
@@ -299,8 +299,8 @@ Test(log_proto, test_log_proto_text_server_not_fixed_encoding)
               LTM_EOF));
   cr_assert(log_proto_server_validate_options(proto),
             "validate_options() returned failure but it should have succeeded");
-  assert_proto_server_fetch(proto, "árvíztűrőtükörfúrógép", -1);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch(&proto, "árvíztűrőtükörfúrógép", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }
 
@@ -322,8 +322,8 @@ Test(log_proto, test_log_proto_text_server_ucs4)
 
   cr_assert(log_proto_server_validate_options(proto),
             "validate_options() returned failure but it should have succeeded");
-  assert_proto_server_fetch(proto, "árvíztűrőtükörfúrógép", -1);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch(&proto, "árvíztűrőtükörfúrógép", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }
 
@@ -341,8 +341,8 @@ Test(log_proto, test_log_proto_text_server_iso8859_2)
 
   cr_assert(log_proto_server_validate_options(proto),
             "validate_options() returned failure but it should have succeeded");
-  assert_proto_server_fetch(proto, "árvíztűrőtükörfúrógép", -1);
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch(&proto, "árvíztűrőtükörfúrógép", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
   log_proto_server_free(proto);
 }
 
@@ -376,9 +376,9 @@ Test(log_proto, test_log_proto_text_server_multi_read)
               LTM_INJECT_ERROR(EIO),
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "foobar", -1);
-  assert_proto_server_fetch(proto, "foobaz", -1);
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, NULL);
+  assert_proto_server_fetch(&proto, "foobar", -1);
+  assert_proto_server_fetch(&proto, "foobaz", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, NULL);
   log_proto_server_free(proto);
 }
 
@@ -396,17 +396,17 @@ Test(log_proto, test_log_proto_text_server_multi_read_not_allowed, .disabled = t
               LTM_EOF));
 
   ((LogProtoBufferedServer *) proto)->no_multi_read = TRUE;
-  assert_proto_server_fetch_single_read(proto, "foobar", -1);
+  assert_proto_server_fetch_single_read(&proto, "foobar", -1);
   /* because of EAGAIN */
-  assert_proto_server_fetch_single_read(proto, NULL, -1);
+  assert_proto_server_fetch_single_read(&proto, NULL, -1);
   /* because of NOMREAD, partial lines are returned as empty */
-  assert_proto_server_fetch_single_read(proto, NULL, -1);
+  assert_proto_server_fetch_single_read(&proto, NULL, -1);
   /* because of EAGAIN */
-  assert_proto_server_fetch_single_read(proto, NULL, -1);
+  assert_proto_server_fetch_single_read(&proto, NULL, -1);
   /* error was detected by this time, partial line is returned before the error */
-  assert_proto_server_fetch_single_read(proto, "foobaz", -1);
+  assert_proto_server_fetch_single_read(&proto, "foobaz", -1);
   /* finally the error is returned too */
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, NULL);
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, NULL);
   log_proto_server_free(proto);
 }
 
@@ -429,11 +429,11 @@ Test(log_proto, test_log_proto_text_server_is_not_fetching_input_as_long_as_ther
               LTM_INJECT_ERROR(EIO),
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "foo", -1);
-  assert_proto_server_fetch(proto, "bar", -1);
-  assert_proto_server_fetch(proto, "baz", -1);
-  assert_proto_server_fetch(proto, "booz", -1);
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, NULL);
+  assert_proto_server_fetch(&proto, "foo", -1);
+  assert_proto_server_fetch(&proto, "bar", -1);
+  assert_proto_server_fetch(&proto, "baz", -1);
+  assert_proto_server_fetch(&proto, "booz", -1);
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, NULL);
   log_proto_server_free(proto);
 }
 
@@ -467,10 +467,10 @@ test_log_proto_text_server_accumulate_line_is_called_for_each_line(LogTransportM
               LTM_PADDING,
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "0 line", -1);
-  assert_proto_server_fetch(proto, "1 line", -1);
-  assert_proto_server_fetch(proto, "2 line", -1);
-  assert_proto_server_fetch(proto, "3 line", -1);
+  assert_proto_server_fetch(&proto, "0 line", -1);
+  assert_proto_server_fetch(&proto, "1 line", -1);
+  assert_proto_server_fetch(&proto, "2 line", -1);
+  assert_proto_server_fetch(&proto, "3 line", -1);
 
   log_proto_server_free(proto);
 }
@@ -509,8 +509,8 @@ test_log_proto_text_server_accumulate_line_can_consume_lines_without_returning_t
               LTM_PADDING,
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "0 line\n1 line", -1);
-  assert_proto_server_fetch(proto, "2 line\n3 line", -1);
+  assert_proto_server_fetch(&proto, "0 line\n1 line", -1);
+  assert_proto_server_fetch(&proto, "2 line\n3 line", -1);
 
   log_proto_server_free(proto);
 }
@@ -558,8 +558,8 @@ test_log_proto_text_server_accumulate_line_can_rewind_lines_if_uninteresting(Log
               LTM_PADDING,
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "0 line\n line", -1);
-  assert_proto_server_fetch(proto, "2 line\n line", -1);
+  assert_proto_server_fetch(&proto, "0 line\n line", -1);
+  assert_proto_server_fetch(&proto, "2 line\n line", -1);
 
   log_proto_server_free(proto);
 }
@@ -585,8 +585,8 @@ test_log_proto_text_server_accumulation_terminated_if_input_is_closed(LogTranspo
               "1 line\n", -1,
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "0 line\n line", -1);
-  assert_proto_server_fetch(proto, "1 line", -1);
+  assert_proto_server_fetch(&proto, "0 line\n line", -1);
+  assert_proto_server_fetch(&proto, "1 line", -1);
 
   log_proto_server_free(proto);
 }
@@ -611,8 +611,8 @@ test_log_proto_text_server_accumulation_terminated_if_buffer_full(LogTransportMo
               " continuation\n", -1,
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "0123456789abcdef\n 0123456789abcd", -1);
-  assert_proto_server_fetch(proto, "ef\n continuation", -1);
+  assert_proto_server_fetch(&proto, "0123456789abcdef\n 0123456789abcd", -1);
+  assert_proto_server_fetch(&proto, "ef\n continuation", -1);
   log_proto_server_free(proto);
 }
 
@@ -648,10 +648,10 @@ test_log_proto_text_server_rewinding_the_initial_line_results_in_an_empty_messag
               LTM_PADDING,
               LTM_EOF));
 
-  assert_proto_server_fetch(proto, "", -1);
-  assert_proto_server_fetch(proto, "0 line", -1);
-  assert_proto_server_fetch(proto, "1 line", -1);
-  assert_proto_server_fetch(proto, "2 line", -1);
+  assert_proto_server_fetch(&proto, "", -1);
+  assert_proto_server_fetch(&proto, "0 line", -1);
+  assert_proto_server_fetch(&proto, "1 line", -1);
+  assert_proto_server_fetch(&proto, "2 line", -1);
 
   log_proto_server_free(proto);
 }
@@ -706,12 +706,12 @@ Test(log_proto, buffer_split_with_encoding_and_position_tracking)
   LogProtoServer *proto = log_proto_text_server_new((LogTransport *) transport, get_inited_proto_server_options());
 
   start_grabbing_messages();
-  assert_proto_server_fetch(proto, data_smaller->str, data_smaller->len - 1);
-  assert_proto_server_fetch(proto, data->str, data->len - 1);
+  assert_proto_server_fetch(&proto, data_smaller->str, data_smaller->len - 1);
+  assert_proto_server_fetch(&proto, data->str, data->len - 1);
   stop_grabbing_messages();
   cr_assert_not(find_grabbed_message("Internal error"));
 
-  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  assert_proto_server_fetch_failure(&proto, LPS_EOF, NULL);
 
   log_proto_server_free(proto);
   g_free(full_payload);

--- a/lib/logproto/tests/test_logproto.c
+++ b/lib/logproto/tests/test_logproto.c
@@ -65,10 +65,10 @@ Test(log_proto, test_base)
   /* check if error state is not forgotten unless reset_error is called */
   proto->status = LPS_ERROR;
   assert_proto_server_status(proto, proto->status, LPS_ERROR);
-  assert_proto_server_fetch_failure(proto, LPS_ERROR, NULL);
+  assert_proto_server_fetch_failure(&proto, LPS_ERROR, NULL);
 
   log_proto_server_reset_error(proto);
-  assert_proto_server_fetch(proto, "árvíztűr", -1);
+  assert_proto_server_fetch(&proto, "árvíztűr", -1);
   assert_proto_server_status(proto, proto->status, LPS_SUCCESS);
 
   log_proto_server_free(proto);

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -407,39 +407,6 @@ _add_aux_nvpair(const gchar *name, const gchar *value, gsize value_len, gpointer
   log_msg_set_value_by_name(msg, name, value, value_len);;
 }
 
-static inline gint
-log_reader_process_handshake(LogReader *self)
-{
-  gboolean handshake_finished = FALSE;
-  LogProtoServer *proto_replacement = NULL;
-  LogProtoStatus status = log_proto_server_handshake(self->proto, &handshake_finished, &proto_replacement);
-
-  if (proto_replacement)
-    {
-      g_assert(handshake_finished == FALSE);
-      log_transport_stack_move(&proto_replacement->transport_stack, &self->proto->transport_stack);
-      log_proto_server_free(self->proto);
-      self->proto = proto_replacement;
-    }
-
-  switch (status)
-    {
-    case LPS_EOF:
-    case LPS_ERROR:
-      return status == LPS_ERROR ? NC_READ_ERROR : NC_CLOSE;
-    case LPS_SUCCESS:
-      if (handshake_finished)
-        self->handshake_in_progress = FALSE;
-      break;
-    case LPS_AGAIN:
-      break;
-    default:
-      g_assert_not_reached();
-      break;
-    }
-  return 0;
-}
-
 static void
 _log_reader_insert_msg_length_stats(LogReader *self, gsize len)
 {
@@ -537,10 +504,6 @@ log_reader_fetch_log(LogReader *self)
     aux = NULL;
 
   log_transport_aux_data_init(aux);
-  if (self->handshake_in_progress)
-    {
-      return log_reader_process_handshake(self);
-    }
 
   /* NOTE: this loop is here to decrease the load on the main loop, we try
    * to fetch a couple of messages in a single run (but only up to
@@ -815,7 +778,6 @@ log_reader_new(GlobalConfig *cfg)
   self->super.super.free_fn = log_reader_free;
   self->super.wakeup = log_reader_wakeup;
   self->super.schedule_dynamic_window_realloc = _schedule_dynamic_window_realloc;
-  self->handshake_in_progress = TRUE;
   log_reader_init_watches(self);
   g_mutex_init(&self->pending_close_lock);
   g_cond_init(&self->pending_close_cond);

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -579,6 +579,7 @@ log_reader_fetch_log(LogReader *self)
         case LPS_SUCCESS:
           break;
         case LPS_AGAIN:
+          log_proto_server_apply_replacement(&self->proto);
           break;
         default:
           g_assert_not_reached();

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -61,7 +61,6 @@ struct _LogReader
 {
   LogSource super;
   LogProtoServer *proto;
-  gboolean handshake_in_progress;
   LogPipe *control;
   LogReaderOptions *options;
   PollEvents *poll_events;

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -68,7 +68,6 @@ struct _LogWriter
   LogQueue *queue;
   guint32 flags:31;
   gint32 seq_num;
-  gboolean handshake_in_progress;
   gboolean partial_write;
 
   struct
@@ -1270,20 +1269,6 @@ log_writer_queue_pop_message(LogWriter *self, LogPathOptions *path_options, gboo
     return log_queue_pop_head(self->queue, path_options);
 }
 
-static inline LogProtoStatus
-log_writer_process_handshake(LogWriter *self)
-{
-  gboolean handshake_finished = FALSE;
-  LogProtoStatus status = log_proto_client_handshake(self->proto, &handshake_finished);
-
-  if (status != LPS_SUCCESS)
-    return LPS_ERROR;
-
-  if (handshake_finished)
-    self->handshake_in_progress = FALSE;
-  return LPS_SUCCESS;
-}
-
 /*
  * @flush_mode specifies how hard LogWriter is trying to send messages to
  * the actual destination:
@@ -1300,9 +1285,6 @@ log_writer_flush(LogWriter *self, LogWriterFlushMode flush_mode)
 
   if (!self->proto)
     return LPS_ERROR;
-
-  if (self->handshake_in_progress)
-    return log_writer_process_handshake(self);
 
   /* NOTE: in case we're reloading or exiting we flush all queued items as
    * long as the destination can consume it.  This is not going to be an
@@ -1882,7 +1864,6 @@ log_writer_new(guint32 flags, GlobalConfig *cfg)
   self->flags = flags;
   self->line_buffer = g_string_sized_new(128);
   self->pollable_state = -1;
-  self->handshake_in_progress = TRUE;
   init_sequence_number(&self->seq_num);
 
   log_writer_init_watches(self);

--- a/libtest/proto_lib.c
+++ b/libtest/proto_lib.c
@@ -26,6 +26,7 @@
 #include "grab-logging.h"
 
 #include "cfg.h"
+#include "messages.h"
 #include <string.h>
 
 LogProtoServerOptions proto_server_options;
@@ -36,38 +37,36 @@ assert_proto_server_status(LogProtoServer *proto, LogProtoStatus status, LogProt
   cr_assert_eq(status, expected_status, "LogProtoServer expected status mismatch");
 }
 
-LogProtoStatus
-proto_server_handshake(LogProtoServer **proto)
+/* One fetch(); a replacement the proto asks for is applied and reported in
+ * @replaced, starting the replacement with a fresh @may_read like the reader's
+ * next pass does, and LPS_AGAIN reads as LPS_SUCCESS. */
+static LogProtoStatus
+_fetch_once(LogProtoServer **proto, const guchar **msg, gsize *msg_len, gboolean *may_read,
+            LogTransportAuxData *aux, Bookmark *bookmark, gboolean *replaced)
 {
-  gboolean handshake_finished = FALSE;
-  LogProtoStatus status;
+  LogProtoStatus status = log_proto_server_fetch(*proto, msg, msg_len, may_read, aux, bookmark);
 
-  start_grabbing_messages();
-  do
+  *replaced = FALSE;
+  if (status == LPS_AGAIN)
     {
-      LogProtoServer *proto_replacement = NULL;
-      status = log_proto_server_handshake(*proto, &handshake_finished, &proto_replacement);
-      if (status == LPS_AGAIN)
-        status = LPS_SUCCESS;
-      if (proto_replacement)
-        {
-          log_transport_stack_move(&proto_replacement->transport_stack, &(*proto)->transport_stack);
-          log_proto_server_free(*proto);
-          *proto = proto_replacement;
-        }
+      *replaced = log_proto_server_apply_replacement(proto);
+      if (*replaced)
+        *may_read = TRUE;
+      status = LPS_SUCCESS;
     }
-  while (status == LPS_SUCCESS && handshake_finished == FALSE);
-  stop_grabbing_messages();
   return status;
 }
 
+/* Fetch until a message is produced, so that logproto-auto-server is
+ * transparent here. */
 LogProtoStatus
-proto_server_fetch(LogProtoServer *proto, const guchar **msg, gsize *msg_len)
+proto_server_fetch(LogProtoServer **proto, const guchar **msg, gsize *msg_len)
 {
   Bookmark bookmark;
   LogTransportAuxData aux = {0};
   GSockAddr *saddr;
   gboolean may_read = TRUE;
+  gboolean replaced;
   LogProtoStatus status;
 
   start_grabbing_messages();
@@ -75,9 +74,7 @@ proto_server_fetch(LogProtoServer *proto, const guchar **msg, gsize *msg_len)
   do
     {
       log_transport_aux_data_reinit(&aux);
-      status = log_proto_server_fetch(proto, msg, msg_len, &may_read, &aux, &bookmark);
-      if (status == LPS_AGAIN)
-        status = LPS_SUCCESS;
+      status = _fetch_once(proto, msg, msg_len, &may_read, &aux, &bookmark, &replaced);
     }
   while (status == LPS_SUCCESS && *msg == NULL && may_read);
 
@@ -102,18 +99,41 @@ construct_server_proto_plugin(const gchar *name, LogTransport *transport)
   return log_proto_server_factory_construct(proto_factory, transport, &proto_server_options, NULL);
 }
 
+/* Assert that *proto replaces itself and apply the replacement.
+ * @detect_message, when given, pins down which proto was chosen. */
 void
-assert_proto_server_handshake(LogProtoServer **proto)
+assert_proto_server_replacement(LogProtoServer **proto, const gchar *detect_message)
 {
+  gboolean replaced = FALSE;
+  const guchar *msg = NULL;
+  gsize msg_len = 0;
+  LogTransportAuxData aux = {0};
+  Bookmark bookmark;
+  gboolean may_read = TRUE;
   LogProtoStatus status;
+  gint saved_debug_flag = debug_flag;
 
-  status = proto_server_handshake(proto);
+  debug_flag = TRUE;
+  start_grabbing_messages();
+  log_transport_aux_data_init(&aux);
+  do
+    {
+      log_transport_aux_data_reinit(&aux);
+      status = _fetch_once(proto, &msg, &msg_len, &may_read, &aux, &bookmark, &replaced);
+      cr_assert_null(msg, "a proto that replaces itself must not return a message");
+    }
+  while (status == LPS_SUCCESS && !replaced && may_read);
+  log_transport_aux_data_destroy(&aux);
+  stop_grabbing_messages();
+  debug_flag = saved_debug_flag;
 
   assert_proto_server_status(*proto, status, LPS_SUCCESS);
+  if (detect_message)
+    assert_grabbed_log_contains(detect_message);
 }
 
 void
-assert_proto_server_fetch(LogProtoServer *proto, const gchar *expected_msg, gssize expected_msg_len)
+assert_proto_server_fetch(LogProtoServer **proto, const gchar *expected_msg, gssize expected_msg_len)
 {
   const guchar *msg = NULL;
   gsize msg_len = 0;
@@ -121,7 +141,7 @@ assert_proto_server_fetch(LogProtoServer *proto, const gchar *expected_msg, gssi
 
   status = proto_server_fetch(proto, &msg, &msg_len);
 
-  assert_proto_server_status(proto, status, LPS_SUCCESS);
+  assert_proto_server_status(*proto, status, LPS_SUCCESS);
 
   if (expected_msg_len < 0)
     expected_msg_len = strlen(expected_msg);
@@ -133,7 +153,7 @@ assert_proto_server_fetch(LogProtoServer *proto, const gchar *expected_msg, gssi
 }
 
 void
-assert_proto_server_fetch_single_read(LogProtoServer *proto, const gchar *expected_msg, gssize expected_msg_len)
+assert_proto_server_fetch_single_read(LogProtoServer **proto, const gchar *expected_msg, gssize expected_msg_len)
 {
   const guchar *msg = NULL;
   gsize msg_len = 0;
@@ -141,11 +161,12 @@ assert_proto_server_fetch_single_read(LogProtoServer *proto, const gchar *expect
   LogTransportAuxData aux = {0};
   Bookmark bookmark;
   gboolean may_read = TRUE;
+  gboolean replaced;
 
   start_grabbing_messages();
   log_transport_aux_data_init(&aux);
-  status = log_proto_server_fetch(proto, &msg, &msg_len, &may_read, &aux, &bookmark);
-  assert_proto_server_status(proto, status, LPS_SUCCESS);
+  status = _fetch_once(proto, &msg, &msg_len, &may_read, &aux, &bookmark, &replaced);
+  assert_proto_server_status(*proto, status, LPS_SUCCESS);
 
   if (expected_msg)
     {
@@ -167,7 +188,7 @@ assert_proto_server_fetch_single_read(LogProtoServer *proto, const gchar *expect
 }
 
 void
-assert_proto_server_fetch_failure(LogProtoServer *proto, LogProtoStatus expected_status, const gchar *error_message)
+assert_proto_server_fetch_failure(LogProtoServer **proto, LogProtoStatus expected_status, const gchar *error_message)
 {
   const guchar *msg = NULL;
   gsize msg_len = 0;
@@ -175,23 +196,14 @@ assert_proto_server_fetch_failure(LogProtoServer *proto, LogProtoStatus expected
 
   status = proto_server_fetch(proto, &msg, &msg_len);
 
-  assert_proto_server_status(proto, status, expected_status);
+  assert_proto_server_status(*proto, status, expected_status);
   if (error_message)
     assert_grabbed_log_contains(error_message);
 }
 
-void
-assert_proto_server_handshake_failure(LogProtoServer **proto, LogProtoStatus expected_status)
-{
-  LogProtoStatus status;
-
-  status = proto_server_handshake(proto);
-
-  assert_proto_server_status(*proto, status, expected_status);
-}
 
 void
-assert_proto_server_fetch_ignored_eof(LogProtoServer *proto)
+assert_proto_server_fetch_ignored_eof(LogProtoServer **proto)
 {
   const guchar *msg = NULL;
   gsize msg_len = 0;
@@ -199,13 +211,12 @@ assert_proto_server_fetch_ignored_eof(LogProtoServer *proto)
   LogTransportAuxData aux = {0};
   Bookmark bookmark;
   gboolean may_read = TRUE;
+  gboolean replaced;
 
   start_grabbing_messages();
   log_transport_aux_data_init(&aux);
-  status = log_proto_server_fetch(proto, &msg, &msg_len, &may_read, &aux, &bookmark);
-  if (status == LPS_AGAIN)
-    status = LPS_SUCCESS;
-  assert_proto_server_status(proto, status, LPS_SUCCESS);
+  status = _fetch_once(proto, &msg, &msg_len, &may_read, &aux, &bookmark, &replaced);
+  assert_proto_server_status(*proto, status, LPS_SUCCESS);
   cr_assert_null(msg, "when an EOF is ignored msg must be NULL");
   cr_assert_null(aux.peer_addr, "returned saddr must be NULL on success");
   log_transport_aux_data_destroy(&aux);

--- a/libtest/proto_lib.h
+++ b/libtest/proto_lib.h
@@ -29,14 +29,14 @@
 extern LogProtoServerOptions proto_server_options;
 
 
-void assert_proto_server_handshake(LogProtoServer **proto);
-void assert_proto_server_handshake_failure(LogProtoServer **proto, LogProtoStatus expected_status);
+LogProtoStatus proto_server_fetch(LogProtoServer **proto, const guchar **msg, gsize *msg_len);
+void assert_proto_server_replacement(LogProtoServer **proto, const gchar *detect_message);
 void assert_proto_server_status(LogProtoServer *proto, LogProtoStatus status, LogProtoStatus expected_status);
-void assert_proto_server_fetch(LogProtoServer *proto, const gchar *expected_msg, gssize expected_msg_len);
-void assert_proto_server_fetch_single_read(LogProtoServer *proto, const gchar *expected_msg, gssize expected_msg_len);
-void assert_proto_server_fetch_failure(LogProtoServer *proto, LogProtoStatus expected_status,
+void assert_proto_server_fetch(LogProtoServer **proto, const gchar *expected_msg, gssize expected_msg_len);
+void assert_proto_server_fetch_single_read(LogProtoServer **proto, const gchar *expected_msg, gssize expected_msg_len);
+void assert_proto_server_fetch_failure(LogProtoServer **proto, LogProtoStatus expected_status,
                                        const gchar *error_message);
-void assert_proto_server_fetch_ignored_eof(LogProtoServer *proto);
+void assert_proto_server_fetch_ignored_eof(LogProtoServer **proto);
 
 LogProtoServer *construct_server_proto_plugin(const gchar *name, LogTransport *transport);
 

--- a/news/developer-note-1231.md
+++ b/news/developer-note-1231.md
@@ -1,0 +1,9 @@
+`logproto`: replaced the handshake phase of `LogProtoServer` with a proto replacement from `fetch()`
+
+A server proto that wants to hand its work over to another one (transport
+auto-detection is the only such case today) now sets the new
+`proto_replacement` member during `fetch()` and returns `LPS_AGAIN` without
+a message.
+
+The previous half-broken LogProtoClient/LogProtoServer handshake()
+mechanisms are now gone.


### PR DESCRIPTION
I was trying to use the LogProtoClient handshake() method in a related work when I noticed it does not handle cases where the connection is re-established.

With that I decided to get rid off the handshake mechanism and hide that behind the single fetch() method. The proto implementation can do its own handshake behind that interface.
