### PR TITLE
build: allow linking against llvm statically

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -438,6 +438,9 @@ AC_ARG_ENABLE(jit,
 AC_ARG_WITH(llvm-config,
               [  --with-llvm-config=path      Specify llvm-config location],
               ,,with_llvm_config="")
+AC_ARG_WITH(llvm-linking,
+              [  --with-llvm-linking=shared|static  Link the JIT against the shared libLLVM or the static component archives (default: whatever llvm-config reports)]
+              ,,with_llvm_linking="auto")
 
 AC_ARG_ENABLE(all-modules,
               [  --enable-all-modules    Forcibly enable all modules. (default: auto)]
@@ -1898,13 +1901,33 @@ else
   AC_MSG_RESULT(no)
 fi
 
+llvm_static="no"
 if test "$enable_jit" = "yes"; then
   LLVM_CFLAGS="`$LLVM_CONFIG --cflags`"
   LLVM_CXXFLAGS="`$LLVM_CONFIG --cxxflags`"
-  llvm__ldflags="`$LLVM_CONFIG --ldflags`"
-  llvm__libs="`$LLVM_CONFIG --libs`"
-  llvm__syslibs="`$LLVM_CONFIG --system-libs`"
+
+  # --link-static/--link-shared apply to the three queries that make up the
+  # link line; llvm-config's default is the shared libLLVM when there is one.
+  case "$with_llvm_linking" in
+    static) llvm__linkflag="--link-static" ;;
+    shared) llvm__linkflag="--link-shared" ;;
+    auto)   llvm__linkflag="" ;;
+    *)      AC_MSG_ERROR([--with-llvm-linking takes shared or static, not '$with_llvm_linking']) ;;
+  esac
+  llvm__ldflags="`$LLVM_CONFIG $llvm__linkflag --ldflags`"
+  llvm__libs="`$LLVM_CONFIG $llvm__linkflag --libs`"
+  llvm__syslibs="`$LLVM_CONFIG $llvm__linkflag --system-libs`"
   LLVM_LIBS="$llvm__ldflags $llvm__libs $llvm__syslibs "
+
+  # Whether LLVM ends up as static archives in our link: asked for above, or
+  # llvm-config's own default on an installation without the libLLVM dylib.
+  # Either way --libs is then the component list (-lLLVMCore -lLLVMSupport ...)
+  # rather than the single -lLLVM-N token. This decides CCLD below.
+  AC_MSG_CHECKING([how LLVM is linked])
+  case " $llvm__libs " in
+    *" -lLLVM-"[[0-9]]*|*" -lLLVM "*) AC_MSG_RESULT([shared libLLVM]) ;;
+    *)                                llvm_static="yes"; AC_MSG_RESULT([static archives]) ;;
+  esac
 
   CPPFLAGS_SAVE="$CPPFLAGS"
   CPPFLAGS="$CPPFLAGS $LLVM_CFLAGS"
@@ -2225,17 +2248,32 @@ fi
 LOGGENPLUGIN_LDFLAGS=$MODULE_LDFLAGS
 MODULE_DEPS_LIBS="\$(top_builddir)/lib/libsyslog-ng.la"
 
-# syslog-ng binary is linked with the default link command (e.g. libtool)
-
-if test "$enable_cpp" = "yes"; then
-  SYSLOGNG_LINK='$(CXXLINK)'
-else
-  SYSLOGNG_LINK='$(LINK)'
-fi
-
+SYSLOGNG_LINK='$(LINK)'
 if test "$enable_jit" = "yes" -a "x$linking_mode" = "xmonolithic"; then
   SYSLOGNG_LINK="$SYSLOGNG_LINK -Wl,--format=binary,lib/filterx/jit/libfilterx.bc,--format=default -Wl,--export-dynamic"
 fi
+
+#
+# C++ objects reach C links in two ways.
+#
+#   1) The C++ modules (grpc, cloud-auth, examples) keep their C++ in a
+#      noinst convenience library and link it into a module whose own sources are
+#      C, so automake would pick the C driver for a library full of C++.
+#
+#   2) LLVM linked statically into libsyslog-ng, then libsyslog-ng needs to
+#      link using the C++ linker.
+#
+#   3) the previous point combined with monolithic builds: every program
+#      that links to libsyslog-ng needs to be linked using the C++ linker.
+#
+# We need to turn these cases into using the C++ linker, which is done by
+# setting CCLD to $(CXX) below, otherwise we would miss C++ related symbols
+# in the final link.
+#
+if test "$enable_cpp" = "yes" -o \( "$enable_jit" = "yes" -a "$llvm_static" = "yes" \); then
+  CCLD='$(CXX)'
+fi
+AC_SUBST([CCLD])
 
 if test "x$linking_mode" = "xdynamic"; then
 	SYSLOGNG_DEPS_LIBS="$LIBS $BASE_LIBS $GLIB_LIBS $EVTLOG_LIBS $SECRETSTORAGE_LIBS $RESOLV_LIBS $LIBCAP_LIBS $PCRE2_LIBS $REGEX_LIBS $LLVM_LIBS $DL_LIBS $LIBUNWIND_LIBS $JSON_LIBS $OPENSSL_LIBS"

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -66,6 +66,8 @@ EXTRA_lib_libsyslog_ng_la_DEPENDENCIES       = lib/eventlog/src/libevtlog.la lib
 if ENABLE_JIT
 lib_libsyslog_ng_la_LDFLAGS += -Wl,--format=binary,lib/filterx/jit/libfilterx.bc,--format=default
 EXTRA_lib_libsyslog_ng_la_DEPENDENCIES += lib/filterx/jit/libfilterx.bc
+# The C++ runtime a statically linked LLVM needs comes from configure setting
+# CCLD to the C++ driver when LLVM is linked that way; see configure.ac.
 endif
 
 if IVYKIS_INTERNAL

--- a/modules/cloud-auth/Makefile.am
+++ b/modules/cloud-auth/Makefile.am
@@ -44,8 +44,6 @@ modules_cloud_auth_libcloud_auth_la_LIBADD = \
   $(MODULE_DEPS_LIBS) \
   $(top_builddir)/modules/cloud-auth/libcloud_auth_cpp.la
 
-nodist_EXTRA_modules_cloud_auth_libcloud_auth_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
-
 modules_cloud_auth_libcloud_auth_la_LDFLAGS = \
   $(MODULE_LDFLAGS)
 

--- a/modules/examples/Makefile.am
+++ b/modules/examples/Makefile.am
@@ -34,10 +34,6 @@ modules_examples_libexamples_la_LIBADD = $(MODULE_DEPS_LIBS) $(EXAMPLE_PLUGINS)
 EXTRA_modules_examples_libexamples_la_DEPENDENCIES = $(MODULE_DEPS_LIBS) $(EXAMPLE_PLUGINS)
 modules_examples_libexamples_la_LDFLAGS = $(MODULE_LDFLAGS)
 
-if ENABLE_CPP
-nodist_EXTRA_modules_examples_libexamples_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
-endif
-
 EXTRA_DIST += modules/examples/CMakeLists.txt
 
 modules/examples modules/examples/ mod-examples: modules/examples/libexamples.la

--- a/modules/grpc/bigquery/Makefile.am
+++ b/modules/grpc/bigquery/Makefile.am
@@ -45,8 +45,6 @@ modules_grpc_bigquery_libbigquery_la_LIBADD = \
   $(top_builddir)/modules/grpc/protos/libgrpc-protos.la \
   $(top_builddir)/modules/grpc/bigquery/libbigquery_cpp.la
 
-nodist_EXTRA_modules_grpc_bigquery_libbigquery_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
-
 modules_grpc_bigquery_libbigquery_la_LDFLAGS = $(MODULE_LDFLAGS)
 EXTRA_modules_grpc_bigquery_libbigquery_la_DEPENDENCIES = \
   $(MODULE_DEPS_LIBS) \

--- a/modules/grpc/clickhouse/Makefile.am
+++ b/modules/grpc/clickhouse/Makefile.am
@@ -47,8 +47,6 @@ modules_grpc_clickhouse_libclickhouse_la_LIBADD = \
   $(top_builddir)/modules/grpc/protos/libgrpc-protos.la \
   $(top_builddir)/modules/grpc/clickhouse/libclickhouse_cpp.la
 
-nodist_EXTRA_modules_grpc_clickhouse_libclickhouse_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
-
 modules_grpc_clickhouse_libclickhouse_la_LDFLAGS = $(MODULE_LDFLAGS)
 EXTRA_modules_grpc_clickhouse_libclickhouse_la_DEPENDENCIES = \
   $(MODULE_DEPS_LIBS) \

--- a/modules/grpc/filterx/Makefile.am
+++ b/modules/grpc/filterx/Makefile.am
@@ -37,8 +37,6 @@ modules_grpc_filterx_libgrpc_filterx_la_LIBADD = \
   $(top_builddir)/modules/grpc/protos/libgrpc-protos.la \
   $(top_builddir)/modules/grpc/filterx/libgrpc-filterx-cpp.la
 
-nodist_EXTRA_modules_grpc_filterx_libgrpc_filterx_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
-
 modules_grpc_filterx_libgrpc_filterx_la_LDFLAGS = $(MODULE_LDFLAGS)
 
 modules_grpc_filterx_libgrpc_filterx_la_DEPENDENCIES = \

--- a/modules/grpc/filterx/tests/Makefile.am
+++ b/modules/grpc/filterx/tests/Makefile.am
@@ -19,8 +19,6 @@ modules_grpc_filterx_tests_test_protobuf_message_LDADD = \
   $(top_builddir)/modules/grpc/common/libgrpc-common.la \
   $(top_builddir)/modules/grpc/filterx/libgrpc-filterx.la
 
-nodist_EXTRA_modules_grpc_filterx_tests_test_protobuf_message_SOURCES = force-cpp-linker-with-default-stdlib2.cpp
-
 endif
 
 EXTRA_DIST += \

--- a/modules/grpc/loki/Makefile.am
+++ b/modules/grpc/loki/Makefile.am
@@ -45,8 +45,6 @@ modules_grpc_loki_libloki_la_LIBADD = \
   $(top_builddir)/modules/grpc/protos/libgrpc-protos.la \
   $(top_builddir)/modules/grpc/loki/libloki_cpp.la
 
-nodist_EXTRA_modules_grpc_loki_libloki_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
-
 modules_grpc_loki_libloki_la_LDFLAGS = $(MODULE_LDFLAGS)
 EXTRA_modules_grpc_loki_libloki_la_DEPENDENCIES = \
   $(MODULE_DEPS_LIBS) \

--- a/modules/grpc/otel/Makefile.am
+++ b/modules/grpc/otel/Makefile.am
@@ -63,8 +63,6 @@ modules_grpc_otel_libotel_la_LIBADD = \
   $(top_builddir)/modules/grpc/otel/libotel_cpp.la \
   $(top_builddir)/modules/grpc/otel/filterx/libfilterx.la
 
-nodist_EXTRA_modules_grpc_otel_libotel_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
-
 modules_grpc_otel_libotel_la_LDFLAGS = $(MODULE_LDFLAGS)
 
 EXTRA_modules_grpc_otel_libotel_la_DEPENDENCIES = \

--- a/modules/grpc/protos/Makefile.am
+++ b/modules/grpc/protos/Makefile.am
@@ -162,8 +162,6 @@ endif
 
 if ENABLE_BUILTIN_MODULES
 modules_grpc_protos_libgrpc_protos_la_LDFLAGS = -static
-else
-nodist_EXTRA_modules_grpc_protos_libgrpc_protos_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
 endif
 
 modules_grpc_protos_libgrpc_protos_la_LIBADD = $(MODULE_DEPS_LIBS) $(PROTOBUF_LIBS) $(GRPCPP_LIBS)

--- a/modules/grpc/pubsub/Makefile.am
+++ b/modules/grpc/pubsub/Makefile.am
@@ -46,8 +46,6 @@ modules_grpc_pubsub_libpubsub_la_LIBADD = \
   $(top_builddir)/modules/grpc/pubsub/libpubsub_cpp.la \
   $(top_builddir)/modules/grpc/pubsub/filterx/libfilterx.la
 
-nodist_EXTRA_modules_grpc_pubsub_libpubsub_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
-
 modules_grpc_pubsub_libpubsub_la_LDFLAGS = $(MODULE_LDFLAGS)
 EXTRA_modules_grpc_pubsub_libpubsub_la_DEPENDENCIES = \
   $(MODULE_DEPS_LIBS) \


### PR DESCRIPTION
This patch also cleans up how we enable linking using the C++ linker in cases where we need it.

