### PR TITLE
http: relax the worker-partition-key() requirement for message-independent URL templates

### DIFF
--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -26,6 +26,7 @@
 #include "template/macros.h"
 #include "template/escaping.h"
 #include "template/repr.h"
+#include "template/simple-function.h"
 #include "timeutils/format.h"
 #include "str-utils.h"
 #include "cfg.h"
@@ -50,6 +51,53 @@ log_template_get_literal_value(const LogTemplate *self, gssize *value_len)
     *value_len = e->text_len;
 
   return e->text;
+}
+
+static gboolean
+_elem_is_message_independent(const LogTemplateElem *e)
+{
+  if (log_template_elem_is_literal_string(e))
+    return TRUE;
+
+  switch (e->type)
+    {
+    case LTE_MACRO:
+    case LTE_VALUE:
+      /* Any non-literal macro (M_HOST, M_MESSAGE, M_DATE, ...) or NV-pair reference resolves against the current
+       * message and is therefore message-dependent by definition. */
+      return FALSE;
+
+    case LTE_FUNC:
+      /* We can only safely introspect template functions implemented through tf_simple_func_prepare(): their output
+       * is a pure function of the already-compiled argument templates.  For functions with a custom prepare()
+       * (format-date, tags, value-pairs, ...) be conservative — they may read message state, time, or other ambient context. */
+      if (e->func.ops->prepare != tf_simple_func_prepare)
+        return FALSE;
+      {
+        const TFSimpleFuncState *state = (const TFSimpleFuncState *) e->func.state;
+        for (gint i = 0; i < state->argc; i++)
+          {
+            if (!log_template_is_message_independent(state->argv_templates[i]))
+              return FALSE;
+          }
+      }
+      return TRUE;
+
+    default:
+      g_assert_not_reached();
+    }
+}
+
+gboolean
+log_template_is_message_independent(const LogTemplate *self)
+{
+  /* An empty template renders to the empty string regardless of input. */
+  for (GList *p = self->compiled_template; p; p = g_list_next(p))
+    {
+      if (!_elem_is_message_independent((const LogTemplateElem *) p->data))
+        return FALSE;
+    }
+  return TRUE;
 }
 
 gboolean

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -76,6 +76,7 @@ void log_template_forget_template_string(LogTemplate *self);
 void log_template_compile_literal_string(LogTemplate *self, const gchar *literal);
 gboolean log_template_is_literal_string(const LogTemplate *self);
 const gchar *log_template_get_literal_value(const LogTemplate *self, gssize *value_len);
+gboolean log_template_is_message_independent(const LogTemplate *self);
 gboolean log_template_is_trivial(LogTemplate *self);
 NVHandle log_template_get_trivial_value_handle(LogTemplate *self);
 const gchar *log_template_get_trivial_value(LogTemplate *self, LogMessage *msg, gssize *value_len);

--- a/lib/template/tests/test_template.c
+++ b/lib/template/tests/test_template.c
@@ -629,6 +629,81 @@ Test(template, test_compile_literal_string)
   log_template_unref(template);
 }
 
+Test(template, test_message_independence_literals)
+{
+  LogTemplate *t = compile_template("");
+  cr_assert(log_template_is_message_independent(t), "Empty template is message-independent");
+  log_template_unref(t);
+
+  t = compile_template("plain literal text");
+  cr_assert(log_template_is_message_independent(t), "Plain literal is message-independent");
+  log_template_unref(t);
+
+  t = compile_template("$$not a macro");
+  cr_assert(log_template_is_message_independent(t), "Escaped '$$' literal is message-independent");
+  log_template_unref(t);
+}
+
+Test(template, test_message_independence_macros_and_values)
+{
+  LogTemplate *t = compile_template("$HOST");
+  cr_assert_not(log_template_is_message_independent(t), "Macros are message-dependent");
+  log_template_unref(t);
+
+  t = compile_template("${MESSAGE}");
+  cr_assert_not(log_template_is_message_independent(t), "Macros are message-dependent");
+  log_template_unref(t);
+
+  t = compile_template("prefix-${my_field}");
+  cr_assert_not(log_template_is_message_independent(t), "NV-pair refs are message-dependent");
+  log_template_unref(t);
+
+  t = compile_template("$DATE");
+  cr_assert_not(log_template_is_message_independent(t), "Timestamp macros are message-dependent");
+  log_template_unref(t);
+}
+
+Test(template, test_message_independence_simple_functions)
+{
+  /* tf_echo is registered with TEMPLATE_FUNCTION_SIMPLE and only depends on its args */
+  LogTemplate *t = compile_template("$(echo literal)");
+  cr_assert(log_template_is_message_independent(t),
+            "Simple func with literal arg is message-independent");
+  log_template_unref(t);
+
+  t = compile_template("prefix-$(echo literal)-suffix");
+  cr_assert(log_template_is_message_independent(t),
+            "Literal text + simple func with literal arg is message-independent");
+  log_template_unref(t);
+
+  /* Nested simple funcs with literal args are still message-independent */
+  t = compile_template("$(echo $(echo literal))");
+  cr_assert(log_template_is_message_independent(t),
+            "Nested simple funcs with literal args are message-independent");
+  log_template_unref(t);
+
+  /* A message-dependent argument poisons the entire expression */
+  t = compile_template("$(echo $HOST)");
+  cr_assert_not(log_template_is_message_independent(t),
+                "Simple func with message-dependent arg is message-dependent");
+  log_template_unref(t);
+
+  t = compile_template("$(echo prefix-${MESSAGE})");
+  cr_assert_not(log_template_is_message_independent(t),
+                "Simple func with NV-pair arg is message-dependent");
+  log_template_unref(t);
+}
+
+Test(template, test_message_independence_non_simple_functions)
+{
+  /* tf_tag uses a custom prepare() — be conservative and treat as message-dependent even with a literal tag name,
+   * because the call() reads ambient message state (the message's tag set). */
+  LogTemplate *t = compile_template("$(tag tagname)");
+  cr_assert_not(log_template_is_message_independent(t),
+                "Functions with custom prepare() are conservatively treated as message-dependent");
+  log_template_unref(t);
+}
+
 Test(template, test_result_of_concatenation_in_templates_are_typed_as_strings)
 {
   assert_template_format_value_and_type("$HOST$PROGRAM", "bzorpsyslog-ng", LM_VT_STRING);

--- a/modules/http/http-loadbalancer.c
+++ b/modules/http/http-loadbalancer.c
@@ -148,6 +148,12 @@ http_lb_target_is_url_templated(HTTPLoadBalancerTarget *self)
   return !log_template_is_literal_string(self->url_template);
 }
 
+gboolean
+http_lb_target_is_url_message_dependent(HTTPLoadBalancerTarget *self)
+{
+  return !log_template_is_message_independent(self->url_template);
+}
+
 const gchar *
 http_lb_target_get_literal_url(HTTPLoadBalancerTarget *self)
 {
@@ -399,6 +405,18 @@ http_load_balancer_is_url_templated(HTTPLoadBalancer *self)
   for (gint i = 0; i < self->num_targets; i++)
     {
       if (http_lb_target_is_url_templated(&self->targets[i]))
+        return TRUE;
+    }
+
+  return FALSE;
+}
+
+gboolean
+http_load_balancer_is_url_message_dependent(HTTPLoadBalancer *self)
+{
+  for (gint i = 0; i < self->num_targets; i++)
+    {
+      if (http_lb_target_is_url_message_dependent(&self->targets[i]))
         return TRUE;
     }
 

--- a/modules/http/http-loadbalancer.h
+++ b/modules/http/http-loadbalancer.h
@@ -57,6 +57,7 @@ struct _HTTPLoadBalancerTarget
 };
 
 gboolean http_lb_target_is_url_templated(HTTPLoadBalancerTarget *self);
+gboolean http_lb_target_is_url_message_dependent(HTTPLoadBalancerTarget *self);
 const gchar *http_lb_target_get_literal_url(HTTPLoadBalancerTarget *self);
 void http_lb_target_format_templated_url(HTTPLoadBalancerTarget *self, LogMessage *msg,
                                          const LogTemplateOptions *template_options, GString *result);
@@ -87,6 +88,7 @@ void http_load_balancer_track_client(HTTPLoadBalancer *self, HTTPLoadBalancerCli
 void http_load_balancer_set_target_failed(HTTPLoadBalancer *self, HTTPLoadBalancerTarget *target);
 void http_load_balancer_set_target_successful(HTTPLoadBalancer *self, HTTPLoadBalancerTarget *target);
 gboolean http_load_balancer_is_url_templated(HTTPLoadBalancer *self);
+gboolean http_load_balancer_is_url_message_dependent(HTTPLoadBalancer *self);
 
 void http_load_balancer_set_recovery_timeout(HTTPLoadBalancer *self, gint recovery_timeout);
 HTTPLoadBalancer *http_load_balancer_new(void);

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -449,18 +449,21 @@ http_dd_init(LogPipe *s)
   gboolean is_batch_templated = http_load_balancer_is_url_templated(self->load_balancer) || is_body_prefix_templated;
 
   if (is_batching_enabled && is_batch_templated)
-    {
-      log_threaded_dest_driver_set_flush_on_worker_key_change(&self->super.super.super, TRUE);
+    log_threaded_dest_driver_set_flush_on_worker_key_change(&self->super.super.super, TRUE);
 
-      if (!self->super.worker_partition_key)
-        {
-          msg_error("http: worker-partition-key() must be set if using templates in the url() option "
-                    "while batching is enabled. "
-                    "Make sure to set worker-partition-key() with a template that contains all the templates "
-                    "used in the url() option",
-                    log_pipe_location_tag(&self->super.super.super.super));
-          return FALSE;
-        }
+  gboolean is_body_prefix_message_dependent = self->body_prefix_template &&
+                                              !log_template_is_message_independent(self->body_prefix_template);
+  gboolean is_batch_message_dependent = http_load_balancer_is_url_message_dependent(self->load_balancer)
+                                        || is_body_prefix_message_dependent;
+
+  if (is_batching_enabled && is_batch_message_dependent && !self->super.worker_partition_key)
+    {
+      msg_error("http: worker-partition-key() must be set if using message-dependent templates "
+                "in the url() or body-prefix() options while batching is enabled. "
+                "Make sure to set worker-partition-key() with a template that contains all the "
+                "message-dependent templates used in the url() and body-prefix() options",
+                log_pipe_location_tag(&self->super.super.super.super));
+      return FALSE;
     }
   if (self->batch_bytes > 0 && self->super.batch_lines == 0)
     self->super.batch_lines = G_MAXINT;

--- a/modules/http/tests/CMakeLists.txt
+++ b/modules/http/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_unit_test(LIBTEST CRITERION TARGET test_http DEPENDS http basicfuncs)
-add_unit_test(LIBTEST CRITERION TARGET test_http-loadbalancer DEPENDS http)
+add_unit_test(LIBTEST CRITERION TARGET test_http-loadbalancer DEPENDS http basicfuncs)
 add_unit_test(CRITERION TARGET test_http-response_handlers DEPENDS http)
 add_unit_test(CRITERION TARGET test_http-signal_slot DEPENDS http)
 add_unit_test(CRITERION TARGET test_compression DEPENDS http)

--- a/modules/http/tests/Makefile.am
+++ b/modules/http/tests/Makefile.am
@@ -20,7 +20,7 @@ modules_http_tests_test_http_LDFLAGS	= \
 EXTRA_modules_http_tests_test_http_loadbalancer_DEPENDENCIES = \
 	$(top_builddir)/modules/http/libhttp.la
 modules_http_tests_test_http_loadbalancer_CFLAGS	= $(TEST_CFLAGS) -I$(top_srcdir)/modules/http
-modules_http_tests_test_http_loadbalancer_LDADD		= $(TEST_LDADD)
+modules_http_tests_test_http_loadbalancer_LDADD		= $(TEST_LDADD) $(PREOPEN_BASICFUNCS)
 modules_http_tests_test_http_loadbalancer_LDFLAGS	= \
 	-dlpreopen $(top_builddir)/modules/http/libhttp.la
 

--- a/modules/http/tests/test_http-loadbalancer.c
+++ b/modules/http/tests/test_http-loadbalancer.c
@@ -26,6 +26,8 @@
 #include "http-loadbalancer.h"
 #include "apphook.h"
 #include "scratch-buffers.h"
+#include "cfg.h"
+#include "plugin.h"
 
 #include <unistd.h>
 
@@ -142,6 +144,52 @@ Test(http_loadbalancer, choose_target_escapes_templated_url)
   log_msg_unref(msg);
   http_lb_client_deinit(&lbc);
   http_load_balancer_free(lb);
+}
+
+Test(http_loadbalancer, url_message_dependence_classification)
+{
+  GError *error = NULL;
+
+  /* Literal URL: not templated, not message-dependent. */
+  {
+    HTTPLoadBalancer *lb = http_load_balancer_new();
+    cr_assert(http_load_balancer_add_target(lb, "http://localhost:8000/path", &error));
+    cr_assert_not(http_load_balancer_is_url_templated(lb));
+    cr_assert_not(http_load_balancer_is_url_message_dependent(lb));
+    http_load_balancer_free(lb);
+  }
+
+  /* Message-dependent macro: both templated and message-dependent. */
+  {
+    HTTPLoadBalancer *lb = http_load_balancer_new();
+    cr_assert(http_load_balancer_add_target(lb, "http://localhost:8000/${HOST}", &error));
+    cr_assert(http_load_balancer_is_url_templated(lb));
+    cr_assert(http_load_balancer_is_url_message_dependent(lb));
+    http_load_balancer_free(lb);
+  }
+
+  /* Pure simple-func with literal argument: templated but NOT message-dependent. This is the case that motivated the
+   * new predicate: $(url-encode literal) inside SCL-wrapped URLs should not require worker-partition-key(). */
+  {
+    HTTPLoadBalancer *lb = http_load_balancer_new();
+    cr_assert(http_load_balancer_add_target(lb,
+                                            "http://localhost:8000/$(url-encode /aws/lambda/fn)",
+                                            &error));
+    cr_assert(http_load_balancer_is_url_templated(lb));
+    cr_assert_not(http_load_balancer_is_url_message_dependent(lb));
+    http_load_balancer_free(lb);
+  }
+
+  /* Simple-func with a message-dependent argument: message-dependent. */
+  {
+    HTTPLoadBalancer *lb = http_load_balancer_new();
+    cr_assert(http_load_balancer_add_target(lb,
+                                            "http://localhost:8000/$(url-encode ${HOST})",
+                                            &error));
+    cr_assert(http_load_balancer_is_url_templated(lb));
+    cr_assert(http_load_balancer_is_url_message_dependent(lb));
+    http_load_balancer_free(lb);
+  }
 }
 
 Test(http_loadbalancer, choose_target_balances_clients_to_targets)
@@ -371,12 +419,17 @@ void
 setup(void)
 {
   app_startup();
+  configuration = cfg_new_snippet();
+  cfg_load_module(configuration, "basicfuncs");
 }
 
 void
 teardown(void)
 {
   scratch_buffers_explicit_gc();
+  if (configuration)
+    cfg_free(configuration);
+  configuration = NULL;
   app_shutdown();
 }
 

--- a/news/feature-1234.md
+++ b/news/feature-1234.md
@@ -1,0 +1,6 @@
+`http()`: relaxed the `worker-partition-key()` requirement for message-independent URL templates
+
+The partition-key check previously fired for any `url()` containing a `$` sign, even when the template was
+effectively constant (for example `$(url-encode literal)` after SCL backtick substitution). The check now walks the
+compiled template and only requires `worker-partition-key()` if the `url()` or `body-prefix()` is genuinely
+message-dependent.


### PR DESCRIPTION
Cherry-picked from syslog-ng/syslog-ng#5740