### PR TITLE
alpine+grpc: patch c-ares crash

### DIFF
--- a/docker/apkbuild/axoflow/c-ares/1256-qid-reuse-detach.patch
+++ b/docker/apkbuild/axoflow/c-ares/1256-qid-reuse-detach.patch
@@ -1,0 +1,25 @@
+Backport of https://github.com/c-ares/c-ares/pull/1256 (unmerged as of 2026-09-06).
+
+A query is detached from queries_by_qid before its callback runs. When the
+callback starts a new query (getaddrinfo does so for every search domain step)
+that draws the same qid, the second detach in ares_free_query() evicts the new
+query, which then never completes.
+
+diff --git a/src/lib/ares_process.c b/src/lib/ares_process.c
+index aa2dc7f13d..9740bad16f 100644
+--- a/src/lib/ares_process.c
++++ b/src/lib/ares_process.c
+@@ -1598,7 +1598,12 @@ static void ares_detach_query(ares_query_t *query)
+ {
+   /* Remove the query from all the lists in which it is linked */
+   ares_query_remove_from_conn(query);
+-  ares_htable_szvp_remove(query->channel->queries_by_qid, query->qid);
++  /* A callback may queue a new query that reuses this ID. Only remove the
++   * entry if it still points to this query. */
++  if (ares_htable_szvp_get_direct(query->channel->queries_by_qid, query->qid) ==
++      query) {
++    ares_htable_szvp_remove(query->channel->queries_by_qid, query->qid);
++  }
+   ares_llist_node_destroy(query->node_all_queries);
+   query->node_all_queries = NULL;
+ }

--- a/docker/apkbuild/axoflow/c-ares/APKBUILD
+++ b/docker/apkbuild/axoflow/c-ares/APKBUILD
@@ -1,0 +1,63 @@
+# Contributor: Carlo Landmeter <clandmeter@alpinelinux.org>
+# Maintainer: Carlo Landmeter <clandmeter@alpinelinux.org>
+pkgname=c-ares
+pkgver=1.34.8
+# keep pkgrel above the aports one so apk prefers this build
+pkgrel=1
+pkgdesc="Asynchronous DNS/names resolver library"
+url="https://c-ares.org/"
+arch="all"
+license="MIT"
+makedepends="cmake samurai"
+checkdepends="gtest-dev"
+subpackages="
+	$pkgname-doc
+	$pkgname-dev
+	$pkgname-utils
+	"
+source="https://github.com/c-ares/c-ares/releases/download/v$pkgver/c-ares-$pkgver.tar.gz
+	1256-qid-reuse-detach.patch
+	"
+
+# secfixes:
+#   1.34.8-r0:
+#     - CVE-2026-33630
+#   1.34.6-r0:
+#     - CVE-2025-62408
+#   1.34.5-r0:
+#     - CVE-2025-31498
+#   1.27.0-r0:
+#     - CVE-2024-25629
+#   1.17.2-r0:
+#     - CVE-2021-3672
+
+build() {
+	cmake -B build -G Ninja \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCARES_SHARED=ON \
+		-DCARES_STATIC=ON \
+		-DCARES_STATIC_PIC=ON \
+		-DCARES_BUILD_TESTS="$(want_check && echo ON || echo OFF)" \
+		-DCARES_SYMBOL_HIDING=ON \
+		-DCARES_THREADS=ON
+
+	cmake --build build
+}
+
+check() {
+	build/bin/arestest --gtest_filter=-*.Live*
+}
+
+package() {
+	DESTDIR="$pkgdir" cmake --install build
+}
+
+utils() {
+	amove usr/bin
+}
+
+sha512sums="
+d5997a57fda9b3a3385b1685e6b2f9292c3a1d39bd27579acaabf3d2d33aa5e91bfec5d41c5e51ca6b50dbc1f4346d75e9bfbccf44a494fbd4bc7613b167143c  c-ares-1.34.8.tar.gz
+10b39f277cacfd4581b679a824b8c81c4d37155d6956e36d08370653ddb7ef454af0436f9b0e85aa04f999aa219392010a8659f47d79220f663cec71531e8737  1256-qid-reuse-detach.patch
+"

--- a/docker/axosyslog-builder.dockerfile
+++ b/docker/axosyslog-builder.dockerfile
@@ -55,6 +55,9 @@ RUN mkdir packages || true \
     && cd axoflow/criterion \
     && export MAKEFLAGS="-j$(nproc)" \
     && abuild checksum \
+    && abuild -r \
+    && cd ../c-ares \
+    && abuild checksum \
     && abuild -r
 
 RUN \

--- a/news/bugfix-1233.md
+++ b/news/bugfix-1233.md
@@ -1,0 +1,6 @@
+`opentelemetry()`, `clickhouse()`, `loki()`, `bigquery()`, `pubsub()` destinations: Fixed a crash
+in the container image when the destination's host name does not resolve.
+
+c-ares 1.34.8 can lose the DNS query that follows a search domain step, so the lookup never
+completes and gRPC aborts the process when it gives up on it. The image now ships c-ares with the
+upstream fix applied.


### PR DESCRIPTION
The Alpine image ships `c-ares` 1.34.8, which can lose the callback of a DNS query that follows a search domain step.

gRPC then aborts the process from `AresResolver::~AresResolver()` once it gives up on the lookup, which showed up on gRPC destinations whose host name does not resolve.

The releases without this regression predate the CVE-2026-33630 fix, so the image stays on 1.34.8 and patches it.

---

https://github.com/c-ares/c-ares/pull/1256