### PR TITLE
logthrsourcedrv: fix frozen timestamps

### DIFF
--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -25,6 +25,7 @@
 #include "mainloop-threaded-worker.h"
 #include "messages.h"
 #include "apphook.h"
+#include "timeutils/cache.h"
 #include "ack-tracker/ack_tracker_factory.h"
 #include "stats/stats-cluster-key-builder.h"
 
@@ -535,6 +536,8 @@ log_threaded_source_worker_post_with_filterx_context(LogThreadedSourceWorker *se
 
   if (self->control->auto_close_batches)
     log_threaded_source_worker_close_batch(self);
+
+  invalidate_cached_realtime();
 }
 
 gboolean

--- a/news/bugfix-1241.md
+++ b/news/bugfix-1241.md
@@ -1,0 +1,1 @@
+`opentelemetry()` source: fix frozen local timestamps


### PR DESCRIPTION
The time calculation at the logreader and threaded source seam gated incorrectly, the timestamp update was load-bearing.

----

For anyone interested in the actual problem: threaded sources never invalidated their time caches, so time would get stuck, for example, when calling `get_timestamp(stamp="recvd")` on an `opentelemetry()` message.

@furiel found it:
```
source s_gen { example-msg-generator(num(0) freq(1) template("probe message")); };

log {
  source(s_gen);
  destination { opentelemetry(url("localhost:4317")); };
};

log {
  source { opentelemetry(port(4317)); };
  filterx {
    $MSG = get_timestamp(stamp="recvd");
  };
  destination { stdout(); };
};

```