### PR TITLE
otel/filterx: build the converted containers as xrefs

### DIFF
--- a/modules/grpc/otel/filterx/otel-field-converter.cpp
+++ b/modules/grpc/otel/filterx/otel-field-converter.cpp
@@ -41,6 +41,7 @@
 #include "filterx/object-dict.h"
 #include "filterx/object-list.h"
 #include "filterx/filterx-sequence.h"
+#include "filterx/filterx-ref.h"
 
 #include "compat/cpp-end.h"
 
@@ -428,6 +429,16 @@ syslogng::grpc::otel::iter_on_otel_protobuf_message_fields(google::protobuf::Mes
 
 static FilterXObject *_convert_field_value_to_plain(FilterXObject *value);
 
+/* the stores below must go through an xref, as that is what links the stored
+ * child to its parent container, making a later write through the child land
+ * in the parent */
+static FilterXObject *
+_new_container_ref(FilterXObject *container)
+{
+  filterx_object_cow_prepare(&container);
+  return container;
+}
+
 static gboolean
 _add_field_to_dict(FilterXObject *key, FilterXObject *value, gpointer user_data)
 {
@@ -463,7 +474,7 @@ _convert_field_value_to_plain(FilterXObject *value)
 {
   if (filterx_object_is_type(value, &FILTERX_TYPE_NAME(otel_kvlist)))
     {
-      FilterXObject *dict = filterx_dict_new();
+      FilterXObject *dict = _new_container_ref(filterx_dict_new());
       if (!filterx_object_iter(value, _add_field_to_dict, dict))
         {
           filterx_object_unref(dict);
@@ -474,7 +485,7 @@ _convert_field_value_to_plain(FilterXObject *value)
 
   if (filterx_object_is_type(value, &FILTERX_TYPE_NAME(otel_array)))
     {
-      FilterXObject *list = filterx_list_new();
+      FilterXObject *list = _new_container_ref(filterx_list_new());
       if (!filterx_object_iter(value, _append_element_to_list, list))
         {
           filterx_object_unref(list);
@@ -492,7 +503,7 @@ syslogng::grpc::otel::otel_protobuf_message_to_filterx_dict(const google::protob
   /* the reflection based getters need a mutable Message, but only set fields are read */
   google::protobuf::Message &mutable_message = const_cast<google::protobuf::Message &>(message);
 
-  FilterXObject *dict = filterx_dict_new();
+  FilterXObject *dict = _new_container_ref(filterx_dict_new());
   if (!iter_on_otel_protobuf_message_fields(mutable_message, _add_field_to_dict, dict))
     {
       filterx_object_unref(dict);

--- a/tests/light/functional_tests/source_drivers/opentelemetry_source/test_opentelemetry_source_acceptance.py
+++ b/tests/light/functional_tests/source_drivers/opentelemetry_source/test_opentelemetry_source_acceptance.py
@@ -440,3 +440,44 @@ def test_opentelemetry_source_filterx_dict_mode_sets_peer_address(
     sourceip, ip_proto = file_destination.read_log().split()
     assert sourceip in ("127.0.0.1", "::1")
     assert ip_proto in ("4", "6")
+
+
+def test_opentelemetry_source_filterx_dict_mode_writes(
+    syslog_ng: SyslogNg,
+    config: SyslogNgConfig,
+    port_allocator,
+) -> None:
+    opentelemetry_source = config.create_opentelemetry_source(port=port_allocator(), mode="filterx-dict")
+    filterx = config.create_filterx(r"""
+        log.body = "new_body";
+        log.attributes.string = "new_string";
+        log.attributes.new_key = "new_value";
+        log.attributes.dict.key = "new_dict_value";
+        log.attributes.list[0] = "new_list_elem";
+        resource.attributes.dict.key = "new_resource_value";
+        scope.attributes.dict.key = "new_scope_value";
+        $MSG = {
+            "body": log.body,
+            "log_attributes": log.attributes,
+            "resource_dict": resource.attributes.dict,
+            "scope_dict": scope.attributes.dict,
+        };""")
+    file_destination = config.create_file_destination(file_name="output.log", template=TEMPLATE)
+    config.create_logpath(statements=[opentelemetry_source, filterx, file_destination])
+
+    expected_log_attributes = dict(LOG_1_OUTPUT["attributes"])
+    expected_log_attributes.update({
+        "string": "new_string",
+        "new_key": "new_value",
+        "dict": {"key": "new_dict_value"},
+        "list": ["new_list_elem"],
+    })
+
+    syslog_ng.start(config)
+    opentelemetry_source.write_log(resource=RESOURCE_1, scope=SCOPE_1, log=LOG_1)
+    assert json.loads(file_destination.read_log()) == {
+        "body": "new_body",
+        "log_attributes": expected_log_attributes,
+        "resource_dict": {"key": "new_resource_value"},
+        "scope_dict": {"key": "new_scope_value"},
+    }


### PR DESCRIPTION
Similar behavior observed as in #1246 but with bit different root cause.

The protobuf to filterx conversion stored its
children into bare dicts and lists.
The parent link is set by the xref set_subscript
after the store, so a child stored into a bare
container never got one.

A later write through such a child found an xref
without a parent, treated it as shared and wrote
into a shadow that nothing stored back. The child
then read back the old value with no error, which
made the resource, scope and log dicts of
mode(filterx-dict) read-only in effect.

The new light test writes into the injected dicts
at each depth and reads the values back.